### PR TITLE
Add golangilint to CI

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -85,7 +85,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
         with:
-          version: v2.0.2
+          version: v2.0.2 # version of golangci-lint, should be in sync with Makefile.
 
       - name: Debug vars
         run: |

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -82,6 +82,11 @@ jobs:
         with:
             go-version-file: 'go.mod'
 
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
+        with:
+          version: v2.0.2
+
       - name: Debug vars
         run: |
           echo "UNSTABLE - is ${{ needs.pre-build.outputs.unstable }}"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,47 +1,81 @@
+version: "2"
 linters:
-  presets:
-    - bugs
-    - complexity
-    - error
-    - format
-    - import
-    - metalinter
-    - module
-    - performance
-    - style
-    - test
-    - unused
+  enable:
+    - asciicheck
+    - bidichk
+    - copyloopvar
+    - cyclop
+    - decorder
+    - dogsled
+    - gocheckcompilerdirectives
+    - goheader
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - grouper
+    - inamedparam
+    - interfacebloat
+    - nakedret
+    - nosprintfhostport
+    - predeclared
+    - promlinter
+    - tagalign
+    - testableexamples
+    - usestdlibvars
   disable:
     - depguard
-    - ineffassign
-    - funlen
-    - forcetypeassert
-    - testpackage
-    - tagliatelle
-    - godot
-    - misspell
-    - goconst
     - dupl
-    - gci
-    - whitespace
+    - errcheck
+    - forcetypeassert
+    - funlen
     - gochecknoinits
     - gocognit
-    - nestif
+    - goconst
     - gocyclo
-    - maintidx
+    - godot
     - godox
-    - gofumpt
-    - gomnd
+    - govet
+    - ineffassign
     - lll
+    - maintidx
+    - misspell
+    - mnd
+    - nestif
     - nlreturn
     - nolintlint
-    - wsl
     - prealloc
-  fast: true
+    - staticcheck
+    - tagliatelle
+    - testpackage
+    - unused
+    - whitespace
+    - wsl
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 output:
   formats:
-    - format: colored-line-number
+    text:
+      path: stdout
 
 run:
   relative-path-mode: gomod

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,6 @@ linters:
     - asciicheck
     - bidichk
     - copyloopvar
-    - cyclop
     - decorder
     - dogsled
     - gocheckcompilerdirectives
@@ -25,6 +24,7 @@ linters:
   disable:
     - depguard
     - dupl
+    - cyclop
     - errcheck
     - forcetypeassert
     - funlen
@@ -57,20 +57,10 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 formatters:
   enable:
     - gofmt
     - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 
 output:
   formats:

--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ YQ             ?= $(LOCALBIN)/yq
 KUSTOMIZE_VERSION        ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
 ENVTEST_VERSION          ?= release-0.17
-GOLANGCI_LINT_VERSION    ?= v1.57.2
+GOLANGCI_LINT_VERSION    ?= v2.0.2
 HELMIFY_VERSION          ?= 0.4.13
 YQ_VERSION               ?= 4.44.3
 

--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ YQ             ?= $(LOCALBIN)/yq
 KUSTOMIZE_VERSION        ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
 ENVTEST_VERSION          ?= release-0.17
-GOLANGCI_LINT_VERSION    ?= v2.0.2
+GOLANGCI_LINT_VERSION    ?= v2.0.2  # Should be in sync with the github CI step.
 HELMIFY_VERSION          ?= 0.4.13
 YQ_VERSION               ?= 4.44.3
 


### PR DESCRIPTION
Golangilint config migrated to v2 with `golangilint migrate` command most of the changes are from there:
looks like they dropped linter presets, that's why they were "unwrapped".

Also `cyclop` linter was disabled, blames about our code.

Adds 4s to the build time.

Closes #662 
