### PR TITLE
images: do not bind-mount slurm configs when possible

### DIFF
--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -120,10 +120,7 @@ pushd "${jaildir}"
 
     echo "Bind-mount slurm configs"
     mkdir -p etc/slurm
-    for file in /mnt/slurm-configs/*; do
-        filename=$(basename "$file")
-        touch "etc/slurm/$filename" && mount --bind "$file" "etc/slurm/$filename"
-    done
+    mount --bind /mnt/slurm-configs etc/slurm
 
     if [ -n "$worker" ]; then
         echo "Bind-mount slurmd spool directory from the host because it should be propagated to the jail"

--- a/images/controller/slurmctld_entrypoint.sh
+++ b/images/controller/slurmctld_entrypoint.sh
@@ -13,11 +13,8 @@ echo "Bind-mount REST JWT secret key from K8S secret"
 touch /var/spool/slurmctld/jwt_hs256.key
 mount --bind /mnt/rest-jwt-key/rest_jwt.key /var/spool/slurmctld/jwt_hs256.key
 
-echo "Bind-mount slurm configs from K8S config map"
-for file in /mnt/slurm-configs/*; do
-    filename=$(basename "$file")
-    touch "/etc/slurm/$filename" && mount --bind "$file" "/etc/slurm/$filename"
-done
+echo "Symlink slurm configs from K8S config map"
+rm -rf /etc/slurm && ln -s /mnt/slurm-configs /etc/slurm
 
 echo "Set permissions for shared /var/spool/slurmctld"
 chmod 755 /var/spool/slurmctld # It changes permissions of this shared directory in other containers as well

--- a/images/nccl_benchmark/nccl_benchmark_entrypoint.sh
+++ b/images/nccl_benchmark/nccl_benchmark_entrypoint.sh
@@ -9,11 +9,8 @@ ln -s /mnt/jail/etc/shadow /etc/shadow
 ln -s /mnt/jail/etc/gshadow /etc/gshadow
 chown -h 0:42 /etc/{shadow,gshadow}
 
-echo "Bind-mount slurm configs from K8S config map"
-for file in /mnt/slurm-configs/*; do
-    filename=$(basename "$file")
-    touch "/etc/slurm/$filename" && mount --bind "$file" "/etc/slurm/$filename"
-done
+echo "Symlink slurm configs from K8S config map"
+rm -rf /etc/slurm && ln -s /mnt/slurm-configs /etc/slurm
 
 echo "Bind-mount munge key from K8S secret"
 mount --bind /mnt/munge-key/munge.key /etc/munge/munge.key

--- a/images/restd/slurmrestd_entrypoint.sh
+++ b/images/restd/slurmrestd_entrypoint.sh
@@ -2,11 +2,8 @@
 
 set -e # Exit immediately if any command returns a non-zero error code
 
-echo "Bind-mount slurm configs from K8S config map"
-for file in /mnt/slurm-configs/*; do
-    filename=$(basename "$file")
-    touch "/etc/slurm/$filename" && mount --bind "$file" "/etc/slurm/$filename"
-done
+echo "Symlink slurm configs from K8S config map"
+rm -rf /etc/slurm && ln -s /mnt/slurm-configs /etc/slurm
 
 chown www-data:www-data /usr/sbin/slurmrestd && chmod 500 /usr/sbin/slurmrestd
 

--- a/images/worker/supervisord_entrypoint.sh
+++ b/images/worker/supervisord_entrypoint.sh
@@ -27,11 +27,8 @@ chown -h 0:42 /etc/{shadow,gshadow}
 echo "Link home from jail because slurmd uses it"
 ln -s /mnt/jail/home /home
 
-echo "Bind-mount slurm configs from K8S config map"
-for file in /mnt/slurm-configs/*; do
-    filename=$(basename "$file")
-    touch "/etc/slurm/$filename" && mount --bind "$file" "/etc/slurm/$filename"
-done
+echo "Symlink slurm configs from K8S config map"
+rm -rf /etc/slurm && ln -s /mnt/slurm-configs /etc/slurm
 
 echo "Bind-mount gpubenchmark from container to jail"
 touch /mnt/jail/usr/bin/gpubench


### PR DESCRIPTION
Jail configs are mounted as a directory, host ones replaced with symlinks.

It allows config updates with ConfigMap changes.