### PR TITLE
Adding DCGM Exporter to helm chart and values

### DIFF
--- a/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/epilog.sh
+++ b/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/epilog.sh
@@ -22,6 +22,9 @@ if [ -n "$SLURM_JOB_GPUS" ]; then
 fi
 
 echo "Unmap the Slurm job with DCGM metrics"
+# set in hpcJobMapDir in soperator/helm/soperator-fluxcd/values.yaml
+#   and dcgm_job_map_dir in nebius-solution-library/soperator/modules/slurm/variables.tf
+#   check those before changing it here
 metrics_dir="/var/run/nebius/slurm"
 
 if [[ -z "${CUDA_VISIBLE_DEVICES:-}" ]]; then

--- a/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/epilog.sh
+++ b/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/epilog.sh
@@ -20,3 +20,19 @@ if [ -n "$SLURM_JOB_GPUS" ]; then
     exit 0
     fi
 fi
+
+echo "Unmap the Slurm job with DCGM metrics"
+metrics_dir="/var/run/nebius/slurm"
+
+if [[ -z "${CUDA_VISIBLE_DEVICES:-}" ]]; then
+    echo "No GPU devices are requested by user" >&2
+    exit 0
+fi
+
+IFS=',' read -ra cuda_devs <<< "$CUDA_VISIBLE_DEVICES"
+
+for gpu_id in "${cuda_devs[@]}"; do
+    [[ -z "$gpu_id" ]] && continue
+    echo "Removing $metrics_dir/${gpu_id:-99}"
+    rm -f "${METRICS_DIR:-}/${gpu_id:-99}" || echo "Unable to remove file ${METRICS_DIR:-}/${gpu_id:-99}"
+done

--- a/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/prolog.sh
+++ b/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/prolog.sh
@@ -21,6 +21,9 @@ if [ -n "$SLURM_JOB_GPUS" ]; then
 fi
 
 echo "Map the Slurm job with DCGM metrics"
+# set in hpcJobMapDir in soperator/helm/soperator-fluxcd/values.yaml
+#   and dcgm_job_map_dir in nebius-solution-library/soperator/modules/slurm/variables.tf
+#   check those before changing it here
 metrics_dir="/var/run/nebius/slurm"
 
 if [[ -z "${CUDA_VISIBLE_DEVICES:-}" ]]; then

--- a/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/prolog.sh
+++ b/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/prolog.sh
@@ -19,3 +19,28 @@ if [ -n "$SLURM_JOB_GPUS" ]; then
     exit 0
     fi
 fi
+
+echo "Map the Slurm job with DCGM metrics"
+metrics_dir="/var/run/nebius/slurm"
+
+if [[ -z "${CUDA_VISIBLE_DEVICES:-}" ]]; then
+    echo "No GPU devices are requested by user" >&2
+    exit 0
+fi
+
+if [[ ! -d "$metrics_dir" ]]; then
+    if ! mkdir -p "$metrics_dir"; then
+        echo "Unable to create the data dir metrics_dir" >&2
+        exit 0
+    fi
+fi
+
+IFS=',' read -ra cuda_devs <<< "$CUDA_VISIBLE_DEVICES"
+
+for gpu_id in "${cuda_devs[@]}"; do
+    [[ -z "$gpu_id" ]] && continue
+    echo "Writing $metrics_dir/$gpu_id"
+    if ! printf "%s" "${SLURM_JOB_ID:-0}" > "$metrics_dir/$gpu_id"; then
+        echo "Unable to write job file $metrics_dir/$gpu_id"
+    fi
+done

