### PR TITLE
Enable gpus metrics in exporter

### DIFF
--- a/images/exporter/exporter.dockerfile
+++ b/images/exporter/exporter.dockerfile
@@ -90,4 +90,4 @@ RUN ldconfig
 
 COPY --from=exporter_builder /app/prometheus-slurm-exporter /opt/bin/
 
-ENTRYPOINT ["/opt/bin/prometheus-slurm-exporter"]
+ENTRYPOINT ["/opt/bin/prometheus-slurm-exporter", "--gpus-acct"]

--- a/images/exporter/exporter.dockerfile
+++ b/images/exporter/exporter.dockerfile
@@ -90,4 +90,4 @@ RUN ldconfig
 
 COPY --from=exporter_builder /app/prometheus-slurm-exporter /opt/bin/
 
-ENTRYPOINT ["/opt/bin/prometheus-slurm-exporter", "--gpus-acct"]
+ENTRYPOINT ["/opt/bin/prometheus-slurm-exporter", "-gpus-acct"]


### PR DESCRIPTION
In order to enable the gpu metrics is necessary to launch the exporter with the -gpus -acct flag. In the https://github.com/vpenso/prometheus-slurm-exporter/ repo we can found this note: 
```
NOTE: since version 0.19, GPU accounting has to be explicitly enabled adding the -gpus-acct option to the command line otherwise it will not be activated.
```
Thanks