### PR TITLE
Flux test

### DIFF
--- a/fluxcd/base/mariadb-operator/resources.yaml
+++ b/fluxcd/base/mariadb-operator/resources.yaml
@@ -43,6 +43,8 @@ spec:
       valuesKey: values.yaml
       optional: true
   values:
-    cert:
-      certManager:
-        enabled: true
+    webhook:
+      enabled: true
+      cert:
+        certManager:
+          enabled: true

--- a/fluxcd/base/mariadb-operator/resources.yaml
+++ b/fluxcd/base/mariadb-operator/resources.yaml
@@ -18,6 +18,7 @@ metadata:
   name: mariadb-operator
   namespace: flux-system
 spec:
+  releaseName: mariadb-operator
   dependsOn:
     - name: cert-manager
   interval: 10m

--- a/fluxcd/base/nodeconfigurator/resources.yaml
+++ b/fluxcd/base/nodeconfigurator/resources.yaml
@@ -16,6 +16,7 @@ metadata:
 spec:
   dependsOn:
     - name: soperator
+  releaseName: nodeconfigurator
   interval: 10m
   timeout: 10m
   install:

--- a/fluxcd/base/opentelemetry-collector-events/resources.yaml
+++ b/fluxcd/base/opentelemetry-collector-events/resources.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   dependsOn:
     - name: vm-logs
+  releaseName: opentelemetry-collector-events
   interval: 10m
   timeout: 10m
   install:

--- a/fluxcd/base/opentelemetry-collector-logs/resources.yaml
+++ b/fluxcd/base/opentelemetry-collector-logs/resources.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   dependsOn:
     - name: vm-logs
+  releaseName: opentelemetry-collector-logs
   interval: 10m
   timeout: 10m
   install:

--- a/fluxcd/base/security-profiles-operator/resources.yaml
+++ b/fluxcd/base/security-profiles-operator/resources.yaml
@@ -19,6 +19,7 @@ metadata:
   name: security-profiles-operator
   namespace: flux-system
 spec:
+  releaseName: security-profiles-operator
   interval: 10m
   timeout: 10m
   install:

--- a/fluxcd/base/slurm-cluster-storage/resources.yaml
+++ b/fluxcd/base/slurm-cluster-storage/resources.yaml
@@ -1,3 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: soperator
+---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/fluxcd/base/slurm-cluster-storage/resources.yaml
+++ b/fluxcd/base/slurm-cluster-storage/resources.yaml
@@ -25,13 +25,13 @@ spec:
       retries: 3
   upgrade:
     crds: CreateReplace
-  targetNamespace: soperator-system
+  targetNamespace: soperator
   chart:
     spec:
       chart: helm-slurm-cluster-storage
       sourceRef:
         kind: HelmRepository
-        name: vm
+        name: slurm-cluster-storage
       interval: 10m
   valuesFrom:
     - kind: ConfigMap

--- a/fluxcd/base/slurm-cluster-storage/resources.yaml
+++ b/fluxcd/base/slurm-cluster-storage/resources.yaml
@@ -16,6 +16,7 @@ metadata:
 spec:
   dependsOn:
     - name: soperator
+  releaseName: slurm-cluster-storage
   interval: 10m
   timeout: 10m
   install:

--- a/fluxcd/base/slurm-cluster/resources.yaml
+++ b/fluxcd/base/slurm-cluster/resources.yaml
@@ -17,7 +17,7 @@ spec:
   dependsOn:
     - name: soperator
     - name: slurm-cluster-storage
-  releaseName: slurm-cluster
+  releaseName: slurm
   interval: 10m
   timeout: 10m
   install:
@@ -26,7 +26,7 @@ spec:
       retries: 3
   upgrade:
     crds: CreateReplace
-  targetNamespace: soperator-system
+  targetNamespace: soperator
   chart:
     spec:
       chart: helm-slurm-cluster

--- a/fluxcd/base/slurm-cluster/resources.yaml
+++ b/fluxcd/base/slurm-cluster/resources.yaml
@@ -17,6 +17,7 @@ spec:
   dependsOn:
     - name: soperator
     - name: slurm-cluster-storage
+  releaseName: slurm-cluster
   interval: 10m
   timeout: 10m
   install:

--- a/fluxcd/base/soperator/resources.yaml
+++ b/fluxcd/base/soperator/resources.yaml
@@ -44,7 +44,6 @@ spec:
       valuesKey: values.yaml
       optional: true
   values:
