### PR TITLE
Bugfix: Fixed all rbac generated under the same roleName

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) crd webhook paths=$(GENPATH) output:crd:artifacts:config=config/crd/bases
-	$(CONTROLLER_GEN) rbac:roleName=manager-role paths="./internal/controller/..." output:artifacts:config=config/rbac/clustercontroller/
 	$(CONTROLLER_GEN) rbac:roleName=nodeconfigurator-role paths="./internal/rebooter/..." output:artifacts:config=config/rbac/nodeconfigurator/
+	$(CONTROLLER_GEN) rbac:roleName=manager-role paths="./internal/controller/clustercontroller/..." output:artifacts:config=config/rbac/clustercontroller/
 	$(CONTROLLER_GEN) rbac:roleName=soperator-checks-role paths="./internal/controller/soperatorchecks/..." output:artifacts:config=config/rbac/soperatorchecks/
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -110,7 +110,7 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 
 .PHONY: helm
 helm: generate manifests ## Update soperator Helm chart
-	$(KUSTOMIZE) build config/crd/bases > $(CHART_OPERATOR_PATH)/crds/slurmcluster-crd.yaml 
+	$(KUSTOMIZE) build config/crd/bases > $(CHART_OPERATOR_PATH)/crds/slurmcluster-crd.yaml
 	$(KUSTOMIZE) build config/crd/bases > $(CHART_OPERATOR_CRDS_PATH)/templates/slurmcluster-crd.yaml
 # Because of helmify rewrite a file we need to make backup of values.yaml
 	mv $(CHART_OPERATOR_PATH)/values.yaml $(CHART_OPERATOR_PATH)/values.yaml.bak

--- a/config/rbac/clustercontroller/role.yaml
+++ b/config/rbac/clustercontroller/role.yaml
@@ -31,26 +31,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
-  verbs:
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes/status
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - podtemplates
   verbs:
   - get
@@ -155,9 +135,6 @@ rules:
 - apiGroups:
   - slurm.nebius.ai
   resources:
-  - activechecks
-  - nodeconfigurators
-  - nodesets
   - slurmclusters
   verbs:
   - create
@@ -170,18 +147,12 @@ rules:
 - apiGroups:
   - slurm.nebius.ai
   resources:
-  - activechecks/finalizers
-  - nodeconfigurators/finalizers
-  - nodesets/finalizers
   - slurmclusters/finalizers
   verbs:
   - update
 - apiGroups:
   - slurm.nebius.ai
   resources:
-  - activechecks/status
-  - nodeconfigurators/status
-  - nodesets/status
   - slurmclusters/status
   verbs:
   - get

--- a/helm/soperator/templates/manager-rbac.yaml
+++ b/helm/soperator/templates/manager-rbac.yaml
@@ -32,26 +32,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
-  verbs:
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes/status
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - podtemplates
   verbs:
   - get
@@ -156,9 +136,6 @@ rules:
 - apiGroups:
   - slurm.nebius.ai
   resources:
-  - activechecks
-  - nodeconfigurators
-  - nodesets
   - slurmclusters
   verbs:
   - create
@@ -171,18 +148,12 @@ rules:
 - apiGroups:
   - slurm.nebius.ai
   resources:
-  - activechecks/finalizers
-  - nodeconfigurators/finalizers
-  - nodesets/finalizers
   - slurmclusters/finalizers
   verbs:
   - update
 - apiGroups:
   - slurm.nebius.ai
   resources:
-  - activechecks/status
-  - nodeconfigurators/status
-  - nodesets/status
   - slurmclusters/status
   verbs:
   - get


### PR DESCRIPTION
There was a line in the Make file:

`$(CONTROLLER_GEN) rbac:roleName=manager-role paths="./internal/controller/..." `

Because of that, all controllers were generating their rbacs to the manager-role
