### PR TITLE
Add Soperator exporter app.

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -218,6 +218,9 @@ jobs:
           make docker-build UNSTABLE="${UNSTABLE}" IMAGE_NAME=exporter DOCKERFILE=exporter/exporter.dockerfile
           make docker-push  UNSTABLE="${UNSTABLE}" IMAGE_NAME=exporter
 
+          make docker-build UNSTABLE="${UNSTABLE}" IMAGE_NAME=soperator-exporter DOCKERFILE=soperator-exporter/soperator-exporter.dockerfile
+          make docker-push  UNSTABLE="${UNSTABLE}" IMAGE_NAME=soperator-exporter
+
           make docker-build UNSTABLE="${UNSTABLE}" IMAGE_NAME=slurmrestd DOCKERFILE=restd/slurmrestd.dockerfile
           make docker-push  UNSTABLE="${UNSTABLE}" IMAGE_NAME=slurmrestd
 

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -79,14 +80,22 @@ func getZapOpts(logFormat, logLevel string) []zap.Opts {
 
 func parseFlags() Flags {
 	var flags Flags
+
 	flag.StringVar(&flags.logFormat, "log-format", "json", "Log format: plain or json")
 	flag.StringVar(&flags.logLevel, "log-level", "debug", "Log level: debug, info, warn, error, dpanic, panic, fatal")
 	flag.StringVar(&flags.metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&flags.slurmAPIServer, "slurm-api-server", "http://localhost:6820", "The address of the Slurm REST API server.")
 	flag.StringVar(&flags.clusterNamespace, "cluster-namespace", "soperator", "The namespace of the Slurm cluster")
-	flag.StringVar(&flags.clusterName, "cluster-name", "soperator", "The name of the Slurm cluster")
+	flag.StringVar(&flags.clusterName, "cluster-name", "", "The name of the Slurm cluster (required)")
 	flag.StringVar(&flags.soperatorVersion, "soperator-version", "", "Version of the soperator")
 	flag.Parse()
+
+	if flags.clusterName == "" {
+		_, _ = fmt.Fprintf(os.Stderr, "Error: cluster-name is required\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
 	return flags
 }
 

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap/zapcore"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"nebius.ai/slurm-operator/internal/exporter"
+	"nebius.ai/slurm-operator/internal/jwt"
+	"nebius.ai/slurm-operator/internal/slurmapi"
+)
+
+type Flags struct {
+	logFormat        string
+	logLevel         string
+	metricsAddr      string
+	slurmAPIServer   string
+	clusterNamespace string
+	clusterName      string
+	soperatorVersion string
+}
+
+func getZapOpts(logFormat, logLevel string) []zap.Opts {
+	var zapOpts []zap.Opts
+
+	if logFormat == "json" {
+		zapOpts = append(zapOpts, zap.UseDevMode(false))
+	} else {
+		zapOpts = append(zapOpts, zap.UseDevMode(true))
+	}
+
+	var level zapcore.Level
+	switch logLevel {
+	case "debug":
+		level = zapcore.DebugLevel
+	case "info":
+		level = zapcore.InfoLevel
+	case "warn":
+		level = zapcore.WarnLevel
+	case "error":
+		level = zapcore.ErrorLevel
+	case "dpanic":
+		level = zapcore.DPanicLevel
+	case "panic":
+		level = zapcore.PanicLevel
+	case "fatal":
+		level = zapcore.FatalLevel
+	default:
+		level = zapcore.InfoLevel
+	}
+	zapOpts = append(zapOpts, zap.Level(level))
+	return zapOpts
+}
+
+func parseFlags() Flags {
+	var flags Flags
+	flag.StringVar(&flags.logFormat, "log-format", "json", "Log format: plain or json")
+	flag.StringVar(&flags.logLevel, "log-level", "debug", "Log level: debug, info, warn, error, dpanic, panic, fatal")
+	flag.StringVar(&flags.metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&flags.slurmAPIServer, "slurm-api-server", "http://localhost:6820", "The address of the Slurm REST API server.")
+	flag.StringVar(&flags.clusterNamespace, "cluster-namespace", "soperator", "The namespace of the Slurm cluster")
+	flag.StringVar(&flags.clusterName, "cluster-name", "soperator", "The name of the Slurm cluster")
+	flag.StringVar(&flags.soperatorVersion, "soperator-version", "", "Version of the soperator")
+	flag.Parse()
+	return flags
+}
+
+func main() {
+	flags := parseFlags()
+	opts := getZapOpts(flags.logFormat, flags.logLevel)
+
+	ctrl.SetLogger(zap.New(opts...))
+	log := ctrl.Log.WithName("soperator-exporter")
+
+	slurmClusterID := types.NamespacedName{
+		Namespace: flags.clusterNamespace,
+		Name:      flags.clusterName,
+	}
+
+	config := ctrl.GetConfigOrDie()
+
+	ctrlClient, err := client.New(config, client.Options{})
+	if err != nil {
+		log.Error(err, "Failed to create Kubernetes client")
+		os.Exit(1)
+	}
+
+	jwtTokenIssuer := jwt.NewToken(ctrlClient).For(slurmClusterID, "root").WithRegistry(
+		jwt.NewTokenRegistry().Build())
+
+	slurmAPIClient, err := slurmapi.NewClient(flags.slurmAPIServer, jwtTokenIssuer, slurmapi.DefaultHTTPClient())
+	if err != nil {
+		log.Error(err, "Failed to initialize Slurm API client")
+		os.Exit(1)
+	}
+
+	clusterExporter := exporter.NewClusterExporter(
+		slurmAPIClient,
+		exporter.Params{
+			SlurmAPIServer:   flags.slurmAPIServer,
+			SlurmClusterID:   slurmClusterID,
+			SoperatorVersion: flags.soperatorVersion,
+		},
+	)
+
+	// Handle graceful shutdown
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := clusterExporter.Start(ctx, flags.metricsAddr); err != nil {
+		log.Error(err, "Failed to start metrics exporter")
+		os.Exit(1)
+	}
+
+	<-ctx.Done()
+	log.Info("Shutdown signal received, stopping exporter...")
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := clusterExporter.Stop(stopCtx); err != nil {
+		log.Error(err, "Failed to stop metrics exporter")
+	}
+
+	log.Info("Metrics exporter stopped gracefully")
+}

--- a/images/soperator-exporter/soperator-exporter.dockerfile
+++ b/images/soperator-exporter/soperator-exporter.dockerfile
@@ -1,0 +1,34 @@
+FROM golang:1.24 AS exporter-builder
+
+ARG GO_LDFLAGS=""
+ARG BUILD_TIME
+ARG CGO_ENABLED=0
+ARG GOOS=linux
+
+WORKDIR /exporter
+
+# Copy only the necessary files to build the binary.
+COPY api api
+COPY cmd cmd
+COPY internal internal
+COPY pkg pkg
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+RUN GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
+    go build -o exporter ./cmd/exporter
+
+#######################################################################################################################
+FROM alpine:latest@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS soperator-exporter
+
+COPY --from=exporter-builder /exporter/exporter /usr/bin/
+
+RUN addgroup -S -g 1001 exporter && \
+    adduser -S -u 1001 exporter -G exporter exporter && \
+    chown 1001:1001 /usr/bin/exporter && \
+    chmod 755 /usr/bin/exporter
+
+USER 1001
+
+ENTRYPOINT ["/usr/bin/exporter"]

--- a/internal/exporter/collector.go
+++ b/internal/exporter/collector.go
@@ -1,0 +1,54 @@
+package exporter
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"nebius.ai/slurm-operator/internal/slurmapi"
+)
+
+// MetricsCollector exposes SLURM metrics by implementing prometheus.Collector interface
+type MetricsCollector struct {
+	slurmAPIClient slurmapi.Client
+
+	clusterInfo *prometheus.Desc
+	nodeInfo    *prometheus.Desc
+	jobInfo     *prometheus.Desc
+	jobNode     *prometheus.Desc
+}
+
+// NewMetricsCollector creates a new MetricsCollector
+func NewMetricsCollector(slurmAPIClient slurmapi.Client, soperatorVersion string) *MetricsCollector {
+	clusterInfoConstLabels := prometheus.Labels{"soperator_version": soperatorVersion}
+	return &MetricsCollector{
+		slurmAPIClient: slurmAPIClient,
+
+		clusterInfo: prometheus.NewDesc("slurm_cluster_info", "Slurm cluster information", []string{}, clusterInfoConstLabels),
+		nodeInfo:    prometheus.NewDesc("slurm_node_info", "Slurm node detail information", []string{}, nil),
+		jobInfo:     prometheus.NewDesc("slurm_job_info", "Slurm job detail information", []string{}, nil),
+		jobNode:     prometheus.NewDesc("slurm_node_job", "Slurm job node information", []string{"job_id", "node_name"}, nil),
+	}
+}
+
+// Describe implements the prometheus.Collector interface
+func (c *MetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.clusterInfo
+	ch <- c.nodeInfo
+	ch <- c.jobInfo
+	ch <- c.jobNode
+}
+
+// Collect implements the prometheus.Collector interface
+func (c *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(c.clusterInfo, prometheus.GaugeValue, 1)
+
+	ctx := context.Background()
+	logger := log.FromContext(ctx).WithName(ControllerName)
+	_, err := c.slurmAPIClient.ListNodes(ctx)
+	if err != nil {
+		logger.Error(err, "Failed to get nodes from SLURM API")
+		return
+	}
+}

--- a/internal/exporter/collector.go
+++ b/internal/exporter/collector.go
@@ -13,28 +13,28 @@ import (
 type MetricsCollector struct {
 	slurmAPIClient slurmapi.Client
 
-	clusterInfo *prometheus.Desc
-	nodeInfo    *prometheus.Desc
-	jobInfo     *prometheus.Desc
-	jobNode     *prometheus.Desc
+	sopClusterInfo *prometheus.Desc
+	nodeInfo       *prometheus.Desc
+	jobInfo        *prometheus.Desc
+	jobNode        *prometheus.Desc
 }
 
 // NewMetricsCollector creates a new MetricsCollector
 func NewMetricsCollector(slurmAPIClient slurmapi.Client, soperatorVersion string) *MetricsCollector {
-	clusterInfoConstLabels := prometheus.Labels{"soperator_version": soperatorVersion}
+	sopClusterInfoConstLabels := prometheus.Labels{"soperator_version": soperatorVersion}
 	return &MetricsCollector{
 		slurmAPIClient: slurmAPIClient,
 
-		clusterInfo: prometheus.NewDesc("slurm_cluster_info", "Slurm cluster information", []string{}, clusterInfoConstLabels),
-		nodeInfo:    prometheus.NewDesc("slurm_node_info", "Slurm node detail information", []string{}, nil),
-		jobInfo:     prometheus.NewDesc("slurm_job_info", "Slurm job detail information", []string{}, nil),
-		jobNode:     prometheus.NewDesc("slurm_node_job", "Slurm job node information", []string{"job_id", "node_name"}, nil),
+		sopClusterInfo: prometheus.NewDesc("soperator_cluster_info", "Soperator cluster information", []string{}, sopClusterInfoConstLabels),
+		nodeInfo:       prometheus.NewDesc("slurm_node_info", "Slurm node detail information", []string{}, nil),
+		jobInfo:        prometheus.NewDesc("slurm_job_info", "Slurm job detail information", []string{}, nil),
+		jobNode:        prometheus.NewDesc("slurm_node_job", "Slurm job node information", []string{"job_id", "node_name"}, nil),
 	}
 }
 
 // Describe implements the prometheus.Collector interface
 func (c *MetricsCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.clusterInfo
+	ch <- c.sopClusterInfo
 	ch <- c.nodeInfo
 	ch <- c.jobInfo
 	ch <- c.jobNode
@@ -42,7 +42,7 @@ func (c *MetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements the prometheus.Collector interface
 func (c *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
-	ch <- prometheus.MustNewConstMetric(c.clusterInfo, prometheus.GaugeValue, 1)
+	ch <- prometheus.MustNewConstMetric(c.sopClusterInfo, prometheus.GaugeValue, 1)
 
 	ctx := context.Background()
 	logger := log.FromContext(ctx).WithName(ControllerName)

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -1,0 +1,113 @@
+package exporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"nebius.ai/slurm-operator/internal/slurmapi"
+)
+
+// ControllerName is the name of the SLURM metrics exporter component
+var ControllerName = "soperator-exporter"
+
+// Params contains configuration parameters for the SLURM metrics exporter
+type Params struct {
+	// SlurmAPIServer is the URL of the SLURM REST API server
+	SlurmAPIServer string
+	// SlurmClusterID is the namespaced name of the SlurmCluster resource
+	SlurmClusterID types.NamespacedName
+	// SoperatorVersion is the version the soperator's custom resource.
+	SoperatorVersion string
+}
+
+// Exporter collects metrics from a SLURM cluster and exports them in Prometheus format
+type Exporter struct {
+	// params stores the configuration parameters
+	params Params
+	// slurmAPIClient is the client for the SLURM REST API
+	slurmAPIClient slurmapi.Client
+	// registry is the Prometheus registry for the metrics
+	registry *prometheus.Registry
+	// collector is the metrics collector
+	collector *MetricsCollector
+	// httpServer is the HTTP server for the metrics endpoint
+	httpServer *http.Server
+	// stopCh is used to signal the exporter to stop
+	stopCh chan struct{}
+}
+
+// NewClusterExporter creates a new SLURM cluster exporter
+func NewClusterExporter(slurmAPIClient slurmapi.Client, params Params) *Exporter {
+	registry := prometheus.NewRegistry()
+	collector := NewMetricsCollector(slurmAPIClient, params.SoperatorVersion)
+
+	return &Exporter{
+		params:         params,
+		slurmAPIClient: slurmAPIClient,
+		registry:       registry,
+		collector:      collector,
+		stopCh:         make(chan struct{}),
+	}
+}
+
+// Start starts the SLURM metrics exporter
+func (e *Exporter) Start(ctx context.Context, addr string) error {
+	logger := log.FromContext(ctx).WithName(ControllerName)
+
+	//if err := prometheus.Register(e.collector); err != nil {
+	//	return fmt.Errorf("failed to register metrics: %w", err)
+	//}
+	if err := e.registry.Register(e.collector); err != nil {
+		return fmt.Errorf("failed to register metrics: %w", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(e.registry, promhttp.HandlerOpts{}))
+	mux.HandleFunc("/health", e.healthHandler)
+
+	e.httpServer = &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	go func() {
+		logger.Info("Starting metrics server", "addr", addr)
+		if err := e.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error(err, "Failed to start metrics server")
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the SLURM metrics exporter
+func (e *Exporter) Stop(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName(ControllerName)
+	logger.Info("Stopping metrics exporter")
+
+	close(e.stopCh) // Signal the collection loop to stop
+
+	shutdownCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	if err := e.httpServer.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("failed to shutdown HTTP server: %w", err)
+	}
+
+	logger.Info("Metrics exporter stopped")
+	return nil
+}
+
+// healthHandler handles health check requests
+func (e *Exporter) healthHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("healthy"))
+}


### PR DESCRIPTION
Initial version of the soperator exporter app. For now, it does two things:
- exposes a single metric
- does an API request which is not used by any metric so far

Infra for the app (the reconciler) will be provided separately.

Issue: #793
