### PR TITLE
#618: Speedup nvidia driver configuration on the worker start

### DIFF
--- a/cmd/soperatorchecks/main.go
+++ b/cmd/soperatorchecks/main.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
+	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
 	"nebius.ai/slurm-operator/internal/controller/soperatorchecks"
 	"nebius.ai/slurm-operator/internal/jwt"
 	"nebius.ai/slurm-operator/internal/slurmapi"
@@ -58,6 +59,7 @@ func init() {
 
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(slurmv1.AddToScheme(scheme))
+	utilruntime.Must(slurmv1alpha1.AddToScheme(scheme))
 }
 
 func getZapOpts(logFormat, logLevel string) []zap.Opts {

--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -65,20 +65,8 @@ pushd "${jaildir}"
     done <<< "$submounts"
 
     if [ -n "$worker" ] && [ "$SLURM_CLUSTER_TYPE" = "gpu" ]; then
-        echo "Run nvidia-container-cli to propagate NVIDIA drivers, CUDA, NVML and other GPU-related stuff to the jail"
-        flock etc/complement_jail_nvidia_container_cli.lock -c "
-            nvidia-container-cli \
-                --user \
-                --debug=/dev/stderr \
-                --no-pivot \
-                configure \
-                --no-cgroups \
-                --ldconfig=\"@$(command -v ldconfig.real || command -v ldconfig)\" \
-                --device=all \
-                --utility \
-                --compute \
-                \"${jaildir}\"
-        "
+        time flock etc/complement_jail_nvidia_container_cli.lock -c \
+          "/opt/bin/slurm/install_nvidia_libs.sh -i etc/complement_jail_nvidia_info.txt -j \"${jaildir}\""
         touch "etc/gpu_libs_installed.flag"
     fi
 

--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -65,7 +65,7 @@ pushd "${jaildir}"
     done <<< "$submounts"
 
     if [ -n "$worker" ] && [ "$SLURM_CLUSTER_TYPE" = "gpu" ]; then
-        time flock etc/complement_jail_nvidia_container_cli.lock -c \
+        flock etc/complement_jail_nvidia_container_cli.lock -c \
           "/opt/bin/slurm/install_nvidia_libs.sh -i etc/complement_jail_nvidia_info.txt -j \"${jaildir}\""
         touch "etc/gpu_libs_installed.flag"
     fi

--- a/images/common/scripts/install_nvidia_libs.sh
+++ b/images/common/scripts/install_nvidia_libs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -x # Print actual command before executing it
+set -e # Exit immediately if any command returns a non-zero error code
+
+usage() { echo "usage: ${0} -j <path_to_jail_dir> -i <path_to_nvidia_container_cli_info> [-h]" >&2; exit 1; }
+
+while getopts i:j:u:wh flag
+do
+    case "${flag}" in
+        i) infopath=${OPTARG};;
+        j) jaildir=${OPTARG};;
+        h) usage;;
+        *) usage;;
+    esac
+done
+
+if [ -z "$jaildir" ] || [ -z "$infopath" ]; then
+    usage
+fi
+
+if ! cmp -s <(nvidia-container-cli info --csv | head -2) "${infopath}" > /dev/null 2>&1; then
+    echo "NVIDIA driver information has changed, updating configuration in the jail..."
+    nvidia-container-cli \
+        --user \
+        --debug=/dev/stderr \
+        --no-pivot \
+        configure \
+        --no-cgroups \
+        --ldconfig="@$(command -v ldconfig.real || command -v ldconfig)" \
+        --device=all \
+        --utility \
+        --compute \
+        "${jaildir}"
+    nvidia-container-cli info --csv | head -2 > "${infopath}"
+else
+    echo "No changes in NVIDIA driver information, skipping configuration"
+fi

--- a/images/worker/slurmd.dockerfile
+++ b/images/worker/slurmd.dockerfile
@@ -151,9 +151,13 @@ COPY common/scripts/complement_jail.sh /opt/bin/slurm/
 # Copy script for bind-mounting slurm into the jail
 COPY common/scripts/bind_slurm_common.sh /opt/bin/slurm/
 
+# Copy script for installing invidia driver libs into the jail
+COPY common/scripts/install_nvidia_libs.sh /opt/bin/slurm/
+
 RUN chmod +x /usr/bin/gpu_healthcheck.sh && \
     chmod +x /opt/bin/slurm/complement_jail.sh && \
-    chmod +x /opt/bin/slurm/bind_slurm_common.sh
+    chmod +x /opt/bin/slurm/bind_slurm_common.sh && \
+    chmod +x /opt/bin/slurm/install_nvidia_libs.sh
 
 # Update linker cache
 RUN ldconfig


### PR DESCRIPTION
Instead of configuring Nvidia container on each worker, configure it once (using flock), and then next worker will only check the version using `nvidia-constainer-cli info` and do nothing. This will speed up this part from 2.5s to 0.5s, which is several minutes speedup for big enough clusters.