-    fullnameOverride: slurm
     controllerManager:
       manager:
         env:

--- a/fluxcd/base/soperator/resources.yaml
+++ b/fluxcd/base/soperator/resources.yaml
@@ -21,6 +21,7 @@ metadata:
 spec:
   dependsOn:
     - name: cert-manager
+  releaseName: soperator
   interval: 10m
   timeout: 10m
   install:

--- a/fluxcd/base/soperatorchecks/resources.yaml
+++ b/fluxcd/base/soperatorchecks/resources.yaml
@@ -16,6 +16,7 @@ metadata:
 spec:
   dependsOn:
     - name: soperator
+  releaseName: soperatorchecks
   interval: 10m
   timeout: 10m
   install:

--- a/fluxcd/base/victoria-logs/resources.yaml
+++ b/fluxcd/base/victoria-logs/resources.yaml
@@ -18,6 +18,7 @@ metadata:
   name: vm-logs
   namespace: flux-system
 spec:
+  releaseName: logs
   interval: 10m
   timeout: 10m
   install:

--- a/fluxcd/base/victoria-metrics-operator/resources.yaml
+++ b/fluxcd/base/victoria-metrics-operator/resources.yaml
@@ -18,6 +18,7 @@ metadata:
   name: vm-stack
   namespace: flux-system
 spec:
+  releaseName: metrics
   interval: 10m
   timeout: 10m
   install:

--- a/fluxcd/enviroment/nebius-cloud/soperator/bootstrap/git-repository.yaml
+++ b/fluxcd/enviroment/nebius-cloud/soperator/bootstrap/git-repository.yaml
@@ -23,4 +23,4 @@ spec:
   url: https://github.com/nebius/soperator
   ref:
     # TODO: Change this to the branch main after the first release
-    branch: flux-test
+    branch: dev

--- a/fluxcd/enviroment/nebius-cloud/soperator/bootstrap/git-repository.yaml
+++ b/fluxcd/enviroment/nebius-cloud/soperator/bootstrap/git-repository.yaml
@@ -23,4 +23,4 @@ spec:
   url: https://github.com/nebius/soperator
   ref:
     # TODO: Change this to the branch main after the first release
-    branch: dev
+    branch: flux-test


### PR DESCRIPTION
[#649](https://github.com/nebius/soperator/issues/649)

```
 ~ %  k -n soperator get ns                                  
NAME                                STATUS   AGE
cert-manager-system                 Active   149m
default                             Active   10d
flux-system                         Active   166m
kube-node-lease                     Active   10d
kube-public                         Active   10d
kube-system                         Active   10d
logs-system                         Active   7d5h
mariadb-operator-system             Active   26m
security-profiles-operator-system   Active   149m
soperator                           Active   4m33s
soperator-system                    Active   149m


~ % flux get helmreleases 
NAME                      	REVISION	SUSPENDED	READY	MESSAGE                                                                                                                                        
cert-manager              	v1.17.1 	False    	True 	Helm install succeeded for release cert-manager-system/cert-manager-system-cert-manager.v1 with chart cert-manager@v1.17.1                    	
mariadb-operator          	0.38.0  	False    	True 	Helm upgrade succeeded for release mariadb-operator-system/mariadb-operator.v2 with chart mariadb-operator@0.38.0                             	
nodeconfigurator          	1.19.0  	False    	True 	Helm install succeeded for release soperator-system/nodeconfigurator.v1 with chart helm-nodeconfigurator@1.19.0                               	
security-profiles-operator	0.8.4   	False    	True 	Helm install succeeded for release security-profiles-operator-system/security-profiles-operator.v1 with chart security-profiles-operator@0.8.4	
slurm-cluster             	1.19.0  	False    	True 	Helm install succeeded for release soperator/slurm.v1 with chart helm-slurm-cluster@1.19.0                                                    	
slurm-cluster-storage     	1.19.0  	False    	True 	Helm upgrade succeeded for release soperator/slurm-cluster-storage.v3 with chart helm-slurm-cluster-storage@1.19.0                            	
soperator                 	1.19.0  	False    	True 	Helm upgrade succeeded for release soperator-system/soperator.v2 with chart helm-soperator@1.19.0                                             	
soperatorchecks           	1.19.0  	False    	True 	Helm install succeeded for release soperator-system/soperatorchecks.v1 with chart helm-soperatorchecks@1.19.0   
```