### PR TITLE
NOISSUE: reduction of DebugFlags and removal of the preStop hook

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -149,7 +149,7 @@ type SlurmConfig struct {
 	// Defines specific subsystems which should provide more detailed event logging.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs"
+	// +kubebuilder:default="Priority,Script,SelectType,Steps"
 	// +kubebuilder:validation:Pattern="^((Accrue|Agent|AuditRPCs|Backfill|BackfillMap|BurstBuffer|Cgroup|ConMgr|CPU_Bind|CpuFrequency|Data|DBD_Agent|Dependency|Elasticsearch|Energy|Federation|FrontEnd|Gres|Hetjob|Gang|GLOB_SILENCE|JobAccountGather|JobComp|JobContainer|License|Network|NetworkRaw|NodeFeatures|NO_CONF_HASH|Power|Priority|Profile|Protocol|Reservation|Route|Script|SelectType|Steps|Switch|TLS|TraceJobs|Triggers)(,)?)+$"
 	DebugFlags *string `json:"debugFlags,omitempty"`
 	// Defines specific file to run the epilog when job ends. Default value is no epilog

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -3077,7 +3077,7 @@ spec:
                     format: int32
                     type: integer
                   debugFlags:
-                    default: Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs
+                    default: Priority,Script,SelectType,Steps
                     description: Defines specific subsystems which should provide
                       more detailed event logging.
                     pattern: ^((Accrue|Agent|AuditRPCs|Backfill|BackfillMap|BurstBuffer|Cgroup|ConMgr|CPU_Bind|CpuFrequency|Data|DBD_Agent|Dependency|Elasticsearch|Energy|Federation|FrontEnd|Gres|Hetjob|Gang|GLOB_SILENCE|JobAccountGather|JobComp|JobContainer|License|Network|NetworkRaw|NodeFeatures|NO_CONF_HASH|Power|Priority|Profile|Protocol|Reservation|Route|Script|SelectType|Steps|Switch|TLS|TraceJobs|Triggers)(,)?)+$

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -15879,7 +15879,7 @@ spec:
                     format: int32
                     type: integer
                   debugFlags:
-                    default: Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs
+                    default: Priority,Script,SelectType,Steps
                     description: Defines specific subsystems which should provide
                       more detailed event logging.
                     pattern: ^((Accrue|Agent|AuditRPCs|Backfill|BackfillMap|BurstBuffer|Cgroup|ConMgr|CPU_Bind|CpuFrequency|Data|DBD_Agent|Dependency|Elasticsearch|Energy|Federation|FrontEnd|Gres|Hetjob|Gang|GLOB_SILENCE|JobAccountGather|JobComp|JobContainer|License|Network|NetworkRaw|NodeFeatures|NO_CONF_HASH|Power|Priority|Profile|Protocol|Reservation|Route|Script|SelectType|Steps|Switch|TLS|TraceJobs|Triggers)(,)?)+$

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -15879,7 +15879,7 @@ spec:
                     format: int32
                     type: integer
                   debugFlags:
-                    default: Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs
+                    default: Priority,Script,SelectType,Steps
                     description: Defines specific subsystems which should provide
                       more detailed event logging.
                     pattern: ^((Accrue|Agent|AuditRPCs|Backfill|BackfillMap|BurstBuffer|Cgroup|ConMgr|CPU_Bind|CpuFrequency|Data|DBD_Agent|Dependency|Elasticsearch|Energy|Federation|FrontEnd|Gres|Hetjob|Gang|GLOB_SILENCE|JobAccountGather|JobComp|JobContainer|License|Network|NetworkRaw|NodeFeatures|NO_CONF_HASH|Power|Priority|Profile|Protocol|Reservation|Route|Script|SelectType|Steps|Switch|TLS|TraceJobs|Triggers)(,)?)+$

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -125,19 +125,6 @@ func renderContainerSlurmd(
 			SuccessThreshold: common.DefaultProbeSuccessThreshold,
 			FailureThreshold: common.DefaultProbeFailureThreshold,
 		},
-		// PreStop lifecycle hook to update the node state to down in case of worker deletion
-		// Node will not be deleted from the slurm cluster if the job is still running
-		Lifecycle: &corev1.Lifecycle{
-			PreStop: &corev1.LifecycleHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{
-						"/bin/bash",
-						"-c",
-						"scontrol update nodename=$(hostname) state=down reason=preStop && scontrol delete nodename=$(hostname);",
-					},
-				},
-			},
-		},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
Default DebugFlags are reduced to prevent job timeouts on large clusters.
preStop hooks are removed because, when jobs are suspended and workers are restarted, the hooks may deallocate workers still associated with suspended jobs. This leads to controller inconsistencies and failure to recover jobs.
Additionally, preStop hooks are unreliable during instance terminations and kernel panics, where they often do not execute.