### PR TITLE
Pre-install multi-node NCCL test binaries

### DIFF
--- a/images/jail/jail.dockerfile
+++ b/images/jail/jail.dockerfile
@@ -72,8 +72,7 @@ ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 # Download NCCL tests executables
 ARG CUDA_VERSION=12.4.1
-ARG SLURM_VERSION=24.05.5
-RUN wget -P /tmp $PACKAGES_REPO_URL/$CUDA_VERSION-$(grep 'VERSION_CODENAME' /etc/os-release | cut -d= -f2)-slurm$SLURM_VERSION/nccl-tests-perf.tar.gz && \
+RUN wget -P /tmp $PACKAGES_REPO_URL/nccl_tests_$CUDA_VERSION/nccl-tests-perf.tar.gz && \
     tar -xvzf /tmp/nccl-tests-perf.tar.gz -C /usr/bin && \
     rm -rf /tmp/nccl-tests-perf.tar.gz
 


### PR DESCRIPTION
`OMPI_MCA_btl_tcp_if_include=eth0 srun --exclusive --mem=0 --nodes=2 --ntasks-per-node=8 --gpus-per-node=8 --mpi=pmix all_reduce_perf_mpi -b 512M -e 8G -f 2 -g 1`

```
# nThread 1 nGpus 1 minBytes 536870912 maxBytes 8589934592 step: 2(factor) warmup iters: 5 iters: 20 agg iters: 1 validation: 1 graph: 0
#
# Using devices
#  Rank  0 Group  0 Pid   1887 on   worker-1 device  0 [0x8d] NVIDIA H100 80GB HBM3
#  Rank  1 Group  0 Pid   1888 on   worker-1 device  1 [0x91] NVIDIA H100 80GB HBM3
#  Rank  2 Group  0 Pid   1889 on   worker-1 device  2 [0x95] NVIDIA H100 80GB HBM3
#  Rank  3 Group  0 Pid   1890 on   worker-1 device  3 [0x99] NVIDIA H100 80GB HBM3
#  Rank  4 Group  0 Pid   1891 on   worker-1 device  4 [0xab] NVIDIA H100 80GB HBM3
#  Rank  5 Group  0 Pid   1892 on   worker-1 device  5 [0xaf] NVIDIA H100 80GB HBM3
#  Rank  6 Group  0 Pid   1893 on   worker-1 device  6 [0xb3] NVIDIA H100 80GB HBM3
#  Rank  7 Group  0 Pid   1894 on   worker-1 device  7 [0xb7] NVIDIA H100 80GB HBM3
#  Rank  8 Group  0 Pid   1885 on   worker-0 device  0 [0x8d] NVIDIA H100 80GB HBM3
#  Rank  9 Group  0 Pid   1886 on   worker-0 device  1 [0x91] NVIDIA H100 80GB HBM3
#  Rank 10 Group  0 Pid   1887 on   worker-0 device  2 [0x95] NVIDIA H100 80GB HBM3
#  Rank 11 Group  0 Pid   1888 on   worker-0 device  3 [0x99] NVIDIA H100 80GB HBM3
#  Rank 12 Group  0 Pid   1889 on   worker-0 device  4 [0xab] NVIDIA H100 80GB HBM3
#  Rank 13 Group  0 Pid   1890 on   worker-0 device  5 [0xaf] NVIDIA H100 80GB HBM3
#  Rank 14 Group  0 Pid   1891 on   worker-0 device  6 [0xb3] NVIDIA H100 80GB HBM3
#  Rank 15 Group  0 Pid   1892 on   worker-0 device  7 [0xb7] NVIDIA H100 80GB HBM3
#
#                                                              out-of-place                       in-place
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)
   536870912     134217728     float     sum      -1   2426.8  221.22  414.79      0   2422.4  221.62  415.55      0
  1073741824     268435456     float     sum      -1   4588.2  234.02  438.79      0   4608.8  232.98  436.83      0
  2147483648     536870912     float     sum      -1   8919.0  240.78  451.45      0   8904.2  241.18  452.20      0
  4294967296    1073741824     float     sum      -1    17582  244.29  458.03      0    17628  243.64  456.83      0
  8589934592    2147483648     float     sum      -1    34971  245.63  460.55      0    34882  246.26  461.74      0
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 444.677
#
```