### PR TITLE
[FIX] Cluster name altering

### DIFF
--- a/helm/slurm-cluster/templates/_helpers.tpl
+++ b/helm/slurm-cluster/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{/* Name of the cluster */}}
 {{- define "slurm-cluster.name" -}}
-    {{- default .Chart.Name .Values.clusterName | kebabcase | trunc 63 | trimSuffix "-" }}
+    {{- default .Chart.Name .Values.clusterName | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/* Create chart name and version as used by the chart label */}}


### PR DESCRIPTION
Cluster names containing digits get kebabed at the start of each digit

**Example**:
`slurm-e2e` gets transformed to `slurm-e-2e`