### PR TITLE
NOTIC: Keep more failed NCCL benchmark jobs in the history instead of…

### DIFF
--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -99,9 +99,9 @@ periodicChecks:
     # CronJob timeout in seconds. By default, equals to 30 min
     activeDeadlineSeconds: 1800
     # Number of successful finished jobs to retain
-    successfulJobsHistoryLimit: 24
+    successfulJobsHistoryLimit: 3
     # Number of failed finished jobs to retain
-    failedJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 24
     # NCCL test settings
     ncclArguments:
       # Minimum memory size to start NCCL with

--- a/images/jail/motd/20-slurm-stats
+++ b/images/jail/motd/20-slurm-stats
@@ -18,7 +18,7 @@ SLURM_STATS_CMD="
       printf \"%s\\n\" \"\${QUEUE}\" | sed 's/^/  /'
     fi
   else
-    printf \"Slurm controllers:\\n\"
+    printf \"\\nSlurm controllers:\\n\"
     echo \"\${CONTROLLERS}\" | sed 's/^/  /'
   fi
 "


### PR DESCRIPTION
… successful ones