### PR TITLE
docs(README): deploy slurm cluster in a namespace aligned with the cluster name

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ In general, you need to follow these steps:
 2. Install the [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator).
 3. If you use InfiniBand, install the [NVIDIA Network Operator](https://github.com/Mellanox/network-operator).
 4. Install Soperator by applying the [soperator](helm/soperator) Helm chart.
-5. Create a Slurm cluster by applying the [slurm-cluster](helm/slurm-cluster) Helm chart.
+5. Create a Slurm cluster in a namespace with the same name as the slurm cluster by 
+   applying the [slurm-cluster](helm/slurm-cluster) Helm chart.
 6. Wait until the `slurm.nebius.ai/SlurmCluster` resource becomes `Available`.
 
 [//]: # (TODO: Refer to Helm OCI images instead of file directories when the repo is open)

--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -2,7 +2,7 @@
 
 # Complement jaildir by bind-mounting virtual filesystems, users, and NVIDIA binaries from the host filesystem
 
-set -x # Print actual command when before
+set -x # Print actual command before executing it
 set -e # Exit immediately if any command returns a non-zero error code
 
 usage() { echo "usage: ${0} -j <path_to_jail_dir> -u <path_to_upper_jail_dir> [-w] [-h]" >&2; exit 1; }


### PR DESCRIPTION
rest.RenderSecret renders the cluster name as the namespace. This should be explicit in the README.

https://github.com/nebius/soperator/blob/8766049c7852fad947ddf1831928f640774d7967/internal/controller/clustercontroller/common.go#L55