### PR TITLE
Allow launching background processes in login container

### DIFF
--- a/images/login/sshd_entrypoint.sh
+++ b/images/login/sshd_entrypoint.sh
@@ -25,5 +25,10 @@ echo "Complement jail rootfs"
 echo "Waiting until munge started"
 while [ ! -S "/run/munge/munge.socket.2" ]; do sleep 2; done
 
+echo "Run jail /etc/rc.local if exists"
+if [ -f "/mnt/jail/etc/rc.local" ]; then
+    . /mnt/jail/etc/rc.local &
+fi
+
 echo "Start sshd daemon"
 /usr/sbin/sshd -D -e -f /mnt/ssh-configs/sshd_config


### PR DESCRIPTION
There are use cases where some commands will need to be executed after login container has been started.

Proposal is making use of /etc/rc.local file from the SysV init startup scripts days and run it in background when it exists in the jail filesystem.

