### PR TITLE
MSP-3992: fix bug with empty version of annotation

### DIFF
--- a/internal/controller/reconciler/k8s_statefulset.go
+++ b/internal/controller/reconciler/k8s_statefulset.go
@@ -48,7 +48,11 @@ func (r *StatefulSetReconciler) patch(existing, desired client.Object) (client.P
 		res := client.MergeFrom(dst.DeepCopy())
 
 		dst.Spec.Template.ObjectMeta.Labels = src.Spec.Template.ObjectMeta.Labels
-		dst.Spec.Template.ObjectMeta.Annotations = src.Spec.Template.ObjectMeta.Annotations
+		// Copy annotations from the desired StatefulSet to the existing StatefulSet
+		// This is necessary because after the StatefulSet is created, patches recreate map of annotations and StatefulSet loses its annotations
+		for k, v := range src.Spec.Template.ObjectMeta.Annotations {
+			dst.Spec.Template.ObjectMeta.Annotations[k] = v
+		}
 		dst.Spec.Replicas = src.Spec.Replicas
 		dst.Spec.UpdateStrategy = src.Spec.UpdateStrategy
 		dst.Spec.VolumeClaimTemplates = append([]corev1.PersistentVolumeClaim{}, src.Spec.VolumeClaimTemplates...)

--- a/internal/controller/reconciler/k8s_statefulset_test.go
+++ b/internal/controller/reconciler/k8s_statefulset_test.go
@@ -1,0 +1,145 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	slurmv1 "nebius.ai/slurm-operator/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAnnotationsMatch(t *testing.T) {
+	scheme := runtime.NewScheme()
+	appsv1.AddToScheme(scheme)
+
+	cluster := &slurmv1.SlurmCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		existing    *appsv1.StatefulSet
+		desired     *appsv1.StatefulSet
+		expectMatch bool
+	}{
+		{
+			name: "Annotations match",
+			existing: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing",
+					Namespace: "default",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"annotation1": "value1",
+								"annotation2": "value2",
+							},
+						},
+					},
+				},
+			},
+			desired: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "desired",
+					Namespace: "default",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"annotation1": "value1",
+								"annotation2": "value2",
+								"versions": `soperator.soperator-munge: "2"
+soperator.soperator-slurm-configs: "2"
+soperator.soperator-slurmdbd-configs: "2"`,
+							},
+						},
+					},
+				},
+			},
+			expectMatch: true,
+		},
+		{
+			name: "Annotations do not match",
+			existing: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing",
+					Namespace: "default",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"annotation1": "value1",
+								"annotation2": "value2",
+								"versions": `soperator.soperator-munge: "1"
+soperator.soperator-slurm-configs: "1"
+soperator.soperator-slurmdbd-configs: "1"`,
+							},
+						},
+					},
+				},
+			},
+			desired: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "desired",
+					Namespace: "default",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"annotation1": "value1",
+								"annotation2": "different_value",
+								"versions": `soperator.soperator-munge: "3"
+soperator.soperator-slurm-configs: "3"
+soperator.soperator-slurmdbd-configs: "3"`,
+							},
+						},
+					},
+				},
+			},
+			expectMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &StatefulSetReconciler{
+				Reconciler: &Reconciler{
+					Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.existing).Build(),
+				},
+			}
+			// Emulate the creation of the StatefulSet
+			patch, err := r.patch(tt.desired, tt.desired)
+			if err != nil {
+				t.Fatalf("patch function returned an error: %v", err)
+			}
+			if err := r.Reconciler.EnsureUpdated(context.TODO(), cluster, tt.existing, tt.desired, patch); err != nil {
+				t.Fatalf("failed to ensure StatefulSet is updated: %v", err)
+			}
+			// Emulate the update of the StatefulSet
+			patch, err = r.patch(tt.existing, tt.desired)
+			if err != nil {
+				t.Fatalf("patch function returned an error: %v", err)
+			}
+			if err := r.Reconciler.EnsureUpdated(context.TODO(), cluster, tt.existing, tt.desired, patch); err != nil {
+				t.Fatalf("failed to ensure StatefulSet is updated: %v", err)
+			}
+			match := equality.Semantic.DeepEqual(tt.existing.Spec.Template.ObjectMeta.Annotations["versions"], tt.desired.Spec.Template.ObjectMeta.Annotations["versions"])
+			if match != tt.expectMatch {
+				t.Errorf("Annotations match expectation failed. Expected: %v, Got: %v", tt.expectMatch, match)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When creating the StatefulSet, it was discovered that the StatefulSet is recreated twice, and during an update, the pod with the `-0` index is not updated. This happens because maps in Go are not merged.
![image](https://github.com/user-attachments/assets/79926183-13bb-4828-a68b-7fc016f64b00)
