### PR TITLE
#618: [Speedup] Disable ldconfig on nvidia driver configuration.

### DIFF
--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -68,7 +68,7 @@ pushd "${jaildir}"
         echo "Run nvidia-container-cli to propagate NVIDIA drivers, CUDA, NVML and other GPU-related stuff to the jail"
 
         # Disable ldconfig to prevent race between the workers.
-        # ldconfig will be run later separately under with flock.
+        # ldconfig is run further in this script under flock.
         readonly FAKE_LDCONFIG=/usr/bin/true
 
         nvidia-container-cli \

--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -66,19 +66,22 @@ pushd "${jaildir}"
 
     if [ -n "$worker" ] && [ "$SLURM_CLUSTER_TYPE" = "gpu" ]; then
         echo "Run nvidia-container-cli to propagate NVIDIA drivers, CUDA, NVML and other GPU-related stuff to the jail"
-        flock etc/complement_jail_nvidia_container_cli.lock -c "
-            nvidia-container-cli \
-                --user \
-                --debug=/dev/stderr \
-                --no-pivot \
-                configure \
-                --no-cgroups \
-                --ldconfig=\"@$(command -v ldconfig.real || command -v ldconfig)\" \
-                --device=all \
-                --utility \
-                --compute \
-                \"${jaildir}\"
-        "
+
+        # Disable ldconfig to prevent race between the workers.
+        # ldconfig will be run later separately under with flock.
+        readonly FAKE_LDCONFIG=/usr/bin/true
+
+        nvidia-container-cli \
+            --user \
+            --debug=/dev/stderr \
+            --no-pivot \
+            configure \
+            --no-cgroups \
+            --ldconfig=$FAKE_LDCONFIG \
+            --device=all \
+            --utility \
+            --compute \
+            "${jaildir}"
         touch "etc/gpu_libs_installed.flag"
     fi
 


### PR DESCRIPTION
`nvidia-container-cli configure` runs for 2-2.5s on average and it was run under `flock` only to prevent races during `ldconfig` calls (it failed which resulted in a pod restart).

Since `ldconfig` is run separately under other `flock`, it was removed from the configuration call with the flock altogether.
It should speed up the workers statefulset restart by 2-2.5s multiplied by the number of workers.