### PR TITLE
MSP-2845: add DefaultContainerAnnotationName for containers with munge

### DIFF
--- a/internal/render/controller/statefulset.go
+++ b/internal/render/controller/statefulset.go
@@ -72,6 +72,7 @@ func RenderStatefulSet(
 						fmt.Sprintf(
 							"%s/%s", consts.AnnotationApparmorKey, consts.ContainerNameMunge,
 						): consts.AnnotationApparmorValueUnconfined,
+						consts.DefaultContainerAnnotationName: consts.ContainerNameSlurmctld,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/internal/render/login/statefulset.go
+++ b/internal/render/login/statefulset.go
@@ -73,6 +73,7 @@ func RenderStatefulSet(
 						fmt.Sprintf(
 							"%s/%s", consts.AnnotationApparmorKey, consts.ContainerNameMunge,
 						): consts.AnnotationApparmorValueUnconfined,
+						consts.DefaultContainerAnnotationName: consts.ContainerNameSshd,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -45,6 +45,7 @@ func RenderStatefulSet(
 		fmt.Sprintf(
 			"%s/%s", consts.AnnotationApparmorKey, consts.ContainerNameMunge,
 		): consts.AnnotationApparmorValueUnconfined,
+		consts.DefaultContainerAnnotationName: consts.ContainerNameSlurmd,
 	}
 	initContainers := []corev1.Container{
 		renderContainerToolkitValidation(&worker.ContainerToolkitValidation),


### PR DESCRIPTION
Currently, when you run kubectl logs or kubectl exec, by default, it connects to the munge container. I would like it to connect to the main container by default, instead of the sidecar.