### PR TITLE
Fix non-zero error handling in gpu_healthcheck.sh

### DIFF
--- a/images/worker/scripts/gpu_healthcheck.sh
+++ b/images/worker/scripts/gpu_healthcheck.sh
@@ -3,8 +3,8 @@
 set -e
 
 # Run GPU healthcheck
-output=$(/usr/bin/nvidia-smi 2>&1)
-exit_code=$?
+exit_code=0
+output=$(/usr/bin/nvidia-smi 2>&1) || exit_code=$?
 
 current_node=$(hostname)
 node_info=$(scontrol show node "$current_node")


### PR DESCRIPTION
When there's a GPU error, nvidia-smi will return with non-zero exit code in the forked shell of /usr/bin/gpu_healthcheck.sh, and given `set -e` option at line 3, it will inmediately exit.

This PR handles nvidia-smi error codes gracefully.