### PR TITLE
bump golang.org/x/net to v0.33.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     target-branch: "dev"
 
   - package-ecosystem: gomod
-    directory: /images/jail/gpubench
+    directory: /images/worker/gpubench
     schedule:
       interval: daily
     target-branch: "dev"

--- a/.github/workflows/gpubench_only.yml
+++ b/.github/workflows/gpubench_only.yml
@@ -81,12 +81,9 @@ jobs:
           OPERATOR_IMAGE_TAG=$(make get-operator-tag-version UNSTABLE=${UNSTABLE})
 
           echo "Running gpubench tests"
-          cd ./images/jail/gpubench/
+          cd ./images/worker/gpubench/
           go test
           cd -
-
-          echo "Removing previous jail rootfs tar archive"
-          rm -rf images/jail_rootfs.tar
 
           echo "Building tarball for jail"
           make docker-build UNSTABLE="${UNSTABLE}" IMAGE_NAME=jail DOCKERFILE=jail/jail.dockerfile DOCKER_OUTPUT="--output type=tar,dest=jail_rootfs.tar"

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -10,7 +10,7 @@ on:
       - 'PROJECT'
       - 'README.md'
       - 'SECURITY.md'
-      - 'images/jail/gpubench/**'
+      - 'images/worker/gpubench/**'
   pull_request:
     branches:
       - main

--- a/images/worker/gpubench/go.mod
+++ b/images/worker/gpubench/go.mod
@@ -50,7 +50,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
-	golang.org/x/net v0.32.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/term v0.27.0 // indirect

--- a/images/worker/gpubench/go.sum
+++ b/images/worker/gpubench/go.sum
@@ -121,8 +121,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
-golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
 golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
CVE https://github.com/nebius/soperator/security/dependabot/8 