### PR TITLE
add crds k8up

### DIFF
--- a/fluxcd/environment/nebius-cloud/base/kustomization.yaml
+++ b/fluxcd/environment/nebius-cloud/base/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ../../../base/soperator-fluxcd/
   - ./flux_kustomization.yaml
+  - https://github.com/k8up-io/k8up/releases/download/k8up-4.8.4/k8up-crd.yaml


### PR DESCRIPTION
```
k -n flux-system get helmreleases.helm.toolkit.fluxcd.io flux-system-soperator-fluxcd-backup-schedule -w
NAME                                           AGE    READY   STATUS
flux-system-soperator-fluxcd-backup-schedule   2d5h   True    Helm install succeeded for release k8up-system/k8up-schedule.v1 with chart raw@2.0.0
```