### PR TITLE
Add workerAnnotations to worker definition

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -724,6 +724,11 @@ type SlurmNodeWorker struct {
 	// +kubebuilder:validation:Optional
 	SSHDConfigMapRefName string `json:"sshdConfigMapRefName,omitempty"`
 
+	// WorkerAnnotations represent K8S annotations that should be added to the workers
+	//
+	// +kubebuilder:validation:Optional
+	WorkerAnnotations map[string]string `json:"workerAnnotations,omitempty"`
+
 	// Volumes represents the volume configurations for the worker node
 	//
 	// +kubebuilder:validation:Required

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -902,6 +902,13 @@ func (in *SlurmNodeWorker) DeepCopyInto(out *SlurmNodeWorker) {
 	out.SlurmNode = in.SlurmNode
 	in.Slurmd.DeepCopyInto(&out.Slurmd)
 	in.Munge.DeepCopyInto(&out.Munge)
+	if in.WorkerAnnotations != nil {
+		in, out := &in.WorkerAnnotations, &out.WorkerAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Volumes.DeepCopyInto(&out.Volumes)
 }
 

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -5537,6 +5537,12 @@ spec:
                         - jailSubMounts
                         - spool
                         type: object
+                      workerAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: WorkerAnnotations represent K8S annotations that
+                          should be added to the workers
+                        type: object
                     required:
                     - k8sNodeFilterName
                     - munge

--- a/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
+++ b/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
@@ -171,6 +171,10 @@ spec:
       {{- if .Values.slurmNodes.worker.sshdConfigMapRefName }}
       sshdConfigMapRefName: {{ .Values.slurmNodes.worker.sshdConfigMapRefName | quote }}
       {{- end }}
+      {{- if .Values.slurmNodes.worker.workerAnnotations }}
+      workerAnnotations: 
+      {{- default list .Values.slurmNodes.worker.workerAnnotations | toYaml | nindent 8 }}
+      {{- end }}
       slurmd:
         image: {{ required "slurmd image" .Values.images.slurmd | quote }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.slurmNodes.worker.slurmd.imagePullPolicy | quote }}

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -290,6 +290,7 @@ slurmNodes:
     slurmNodeExtra: ""
     supervisordConfigMapRefName: ""
     sshdConfigMapRefName: ""
+    # workerAnnotations: []
     slurmd:
       imagePullPolicy: "IfNotPresent"
       appArmorProfile: "unconfined"

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -9181,6 +9181,12 @@ spec:
                         description: SSHDConfigMapRefName is the name of the SSHD
                           config, which runs in slurmd container
                         type: string
+                      workerAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: WorkerAnnotations represent K8S annotations
+                          that should be added to the worker nodes 
+                        type: object                      
                       supervisordConfigMapRefName:
                         description: SupervisordConfigMapRefName is the name of the
                           supervisord config, which runs in slurmd container

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -9181,6 +9181,12 @@ spec:
                         description: SSHDConfigMapRefName is the name of the SSHD
                           config, which runs in slurmd container
                         type: string
+                      workerAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: WorkerAnnotations represent K8S annotations
+                          that should be added to the worker nodes 
+                        type: object
                       supervisordConfigMapRefName:
                         description: SupervisordConfigMapRefName is the name of the
                           supervisord config, which runs in slurmd container

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"fmt"
+	"maps"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -146,6 +147,8 @@ func renderAnnotations(worker *values.SlurmWorker, clusterName, namespace string
 		): mungeAppArmorProfile,
 		consts.DefaultContainerAnnotationName: consts.ContainerNameSlurmd,
 	}
+
+	maps.Copy(annotations, worker.WorkerAnnotations)
 
 	return annotations
 }

--- a/internal/values/slurm_worker.go
+++ b/internal/values/slurm_worker.go
@@ -24,6 +24,8 @@ type SlurmWorker struct {
 	IsSSHDConfigMapDefault bool
 	SSHDConfigMapName      string
 
+	WorkerAnnotations map[string]string
+
 	CgroupVersion  string
 	EnableGDRCopy  bool
 	SlurmNodeExtra string
@@ -80,6 +82,7 @@ func buildSlurmWorkerFrom(
 		),
 		SupervisordConfigMapDefault: supervisordConfigDefault,
 		SupervisordConfigMapName:    supervisordConfigName,
+		WorkerAnnotations:           worker.WorkerAnnotations,
 		Service:                     buildServiceFrom(naming.BuildServiceName(consts.ComponentTypeWorker, clusterName)),
 		StatefulSet: buildStatefulSetFrom(
 			naming.BuildStatefulSetName(consts.ComponentTypeWorker, clusterName),


### PR DESCRIPTION
Provide a new field for workerAnnotations in worker definition.

This workerAnnotations map will be added to the worker statefulset spec annotations for workers, so annotations required for workers only (like the ones for providing RoCE backend NICs) can be set.