### PR TITLE
Temporary remove `expose_enroot_logs` flag

### DIFF
--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -220,7 +220,8 @@ func generateSpankConfig() renderutils.ConfigFile {
 	res := &renderutils.MultilineStringConfig{}
 	res.AddLine(fmt.Sprintf("required chroot.so %s", consts.VolumeMountPathJail))
 	// TODO: make `container_image_save` and `expose_enroot_logs` configurable
-	res.AddLine("required spank_pyxis.so runtime_path=/run/pyxis execute_entrypoint=0 container_scope=global sbatch_support=1 expose_enroot_logs=1 container_image_save=/var/cache/enroot-container-images/")
+	// TODO: enable `expose_enroot_logs` once #413 is resolved.
+	res.AddLine("required spank_pyxis.so runtime_path=/run/pyxis execute_entrypoint=0 container_scope=global sbatch_support=1 container_image_save=/var/cache/enroot-container-images/")
 	return res
 }
 


### PR DESCRIPTION
This flag is currently breaking `srun --pty`