### PR TITLE
bump golang version to 1.24 and fix bug with parse of args

### DIFF
--- a/images/worker/gpubench/go.mod
+++ b/images/worker/gpubench/go.mod
@@ -1,8 +1,6 @@
 module nebius.ai/slurm-operator/image/worker/gpubench
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.24.1
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/images/worker/gpubench/main.go
+++ b/images/worker/gpubench/main.go
@@ -72,6 +72,11 @@ var (
 )
 
 func init() {
+	log = logrus.WithField("slurmNode", currentNode)
+}
+
+func main() {
+	fs.Parse(os.Args[1:])
 	if *logFormat != logFormatText && *logFormat != logFormatJSON {
 		logrus.WithField("logFormat", *logFormat).Fatal("Invalid log format")
 	}
@@ -92,11 +97,7 @@ func init() {
 	} else {
 		logrus.SetLevel(logrus.InfoLevel)
 	}
-	log = logrus.WithField("slurmNode", currentNode)
-}
 
-func main() {
-	fs.Parse(os.Args[1:])
 	log.Info(fmt.Sprintf("Starting %s", nameNCCL))
 	if *debugLog {
 		debugFlags()

--- a/images/worker/slurmd.dockerfile
+++ b/images/worker/slurmd.dockerfile
@@ -2,7 +2,7 @@
 ARG BASE_IMAGE=cr.eu-north1.nebius.cloud/soperator/ubuntu:jammy
 
 # First stage: Build the gpubench application
-FROM cr.eu-north1.nebius.cloud/soperator/golang:1.23 AS gpubench_builder
+FROM golang:1.24 AS gpubench_builder
 
 ARG GO_LDFLAGS=""
 ARG CGO_ENABLED=0


### PR DESCRIPTION
This PR fixes an issue with resource synchronization in nebius/soperator by  version of golang and fix bug with parsing args