### PR TITLE
add Slurm topology config support

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -93,6 +93,13 @@ type SlurmClusterSpec struct {
 	// +kubebuilder:default={pmixEnv: "OMPI_MCA_btl_tcp_if_include=eth0"}
 	MPIConfig MPIConfig `json:"mpiConfig,omitempty"`
 
+	// SlurmTopologyConfigMapRefName is the name of the slurm topology config.
+	// When exists, TopologyPlugin is automatically set to `topology/tree` in slurm.conf
+	// if TopologyPlugin is not explicitly specified in SlurmConfig.
+	//
+	// +kubebuilder:validation:Optional
+	SlurmTopologyConfigMapRefName string `json:"slurmTopologyConfigMapRefName,omitempty"`
+
 	// Generate and set default AppArmor profile for the Slurm worker and login nodes. The Security Profiles Operator must be installed.
 	//
 	// +kubebuilder:default=false
@@ -154,6 +161,15 @@ type SlurmConfig struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=30
 	MessageTimeout *int32 `json:"messageTimeout,omitempty"`
+	// TopologyPlugin identifies the plugin to determine network topology for optimizations.
+	// It is set automatically to `topology/tree` if SlurmTopologyConfigMapRefName is specified.
+	//
+	// +kubebuilder:validation:Optional
+	TopologyPlugin string `json:"topologyPlugin,omitempty"`
+	// TopologyParam is list of comma-separated options identifying network topology options.
+	//
+	// +kubebuilder:validation:Optional
+	TopologyParam string `json:"topologyParam,omitempty"`
 }
 
 type MPIConfig struct {

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -1564,6 +1564,15 @@ spec:
                     description: Additional parameters for the task plugin
                     pattern: ^(|((None|Cores|Sockets|Threads|SlurmdOffSpec|OOMKillStep|Verbose|Autobind)(,)?)+)$
                     type: string
+                  topologyParam:
+                    description: TopologyParam is list of comma-separated options
+                      identifying network topology options.
+                    type: string
+                  topologyPlugin:
+                    description: |-
+                      TopologyPlugin identifies the plugin to determine network topology for optimizations.
+                      It is set automatically to `topology/tree` if SlurmTopologyConfigMapRefName is specified.
+                    type: string
                 type: object
               slurmNodes:
                 description: SlurmNodes define the desired state of Slurm nodes
@@ -5535,6 +5544,12 @@ spec:
                 - rest
                 - worker
                 type: object
+              slurmTopologyConfigMapRefName:
+                description: |-
+                  SlurmTopologyConfigMapRefName is the name of the slurm topology config.
+                  When exists, TopologyPlugin is automatically set to `topology/tree` in slurm.conf
+                  if TopologyPlugin is not explicitly specified in SlurmConfig.
+                type: string
               telemetry:
                 description: Metrics define the desired state of the prometheus or
                   opentelemetry metrics

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -6131,6 +6131,15 @@ spec:
                     description: Additional parameters for the task plugin
                     pattern: ^(|((None|Cores|Sockets|Threads|SlurmdOffSpec|OOMKillStep|Verbose|Autobind)(,)?)+)$
                     type: string
+                  topologyParam:
+                    description: TopologyParam is list of comma-separated options
+                      identifying network topology options.
+                    type: string
+                  topologyPlugin:
+                    description: |-
+                      TopologyPlugin identifies the plugin to determine network topology for optimizations.
+                      It is set automatically to `topology/tree` if SlurmTopologyConfigMapRefName is specified.
+                    type: string
                 type: object
               slurmNodes:
                 description: SlurmNodes define the desired state of Slurm nodes
@@ -10102,6 +10111,12 @@ spec:
                 - rest
                 - worker
                 type: object
+              slurmTopologyConfigMapRefName:
+                description: |-
+                  SlurmTopologyConfigMapRefName is the name of the slurm topology config.
+                  When exists, TopologyPlugin is automatically set to `topology/tree` in slurm.conf
+                  if TopologyPlugin is not explicitly specified in SlurmConfig.
+                type: string
               telemetry:
                 description: Metrics define the desired state of the prometheus or
                   opentelemetry metrics

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -6131,6 +6131,15 @@ spec:
                     description: Additional parameters for the task plugin
                     pattern: ^(|((None|Cores|Sockets|Threads|SlurmdOffSpec|OOMKillStep|Verbose|Autobind)(,)?)+)$
                     type: string
+                  topologyParam:
+                    description: TopologyParam is list of comma-separated options
+                      identifying network topology options.
+                    type: string
+                  topologyPlugin:
+                    description: |-
+                      TopologyPlugin identifies the plugin to determine network topology for optimizations.
+                      It is set automatically to `topology/tree` if SlurmTopologyConfigMapRefName is specified.
+                    type: string
                 type: object
               slurmNodes:
                 description: SlurmNodes define the desired state of Slurm nodes
@@ -10102,6 +10111,12 @@ spec:
                 - rest
                 - worker
                 type: object
+              slurmTopologyConfigMapRefName:
+                description: |-
+                  SlurmTopologyConfigMapRefName is the name of the slurm topology config.
+                  When exists, TopologyPlugin is automatically set to `topology/tree` in slurm.conf
+                  if TopologyPlugin is not explicitly specified in SlurmConfig.
+                type: string
               telemetry:
                 description: Metrics define the desired state of the prometheus or
                   opentelemetry metrics

--- a/internal/consts/configmap.go
+++ b/internal/consts/configmap.go
@@ -1,8 +1,7 @@
 package consts
 
 const (
-	slurmConfigs   = slurmPrefix + "configs"
-	slurmdbdSecret = "slurm-secrets"
+	slurmConfigs = slurmPrefix + "configs"
 )
 
 const (
@@ -20,6 +19,7 @@ const (
 	ConfigMapKeyGresConfig     = "gres.conf"
 	ConfigMapKeyMPIConfig      = "mpi.conf"
 	ConfigMapKeySlurmdbdConfig = "slurmdbd.conf"
+	ConfigMapKeyTopologyConfig = "topology.conf"
 
 	ConfigMapKeySshdConfig              = SshdName + "_config"
 	ConfigMapKeySshRootPublicKeysConfig = authorizedKeys

--- a/internal/consts/volume.go
+++ b/internal/consts/volume.go
@@ -27,8 +27,9 @@ const (
 )
 
 const (
+	SlurmdbdConfFile = "slurmdbd.conf"
+
 	VolumeNameSlurmConfigs         = slurmConfigs
-	VolumeNameSlurmdbdSecret       = slurmdbdSecret
 	VolumeNameSpool                = spool
 	VolumeNameJail                 = jail
 	VolumeNameJailSnapshot         = jail + "-snapshot"
@@ -50,7 +51,6 @@ const (
 	VolumeNameTmpDisk              = "tmp-disk"
 
 	VolumeMountPathSlurmConfigs      = "/mnt/" + slurmConfigs
-	VolumeMountPathSlurmdbdSecret    = "/mnt/" + slurmdbdSecret
 	VolumeMountPathSpool             = "/var/" + spool
 	VolumeMountPathSpoolSlurmdbd     = "/var/spool/slurmdbd"
 	VolumeMountPathJail              = "/mnt/" + jail

--- a/internal/controller/clustercontroller/accounting.go
+++ b/internal/controller/clustercontroller/accounting.go
@@ -345,6 +345,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 						&clusterValues.NodeAccounting,
 						clusterValues.NodeFilters,
 						clusterValues.VolumeSources,
+						clusterValues.SlurmTopologyConfigMapRefName,
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")

--- a/internal/controller/clustercontroller/benchmark.go
+++ b/internal/controller/clustercontroller/benchmark.go
@@ -66,6 +66,7 @@ func (r SlurmClusterReconciler) ReconcileNCCLBenchmark(
 						clusterValues.VolumeSources,
 						&clusterValues.NCCLBenchmark,
 						clusterValues.Telemetry,
+						clusterValues.SlurmTopologyConfigMapRefName,
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")

--- a/internal/controller/clustercontroller/controller.go
+++ b/internal/controller/clustercontroller/controller.go
@@ -89,6 +89,7 @@ func (r SlurmClusterReconciler) ReconcileControllers(
 						&clusterValues.Secrets,
 						clusterValues.VolumeSources,
 						&clusterValues.NodeController,
+						clusterValues.SlurmTopologyConfigMapRefName,
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")

--- a/internal/controller/clustercontroller/login.go
+++ b/internal/controller/clustercontroller/login.go
@@ -187,6 +187,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 						&clusterValues.Secrets,
 						clusterValues.VolumeSources,
 						&clusterValues.NodeLogin,
+						clusterValues.SlurmTopologyConfigMapRefName,
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")

--- a/internal/controller/clustercontroller/reconcile.go
+++ b/internal/controller/clustercontroller/reconcile.go
@@ -588,10 +588,11 @@ func (r *SlurmClusterReconciler) patchStatus(ctx context.Context, cluster *slurm
 type statusPatcher func(status *slurmv1.SlurmClusterStatus)
 
 const (
-	podTemplateField          = ".spec.slurmNodes.exporter.exporter.podTemplateNameRef"
-	supervisordConfigMapField = ".spec.slurmNodes.worker.supervisordConfigMapRefName"
-	sshdLoginConfigMapField   = ".spec.slurmNodes.login.sshdConfigMapRefName"
-	sshdWorkerConfigMapField  = ".spec.slurmNodes.worker.sshdConfigMapRefName"
+	podTemplateField            = ".spec.slurmNodes.exporter.exporter.podTemplateNameRef"
+	supervisordConfigMapField   = ".spec.slurmNodes.worker.supervisordConfigMapRefName"
+	sshdLoginConfigMapField     = ".spec.slurmNodes.login.sshdConfigMapRefName"
+	sshdWorkerConfigMapField    = ".spec.slurmNodes.worker.sshdConfigMapRefName"
+	slurmTopologyConfigMapField = ".spec.slurmTopologyConfigMapRefName"
 )
 
 func (r *SlurmClusterReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrency int, cacheSyncTimeout time.Duration) error {
@@ -654,6 +655,9 @@ func (r *SlurmClusterReconciler) setupConfigMapIndexer(mgr ctrl.Manager) error {
 		},
 		sshdWorkerConfigMapField: func(sc *slurmv1.SlurmCluster) string {
 			return sc.Spec.SlurmNodes.Worker.SSHDConfigMapRefName
+		},
+		slurmTopologyConfigMapField: func(sc *slurmv1.SlurmCluster) string {
+			return sc.Spec.SlurmTopologyConfigMapRefName
 		},
 	}
 

--- a/internal/controller/clustercontroller/worker.go
+++ b/internal/controller/clustercontroller/worker.go
@@ -240,6 +240,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 						&clusterValues.Secrets,
 						clusterValues.VolumeSources,
 						&clusterValues.NodeWorker,
+						clusterValues.SlurmTopologyConfigMapRefName,
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")

--- a/internal/render/accounting/container.go
+++ b/internal/render/accounting/container.go
@@ -31,7 +31,6 @@ func renderContainerAccounting(container values.Container) corev1.Container {
 			common.RenderVolumeMountSlurmConfigs(),
 			common.RenderVolumeMountMungeSocket(),
 			common.RenderVolumeMountRESTJWTKey(),
-			RenderVolumeMountSlurmdbdConfigs(),
 			RenderVolumeMountSlurmdbdSpool(),
 		},
 		ReadinessProbe: &corev1.Probe{

--- a/internal/render/accounting/deployment.go
+++ b/internal/render/accounting/deployment.go
@@ -19,6 +19,7 @@ func RenderDeployment(
 	accounting *values.SlurmAccounting,
 	nodeFilter []slurmv1.K8sNodeFilter,
 	volumeSources []slurmv1.VolumeSource,
+	slurmTopologyConfigMapRefName string,
 ) (deployment *appsv1.Deployment, err error) {
 	labels := common.RenderLabels(consts.ComponentTypeAccounting, clusterName)
 	matchLabels := common.RenderMatchLabels(consts.ComponentTypeAccounting, clusterName)
@@ -29,6 +30,7 @@ func RenderDeployment(
 		nodeFilter,
 		volumeSources,
 		matchLabels,
+		slurmTopologyConfigMapRefName,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/render/accounting/deployment_test.go
+++ b/internal/render/accounting/deployment_test.go
@@ -8,13 +8,13 @@ import (
 
 	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/naming"
-	accounting "nebius.ai/slurm-operator/internal/render/accounting"
+	"nebius.ai/slurm-operator/internal/render/accounting"
 	"nebius.ai/slurm-operator/internal/render/common"
 )
 
 func Test_RenderDeployment(t *testing.T) {
 
-	deployment, err := accounting.RenderDeployment(defaultNamespace, defaultNameCluster, acc, defaultNodeFilter, defaultVolumeSources)
+	deployment, err := accounting.RenderDeployment(defaultNamespace, defaultNameCluster, acc, defaultNodeFilter, defaultVolumeSources, slurmTopologyConfigMapRefName)
 	assert.NoError(t, err)
 
 	assert.Equal(t, naming.BuildDeploymentName(consts.ComponentTypeAccounting), deployment.Name)

--- a/internal/render/accounting/pod.go
+++ b/internal/render/accounting/pod.go
@@ -19,14 +19,18 @@ func BasePodTemplateSpec(
 	nodeFilters []slurmv1.K8sNodeFilter,
 	volumeSources []slurmv1.VolumeSource,
 	matchLabels map[string]string,
+	slurmTopologyConfigMapRefName string,
 ) (*corev1.PodTemplateSpec, error) {
 	volumes := []corev1.Volume{
 		common.RenderVolumeJailFromSource(volumeSources, *accounting.VolumeJail.VolumeSourceName),
-		common.RenderVolumeSlurmConfigs(clusterName),
+		common.RenderVolumeProjectedSlurmConfigs(
+			clusterName,
+			common.RenderVolumeProjectionSlurmTopologyConfig(slurmTopologyConfigMapRefName),
+			RenderVolumeProjecitonSlurmdbdConfigs(clusterName),
+		),
 		common.RenderVolumeMungeKey(clusterName),
 		common.RenderVolumeRESTJWTKey(clusterName),
 		common.RenderVolumeMungeSocket(),
-		RenderVolumeSlurmdbdConfigs(clusterName),
 		RenderVolumeSlurmdbdSpool(accounting),
 	}
 

--- a/internal/render/accounting/pod_test.go
+++ b/internal/render/accounting/pod_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"nebius.ai/slurm-operator/internal/consts"
-	accounting "nebius.ai/slurm-operator/internal/render/accounting"
+	"nebius.ai/slurm-operator/internal/render/accounting"
 )
 
 func Test_BasePodTemplateSpec(t *testing.T) {
@@ -59,7 +59,7 @@ func Test_BasePodTemplateSpec(t *testing.T) {
 	}
 
 	result, err := accounting.BasePodTemplateSpec(
-		defaultNameCluster, acc, defaultNodeFilter, defaultVolumeSources, matchLabels,
+		defaultNameCluster, acc, defaultNodeFilter, defaultVolumeSources, matchLabels, slurmTopologyConfigMapRefName,
 	)
 	assert.NoError(t, err)
 

--- a/internal/render/accounting/vars_test.go
+++ b/internal/render/accounting/vars_test.go
@@ -133,4 +133,6 @@ var (
 			passwordKey: []byte("test-password"),
 		},
 	}
+
+	slurmTopologyConfigMapRefName = "topology-config"
 )

--- a/internal/render/accounting/volume.go
+++ b/internal/render/accounting/volume.go
@@ -9,22 +9,18 @@ import (
 	"nebius.ai/slurm-operator/internal/values"
 )
 
-// RenderVolumeMountSlurmConfigs renders [corev1.VolumeMount] defining the mounting path for Slurm config files
-func RenderVolumeMountSlurmdbdConfigs() corev1.VolumeMount {
-	return corev1.VolumeMount{
-		Name:      consts.VolumeNameSlurmdbdSecret,
-		MountPath: consts.VolumeMountPathSlurmdbdSecret,
-		ReadOnly:  true,
-	}
-}
-
-func RenderVolumeSlurmdbdConfigs(clusterName string) corev1.Volume {
-	return corev1.Volume{
-		Name: consts.VolumeNameSlurmdbdSecret,
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName:  naming.BuildSecretSlurmdbdConfigsName(clusterName),
-				DefaultMode: ptr.To(int32(0600)),
+func RenderVolumeProjecitonSlurmdbdConfigs(clusterName string) *corev1.VolumeProjection {
+	return &corev1.VolumeProjection{
+		Secret: &corev1.SecretProjection{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: naming.BuildSecretSlurmdbdConfigsName(clusterName),
+			},
+			Items: []corev1.KeyToPath{
+				{
+					Key:  consts.SlurmdbdConfFile,
+					Path: consts.SlurmdbdConfFile,
+					Mode: ptr.To(int32(0600)),
+				},
 			},
 		},
 	}

--- a/internal/render/accounting/volume_test.go
+++ b/internal/render/accounting/volume_test.go
@@ -9,23 +9,9 @@ import (
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"nebius.ai/slurm-operator/internal/consts"
-	"nebius.ai/slurm-operator/internal/naming"
-	accounting "nebius.ai/slurm-operator/internal/render/accounting"
+	"nebius.ai/slurm-operator/internal/render/accounting"
 	"nebius.ai/slurm-operator/internal/values"
 )
-
-func Test_RenderVolumeSlurmdbdConfigs(t *testing.T) {
-	volume := accounting.RenderVolumeSlurmdbdConfigs(defaultNameCluster)
-	assert.Equal(t, consts.VolumeNameSlurmdbdSecret, volume.Name)
-	assert.Equal(t, naming.BuildSecretSlurmdbdConfigsName(defaultNameCluster), volume.VolumeSource.Secret.SecretName)
-}
-
-func Test_RenderVolumeMountSlurmdbdConfigs(t *testing.T) {
-	volumeMount := accounting.RenderVolumeMountSlurmdbdConfigs()
-	assert.Equal(t, consts.VolumeNameSlurmdbdSecret, volumeMount.Name)
-	assert.Equal(t, consts.VolumeMountPathSlurmdbdSecret, volumeMount.MountPath)
-	assert.True(t, volumeMount.ReadOnly)
-}
 
 func Test_RenderVolumeSlurmdbd(t *testing.T) {
 	sizeGi := resource.MustParse("1Gi")

--- a/internal/render/benchmark/cronjob.go
+++ b/internal/render/benchmark/cronjob.go
@@ -23,6 +23,7 @@ func RenderNCCLBenchmarkCronJob(
 	volumeSources []slurmv1.VolumeSource,
 	ncclBenchmark *values.SlurmNCCLBenchmark,
 	metrics *slurmv1.Telemetry,
+	slurmTopologyConfigMapRefName string,
 ) (batchv1.CronJob, error) {
 	labels := common.RenderLabels(consts.ComponentTypeBenchmark, clusterName)
 
@@ -62,7 +63,10 @@ func RenderNCCLBenchmarkCronJob(
 							ActiveDeadlineSeconds: &ncclBenchmark.ActiveDeadlineSeconds,
 							RestartPolicy:         corev1.RestartPolicyNever,
 							Volumes: []corev1.Volume{
-								common.RenderVolumeSlurmConfigs(clusterName),
+								common.RenderVolumeProjectedSlurmConfigs(
+									clusterName,
+									common.RenderVolumeProjectionSlurmTopologyConfig(slurmTopologyConfigMapRefName),
+								),
 								common.RenderVolumeMungeKey(clusterName),
 								common.RenderVolumeJailFromSource(volumeSources, *ncclBenchmark.VolumeJail.VolumeSourceName),
 							},

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -20,7 +20,7 @@ import (
 // [consts.ConfigMapKeyCGroupConfig] - cgroup config
 // [consts.ConfigMapKeySpankConfig] - SPANK plugins config
 // [consts.ConfigMapKeyGresConfig] - gres config
-func RenderConfigMapSlurmConfigs(cluster *values.SlurmCluster) (corev1.ConfigMap, error) {
+func RenderConfigMapSlurmConfigs(cluster *values.SlurmCluster, topologyConfig corev1.ConfigMap) (corev1.ConfigMap, error) {
 	return corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      naming.BuildConfigMapSlurmConfigsName(cluster.Name),
@@ -28,7 +28,7 @@ func RenderConfigMapSlurmConfigs(cluster *values.SlurmCluster) (corev1.ConfigMap
 			Labels:    RenderLabels(consts.ComponentTypeController, cluster.Name),
 		},
 		Data: map[string]string{
-			consts.ConfigMapKeySlurmConfig:  generateSlurmConfig(cluster).Render(),
+			consts.ConfigMapKeySlurmConfig:  generateSlurmConfig(cluster, topologyConfig).Render(),
 			consts.ConfigMapKeyCGroupConfig: generateCGroupConfig(cluster).Render(),
 			consts.ConfigMapKeySpankConfig:  generateSpankConfig().Render(),
 			consts.ConfigMapKeyGresConfig:   generateGresConfig(cluster.ClusterType).Render(),
@@ -37,7 +37,7 @@ func RenderConfigMapSlurmConfigs(cluster *values.SlurmCluster) (corev1.ConfigMap
 	}, nil
 }
 
-func generateSlurmConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
+func generateSlurmConfig(cluster *values.SlurmCluster, topologyConfig corev1.ConfigMap) renderutils.ConfigFile {
 	res := &renderutils.PropertiesConfig{}
 
 	res.AddProperty("ClusterName", cluster.Name)
@@ -155,6 +155,14 @@ func generateSlurmConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
 			res.AddProperty("AuthAltParameters", "jwt_key="+consts.RESTJWTKeyPath)
 		}
 	}
+
+	if cluster.SlurmConfig.TopologyPlugin == "" && topologyConfig.Data != nil {
+		if _, ok := topologyConfig.Data[consts.ConfigMapKeyTopologyConfig]; ok {
+			res.AddComment("AUTO TOPOLOGY, triggered by slurmTopologyConfigMapRefName")
+			res.AddProperty("TopologyPlugin", "topology/tree")
+		}
+	}
+
 	return res
 }
 

--- a/internal/render/common/volume.go
+++ b/internal/render/common/volume.go
@@ -83,6 +83,51 @@ func RenderVolumeMountSlurmConfigs() corev1.VolumeMount {
 
 // endregion Slurm configs
 
+// region Slurm topology config
+
+// RenderVolumeProjectedSlurmConfigs renders [corev1.Volume] containing Slurm common configs + topology config file
+func RenderVolumeProjectedSlurmConfigs(clusterName string, additionalProjections ...*corev1.VolumeProjection) corev1.Volume {
+	sources := []corev1.VolumeProjection{
+		{
+			ConfigMap: &corev1.ConfigMapProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: naming.BuildConfigMapSlurmConfigsName(clusterName),
+				},
+			},
+		},
+	}
+	for _, projection := range additionalProjections {
+		if projection != nil {
+			sources = append(sources, *projection)
+		}
+	}
+	return corev1.Volume{
+		Name: consts.VolumeNameSlurmConfigs,
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: sources,
+			},
+		},
+	}
+}
+
+// RenderVolumeProjectionSlurmTopologyConfig renders [corev1.VolumeProjection]
+// defining the configmap to overlay in /etc/slurm
+func RenderVolumeProjectionSlurmTopologyConfig(slurmTopologyConfigMapRefName string) *corev1.VolumeProjection {
+	if slurmTopologyConfigMapRefName == "" {
+		return nil
+	}
+	return &corev1.VolumeProjection{
+		ConfigMap: &corev1.ConfigMapProjection{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: slurmTopologyConfigMapRefName,
+			},
+		},
+	}
+}
+
+// endregion Slurm topology config
+
 // region Spool
 
 func RenderVolumeNameSpool(componentType consts.ComponentType) string {

--- a/internal/render/controller/statefulset.go
+++ b/internal/render/controller/statefulset.go
@@ -24,6 +24,7 @@ func RenderStatefulSet(
 	secrets *slurmv1.Secrets,
 	volumeSources []slurmv1.VolumeSource,
 	controller *values.SlurmController,
+	slurmTopologyConfigMapRefName string,
 ) (appsv1.StatefulSet, error) {
 	labels := common.RenderLabels(consts.ComponentTypeController, clusterName)
 	matchLabels := common.RenderMatchLabels(consts.ComponentTypeController, clusterName)
@@ -34,7 +35,8 @@ func RenderStatefulSet(
 		func(f slurmv1.K8sNodeFilter) string { return f.Name },
 	)
 
-	volumes, pvcTemplateSpecs, err := renderVolumesAndClaimTemplateSpecs(clusterName, volumeSources, controller)
+	volumes, pvcTemplateSpecs, err := renderVolumesAndClaimTemplateSpecs(
+		clusterName, volumeSources, controller, slurmTopologyConfigMapRefName)
 	if err != nil {
 		return appsv1.StatefulSet{}, fmt.Errorf("rendering volumes and claim template specs: %w", err)
 	}

--- a/internal/render/controller/volume.go
+++ b/internal/render/controller/volume.go
@@ -13,9 +13,13 @@ func renderVolumesAndClaimTemplateSpecs(
 	clusterName string,
 	volumeSources []slurmv1.VolumeSource,
 	controller *values.SlurmController,
+	slurmTopologyConfigMapRefName string,
 ) (volumes []corev1.Volume, pvcTemplateSpecs []values.PVCTemplateSpec, err error) {
 	volumes = []corev1.Volume{
-		common.RenderVolumeSlurmConfigs(clusterName),
+		common.RenderVolumeProjectedSlurmConfigs(
+			clusterName,
+			common.RenderVolumeProjectionSlurmTopologyConfig(slurmTopologyConfigMapRefName),
+		),
 		common.RenderVolumeMungeKey(clusterName),
 		common.RenderVolumeMungeSocket(),
 		common.RenderVolumeSecurityLimits(clusterName, consts.ComponentTypeController),

--- a/internal/render/login/statefulset.go
+++ b/internal/render/login/statefulset.go
@@ -26,6 +26,7 @@ func RenderStatefulSet(
 	secrets *slurmv1.Secrets,
 	volumeSources []slurmv1.VolumeSource,
 	login *values.SlurmLogin,
+	slurmTopologyConfigMapRefName string,
 ) (appsv1.StatefulSet, error) {
 	labels := common.RenderLabels(consts.ComponentTypeLogin, clusterName)
 	matchLabels := common.RenderMatchLabels(consts.ComponentTypeLogin, clusterName)
@@ -36,7 +37,8 @@ func RenderStatefulSet(
 		func(f slurmv1.K8sNodeFilter) string { return f.Name },
 	)
 
-	volumes, pvcTemplateSpecs, err := renderVolumesAndClaimTemplateSpecs(clusterName, secrets, volumeSources, login)
+	volumes, pvcTemplateSpecs, err := renderVolumesAndClaimTemplateSpecs(
+		clusterName, secrets, volumeSources, login, slurmTopologyConfigMapRefName)
 	if err != nil {
 		return appsv1.StatefulSet{}, fmt.Errorf("rendering volumes and claim template specs: %w", err)
 	}

--- a/internal/render/login/volume.go
+++ b/internal/render/login/volume.go
@@ -14,9 +14,13 @@ func renderVolumesAndClaimTemplateSpecs(
 	secrets *slurmv1.Secrets,
 	volumeSources []slurmv1.VolumeSource,
 	login *values.SlurmLogin,
+	slurmTopologyConfigMapRefName string,
 ) (volumes []corev1.Volume, pvcTemplateSpecs []values.PVCTemplateSpec, err error) {
 	volumes = []corev1.Volume{
-		common.RenderVolumeSlurmConfigs(clusterName),
+		common.RenderVolumeProjectedSlurmConfigs(
+			clusterName,
+			common.RenderVolumeProjectionSlurmTopologyConfig(slurmTopologyConfigMapRefName),
+		),
 		common.RenderVolumeMungeKey(clusterName),
 		common.RenderVolumeMungeSocket(),
 		common.RenderVolumeSecurityLimits(clusterName, consts.ComponentTypeLogin),

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -26,6 +26,7 @@ func RenderStatefulSet(
 	secrets *slurmv1.Secrets,
 	volumeSources []slurmv1.VolumeSource,
 	worker *values.SlurmWorker,
+	slurmTopologyConfigMapRefName string,
 ) (appsv1.StatefulSet, error) {
 	labels := common.RenderLabels(consts.ComponentTypeWorker, clusterName)
 	matchLabels := common.RenderMatchLabels(consts.ComponentTypeWorker, clusterName)
@@ -37,7 +38,7 @@ func RenderStatefulSet(
 	)
 
 	volumes, pvcTemplateSpecs, err := renderVolumesAndClaimTemplateSpecs(
-		clusterName, secrets, volumeSources, worker,
+		clusterName, secrets, volumeSources, worker, slurmTopologyConfigMapRefName,
 	)
 	if err != nil {
 		return appsv1.StatefulSet{}, fmt.Errorf("rendering volumes and claim template specs: %w", err)

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -17,6 +17,7 @@ import (
 func Test_RenderStatefulSet(t *testing.T) {
 	testNamespace := "test-namespace"
 	testCluster := "test-cluster"
+	testTopologyConfig := "test-topology-config"
 	nodeFilter := []slurmv1.K8sNodeFilter{
 		{
 			Name: "cpu",
@@ -127,7 +128,7 @@ func Test_RenderStatefulSet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := worker.RenderStatefulSet(testNamespace, testCluster, tt.clusterType, nodeFilter, tt.secrets, volumeSource, tt.worker)
+			result, err := worker.RenderStatefulSet(testNamespace, testCluster, tt.clusterType, nodeFilter, tt.secrets, volumeSource, tt.worker, testTopologyConfig)
 			assert.NoError(t, err)
 
 			assert.Equal(t, consts.ContainerNameSlurmd, result.Spec.Template.Spec.Containers[0].Name)

--- a/internal/render/worker/volume.go
+++ b/internal/render/worker/volume.go
@@ -19,9 +19,13 @@ func renderVolumesAndClaimTemplateSpecs(
 	secrets *slurmv1.Secrets,
 	volumeSources []slurmv1.VolumeSource,
 	worker *values.SlurmWorker,
+	slurmTopologyConfigMapRefName string,
 ) (volumes []corev1.Volume, pvcTemplateSpecs []values.PVCTemplateSpec, err error) {
 	volumes = []corev1.Volume{
-		common.RenderVolumeSlurmConfigs(clusterName),
+		common.RenderVolumeProjectedSlurmConfigs(
+			clusterName,
+			common.RenderVolumeProjectionSlurmTopologyConfig(slurmTopologyConfigMapRefName),
+		),
 		common.RenderVolumeMungeKey(clusterName),
 		common.RenderVolumeMungeSocket(),
 		common.RenderVolumeSecurityLimits(clusterName, consts.ComponentTypeWorker),

--- a/internal/values/slurm_cluster.go
+++ b/internal/values/slurm_cluster.go
@@ -27,15 +27,16 @@ type SlurmCluster struct {
 	VolumeSources []slurmv1.VolumeSource
 	Secrets       slurmv1.Secrets
 
-	NodeController SlurmController
-	NodeAccounting SlurmAccounting
-	NodeRest       SlurmREST
-	NodeWorker     SlurmWorker
-	NodeLogin      SlurmLogin
-	Telemetry      *slurmv1.Telemetry
-	SlurmExporter  SlurmExporter
-	SlurmConfig    slurmv1.SlurmConfig
-	MPIConfig      slurmv1.MPIConfig
+	NodeController                SlurmController
+	NodeAccounting                SlurmAccounting
+	NodeRest                      SlurmREST
+	NodeWorker                    SlurmWorker
+	NodeLogin                     SlurmLogin
+	Telemetry                     *slurmv1.Telemetry
+	SlurmExporter                 SlurmExporter
+	SlurmConfig                   slurmv1.SlurmConfig
+	MPIConfig                     slurmv1.MPIConfig
+	SlurmTopologyConfigMapRefName string
 }
 
 // BuildSlurmClusterFrom creates a new instance of SlurmCluster given a SlurmCluster CRD
@@ -71,11 +72,12 @@ func BuildSlurmClusterFrom(ctx context.Context, cluster *slurmv1.SlurmCluster) (
 			&cluster.Spec.NCCLSettings,
 			cluster.Spec.UseDefaultAppArmorProfile,
 		),
-		NodeLogin:     buildSlurmLoginFrom(cluster.Name, cluster.Spec.Maintenance, &cluster.Spec.SlurmNodes.Login, cluster.Spec.UseDefaultAppArmorProfile),
-		Telemetry:     cluster.Spec.Telemetry,
-		SlurmExporter: buildSlurmExporterFrom(cluster.Spec.Maintenance, &cluster.Spec.SlurmNodes.Exporter),
-		SlurmConfig:   cluster.Spec.SlurmConfig,
-		MPIConfig:     cluster.Spec.MPIConfig,
+		NodeLogin:                     buildSlurmLoginFrom(cluster.Name, cluster.Spec.Maintenance, &cluster.Spec.SlurmNodes.Login, cluster.Spec.UseDefaultAppArmorProfile),
+		Telemetry:                     cluster.Spec.Telemetry,
+		SlurmExporter:                 buildSlurmExporterFrom(cluster.Spec.Maintenance, &cluster.Spec.SlurmNodes.Exporter),
+		SlurmConfig:                   cluster.Spec.SlurmConfig,
+		MPIConfig:                     cluster.Spec.MPIConfig,
+		SlurmTopologyConfigMapRefName: cluster.Spec.SlurmTopologyConfigMapRefName,
 	}
 
 	if err := res.Validate(ctx); err != nil {


### PR DESCRIPTION
This led to some refactoring of ConfigMap mount system. Will be deprecated after introduction of config controller (soon), but allows testing Slurm topologies right now.

Now ConfigMaps and Secrets are mounted to some containers via projection, which allows multiple files to appear in the same directory.

/etc/slurm is now read-only in all contexts.