### PR TITLE
MSP-3918: Fix bug reconciliation logic for scenarios with maintenance=true and accounting=false

### DIFF
--- a/internal/controller/reconciler/grant.go
+++ b/internal/controller/reconciler/grant.go
@@ -7,6 +7,7 @@ import (
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
@@ -60,6 +61,11 @@ func (r *MariaDbGrantReconciler) deleteIfOwnedByController(
 	name string,
 ) error {
 	grant, err := r.getMariaDbGrant(ctx, namespace, name)
+	if apierrors.IsNotFound(err) {
+		log.FromContext(ctx).Info("MariaDbGrant is not found, skipping deletion")
+		return nil
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "getting MariaDbGrant")
 	}

--- a/internal/controller/reconciler/k8s_service.go
+++ b/internal/controller/reconciler/k8s_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -60,6 +61,10 @@ func (r *ServiceReconciler) deleteIfOwnedByController(
 	name string,
 ) error {
 	service, err := r.getService(ctx, namespace, name)
+	if apierrors.IsNotFound(err) {
+		log.FromContext(ctx).Info("Service not found, skipping deletion")
+		return nil
+	}
 	if err != nil {
 		return errors.Wrap(err, "getting Service")
 	}

--- a/internal/controller/reconciler/mariadb.go
+++ b/internal/controller/reconciler/mariadb.go
@@ -7,6 +7,7 @@ import (
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
@@ -61,6 +62,10 @@ func (r *MariaDbReconciler) deleteIfOwnedByController(
 	name string,
 ) error {
 	mariaDb, err := r.getMariaDb(ctx, namespace, name)
+	if apierrors.IsNotFound(err) {
+		log.FromContext(ctx).Info("MariaDb is not found, skipping deletion")
+		return nil
+	}
 	if err != nil {
 		return errors.Wrap(err, "getting MariaDb")
 	}

--- a/internal/controller/reconciler/pod_monitor_test.go
+++ b/internal/controller/reconciler/pod_monitor_test.go
@@ -5,60 +5,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
-
-func Test_IsControllerOwnerPodMonitor(t *testing.T) {
-	defaultNameCluster := "test-cluster"
-
-	cluster := &slurmv1.SlurmCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: defaultNameCluster,
-		},
-	}
-
-	t.Run("controller is owner", func(t *testing.T) {
-		podMonitor := &prometheusv1.PodMonitor{
-			ObjectMeta: metav1.ObjectMeta{
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						Kind: slurmv1.SlurmClusterKind,
-						Name: defaultNameCluster,
-					},
-				},
-			},
-		}
-
-		isOwner := isControllerOwnerPodMonitor(podMonitor, cluster)
-
-		assert.True(t, isOwner)
-	})
-
-	t.Run("controller is not owner", func(t *testing.T) {
-		podMonitor := &prometheusv1.PodMonitor{
-			ObjectMeta: metav1.ObjectMeta{
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						Kind: "OtherKind",
-						Name: "other-name",
-					},
-				},
-			},
-		}
-
-		isOwner := isControllerOwnerPodMonitor(podMonitor, cluster)
-
-		assert.False(t, isOwner)
-	})
-}
 
 func Test_GetPodMonitor(t *testing.T) {
 	defaultNamespace := "test-namespace"
@@ -163,92 +117,6 @@ func Test_GetPodMonitor(t *testing.T) {
 				assert.Equal(t, "", podMonitor.Namespace)
 			default:
 				assert.Nil(t, podMonitor)
-			}
-		})
-	}
-}
-
-func Test_DeletePodMonitorOwnedByController(t *testing.T) {
-	defaultNamespace := "test-namespace"
-	defaultNameCluster := "test-cluster"
-
-	scheme := runtime.NewScheme()
-	_ = slurmv1.AddToScheme(scheme)
-	_ = prometheusv1.AddToScheme(scheme)
-
-	tests := []struct {
-		name       string
-		cluster    *slurmv1.SlurmCluster
-		podMonitor *prometheusv1.PodMonitor
-		expectErr  bool
-	}{
-		{
-			name: "PodMonitor deleted successfully",
-			cluster: &slurmv1.SlurmCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      defaultNameCluster,
-					Namespace: defaultNamespace,
-				},
-			},
-			podMonitor: &prometheusv1.PodMonitor{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      defaultNameCluster,
-					Namespace: defaultNamespace,
-				},
-			},
-			expectErr: false,
-		},
-		{
-			name: "Error deleting PodMonitor",
-			cluster: &slurmv1.SlurmCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      defaultNameCluster,
-					Namespace: defaultNamespace,
-				},
-			},
-			podMonitor: &prometheusv1.PodMonitor{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      defaultNameCluster,
-					Namespace: defaultNamespace,
-				},
-			},
-			expectErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Set up the fake client
-			objs := []runtime.Object{tt.podMonitor}
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
-
-			r := &PodMonitorReconciler{
-				Reconciler: &Reconciler{
-					Client: fakeClient,
-					Scheme: scheme,
-				},
-			}
-
-			if tt.expectErr {
-				// Override the client with our fake client to simulate the error on delete
-				r.Client = &fakeErrorClient{Client: fakeClient}
-			}
-
-			// Run the test
-			ctx := context.TODO()
-			err := r.deletePodMonitorOwnedByController(ctx, tt.cluster, tt.podMonitor)
-
-			if tt.expectErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-
-				// Verify the pod monitor was deleted
-				err = fakeClient.Get(ctx, types.NamespacedName{
-					Namespace: tt.podMonitor.Namespace,
-					Name:      tt.podMonitor.Name,
-				}, &prometheusv1.PodMonitor{})
-				assert.True(t, apierrors.IsNotFound(err))
 			}
 		})
 	}


### PR DESCRIPTION
This PR fixes the reconciliation logic to handle the scenario where maintenance is set to true and accounting is set to false. The changes ensure that the reconciliation process behaves correctly under these conditions, addressing any inconsistencies or errors observed previously.