### PR TITLE
Basic Helm chart for DCGM exporter with HPC job mapping

### DIFF
--- a/helm/soperator-dcgm-exporter/.helmignore
+++ b/helm/soperator-dcgm-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/soperator-dcgm-exporter/Chart.yaml
+++ b/helm/soperator-dcgm-exporter/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: helm-soperator-dcgm-exporter
+description: A Helm chart for Nvidia DCGM Exporter
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/helm/soperator-dcgm-exporter/templates/_helpers.tpl
+++ b/helm/soperator-dcgm-exporter/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "soperator-dcgm-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "soperator-dcgm-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "soperator-dcgm-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "soperator-dcgm-exporter.labels" -}}
+helm.sh/chart: {{ include "soperator-dcgm-exporter.chart" . }}
+{{ include "soperator-dcgm-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "soperator-dcgm-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "soperator-dcgm-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/soperator-dcgm-exporter/templates/configmap.yaml
+++ b/helm/soperator-dcgm-exporter/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "soperator-dcgm-exporter.fullname" . }}-metrics
+  labels:
+  {{- include "soperator-dcgm-exporter.labels" . | nindent 4 }}
+data:
+  dcgm-metrics.csv: {{ .Values.exporterMetricsConfigMap.dcgmMetricsCsv | toYaml | indent 1 }}

