### PR TITLE
HOTFIX: make worker pod as a Guaranteed

### DIFF
--- a/internal/render/common/container.go
+++ b/internal/render/common/container.go
@@ -11,9 +11,24 @@ import (
 )
 
 // RenderContainerMunge renders [corev1.Container] for munge
-func RenderContainerMunge(container *values.Container) corev1.Container {
-	// Create a copy of the container's limits and add non-CPU resources from Requests
-	limits := CopyNonCPUResources(container.Resources)
+func RenderContainerMunge(container *values.Container, opts ...RenderOption) corev1.Container {
+
+	// No all munge containers need to have guaranteed resources
+	options := renderOptions{
+		guaranteed: false, // default value
+	}
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	limits := container.Resources
+
+	if !options.guaranteed {
+		// Create a copy of the container's limits and add non-CPU resources from Requests
+		limits = CopyNonCPUResources(container.Resources)
+	}
+
 	return corev1.Container{
 		Name:            consts.ContainerNameMunge,
 		Image:           container.Image,

--- a/internal/render/common/container.go
+++ b/internal/render/common/container.go
@@ -15,7 +15,7 @@ func RenderContainerMunge(container *values.Container, opts ...RenderOption) cor
 
 	// No all munge containers need to have guaranteed resources
 	options := renderOptions{
-		guaranteed: false, // default value
+		guaranteed: false,
 	}
 
 	for _, opt := range opts {

--- a/internal/render/common/container.go
+++ b/internal/render/common/container.go
@@ -13,7 +13,7 @@ import (
 // RenderContainerMunge renders [corev1.Container] for munge
 func RenderContainerMunge(container *values.Container, opts ...RenderOption) corev1.Container {
 
-	// No all munge containers need to have guaranteed resources
+	// Not all resources are guaranteed to be set in the container.Resources field.
 	options := renderOptions{
 		guaranteed: false,
 	}

--- a/internal/render/common/resources.go
+++ b/internal/render/common/resources.go
@@ -16,3 +16,19 @@ func CopyNonCPUResources(resourceList corev1.ResourceList) corev1.ResourceList {
 	}
 	return limits
 }
+
+type RenderOption func(*renderOptions)
+
+type renderOptions struct {
+	guaranteed bool
+}
+
+// GuaranteedPod is a RenderOption that sets the guaranteed flag
+// Needed for setting the limits of the container to the same values as the requests.
+// This is useful for slurm worker cgroupv2 support.
+// It's neccessary for cpuset https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy
+func GuaranteedPod(guaranteed bool) RenderOption {
+	return func(opts *renderOptions) {
+		opts.guaranteed = guaranteed
+	}
+}

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -65,8 +65,7 @@ func renderContainerSlurmd(
 		renderVolumeMountSysctl(),
 	}
 	volumeMounts = append(volumeMounts, common.RenderVolumeMountsForJailSubMounts(jailSubMounts)...)
-	// Create a copy of the container's limits and add non-CPU resources from Requests
-	limits := common.CopyNonCPUResources(container.Resources)
+
 	return corev1.Container{
 		Name:            consts.ContainerNameSlurmd,
 		Image:           container.Image,
@@ -103,7 +102,7 @@ func renderContainerSlurmd(
 			ProcMount: ptr.To(corev1.UnmaskedProcMount),
 		},
 		Resources: corev1.ResourceRequirements{
-			Limits:   limits,
+			Limits:   container.Resources,
 			Requests: container.Resources,
 		},
 	}

--- a/internal/render/worker/container_test.go
+++ b/internal/render/worker/container_test.go
@@ -39,6 +39,7 @@ func Test_RenderContainerSlurmd(t *testing.T) {
 			},
 			wantLimits: corev1.ResourceList{
 				corev1.ResourceMemory:           resource.MustParse("1Gi"),
+				corev1.ResourceCPU:              resource.MustParse("100m"),
 				corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 			},
 			wantReqs: corev1.ResourceList{
@@ -57,7 +58,7 @@ func Test_RenderContainerSlurmd(t *testing.T) {
 				},
 				Name: containerName,
 			},
-			wantLimits: corev1.ResourceList{},
+			wantLimits: nil,
 			wantReqs:   nil,
 		},
 	}


### PR DESCRIPTION
For Slurm, it's necessary to use cpuset in cgroups. [Slurm Cgroups Documentation](https://slurm.schedmd.com/cgroups.html). In Kubernetes, cpuset is only created if a pod has a QoS of Guaranteed. [Kubernetes CPU Management Policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy).

Related issue: [kubernetes/kubernetes#85764](https://github.com/kubernetes/kubernetes/issues/85764)