### PR TITLE
Update pyxis version with `container_image_save` and `expose_enroot_logs` enagled

### DIFF
--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -110,6 +110,9 @@ pushd "${jaildir}"
         flock etc/complement_jail_setcap_enroot_aufs2ovlfs.lock -c "setcap cap_sys_admin,cap_mknod+pe usr/bin/enroot-aufs2ovlfs"
     fi
 
+    echo "Shared folder for pyxis output /var/cache/enroot-container-images"
+    mkdir -m 1777 -p var/cache/enroot-container-images
+
     echo "Bind-mount pyxis plugin from container to the jail"
     touch usr/lib/x86_64-linux-gnu/slurm/spank_pyxis.so
     mount --bind /usr/lib/x86_64-linux-gnu/slurm/spank_pyxis.so usr/lib/x86_64-linux-gnu/slurm/spank_pyxis.so

--- a/images/common/scripts/install_pyxis_plugin.sh
+++ b/images/common/scripts/install_pyxis_plugin.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PYXIS_VERSION=0.20.0
+PYXIS_VERSION=0.21.0
 
 wget -q -P /tmp https://github.com/nebius/slurm-deb-packages/releases/download/12.4.1-jammy-slurm24.05.5/nvslurm-plugin-pyxis_"$PYXIS_VERSION"-1_amd64.deb
 dpkg -i /tmp/nvslurm-plugin-pyxis_"$PYXIS_VERSION"-1_amd64.deb

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -219,7 +219,8 @@ func generateCGroupConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
 func generateSpankConfig() renderutils.ConfigFile {
 	res := &renderutils.MultilineStringConfig{}
 	res.AddLine(fmt.Sprintf("required chroot.so %s", consts.VolumeMountPathJail))
-	res.AddLine("required spank_pyxis.so runtime_path=/run/pyxis execute_entrypoint=0 container_scope=global sbatch_support=1")
+	// TODO: make `container_image_save` and `expose_enroot_logs` configurable
+	res.AddLine("required spank_pyxis.so runtime_path=/run/pyxis execute_entrypoint=0 container_scope=global sbatch_support=1 expose_enroot_logs=1 container_image_save=/var/cache/enroot-container-images/")
 	return res
 }
 


### PR DESCRIPTION
Use new pyxis with options to save squashfs files and expose enroot logs.
Closes #396 