### PR TITLE
add downscaleAndOverwritePopulateJail

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -28,10 +28,11 @@ type SlurmClusterSpec struct {
 	// - none: No maintenance is performed. The cluster operates normally.
 	// - downscale: Scales down all components to 0.
 	// - downscaleAndDeletePopulateJail: Scales down all components to 0 and deletes the kubernetes Kind Jobs populateJail.
+	// - downscaleAndOverwritePopulateJail: Scales down all components to 0 and overwrite populateJail (same as overwrite=true).
 	// - skipPopulateJail: Skips the execution of the populateJail job during maintenance.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum=none;downscale;downscaleAndDeletePopulateJail;skipPopulateJail
+	// +kubebuilder:validation:Enum=none;downscale;downscaleAndDeletePopulateJail;downscaleAndOverwritePopulateJail;skipPopulateJail
 	// +kubebuilder:default="none"
 	Maintenance *consts.MaintenanceMode `json:"maintenance,omitempty"`
 
@@ -1000,6 +1001,7 @@ const (
 	ConditionClusterWorkersAvailable     = "WorkersAvailable"
 	ConditionClusterLoginAvailable       = "LoginAvailable"
 	ConditionClusterAccountingAvailable  = "AccountingAvailable"
+	ConditionClusterPopulateJailMode     = "PopulateJailMode"
 
 	PhaseClusterReconciling  = "Reconciling"
 	PhaseClusterNotAvailable = "Not available"

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -1073,11 +1073,13 @@ spec:
                   - none: No maintenance is performed. The cluster operates normally.
                   - downscale: Scales down all components to 0.
                   - downscaleAndDeletePopulateJail: Scales down all components to 0 and deletes the kubernetes Kind Jobs populateJail.
+                  - downscaleAndOverwritePopulateJail: Scales down all components to 0 and overwrite populateJail (same as overwrite=true).
                   - skipPopulateJail: Skips the execution of the populateJail job during maintenance.
                 enum:
                 - none
                 - downscale
                 - downscaleAndDeletePopulateJail
+                - downscaleAndOverwritePopulateJail
                 - skipPopulateJail
                 type: string
               ncclSettings:

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -8,6 +8,7 @@ useDefaultAppArmorProfile: true
 # - none: No maintenance is performed. The cluster operates normally.
 # - downscale: Scales down all components to 0.
 # - downscaleAndDeletePopulateJail: Scales down all components to 0 and deletes the kubernetes Kind Jobs populateJail.
+# - downscaleAndOverwritePopulateJail: Scales down all components to 0 and overwrite populateJail (same as overwrite=true).
 # - skipPopulateJail: Skips the execution of the populateJail job during maintenance.
 maintenance: "none"
 # Slurm cluster type. Can be now gpu or cpu

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -1072,11 +1072,13 @@ spec:
                   - none: No maintenance is performed. The cluster operates normally.
                   - downscale: Scales down all components to 0.
                   - downscaleAndDeletePopulateJail: Scales down all components to 0 and deletes the kubernetes Kind Jobs populateJail.
+                  - downscaleAndOverwritePopulateJail: Scales down all components to 0 and overwrite populateJail (same as overwrite=true).
                   - skipPopulateJail: Skips the execution of the populateJail job during maintenance.
                 enum:
                 - none
                 - downscale
                 - downscaleAndDeletePopulateJail
+                - downscaleAndOverwritePopulateJail
                 - skipPopulateJail
                 type: string
               ncclSettings:

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -1072,11 +1072,13 @@ spec:
                   - none: No maintenance is performed. The cluster operates normally.
                   - downscale: Scales down all components to 0.
                   - downscaleAndDeletePopulateJail: Scales down all components to 0 and deletes the kubernetes Kind Jobs populateJail.
+                  - downscaleAndOverwritePopulateJail: Scales down all components to 0 and overwrite populateJail (same as overwrite=true).
                   - skipPopulateJail: Skips the execution of the populateJail job during maintenance.
                 enum:
                 - none
                 - downscale
                 - downscaleAndDeletePopulateJail
+                - downscaleAndOverwritePopulateJail
                 - skipPopulateJail
                 type: string
               ncclSettings:

--- a/internal/check/maintanence.go
+++ b/internal/check/maintanence.go
@@ -10,6 +10,10 @@ func IsModeDownscaleAndDeletePopulate(maintenance *consts.MaintenanceMode) bool 
 	return maintenance != nil && *maintenance == consts.ModeDownscaleAndDeletePopulate
 }
 
+func IsModeDownscaleAndOverwritePopulate(maintenance *consts.MaintenanceMode) bool {
+	return maintenance != nil && *maintenance == consts.ModeDownscaleAndOverwritePopulate
+}
+
 func IsModeSkipPopulateJail(maintenance *consts.MaintenanceMode) bool {
-	return maintenance != nil && *maintenance == consts.ModeSkipPopulateJail
+	return maintenance != nil && *maintenance == consts.ModeSkipPopulate
 }

--- a/internal/consts/maintenance.go
+++ b/internal/consts/maintenance.go
@@ -3,10 +3,11 @@ package consts
 type MaintenanceMode string
 
 const (
-	ModeNone                       MaintenanceMode = "none"
-	ModeDownscale                  MaintenanceMode = "downscale"
-	ModeDownscaleAndDeletePopulate MaintenanceMode = "downscaleAndDeletePopulateJail"
-	ModeSkipPopulateJail           MaintenanceMode = "skipPopulateJail"
+	ModeNone                          MaintenanceMode = "none"
+	ModeDownscale                     MaintenanceMode = "downscale"
+	ModeDownscaleAndDeletePopulate    MaintenanceMode = "downscaleAndDeletePopulateJail"
+	ModeDownscaleAndOverwritePopulate MaintenanceMode = "downscaleAndOverwritePopulateJail"
+	ModeSkipPopulate                  MaintenanceMode = "skipPopulateJail"
 )
 
 const (

--- a/internal/controller/clustercontroller/reconcile.go
+++ b/internal/controller/clustercontroller/reconcile.go
@@ -3,6 +3,7 @@ package clustercontroller
 import (
 	"context"
 	errorsStd "errors"
+	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -33,6 +34,7 @@ import (
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"nebius.ai/slurm-operator/internal/check"
+	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/controller/reconciler"
 	"nebius.ai/slurm-operator/internal/controller/state"
 	"nebius.ai/slurm-operator/internal/logfield"
@@ -281,6 +283,60 @@ func (r *SlurmClusterReconciler) reconcile(ctx context.Context, cluster *slurmv1
 				})
 			}); err != nil {
 				return ctrl.Result{}, err
+			}
+
+			// Popolate Jail
+			switch {
+			case check.IsModeSkipPopulateJail(clusterValues.PopulateJail.Maintenance):
+				if err = r.patchStatus(ctx, cluster, func(status *slurmv1.SlurmClusterStatus) {
+					status.SetCondition(metav1.Condition{
+						Type:   slurmv1.ConditionClusterPopulateJailMode,
+						Status: metav1.ConditionTrue, Reason: string(consts.ModeSkipPopulate),
+						Message: "Populate Jail is skipped",
+					})
+				}); err != nil {
+					return ctrl.Result{}, err
+				}
+			case check.IsModeDownscaleAndDeletePopulate(clusterValues.PopulateJail.Maintenance):
+				if err = r.patchStatus(ctx, cluster, func(status *slurmv1.SlurmClusterStatus) {
+					status.SetCondition(metav1.Condition{
+						Type:   slurmv1.ConditionClusterPopulateJailMode,
+						Status: metav1.ConditionTrue, Reason: string(consts.ModeDownscaleAndDeletePopulate),
+						Message: "Populate Jail is deleted",
+					})
+				}); err != nil {
+					return ctrl.Result{}, err
+				}
+			case check.IsModeDownscaleAndOverwritePopulate(clusterValues.PopulateJail.Maintenance):
+				if err = r.patchStatus(ctx, cluster, func(status *slurmv1.SlurmClusterStatus) {
+					status.SetCondition(metav1.Condition{
+						Type:   slurmv1.ConditionClusterPopulateJailMode,
+						Status: metav1.ConditionTrue, Reason: string(consts.ModeDownscaleAndOverwritePopulate),
+						Message: "Populate Jail is overwritten",
+					})
+				}); err != nil {
+					return ctrl.Result{}, err
+				}
+			case !check.IsMaintenanceActive(clusterValues.PopulateJail.Maintenance):
+				if err = r.patchStatus(ctx, cluster, func(status *slurmv1.SlurmClusterStatus) {
+					status.SetCondition(metav1.Condition{
+						Type:   slurmv1.ConditionClusterPopulateJailMode,
+						Status: metav1.ConditionTrue, Reason: string(consts.ModeNone),
+						Message: fmt.Sprintf("Populate Jail maintenanceMode is %s", consts.ModeNone),
+					})
+				}); err != nil {
+					return ctrl.Result{}, err
+				}
+			default:
+				if err = r.patchStatus(ctx, cluster, func(status *slurmv1.SlurmClusterStatus) {
+					status.SetCondition(metav1.Condition{
+						Type:   slurmv1.ConditionClusterPopulateJailMode,
+						Status: metav1.ConditionUnknown, Reason: "Unknown",
+						Message: "Unknown Populate Jail maintenanceMode",
+					})
+				}); err != nil {
+					return ctrl.Result{}, err
+				}
 			}
 
 			// Controllers

--- a/internal/render/populate_jail/container.go
+++ b/internal/render/populate_jail/container.go
@@ -3,6 +3,7 @@ package populate_jail
 import (
 	corev1 "k8s.io/api/core/v1"
 
+	"nebius.ai/slurm-operator/internal/check"
 	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/render/common"
 	"nebius.ai/slurm-operator/internal/values"
@@ -16,9 +17,10 @@ func renderContainerPopulateJail(clusterType consts.ClusterType, populateJail *v
 		volumeMounts = append(volumeMounts, common.RenderVolumeMountJailSnapshot())
 	}
 	overwriteEnv := "0"
-	if populateJail.Overwrite {
+	if populateJail.Overwrite || check.IsModeDownscaleAndOverwritePopulate(populateJail.Maintenance) {
 		overwriteEnv = "1"
 	}
+
 	return corev1.Container{
 		Name:            populateJail.ContainerPopulateJail.Name,
 		Image:           populateJail.ContainerPopulateJail.Image,


### PR DESCRIPTION
This PR adds the ability to delete and recreate the `populateJob` with the overwrite option in Maintenance mode `downscaleAndOverwritePopulateJail`