--- a/helm/soperator-fluxcd/templates/dcgm-exporter.yaml
+++ b/helm/soperator-fluxcd/templates/dcgm-exporter.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.observability.enabled .Values.observability.dcgmExporter.enabled }}
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: {{ include "soperator-fluxcd.fullname" . }}-dcgm-exporter
+  labels:
+  {{- include "soperator-fluxcd.labels" . | nindent 4 }}
+spec:
+  chart:
+    spec:
+      chart: soperator-dcgm-exporter
+      interval: {{ .Values.observability.dcgmExporter.interval }}
+      sourceRef:
+        kind: HelmRepository
+        name: {{ include "soperator-fluxcd.fullname" . }}-dcgm-exporter
+      version: {{ .Values.observability.dcgmExporter.version }}
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  interval: {{ .Values.observability.dcgmExporter.interval }}
+  timeout: {{ .Values.observability.dcgmExporter.timeout }}
+  releaseName: {{ .Values.observability.dcgmExporter.releaseName }}
+  targetNamespace: {{ .Values.observability.dcgmExporter.namespace }}
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  values:
+    dcgmHpcJobMappingDir: {{ .Values.observability.dcgmExporter.values.hpcJobMapDir }}
+    {{- if .Values.observability.dcgmExporter.values.resources }}
+    daemonSet:
+      nvidiaDcgmExporter:
+        resources:
+          {{- toYaml .Values.observability.dcgmExporter.values.resources | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/helm/soperator-fluxcd/templates/dcgm-exporter.yaml
+++ b/helm/soperator-fluxcd/templates/dcgm-exporter.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   chart:
     spec:
-      chart: soperator-dcgm-exporter
+      chart: helm-soperator-dcgm-exporter
       interval: {{ .Values.observability.dcgmExporter.interval }}
       sourceRef:
         kind: HelmRepository
-        name: {{ include "soperator-fluxcd.fullname" . }}-dcgm-exporter
+        name: {{ include "soperator-fluxcd.fullname" . }}-soperator
       version: {{ .Values.observability.dcgmExporter.version }}
   install:
     crds: CreateReplace

--- a/helm/soperator-fluxcd/templates/helmrepository.yaml
+++ b/helm/soperator-fluxcd/templates/helmrepository.yaml
@@ -130,15 +130,4 @@ spec:
   interval: {{ .Values.helmRepository.interval }}
   url: {{ .Values.helmRepository.victoriaMetrics.url }}
   type: {{ .Values.helmRepository.victoriaMetrics.type }}
----
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: {{ include "soperator-fluxcd.fullname" . }}-dcgm-exporter
-  labels:
-    {{- include "soperator-fluxcd.labels" . | nindent 4 }}
-spec:
-  interval: {{ .Values.helmRepository.interval }}
-  url: {{ .Values.helmRepository.dcgmExporter.url }}
-  type: {{ .Values.helmRepository.dcgmExporter.type }}
 {{- end }}

--- a/helm/soperator-fluxcd/templates/helmrepository.yaml
+++ b/helm/soperator-fluxcd/templates/helmrepository.yaml
@@ -130,4 +130,15 @@ spec:
   interval: {{ .Values.helmRepository.interval }}
   url: {{ .Values.helmRepository.victoriaMetrics.url }}
   type: {{ .Values.helmRepository.victoriaMetrics.type }}
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: {{ include "soperator-fluxcd.fullname" . }}-dcgm-exporter
+  labels:
+    {{- include "soperator-fluxcd.labels" . | nindent 4 }}
+spec:
+  interval: {{ .Values.helmRepository.interval }}
+  url: {{ .Values.helmRepository.dcgmExporter.url }}
+  type: {{ .Values.helmRepository.dcgmExporter.type }}
 {{- end }}

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -30,7 +30,6 @@ helmRepository:
   victoriaMetrics:
     url: https://victoriametrics.github.io/helm-charts/
     type: default
-
 ns:
   enabled: true
   interval: 5m

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -160,7 +160,7 @@ observability:
     enabled: true
     interval: 5m
     timeout: 5m
-    version: 1.19.0-463aee07
+    version: 1.19.0
     namespace: soperator
     releaseName: soperator-dcgm-exporter
     values:

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -30,9 +30,6 @@ helmRepository:
   victoriaMetrics:
     url: https://victoriametrics.github.io/helm-charts/
     type: default
-  dcgmExporter:
-    url: oci://cr.eu-north1.nebius.cloud/soperator-unstable/helm-soperator-dcgm-exporter
-    type: oci
 
 ns:
   enabled: true

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -30,6 +30,10 @@ helmRepository:
   victoriaMetrics:
     url: https://victoriametrics.github.io/helm-charts/
     type: default
+  dcgmExporter:
+    url: oci://cr.eu-north1.nebius.cloud/soperator-unstable/helm-soperator-dcgm-exporter
+    type: oci
+
 ns:
   enabled: true
   interval: 5m
@@ -156,6 +160,16 @@ observability:
         accessMode: ReadWriteOnce
       resources: {}
     overrideValues: null
+  dcgmExporter:
+    enabled: true
+    interval: 5m
+    timeout: 5m
+    version: 1.19.0-463aee07
+    namespace: soperator
+    releaseName: soperator-dcgm-exporter
+    values:
+      hpcJobMapDir: /var/run/nebius/slurm
+      resources: {}
 securityProfilesOperator:
   enabled: true
   interval: 5m


### PR DESCRIPTION
This enabled installing the exporter separate from GPU Operator, which let's us configure [HPC job mapping](https://github.com/NVIDIA/dcgm-exporter/tree/main?tab=readme-ov-file#how-to-include-hpc-jobs-in-metric-labels) feature

https://github.com/nebius/soperator/issues/907