### PR TITLE
#623 Advanced stateful sets

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	apparmor "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 
@@ -72,6 +73,7 @@ func init() {
 	if check.IsAppArmorCRDInstalled() {
 		utilruntime.Must(apparmor.AddToScheme(scheme))
 	}
+	utilruntime.Must(kruisev1b1.AddToScheme(scheme))
 
 	utilruntime.Must(slurmv1.AddToScheme(scheme))
 

--- a/config/rbac/clustercontroller/role.yaml
+++ b/config/rbac/clustercontroller/role.yaml
@@ -51,6 +51,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps.kruise.io
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - batch
   resources:
   - cronjobs

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
+	github.com/openkruise/kruise-api v1.8.0 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/seccomp/libseccomp-golang v0.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	sigs.k8s.io/release-utils v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 h1:1UoZQm6f0P/ZO0w1Ri+f+ifG/
 golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
-golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc h1:d2hUh5O6MRBvStV55MQ8we08t42zSTqBbscoQccWmMc=
 github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc/go.mod h1:8tx1helyqhUC65McMm3x7HmOex8lO2/v9zPuxmKHurs=
+github.com/openkruise/kruise-api v1.8.0 h1:DoUb873uuf2Bhoajim+9tb/X0eFpwIxRydc4Awfeeiw=
+github.com/openkruise/kruise-api v1.8.0/go.mod h1:XRpoTk7VFgh9r5HRUZurwhiC3cpCf5BX8X4beZLcIfA=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/helm/soperator/.gitignore
+++ b/helm/soperator/.gitignore
@@ -1,0 +1,2 @@
+charts/kruise-*.tgz
+Chart.lock

--- a/helm/soperator/Chart.yaml
+++ b/helm/soperator/Chart.yaml
@@ -5,3 +5,8 @@ type: application
 version: 1.19.0
 appVersion: "1.19.0"
 kubeVersion: ">=1.29.0-0"
+dependencies:
+  - name: kruise
+    version: 1.8.0
+    repository: https://openkruise.github.io/charts/
+    condition: kruise.installOperator

--- a/helm/soperator/README.md
+++ b/helm/soperator/README.md
@@ -1,0 +1,60 @@
+# Soperator Helm chart
+
+This Helm chart deploys Soperator,
+a Kubernetes operator designed to manage and run Slurm clusters within Kubernetes environments.
+
+## Prerequisites
+
+Before deploying Soperator, ensure the following prerequisites are met:
+
+- **Kubernetes Cluster**: A running Kubernetes cluster, version 1.30 or higher.
+- **Helm**: Helm package manager installed.
+- **NVIDIA GPU Operator**: Installed if utilizing NVIDIA GPUs.
+- **NVIDIA Network Operator**: Installed if using InfiniBand networking.
+
+### OpenKruise
+
+Soperator relies on [**OpenKruise operator**](https://github.com/openkruise/charts/tree/master/versions/kruise/1.8.0)
+to manage **Advanced StatefulSets**.
+
+By default, it's installed within this chart.
+However, you can disable its installation if you already have OpenKruise operator installed in your cluster.
+
+> [!IMPORTANT]
+> Make sure you have required feature gates stated in [values.yaml](./values.yaml)/`kruise.featureGates`
+> opened in case of self-installation.
+
+## Installation
+
+To install the Soperator Helm chart, follow these steps:
+
+### Experimental OCI
+
+Make sure you have experimental OCI-based registries:
+```bash
+export HELM_EXPERIMENTAL_OCI=1
+````
+
+### Add the Helm Repository
+
+For the stable version:
+```bash
+helm repo add soperator oci://cr.eu-north1.nebius.cloud/soperator
+```
+
+For the dev version:
+```bash
+helm repo add soperator-dev oci://cr.eu-north1.nebius.cloud/soperator-unstable
+```
+
+### Update Helm Repositories
+
+```bash
+helm repo update
+```
+
+### Install Soperator
+
+```bash
+helm install soperator soperator[-dev]/helm-soperator --namespace soperator-system --create-namespace
+```

--- a/helm/soperator/templates/manager-rbac.yaml
+++ b/helm/soperator/templates/manager-rbac.yaml
@@ -52,6 +52,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps.kruise.io
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - batch
   resources:
   - cronjobs

--- a/helm/soperator/values.yaml
+++ b/helm/soperator/values.yaml
@@ -77,3 +77,8 @@ webhookService:
   type: ClusterIP
 certManager:
   enabled: false
+kruise:
+  installOperator: true
+  manager:
+    replicas: 1
+  featureGates: "ImagePullJobGate=true,RecreatePodWhenChangeVCTInCloneSetGate=true,StatefulSetAutoResizePVCGate=true,StatefulSetAutoDeletePVC=true,PreDownloadImageForInPlaceUpdate=true"

--- a/internal/check/consts.go
+++ b/internal/check/consts.go
@@ -1,0 +1,6 @@
+package check
+
+const (
+	ForceTrue  = true
+	ForceFalse = false
+)

--- a/internal/controller/clustercontroller/controller.go
+++ b/internal/controller/clustercontroller/controller.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
+	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,7 +105,7 @@ func (r SlurmClusterReconciler) ReconcileControllers(
 					}
 					stepLogger.V(1).Info("Retrieved dependencies")
 
-					if err = r.StatefulSet.Reconcile(stepCtx, cluster, &desired, deps...); err != nil {
+					if err = r.AdvancedStatefulSet.Reconcile(stepCtx, cluster, &desired, deps...); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
 						return errors.Wrap(err, "reconciling controller StatefulSet")
 					}
@@ -133,7 +133,7 @@ func (r SlurmClusterReconciler) ValidateControllers(
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	existing := &appsv1.StatefulSet{}
+	existing := &kruisev1b1.StatefulSet{}
 	err := r.Get(
 		ctx,
 		types.NamespacedName{

--- a/internal/controller/clustercontroller/exporter.go
+++ b/internal/controller/clustercontroller/exporter.go
@@ -121,6 +121,6 @@ func (r SlurmClusterReconciler) ReconcileExporter(
 		logger.Error(err, "Failed to reconcile exporter resources")
 		return errors.Wrap(err, "reconciling exporter resources")
 	}
-	logger.V(1).Info("Reconciled exporter resources")
+	logger.Info("Reconciled exporter resources")
 	return nil
 }

--- a/internal/controller/clustercontroller/login.go
+++ b/internal/controller/clustercontroller/login.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
+	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -203,7 +203,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 					}
 					stepLogger.V(1).Info("Retrieved dependencies")
 
-					if err = r.StatefulSet.Reconcile(stepCtx, cluster, &desired, deps...); err != nil {
+					if err = r.AdvancedStatefulSet.Reconcile(stepCtx, cluster, &desired, deps...); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
 						return errors.Wrap(err, "reconciling login StatefulSet")
 					}
@@ -219,7 +219,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 		logger.Error(err, "Failed to reconcile Slurm Login")
 		return errors.Wrap(err, "reconciling Slurm Login")
 	}
-	logger.V(1).Info("Reconciled Slurm Login")
+	logger.Info("Reconciled Slurm Login")
 	return nil
 }
 
@@ -231,7 +231,7 @@ func (r SlurmClusterReconciler) ValidateLogin(
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	existing := &appsv1.StatefulSet{}
+	existing := &kruisev1b1.StatefulSet{}
 	err := r.Get(
 		ctx,
 		types.NamespacedName{

--- a/internal/controller/clustercontroller/reconcile.go
+++ b/internal/controller/clustercontroller/reconcile.go
@@ -255,6 +255,8 @@ func (r *SlurmClusterReconciler) reconcile(ctx context.Context, cluster *slurmv1
 				return ctrl.Result{}, err
 			}
 
+			logger.Info("Reconciled Slurm Cluster")
+
 			return ctrl.Result{}, nil
 		},
 	)

--- a/internal/controller/clustercontroller/rest.go
+++ b/internal/controller/clustercontroller/rest.go
@@ -116,7 +116,7 @@ func (r SlurmClusterReconciler) ReconcileREST(
 		logger.Error(err, "Failed to reconcile REST resources")
 		return errors.Wrap(err, "reconciling REST resources")
 	}
-	logger.V(1).Info("Reconciled REST resources")
+	logger.Info("Reconciled REST resources")
 	return nil
 }
 

--- a/internal/controller/clustercontroller/worker.go
+++ b/internal/controller/clustercontroller/worker.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
+	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -257,7 +257,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 					}
 					stepLogger.V(1).Info("Retrieved dependencies")
 
-					if err = r.StatefulSet.Reconcile(stepCtx, cluster, &desired, deps...); err != nil {
+					if err = r.AdvancedStatefulSet.Reconcile(stepCtx, cluster, &desired, deps...); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
 						return errors.Wrap(err, "reconciling worker StatefulSet")
 					}
@@ -371,7 +371,7 @@ func (r SlurmClusterReconciler) ValidateWorkers(
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	existing := &appsv1.StatefulSet{}
+	existing := &kruisev1b1.StatefulSet{}
 	err := r.Get(
 		ctx,
 		types.NamespacedName{

--- a/internal/controller/reconciler/k8s_statefulset_advanced.go
+++ b/internal/controller/reconciler/k8s_statefulset_advanced.go
@@ -1,0 +1,70 @@
+package reconciler
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
+
+	slurmv1 "nebius.ai/slurm-operator/api/v1"
+	"nebius.ai/slurm-operator/internal/logfield"
+)
+
+type AdvancedStatefulSetReconciler struct {
+	*Reconciler
+}
+
+var (
+	_ patcher = &AdvancedStatefulSetReconciler{}
+)
+
+func NewAdvancedStatefulSetReconciler(r *Reconciler) *AdvancedStatefulSetReconciler {
+	return &AdvancedStatefulSetReconciler{
+		Reconciler: r,
+	}
+}
+
+func (r *AdvancedStatefulSetReconciler) Reconcile(
+	ctx context.Context,
+	cluster *slurmv1.SlurmCluster,
+	desired *kruisev1b1.StatefulSet,
+	deps ...metav1.Object,
+) error {
+	if err := r.reconcile(ctx, cluster, desired, r.patch, deps...); err != nil {
+		log.FromContext(ctx).
+			WithValues(logfield.ResourceKV(desired)...).
+			Error(err, "Failed to reconcile StatefulSet")
+		return errors.Wrap(err, "reconciling StatefulSet")
+	}
+	return nil
+}
+
+func (r *AdvancedStatefulSetReconciler) patch(existing, desired client.Object) (client.Patch, error) {
+	patchImpl := func(dst, src *kruisev1b1.StatefulSet) client.Patch {
+		original := dst.DeepCopy()
+
+		res := client.MergeFrom(original)
+
+		dst.Spec.Template.ObjectMeta.Labels = src.Spec.Template.ObjectMeta.Labels
+		// Copy annotations from the desired StatefulSet to the existing StatefulSet
+		// This is necessary because after the StatefulSet is created, patches recreate map of annotations and StatefulSet loses its annotations
+		for k, v := range src.Spec.Template.ObjectMeta.Annotations {
+			dst.Spec.Template.ObjectMeta.Annotations[k] = v
+		}
+		dst.Spec.Replicas = src.Spec.Replicas
+		dst.Spec.UpdateStrategy = src.Spec.UpdateStrategy
+		dst.Spec.Template.Spec = src.Spec.Template.Spec
+
+		if len(src.Spec.VolumeClaimTemplates) > 0 {
+			dst.Spec.VolumeClaimTemplates = append([]corev1.PersistentVolumeClaim{}, src.Spec.VolumeClaimTemplates...)
+		}
+
+		return res
+	}
+	return patchImpl(existing.(*kruisev1b1.StatefulSet), desired.(*kruisev1b1.StatefulSet)), nil
+}

--- a/internal/controller/reconciler/reconciler.go
+++ b/internal/controller/reconciler/reconciler.go
@@ -17,11 +17,12 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	apparmor "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	apparmor "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"nebius.ai/slurm-operator/internal/logfield"
@@ -193,6 +194,8 @@ func (r Reconciler) reconcile(
 				existing = &rbacv1.Role{}
 			case *rbacv1.RoleBinding:
 				existing = &rbacv1.RoleBinding{}
+			case *kruisev1b1.StatefulSet:
+				existing = &kruisev1b1.StatefulSet{}
 			case *otelv1beta1.OpenTelemetryCollector:
 				existing = &otelv1beta1.OpenTelemetryCollector{}
 			case *appsv1.Deployment:

--- a/internal/render/common/container.go
+++ b/internal/render/common/container.go
@@ -57,6 +57,10 @@ func RenderContainerMunge(container *values.Container, opts ...RenderOption) cor
 					},
 				},
 			},
+			TimeoutSeconds:   DefaultProbeTimeoutSeconds,
+			PeriodSeconds:    DefaultProbePeriodSeconds,
+			SuccessThreshold: DefaultProbeSuccessThreshold,
+			FailureThreshold: DefaultProbeFailureThreshold,
 		},
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -68,6 +72,10 @@ func RenderContainerMunge(container *values.Container, opts ...RenderOption) cor
 					},
 				},
 			},
+			TimeoutSeconds:   DefaultProbeTimeoutSeconds,
+			PeriodSeconds:    DefaultProbePeriodSeconds,
+			SuccessThreshold: DefaultProbeSuccessThreshold,
+			FailureThreshold: DefaultProbeFailureThreshold,
 		},
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
@@ -78,5 +86,7 @@ func RenderContainerMunge(container *values.Container, opts ...RenderOption) cor
 			Limits:   limits,
 			Requests: container.Resources,
 		},
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 	}
 }

--- a/internal/render/common/pod.go
+++ b/internal/render/common/pod.go
@@ -8,6 +8,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 )
 
+const (
+	DefaultPodTerminationGracePeriodSeconds = int64(30)
+)
+
 func MergePodTemplateSpecs(
 	baseSpec corev1.PodTemplateSpec,
 	refSpec *corev1.PodTemplateSpec,

--- a/internal/render/common/probe.go
+++ b/internal/render/common/probe.go
@@ -1,0 +1,8 @@
+package common
+
+const (
+	DefaultProbeTimeoutSeconds   = 1
+	DefaultProbePeriodSeconds    = 10
+	DefaultProbeSuccessThreshold = 1
+	DefaultProbeFailureThreshold = 3
+)

--- a/internal/render/common/volume.go
+++ b/internal/render/common/volume.go
@@ -16,6 +16,10 @@ import (
 	"nebius.ai/slurm-operator/internal/values"
 )
 
+const (
+	DefaultFileMode = int32(0420)
+)
+
 // region PVC template
 
 func RenderVolumeClaimTemplates(
@@ -34,6 +38,7 @@ func RenderVolumeClaimTemplates(
 			renderVolumeClaimTemplate(componentType, namespace, clusterName, template.Name, *template.Spec),
 		)
 	}
+
 	return res
 }
 
@@ -221,6 +226,7 @@ func RenderVolumeMungeKey(clusterName string) corev1.Volume {
 						Mode: ptr.To(consts.SecretMungeKeyFileMode),
 					},
 				},
+				DefaultMode: ptr.To(DefaultFileMode),
 			},
 		},
 	}
@@ -269,6 +275,7 @@ func RenderVolumeSecurityLimits(clusterName string, componentType consts.Compone
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: naming.BuildConfigMapSecurityLimitsName(componentType, clusterName),
 				},
+				DefaultMode: ptr.To(DefaultFileMode),
 			},
 		},
 	}
@@ -301,6 +308,7 @@ func RenderVolumeRESTJWTKey(clusterName string) corev1.Volume {
 						Mode: ptr.To(consts.SecretRESTJWTKeyFileMode),
 					},
 				},
+				DefaultMode: ptr.To(DefaultFileMode),
 			},
 		},
 	}
@@ -389,6 +397,7 @@ func RenderVolumeSshdKeys(sshdKeysSecretName string) corev1.Volume {
 						Mode: ptr.To(consts.SecretSshdKeysPublicFileMode),
 					},
 				},
+				DefaultMode: ptr.To(DefaultFileMode),
 			},
 		},
 	}

--- a/internal/render/controller/container.go
+++ b/internal/render/controller/container.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	corev1 "k8s.io/api/core/v1"
+
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 
 	"nebius.ai/slurm-operator/internal/consts"
@@ -41,6 +42,10 @@ func renderContainerSlurmctld(container *values.Container, customMounts []slurmv
 					},
 				},
 			},
+			TimeoutSeconds:   common.DefaultProbeTimeoutSeconds,
+			PeriodSeconds:    common.DefaultProbePeriodSeconds,
+			SuccessThreshold: common.DefaultProbeSuccessThreshold,
+			FailureThreshold: common.DefaultProbeFailureThreshold,
 		},
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
@@ -53,5 +58,7 @@ func renderContainerSlurmctld(container *values.Container, customMounts []slurmv
 			Limits:   limits,
 			Requests: container.Resources,
 		},
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 	}
 }

--- a/internal/render/login/container.go
+++ b/internal/render/login/container.go
@@ -55,6 +55,10 @@ func renderContainerSshd(
 					Port: intstr.FromInt32(container.Port),
 				},
 			},
+			TimeoutSeconds:   common.DefaultProbeTimeoutSeconds,
+			PeriodSeconds:    common.DefaultProbePeriodSeconds,
+			SuccessThreshold: common.DefaultProbeSuccessThreshold,
+			FailureThreshold: common.DefaultProbeFailureThreshold,
 		},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: ptr.To(true),
@@ -68,5 +72,7 @@ func renderContainerSshd(
 			Limits:   limits,
 			Requests: container.Resources,
 		},
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 	}
 }

--- a/internal/render/login/volume.go
+++ b/internal/render/login/volume.go
@@ -2,6 +2,7 @@ package login
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"nebius.ai/slurm-operator/internal/consts"
@@ -90,6 +91,7 @@ func renderVolumeSshdConfigs(sshdConfigMapName string) corev1.Volume {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: sshdConfigMapName,
 				},
+				DefaultMode: ptr.To(common.DefaultFileMode),
 			},
 		},
 	}

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -41,8 +41,8 @@ func renderContainerToolkitValidation(container *values.Container) corev1.Contai
 		VolumeMounts: []corev1.VolumeMount{
 			renderVolumeMountNvidia(),
 		},
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		TerminationMessagePath:   "/dev/termination-log",
 	}
 }
 
@@ -120,7 +120,10 @@ func renderContainerSlurmd(
 					},
 				},
 			},
-			PeriodSeconds: 1,
+			PeriodSeconds:    1,
+			TimeoutSeconds:   common.DefaultProbeTimeoutSeconds,
+			SuccessThreshold: common.DefaultProbeSuccessThreshold,
+			FailureThreshold: common.DefaultProbeFailureThreshold,
 		},
 		// PreStop lifecycle hook to update the node state to down in case of worker deletion
 		// Node will not be deleted from the slurm cluster if the job is still running
@@ -147,7 +150,9 @@ func renderContainerSlurmd(
 			},
 			ProcMount: ptr.To(corev1.UnmaskedProcMount),
 		},
-		Resources: resources,
+		Resources:                resources,
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 	}, nil
 }
 
@@ -172,7 +177,8 @@ func renderSlurmdEnv(
 			Name: "K8S_POD_NAME",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.name",
+					APIVersion: corev1.SchemeGroupVersion.Version,
+					FieldPath:  "metadata.name",
 				},
 			},
 		},
@@ -180,7 +186,8 @@ func renderSlurmdEnv(
 			Name: "K8S_POD_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.namespace",
+					APIVersion: corev1.SchemeGroupVersion.Version,
+					FieldPath:  "metadata.namespace",
 				},
 			},
 		},
@@ -188,7 +195,8 @@ func renderSlurmdEnv(
 			Name: "INSTANCE_ID",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "spec.nodeName",
+					APIVersion: corev1.SchemeGroupVersion.Version,
+					FieldPath:  "spec.nodeName",
 				},
 			},
 		},

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 
+	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +19,7 @@ import (
 	"nebius.ai/slurm-operator/internal/values"
 )
 
-// RenderStatefulSet renders new [appsv1.StatefulSet] containing Slurm worker pods
+// RenderStatefulSet renders new [kruisev1b1.StatefulSet] containing Slurm worker pods
 func RenderStatefulSet(
 	namespace,
 	clusterName string,
@@ -29,7 +30,7 @@ func RenderStatefulSet(
 	worker *values.SlurmWorker,
 	slurmTopologyConfigMapRefName string,
 	workerFeatures []slurmv1.WorkerFeature,
-) (appsv1.StatefulSet, error) {
+) (kruisev1b1.StatefulSet, error) {
 	labels := common.RenderLabels(consts.ComponentTypeWorker, clusterName)
 	matchLabels := common.RenderMatchLabels(consts.ComponentTypeWorker, clusterName)
 
@@ -43,7 +44,7 @@ func RenderStatefulSet(
 		clusterName, secrets, volumeSources, worker, slurmTopologyConfigMapRefName,
 	)
 	if err != nil {
-		return appsv1.StatefulSet{}, fmt.Errorf("rendering volumes and claim template specs: %w", err)
+		return kruisev1b1.StatefulSet{}, fmt.Errorf("rendering volumes and claim template specs: %w", err)
 	}
 
 	// Since 1.29 is native sidecar support, we can use the native restart policy
@@ -67,7 +68,7 @@ func RenderStatefulSet(
 		workerFeatures,
 	)
 	if err != nil {
-		return appsv1.StatefulSet{}, fmt.Errorf("rendering slurmd container: %w", err)
+		return kruisev1b1.StatefulSet{}, fmt.Errorf("rendering slurmd container: %w", err)
 	}
 
 	replicas := &worker.StatefulSet.Replicas
@@ -85,32 +86,40 @@ func RenderStatefulSet(
 		Containers: []corev1.Container{
 			slurmdContainer,
 		},
-		Volumes: volumes,
+		Volumes:   volumes,
+		DNSPolicy: corev1.DNSClusterFirst,
 		DNSConfig: &corev1.PodDNSConfig{
 			Searches: []string{
 				naming.BuildServiceFQDN(consts.ComponentTypeWorker, namespace, clusterName),
 			},
 		},
+		RestartPolicy:                 corev1.RestartPolicyAlways,
+		TerminationGracePeriodSeconds: ptr.To(common.DefaultPodTerminationGracePeriodSeconds),
+		SecurityContext:               &corev1.PodSecurityContext{},
+		SchedulerName:                 corev1.DefaultSchedulerName,
 	}
 
 	if worker.PriorityClass != "" {
 		spec.PriorityClassName = worker.PriorityClass
 	}
 
-	return appsv1.StatefulSet{
+	return kruisev1b1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      worker.StatefulSet.Name,
 			Namespace: namespace,
 			Labels:    labels,
 		},
-		Spec: appsv1.StatefulSetSpec{
+		Spec: kruisev1b1.StatefulSetSpec{
 			PodManagementPolicy: consts.PodManagementPolicy,
 			ServiceName:         worker.Service.Name,
 			Replicas:            replicas,
-			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+			UpdateStrategy: kruisev1b1.StatefulSetUpdateStrategy{
 				Type: appsv1.RollingUpdateStatefulSetStrategyType,
-				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
-					MaxUnavailable: &worker.StatefulSet.MaxUnavailable,
+				RollingUpdate: &kruisev1b1.RollingUpdateStatefulSetStrategy{
+					MaxUnavailable:  &worker.StatefulSet.MaxUnavailable,
+					PodUpdatePolicy: kruisev1b1.RecreatePodUpdateStrategyType,
+					Partition:       ptr.To(int32(0)),
+					MinReadySeconds: ptr.To(int32(0)),
 				},
 			},
 			Selector: &metav1.LabelSelector{
@@ -122,6 +131,9 @@ func RenderStatefulSet(
 				clusterName,
 				pvcTemplateSpecs,
 			),
+			VolumeClaimUpdateStrategy: kruisev1b1.VolumeClaimUpdateStrategy{
+				Type: kruisev1b1.OnPodRollingUpdateVolumeClaimUpdateStrategyType,
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,

--- a/internal/render/worker/volume.go
+++ b/internal/render/worker/volume.go
@@ -118,6 +118,7 @@ func renderSupervisordConfigMap(name string) corev1.Volume {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: name,
 				},
+				DefaultMode: ptr.To(common.DefaultFileMode),
 			},
 		},
 	}
@@ -134,6 +135,7 @@ func renderVolumeNvidia() corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: consts.VolumeMountPathNvidia,
+				Type: ptr.To(corev1.HostPathType("")),
 			},
 		},
 	}
@@ -159,6 +161,7 @@ func renderVolumeBoot() corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: consts.VolumeMountPathBoot,
+				Type: ptr.To(corev1.HostPathType("")),
 			},
 		},
 	}
@@ -186,6 +189,7 @@ func renderVolumeNCCLTopology(clusterName string) corev1.Volume {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: naming.BuildConfigMapNCCLTopologyName(clusterName),
 				},
+				DefaultMode: ptr.To(common.DefaultFileMode),
 			},
 		},
 	}
@@ -238,6 +242,7 @@ func renderVolumeSysctl(clusterName string) corev1.Volume {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: naming.BuildConfigMapSysctlName(clusterName),
 				},
+				DefaultMode: ptr.To(common.DefaultFileMode),
 			},
 		},
 	}
@@ -265,6 +270,7 @@ func renderVolumeSshdConfigs(sshdConfigMapName string) corev1.Volume {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: sshdConfigMapName,
 				},
+				DefaultMode: ptr.To(common.DefaultFileMode),
 			},
 		},
 	}

--- a/release_helm.sh
+++ b/release_helm.sh
@@ -40,6 +40,9 @@ chart() {
   shift 1
   CHART_TARGET="${CHART_NAME}-${CHART_VERSION}.tgz"
 
+  echo "Updating dependencies of chart ${CHART_NAME}."
+  helm dependency update "${HELM_PATH}/${CHART_NAME}"
+
   echo "Packaging chart ${CHART_NAME} as ${CHART_TARGET}."
   helm package -d "${RELEASE_PATH}" "${HELM_PATH}/${CHART_NAME}"
 


### PR DESCRIPTION
This PR adds integration with Kruise’s Advanced StatefulSets - enables Soperator to leverage Kruise’s extended StatefulSet capabilities.

This feature requires that the Kruise controller is deployed and properly configured in the cluster, which is stated in Soperator Helm chart's `README.md`.