### PR TITLE
Add Epilog and Prolog options

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -84,7 +84,7 @@ type SlurmClusterSpec struct {
 	// SlurmConfig represents the Slurm configuration in slurm.conf. Not all options are supported.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={defMemPerNode: 1228800, defCpuPerGPU: 16, completeWait: 5, debugFlags: "Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs", taskPluginParam: "", maxJobCount: 10000, minJobAge: 86400}
+	// +kubebuilder:default={defMemPerNode: 1228800, defCpuPerGPU: 16, completeWait: 5, debugFlags: "Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs", epilog: "", prolog: "", taskPluginParam: "", maxJobCount: 10000, minJobAge: 86400}
 	SlurmConfig SlurmConfig `json:"slurmConfig,omitempty"`
 	// Generate and set default AppArmor profile for the Slurm worker and login nodes. The Security Profiles Operator must be installed.
 	//
@@ -115,6 +115,16 @@ type SlurmConfig struct {
 	// +kubebuilder:default="Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs"
 	// +kubebuilder:validation:Pattern="^((Accrue|Agent|AuditRPCs|Backfill|BackfillMap|BurstBuffer|Cgroup|ConMgr|CPU_Bind|CpuFrequency|Data|DBD_Agent|Dependency|Elasticsearch|Energy|Federation|FrontEnd|Gres|Hetjob|Gang|GLOB_SILENCE|JobAccountGather|JobComp|JobContainer|License|Network|NetworkRaw|NodeFeatures|NO_CONF_HASH|Power|Priority|Profile|Protocol|Reservation|Route|Script|SelectType|Steps|Switch|TLS|TraceJobs|Triggers)(,)?)+$"
 	DebugFlags *string `json:"debugFlags,omitempty"`
+	// Defines specific file to run the epilog when job ends. Default value is no epilog
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=""
+	Epilog *string `json:"epilog,omitempty"`
+	// Defines specific file to run the prolog when job starts. Default value is no prolog
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=""
+	Prolog *string `json:"prolog,omitempty"`
 	// Additional parameters for the task plugin
 	//
 	// +kubebuilder:validation:Optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -678,6 +678,16 @@ func (in *SlurmConfig) DeepCopyInto(out *SlurmConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Epilog != nil {
+		in, out := &in.Epilog, &out.Epilog
+		*out = new(string)
+		**out = **in
+	}
+	if in.Prolog != nil {
+		in, out := &in.Prolog, &out.Prolog
+		*out = new(string)
+		**out = **in
+	}
 	if in.TaskPluginParam != nil {
 		in, out := &in.TaskPluginParam, &out.TaskPluginParam
 		*out = new(string)

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -1486,6 +1486,8 @@ spec:
                   debugFlags: Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs
                   defCpuPerGPU: 16
                   defMemPerNode: 1228800
+                  epilog: ""
+                  prolog: ""
                   maxJobCount: 10000
                   minJobAge: 86400
                   taskPluginParam: ""
@@ -1515,6 +1517,14 @@ spec:
                       node in mebibytes.
                     format: int32
                     type: integer
+                  epilog:
+                    default: ""
+                    description: The Epilog script runs after a job completes
+                    type: string
+                  prolog:
+                    default: ""
+                    description: The Prolog script runs before a job starts on the compute node
+                    type: string
                   maxJobCount:
                     default: 10000
                     description: Keep N last jobs in controller memory

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -129,6 +129,8 @@ slurmConfig: {}
 # defCpuPerGPU: 16
 # completeWait: 5
 # debugFlags: "Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs"
+# epilog: "/path/to/epilog.sh"
+# prolog: "/path/to/prolog.sh"
 # taskPluginParam: "Verbose"
 # maxJobCount: 10000
 # minJobAge: 86400

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -1485,6 +1485,8 @@ spec:
                   debugFlags: Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs
                   defCpuPerGPU: 16
                   defMemPerNode: 1228800
+                  epilog: ""
+                  prolog: ""
                   maxJobCount: 10000
                   minJobAge: 86400
                   taskPluginParam: ""
@@ -1514,6 +1516,14 @@ spec:
                       node in mebibytes.
                     format: int32
                     type: integer
+                  epilog:
+                    default: ""
+                    description: The Epilog script runs after a job completes
+                    type: string
+                  prolog:
+                    default: ""
+                    description: The Prolog script runs before a job starts on the compute node
+                    type: string
                   maxJobCount:
                     default: 10000
                     description: Keep N last jobs in controller memory

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -1485,6 +1485,8 @@ spec:
                   debugFlags: Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs
                   defCpuPerGPU: 16
                   defMemPerNode: 1228800
+                  epilog: ""
+                  prolog: ""
                   maxJobCount: 10000
                   minJobAge: 86400
                   taskPluginParam: ""
@@ -1514,6 +1516,14 @@ spec:
                       node in mebibytes.
                     format: int32
                     type: integer
+                  epilog:
+                    default: ""
+                    description: The Epilog script runs after a job completes
+                    type: string
+                  prolog:
+                    default: ""
+                    description: The Prolog script runs before a job starts on the compute node
+                    type: string
                   maxJobCount:
                     default: 10000
                     description: Keep N last jobs in controller memory


### PR DESCRIPTION
**Prolog** and **Epilog** in Slurm are crucial for automating job setup and cleanup on compute nodes. 

- The Prolog script runs before a job starts, ensuring the environment is correctly configured, resources are prepared, and any necessary checks are performed. 

- The Epilog script runs after a job finishes, handling cleanup tasks like deleting temporary files, releasing resources, and logging job completion. 
 
These scripts help maintain node consistency, optimize resource utilization, and improve job management in HPC environments.