--- a/helm/soperator-dcgm-exporter/templates/daemonset.yaml
+++ b/helm/soperator-dcgm-exporter/templates/daemonset.yaml
@@ -1,0 +1,137 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "soperator-dcgm-exporter.fullname" . }}-ds
+  labels:
+    app: nvidia-dcgm-exporter
+  {{- include "soperator-dcgm-exporter.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-dcgm-exporter
+    {{- include "soperator-dcgm-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app: nvidia-dcgm-exporter
+      {{- include "soperator-dcgm-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - env:
+        - name: DCGM_EXPORTER_LISTEN
+          value: :{{ .Values.metricsPort }}
+        - name: DCGM_EXPORTER_KUBERNETES
+          value: "true"
+        - name: DCGM_EXPORTER_COLLECTORS
+          value: /etc/dcgm-exporter/dcgm-metrics.csv
+        - name: DCGM_HPC_JOB_MAPPING_DIR
+          value: {{ .Values.dcgmHpcJobMappingDir }}
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ quote .Values.kubernetesClusterDomain }}
+        image: {{ .Values.daemonSet.nvidiaDcgmExporter.image.repository }}:{{
+          .Values.daemonSet.nvidiaDcgmExporter.image.tag | default .Chart.AppVersion
+          }}
+        imagePullPolicy: IfNotPresent
+        name: nvidia-dcgm-exporter
+        ports:
+        - containerPort: {{ .Values.metricsPort }}
+          name: metrics
+          protocol: TCP
+        resources: {{- toYaml .Values.daemonSet.nvidiaDcgmExporter.resources | nindent 10 }}
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/kubelet/pod-resources
+          name: pod-gpu-resources
+          readOnly: true
+        - mountPath: /etc/dcgm-exporter/dcgm-metrics.csv
+          name: metrics-config
+          readOnly: true
+          subPath: dcgm-metrics.csv
+        - mountPath: {{ .Values.dcgmHpcJobMappingDir }}
+          mountPropagation: HostToContainer
+          name: hpc-jobs-dir
+      dnsPolicy: ClusterFirst
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - |
+          mkdir -p {{ .Values.dcgmHpcJobMappingDir }}
+        env:
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ quote .Values.kubernetesClusterDomain }}
+        image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
+        imagePullPolicy: IfNotPresent
+        name: create-hpc-jobs-dir
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var
+          mountPropagation: HostToContainer
+          name: host-var
+      - args:
+        - until [ -f /run/nvidia/validations/toolkit-ready ]; do echo waiting for nvidia container stack to be setup; sleep 5; done 
+        command:
+        - sh
+        - -c
+        env:
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ quote .Values.kubernetesClusterDomain }}
+        image: {{ .Values.daemonSet.toolkitValidation.image.repository }}:{{ .Values.daemonSet.toolkitValidation.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: IfNotPresent
+        name: toolkit-validation
+        resources: {}
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /run/nvidia
+          mountPropagation: HostToContainer
+          name: run-nvidia
+      nodeSelector: {{- toYaml .Values.daemonSet.nodeSelector | nindent 8 }}
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      runtimeClassName: nvidia
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: nvidia-dcgm-exporter
+      serviceAccountName: {{ include "soperator-dcgm-exporter.fullname" . }}-sa
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet/pod-resources
+          type: ""
+        name: pod-gpu-resources
+      - hostPath:
+          path: /run/nvidia
+          type: ""
+        name: run-nvidia
+      - hostPath:
+          path: {{ .Values.dcgmHpcJobMappingDir }}
+          type: ""
+        name: hpc-jobs-dir
+      - hostPath:
+          path: /var
+          type: ""
+        name: host-var
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: dcgm-metrics.csv
+            path: dcgm-metrics.csv
+          name: {{ include "soperator-dcgm-exporter.fullname" . }}-metrics
+        name: metrics-config

--- a/helm/soperator-dcgm-exporter/templates/role.yaml
+++ b/helm/soperator-dcgm-exporter/templates/role.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "soperator-dcgm-exporter.fullname" . }}-role
+  labels:
+    app: nvidia-dcgm-exporter
+  {{- include "soperator-dcgm-exporter.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  verbs:
+  - get
+  - list

--- a/helm/soperator-dcgm-exporter/templates/rolebinding.yaml
+++ b/helm/soperator-dcgm-exporter/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "soperator-dcgm-exporter.fullname" . }}-role-binding
+  labels:
+    app: nvidia-dcgm-exporter
+  {{- include "soperator-dcgm-exporter.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "soperator-dcgm-exporter.fullname" . }}-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "soperator-dcgm-exporter.fullname" . }}-sa
+  namespace: '{{ .Release.Namespace }}'

--- a/helm/soperator-dcgm-exporter/templates/service.yaml
+++ b/helm/soperator-dcgm-exporter/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "soperator-dcgm-exporter.fullname" . }}-svc
+  labels:
+    app: nvidia-dcgm-exporter
+  {{- include "soperator-dcgm-exporter.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/scrape: "true"
+spec:
+  type: {{ .Values.serviceType }}
+  selector:
+    app: nvidia-dcgm-exporter
+    {{- include "soperator-dcgm-exporter.selectorLabels" . | nindent 4 }}
+  ports:
+  - name: gpu-metrics
+    port: {{ .Values.metricsPort }}
+    protocol: TCP
+    targetPort: {{ .Values.metricsPort }}

--- a/helm/soperator-dcgm-exporter/templates/serviceaccount.yaml
+++ b/helm/soperator-dcgm-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "soperator-dcgm-exporter.fullname" . }}-sa
+  labels:
+    app: nvidia-dcgm-exporter
+  {{- include "soperator-dcgm-exporter.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}

--- a/helm/soperator-dcgm-exporter/templates/servicemonitor.yaml
+++ b/helm/soperator-dcgm-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "soperator-dcgm-exporter.fullname" . }}-service-monitor
+  labels:
+    app: nvidia-dcgm-exporter
+  {{- include "soperator-dcgm-exporter.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  - interval: 15s
+    path: /metrics
+    port: gpu-metrics
+    relabelings:
+    - action: replace
+      regex: nvidia-dcgm-exporter
+      replacement: dcgm-exporter
+      sourceLabels:
+      - __meta_kubernetes_pod_label_app
+      targetLabel: app_kubernetes_io_name
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - soperator
+  selector:
+    matchLabels:
+      app: nvidia-dcgm-exporter

--- a/helm/soperator-dcgm-exporter/values.yaml
+++ b/helm/soperator-dcgm-exporter/values.yaml
@@ -1,0 +1,95 @@
+kubernetesClusterDomain: cluster.local
+
+dcgmHpcJobMappingDir: /var/run/nebius/slurm
+
+metricsPort: 9400
+
+serviceType: ClusterIP
+
+daemonSet:
+  # init container
+  toolkitValidation:
+    image:
+      repository: cr.eu-north1.nebius.cloud/marketplace/nebius/nvidia-gpu-operator/image/gpu-operator-validator
+      tag: v24.6.2
+
+  nvidiaDcgmExporter:
+    image:
+      repository: cr.eu-north1.nebius.cloud/marketplace/nebius/nvidia-gpu-operator/image/dcgm-exporter
+      tag: 3.3.7-3.5.0-ubuntu22.04
+
+    env:
+      dcgmExporterListen: :9400
+
+    resources: {}
+
+  nodeSelector:
+    nvidia.com/gpu.deploy.dcgm-exporter: "true"
+
+serviceAccount:
+  annotations: {}
+
+exporterMetricsConfigMap:
+  dcgmMetricsCsv: |-
+    # Format
+    # If line starts with a '#' it is considered a comment
+    # DCGM FIELD                                                      ,Prometheus metric type ,help message
+    # Clocks
+    DCGM_FI_DEV_SM_CLOCK                                              ,gauge                  ,SM clock frequency (in MHz).
+    DCGM_FI_DEV_MEM_CLOCK                                             ,gauge                  ,Memory clock frequency (in MHz).
+    # Temperature
+    DCGM_FI_DEV_MEMORY_TEMP                                           ,gauge                  ,Memory temperature (in C).
+    DCGM_FI_DEV_GPU_TEMP                                              ,gauge                  ,GPU temperature (in C).
+    # Power
+    DCGM_FI_DEV_POWER_USAGE                                           ,gauge                  ,Power draw (in W).
+    DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION                              ,counter                ,Total energy consumption since boot (in mJ).
+    # PCIE
+    DCGM_FI_DEV_PCIE_REPLAY_COUNTER                                   ,counter                ,Total number of PCIe retries.
+    # Utilization (the sample period varies depending on the product)
+    DCGM_FI_DEV_GPU_UTIL                                              ,gauge                  ,GPU utilization (in %).
+    DCGM_FI_DEV_MEM_COPY_UTIL                                         ,gauge                  ,Memory utilization (in %).
+    DCGM_FI_DEV_ENC_UTIL                                              ,gauge                  ,Encoder utilization (in %).
+    DCGM_FI_DEV_DEC_UTIL                                              ,gauge                  ,Decoder utilization (in %).
+    # Errors and violations
+    DCGM_FI_DEV_XID_ERRORS                                            ,gauge                  ,Value of the last XID error encountered.
+    # Memory usage
+    DCGM_FI_DEV_FB_FREE                                               ,gauge                  ,Framebuffer memory free (in MiB).
+    DCGM_FI_DEV_FB_USED                                               ,gauge                  ,Framebuffer memory used (in MiB).
+    # NVLink
+    DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL                                ,counter                ,Total number of NVLink bandwidth counters for all lanes.
+    DCGM_FI_PROF_NVLINK_TX_BYTES                                      ,gauge                  ,The number of bytes of active NvLink tx (transmit) data including both header and payload.
+    DCGM_FI_PROF_NVLINK_RX_BYTES                                      ,gauge                  ,The number of bytes of active NvLink rx (read) data including both header and payload.
+    # VGPU License status
+    DCGM_FI_DEV_VGPU_LICENSE_STATUS                                   ,gauge                  ,vGPU License status
+    # Remapped rows
+    DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS                           ,counter                ,Number of remapped rows for uncorrectable errors
+    DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS                             ,counter                ,Number of remapped rows for correctable errors
+    DCGM_FI_DEV_ROW_REMAP_FAILURE                                     ,gauge                  ,Whether remapping of rows has failed
+    # DCP metrics
+    DCGM_FI_PROF_PCIE_TX_BYTES                                        ,counter                ,The number of bytes of active pcie tx data including both header and payload.
+    DCGM_FI_PROF_PCIE_RX_BYTES                                        ,counter                ,The number of bytes of active pcie rx data including both header and payload.
+    DCGM_FI_PROF_GR_ENGINE_ACTIVE                                     ,gauge                  ,Ratio of time the graphics engine is active (in %).
+    DCGM_FI_PROF_SM_ACTIVE                                            ,gauge                  ,The ratio of cycles an SM has at least 1 warp assigned (in %).
+    DCGM_FI_PROF_SM_OCCUPANCY                                         ,gauge                  ,The ratio of number of warps resident on an SM (in %).
+    DCGM_FI_PROF_PIPE_TENSOR_ACTIVE                                   ,gauge                  ,Ratio of cycles the tensor (HMMA) pipe is active (in %).
+    DCGM_FI_PROF_DRAM_ACTIVE                                          ,gauge                  ,Ratio of cycles the device memory interface is active sending or receiving data (in %).
+    DCGM_FI_PROF_PIPE_FP64_ACTIVE                                     ,gauge                  ,Ratio of cycles the fp64 pipes are active (in %).
+    DCGM_FI_PROF_PIPE_FP32_ACTIVE                                     ,gauge                  ,Ratio of cycles the fp32 pipes are active (in %).
+    DCGM_FI_PROF_PIPE_FP16_ACTIVE                                     ,gauge                  ,Ratio of cycles the fp16 pipes are active (in %).
+    # Datadog additional recommended fields
+    DCGM_FI_DEV_COUNT                                                 ,counter                ,Number of Devices on the node.
+    DCGM_FI_DEV_FAN_SPEED                                             ,gauge                  ,Fan speed for the device in percent 0-100.
+    DCGM_FI_DEV_SLOWDOWN_TEMP                                         ,gauge                  ,Slowdown temperature for the device.
+    DCGM_FI_DEV_POWER_MGMT_LIMIT                                      ,gauge                  ,Current power limit for the device.
+    DCGM_FI_DEV_PSTATE                                                ,gauge                  ,Performance state (P-State) 0-15. 0=highest
+    DCGM_FI_DEV_FB_TOTAL                                              ,gauge                  ,
+    DCGM_FI_DEV_FB_RESERVED                                           ,gauge                  ,
+    DCGM_FI_DEV_FB_USED_PERCENT                                       ,gauge                  ,
+    DCGM_FI_DEV_CLOCK_THROTTLE_REASONS                                ,gauge                  ,Current clock throttle reasons (bitmask of DCGM_CLOCKS_THROTTLE_REASON_*)
+    DCGM_FI_PROCESS_NAME                                              ,label                  ,The Process Name.
+    DCGM_FI_CUDA_DRIVER_VERSION                                       ,label                  ,
+    DCGM_FI_DEV_NAME                                                  ,label                  ,
+    DCGM_FI_DEV_MINOR_NUMBER                                          ,label                  ,
+    DCGM_FI_DRIVER_VERSION                                            ,label                  ,
+    DCGM_FI_DEV_BRAND                                                 ,label                  ,
+    DCGM_FI_DEV_SERIAL                                                ,label                  ,


### PR DESCRIPTION
This is a bare basic Helm chart generated from existing resources to get a DCGM exporter with HPC job mapping (volume mount and env var)