### PR TITLE
Limit search namespaces for dashboard loading

### DIFF
--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -69,9 +69,9 @@ spec:
           - victoriametrics-logs-datasource
         sidecar:
           dashboards:
-            searchNamespace: ALL
+            searchNamespace: {{- toYaml .Values.observability.vmStack.values.dashboardNamespaces | nindent 12 }}
           datasources:
-            searchNamespace: ALL
+            searchNamespace: {{- toYaml .Values.observability.vmStack.values.dashboardNamespaces | nindent 12 }}
       kube-state-metrics:
         prometheusScrape: false
         selfMonitor:

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -111,6 +111,12 @@ observability:
     namespace: monitoring-system
     releaseName: metrics
     values:
+      dashboardNamespaces:
+      - soperator
+      - soperator-system
+      - gpu-operator
+      - monitoring-system
+      - logs-system
       grafanaIni:
         auth:
           disable_login_form: true


### PR DESCRIPTION
Addresses [this](https://github.com/nebius/soperator/issues/911)

Current list of dashboards are:
<img width="700" alt="Screenshot 2025-05-22 at 10 27 30" src="https://github.com/user-attachments/assets/dbccb5f6-f1e0-4d52-b55a-bf75fb6bdcbc" />

Hubble and Cilium dashboards are in `kube-system` namespace, I added some extra namespaces for possible future use.