### PR TITLE
[docker] containers runs outside parent cgroup of slurmd #563

### DIFF
--- a/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/daemon.json
+++ b/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/daemon.json
@@ -1,6 +1,6 @@
 {
   "data-root": "/mnt/jail/mnt/image-storage/docker",
-  
+  "cgroup-parent": "docker.slice",
   "hosts": [
     "unix:///var/run/docker.sock"
   ],


### PR DESCRIPTION
#563