### PR TITLE
Migrate from pkg/errors to standard library and enable depguard linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,7 @@ linters:
     - bidichk # Detect dangerous unicode character sequences.
     - copyloopvar # Check for pointers to enclosing loop variables.
     - decorder # Verify consistency in declaration order (constants, variables, types).
+    - depguard # Check for dependencies in go.mod and enforce import restrictions.
     - dogsled # Detect excessive use of blank identifiers in assignments.
     - durationcheck # Check for two durations multiplied together.
     - errcheck # Check for unchecked errors in function calls.
@@ -35,9 +36,14 @@ linters:
     unparam:
       # Inspect exported functions. Default: false.
       check-exported: true
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: "github.com/pkg/errors"
+              desc: "Use fmt.Errorf() with %w verb instead of pkg/errors for error wrapping"
 
   disable:
-    - depguard # Check for dependencies in go.mod.
     - dupl # Detect duplicate code.
     - cyclop # Detect function with too many branches.
     - forcetypeassert # Check for unnecessary type assertions.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.36.3
 	github.com/open-telemetry/opentelemetry-operator v0.103.0
-	github.com/pkg/errors v0.9.1
+	github.com/openkruise/kruise-api v1.8.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.81.0
 	github.com/sethvargo/go-password v0.3.1
 	github.com/stretchr/testify v1.10.0
@@ -65,8 +65,8 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
-	github.com/openkruise/kruise-api v1.8.0 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/seccomp/libseccomp-golang v0.10.0 // indirect
 	github.com/sethvargo/go-envconfig v1.1.1 // indirect
@@ -108,8 +108,8 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.20.5 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
+	github.com/prometheus/client_golang v1.20.5
+	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.61.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/internal/controller/clustercontroller/accounting.go
+++ b/internal/controller/clustercontroller/accounting.go
@@ -2,11 +2,11 @@ package clustercontroller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -83,7 +83,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")
-						return errors.Wrap(err, "rendering accounting Secret")
+						return fmt.Errorf("rendering accounting Secret: %w", err)
 					}
 
 					stepLogger = stepLogger.WithValues(logfield.ResourceKV(desired)...)
@@ -91,7 +91,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 
 					if err = r.Secret.Reconcile(stepCtx, cluster, desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling accounting Secret")
+						return fmt.Errorf("reconciling accounting Secret: %w", err)
 					}
 
 					stepLogger.V(1).Info("Reconciled")
@@ -126,7 +126,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 						)
 						if err != nil {
 							stepLogger.Error(err, "Failed to render")
-							return errors.Wrap(err, "rendering mariadb password Secret")
+							return fmt.Errorf("rendering mariadb password Secret: %w", err)
 						}
 						stepLogger = stepLogger.WithValues(logfield.ResourceKV(desired)...)
 						stepLogger.V(1).Info("Rendered")
@@ -134,7 +134,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 						err = r.Create(ctx, desired)
 						if err != nil {
 							stepLogger.Error(err, "Failed to create")
-							return errors.Wrap(err, "creating mariadb password Secret")
+							return fmt.Errorf("creating mariadb password Secret: %w", err)
 						}
 					}
 					return err
@@ -169,7 +169,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 						)
 						if err != nil {
 							stepLogger.Error(err, "Failed to render")
-							return errors.Wrap(err, "rendering mariadb root password Secret")
+							return fmt.Errorf("rendering mariadb root password Secret: %w", err)
 						}
 						stepLogger = stepLogger.WithValues(logfield.ResourceKV(desired)...)
 						stepLogger.V(1).Info("Rendered")
@@ -177,7 +177,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 						err = r.Create(ctx, desired)
 						if err != nil {
 							stepLogger.Error(err, "Failed to create")
-							return errors.Wrap(err, "creating mariadb root password Secret")
+							return fmt.Errorf("creating mariadb root password Secret: %w", err)
 						}
 					}
 					return err
@@ -200,7 +200,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 
 						if err = r.Service.Reconcile(stepCtx, cluster, desired, accountingServiceNamePtr); err != nil {
 							stepLogger.Error(err, "Failed to reconcile")
-							return errors.Wrap(err, "reconciling accounting service")
+							return fmt.Errorf("reconciling accounting service: %w", err)
 						}
 						stepLogger.V(1).Info("Reconciled")
 						return nil
@@ -216,7 +216,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 
 					if err = r.Service.Reconcile(stepCtx, cluster, desired, accountingServiceNamePtr); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling accounting service")
+						return fmt.Errorf("reconciling accounting service: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 					return nil
@@ -243,7 +243,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 						mariaDbGrantNamePtr = &mariaDbGrantName
 						if err = r.MariaDbGrant.Reconcile(stepCtx, cluster, desired, mariaDbGrantNamePtr); err != nil {
 							stepLogger.Error(err, "Failed to reconcile")
-							return errors.Wrap(err, "reconciling accounting mariadb grant")
+							return fmt.Errorf("reconciling accounting mariadb grant: %w", err)
 						}
 						stepLogger.V(1).Info("Reconciled")
 						return nil
@@ -256,14 +256,14 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")
-						return errors.Wrap(err, "rendering accounting mariadb grant")
+						return fmt.Errorf("rendering accounting mariadb grant: %w", err)
 					}
 					stepLogger = stepLogger.WithValues(logfield.ResourceKV(desired)...)
 					stepLogger.V(1).Info("Rendered")
 
 					if err = r.MariaDbGrant.Reconcile(ctx, cluster, desired, mariaDbGrantNamePtr); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling accounting mariadb grant")
+						return fmt.Errorf("reconciling accounting mariadb grant: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 					return nil
@@ -290,7 +290,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 						mariaDbNamePtr = &mariaDbName
 						if err = r.MariaDb.Reconcile(stepCtx, cluster, desired, mariaDbNamePtr); err != nil {
 							stepLogger.Error(err, "Failed to reconcile")
-							return errors.Wrap(err, "reconciling accounting mariadb")
+							return fmt.Errorf("reconciling accounting mariadb: %w", err)
 						}
 						stepLogger.V(1).Info("Reconciled")
 						return nil
@@ -304,14 +304,14 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")
-						return errors.Wrap(err, "rendering accounting mariadb")
+						return fmt.Errorf("rendering accounting mariadb: %w", err)
 					}
 					stepLogger = stepLogger.WithValues(logfield.ResourceKV(desired)...)
 					stepLogger.V(1).Info("Rendered")
 
 					if err = r.MariaDb.Reconcile(ctx, cluster, desired, mariaDbNamePtr); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling accounting mariadb")
+						return fmt.Errorf("reconciling accounting mariadb: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 					return nil
@@ -333,7 +333,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 						deploymentNamePtr = &deploymentName
 						if err = r.Deployment.Reconcile(stepCtx, cluster, desired, deploymentNamePtr); err != nil {
 							stepLogger.Error(err, "Failed to reconcile")
-							return errors.Wrap(err, "reconciling accounting Deployment")
+							return fmt.Errorf("reconciling accounting Deployment: %w", err)
 						}
 						stepLogger.V(1).Info("Reconciled")
 						return nil
@@ -348,7 +348,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")
-						return errors.Wrap(err, "rendering accounting Deployment")
+						return fmt.Errorf("rendering accounting Deployment: %w", err)
 					}
 					stepLogger = stepLogger.WithValues(logfield.ResourceKV(desired)...)
 					stepLogger.V(1).Info("Rendered")
@@ -356,13 +356,13 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 					deps, err := r.getAccountingDeploymentDependencies(ctx, clusterValues)
 					if err != nil {
 						stepLogger.Error(err, "Failed to retrieve dependencies")
-						return errors.Wrap(err, "retrieving dependencies for accounting Deployment")
+						return fmt.Errorf("retrieving dependencies for accounting Deployment: %w", err)
 					}
 					stepLogger.V(1).Info("Retrieved dependencies")
 
 					if err = r.Deployment.Reconcile(stepCtx, cluster, desired, deploymentNamePtr, deps...); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling accounting Deployment")
+						return fmt.Errorf("reconciling accounting Deployment: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 					return nil
@@ -373,7 +373,7 @@ func (r SlurmClusterReconciler) ReconcileAccounting(
 
 	if err := reconcileAccountingImpl(); err != nil {
 		logger.Error(err, "Failed to reconcile Slurm Accounting")
-		return errors.Wrap(err, "reconciling Slurm Accounting")
+		return fmt.Errorf("reconciling Slurm Accounting: %w", err)
 	}
 	logger.Info("Reconciled Slurm Accounting")
 	return nil
@@ -402,7 +402,7 @@ func (r SlurmClusterReconciler) handleExternalDB(
 	)
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("Failed to get Secret %s", secretNameAcc))
-		return errors.Wrap(err, fmt.Sprintf("getting Secret %s", secretNameAcc))
+		return fmt.Errorf("getting Secret %s: %w", secretNameAcc, err)
 	}
 
 	return nil
@@ -425,7 +425,7 @@ func (r SlurmClusterReconciler) handleMariaDB(
 	)
 	if err != nil {
 		logger.Error(err, "Failed to get Secret")
-		return errors.Wrap(err, "getting Secret")
+		return fmt.Errorf("getting Secret: %w", err)
 	}
 
 	return nil
@@ -495,7 +495,7 @@ func getTypedResource[T client.Object](
 			var zeroValue T // This creates the zero value for type T
 			return zeroValue, nil
 		}
-		return obj, errors.Wrap(err, "failed to get resource")
+		return obj, fmt.Errorf("failed to get resource: %w", err)
 	}
 	return obj, nil
 }

--- a/internal/controller/clustercontroller/benchmark.go
+++ b/internal/controller/clustercontroller/benchmark.go
@@ -2,8 +2,8 @@ package clustercontroller
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,7 +44,7 @@ func (r SlurmClusterReconciler) ReconcileNCCLBenchmark(
 
 					if err := r.ConfigMap.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling nccl benchmark security limits configmap")
+						return fmt.Errorf("reconciling nccl benchmark security limits configmap: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -73,13 +73,13 @@ func (r SlurmClusterReconciler) ReconcileNCCLBenchmark(
 					deps, err := r.getNCCLBenchmarkDependencies(stepCtx, clusterValues)
 					if err != nil {
 						stepLogger.Error(err, "Failed to retrieve dependencies")
-						return errors.Wrap(err, "retrieving dependencies for NCCLBenchmark CronJob")
+						return fmt.Errorf("retrieving dependencies for NCCLBenchmark CronJob: %w", err)
 					}
 					stepLogger.V(1).Info("Retrieved dependencies")
 
 					if err = r.CronJob.Reconcile(stepCtx, cluster, &desired, deps...); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling NCCL benchmark CronJob")
+						return fmt.Errorf("reconciling NCCL benchmark CronJob: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -91,7 +91,7 @@ func (r SlurmClusterReconciler) ReconcileNCCLBenchmark(
 
 	if err := reconcileNCCLBenchmarkImpl(); err != nil {
 		logger.Error(err, "Failed to reconcile NCCL benchmark")
-		return errors.Wrap(err, "reconciling NCCL benchmark")
+		return fmt.Errorf("reconciling NCCL benchmark: %w", err)
 	}
 	logger.Info("Reconciled NCCL benchmark")
 	return nil

--- a/internal/controller/clustercontroller/common.go
+++ b/internal/controller/clustercontroller/common.go
@@ -2,8 +2,8 @@ package clustercontroller
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -49,13 +49,13 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 					); getErr != nil {
 						if !apierrors.IsNotFound(getErr) {
 							stepLogger.Error(getErr, "Failed to get")
-							return errors.Wrap(getErr, "getting REST JWT Key Secret")
+							return fmt.Errorf("getting REST JWT Key Secret: %w", getErr)
 						}
 
 						renderedDesired, err := rest.RenderSecret(clusterValues.Name, clusterValues.Namespace)
 						if err != nil {
 							stepLogger.Error(err, "Failed to render")
-							return errors.Wrap(err, "rendering REST JWT secret key")
+							return fmt.Errorf("rendering REST JWT secret key: %w", err)
 						}
 						desired = *renderedDesired.DeepCopy()
 						stepLogger.V(1).Info("Rendered")
@@ -64,7 +64,7 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 
 					if err := r.Secret.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling REST JWT secret key")
+						return fmt.Errorf("reconciling REST JWT secret key: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -89,7 +89,7 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 							&topologyConfig,
 						); getErr != nil {
 							stepLogger.Error(getErr, "Failed to get topology config")
-							return errors.Wrap(getErr, "failed to get topology config")
+							return fmt.Errorf("failed to get topology config: %w", getErr)
 						}
 					}
 
@@ -99,7 +99,7 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 
 					if err := r.ConfigMap.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling ConfigMap with Slurm configs")
+						return fmt.Errorf("reconciling ConfigMap with Slurm configs: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -133,7 +133,7 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 									foundPodTemplate,
 								); err != nil {
 									stepLogger.Error(err, "Failed to get PodTemplate")
-									return errors.Wrap(err, "getting PodTemplate")
+									return fmt.Errorf("getting PodTemplate: %w", err)
 								}
 							}
 
@@ -156,7 +156,7 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 							err = r.Otel.Reconcile(stepCtx, cluster, desired)
 							if err != nil {
 								stepLogger.Error(err, "Failed to reconcile")
-								return errors.Wrap(err, "reconciling OpenTelemetry Collector")
+								return fmt.Errorf("reconciling OpenTelemetry Collector: %w", err)
 							}
 
 							stepLogger.V(1).Info("Reconciled")
@@ -182,13 +182,13 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 					); getErr != nil {
 						if !apierrors.IsNotFound(getErr) {
 							stepLogger.Error(getErr, "Failed to get")
-							return errors.Wrap(getErr, "getting Munge Key Secret")
+							return fmt.Errorf("getting Munge Key Secret: %w", getErr)
 						}
 
 						renderedDesired, err := common.RenderMungeKeySecret(clusterValues.Name, clusterValues.Namespace)
 						if err != nil {
 							stepLogger.Error(err, "Failed to render")
-							return errors.Wrap(err, "rendering Munge Key Secret")
+							return fmt.Errorf("rendering Munge Key Secret: %w", err)
 						}
 						desired = *renderedDesired.DeepCopy()
 						stepLogger.V(1).Info("Rendered")
@@ -197,7 +197,7 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 
 					if err := r.Secret.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling Munge Key Secret")
+						return fmt.Errorf("reconciling Munge Key Secret: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -226,7 +226,7 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 
 					if err := r.AppArmorProfile.Reconcile(stepCtx, cluster, desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling AppArmor profiles")
+						return fmt.Errorf("reconciling AppArmor profiles: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 					return nil
@@ -237,7 +237,7 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 
 	if err := reconcileCommonImpl(); err != nil {
 		logger.Error(err, "Failed to reconcile common resources")
-		return errors.Wrap(err, "reconciling common resources")
+		return fmt.Errorf("reconciling common resources: %w", err)
 	}
 	logger.Info("Reconciled common resources")
 	return nil

--- a/internal/controller/clustercontroller/exporter.go
+++ b/internal/controller/clustercontroller/exporter.go
@@ -2,8 +2,8 @@ package clustercontroller
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -57,7 +57,7 @@ func (r SlurmClusterReconciler) ReconcileExporter(
 							err = r.PodMonitor.Reconcile(stepCtx, cluster, desired)
 							if err != nil {
 								stepLogger.Error(err, "Failed to reconcile")
-								return errors.Wrap(err, "reconciling PodMonitor")
+								return fmt.Errorf("reconciling PodMonitor: %w", err)
 							}
 							stepLogger.V(1).Info("Reconciled")
 						}
@@ -91,7 +91,7 @@ func (r SlurmClusterReconciler) ReconcileExporter(
 								)
 								if err != nil {
 									stepLogger.Error(err, "Failed to get PodTemplate")
-									return errors.Wrap(err, "getting PodTemplate")
+									return fmt.Errorf("getting PodTemplate: %w", err)
 								}
 							}
 							desired, err := slurmprometheus.RenderDeploymentExporter(
@@ -113,7 +113,7 @@ func (r SlurmClusterReconciler) ReconcileExporter(
 							err = r.Deployment.Reconcile(stepCtx, cluster, desired, exporterNamePtr)
 							if err != nil {
 								stepLogger.Error(err, "Failed to reconcile")
-								return errors.Wrap(err, "reconciling Slurm Exporter Deployment")
+								return fmt.Errorf("reconciling Slurm Exporter Deployment: %w", err)
 							}
 							stepLogger.V(1).Info("Reconciled")
 						}
@@ -135,7 +135,7 @@ func (r SlurmClusterReconciler) ReconcileExporter(
 
 					if err := r.ServiceAccount.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling Exporter ServiceAccount")
+						return fmt.Errorf("reconciling Exporter ServiceAccount: %w", err)
 					}
 
 					stepLogger.V(1).Info("Reconciled")
@@ -156,7 +156,7 @@ func (r SlurmClusterReconciler) ReconcileExporter(
 
 					if err := r.Role.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling Exporter Role")
+						return fmt.Errorf("reconciling Exporter Role: %w", err)
 					}
 
 					stepLogger.V(1).Info("Reconciled")
@@ -178,7 +178,7 @@ func (r SlurmClusterReconciler) ReconcileExporter(
 
 					if err := r.RoleBinding.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling Exporter RoleBinding")
+						return fmt.Errorf("reconciling Exporter RoleBinding: %w", err)
 					}
 
 					stepLogger.V(1).Info("Reconciled")
@@ -191,7 +191,7 @@ func (r SlurmClusterReconciler) ReconcileExporter(
 
 	if err := reconcileExporterImpl(); err != nil {
 		logger.Error(err, "Failed to reconcile exporter resources")
-		return errors.Wrap(err, "reconciling exporter resources")
+		return fmt.Errorf("reconciling exporter resources: %w", err)
 	}
 	logger.Info("Reconciled exporter resources")
 	return nil

--- a/internal/controller/clustercontroller/login.go
+++ b/internal/controller/clustercontroller/login.go
@@ -2,10 +2,10 @@ package clustercontroller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,7 +53,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 
 					if err := r.ConfigMap.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling login default SSHD ConfigMap")
+						return fmt.Errorf("reconciling login default SSHD ConfigMap: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -73,7 +73,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 
 					if err := r.ConfigMap.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling login SSHRootPublicKeys ConfigMap")
+						return fmt.Errorf("reconciling login SSHRootPublicKeys ConfigMap: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -98,7 +98,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 					); getErr != nil {
 						if !apierrors.IsNotFound(getErr) {
 							stepLogger.Error(getErr, "Failed to get")
-							return errors.Wrap(getErr, "getting login SSHDKeys Secrets")
+							return fmt.Errorf("getting login SSHDKeys Secrets: %w", getErr)
 						}
 
 						renderedDesired, err := common.RenderSSHDKeysSecret(
@@ -109,7 +109,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 						)
 						if err != nil {
 							stepLogger.Error(err, "Failed to render")
-							return errors.Wrap(err, "rendering login SSHDKeys Secrets")
+							return fmt.Errorf("rendering login SSHDKeys Secrets: %w", err)
 						}
 						desired = *renderedDesired.DeepCopy()
 						stepLogger.V(1).Info("Rendered")
@@ -118,7 +118,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 
 					if err := r.Secret.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling login SSHDKeys Secrets")
+						return fmt.Errorf("reconciling login SSHDKeys Secrets: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -138,7 +138,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 
 					if err := r.ConfigMap.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling login security limits configmap")
+						return fmt.Errorf("reconciling login security limits configmap: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -158,7 +158,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 					var loginNamePtr *string = nil
 					if err := r.Service.Reconcile(stepCtx, cluster, &desired, loginNamePtr); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling login Service")
+						return fmt.Errorf("reconciling login Service: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -178,7 +178,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 					var loginHeadlessNamePtr *string = nil
 					if err := r.Service.Reconcile(stepCtx, cluster, &desired, loginHeadlessNamePtr); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling login Headless Service")
+						return fmt.Errorf("reconciling login Headless Service: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -203,7 +203,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")
-						return errors.Wrap(err, "rendering login StatefulSet")
+						return fmt.Errorf("rendering login StatefulSet: %w", err)
 					}
 					stepLogger = stepLogger.WithValues(logfield.ResourceKV(&desired)...)
 					stepLogger.V(1).Info("Rendered")
@@ -211,13 +211,13 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 					deps, err := r.getLoginStatefulSetDependencies(stepCtx, clusterValues)
 					if err != nil {
 						stepLogger.Error(err, "Failed to retrieve dependencies")
-						return errors.Wrap(err, "retrieving dependencies for login StatefulSet")
+						return fmt.Errorf("retrieving dependencies for login StatefulSet: %w", err)
 					}
 					stepLogger.V(1).Info("Retrieved dependencies")
 
 					if err = r.AdvancedStatefulSet.Reconcile(stepCtx, cluster, &desired, deps...); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling login StatefulSet")
+						return fmt.Errorf("reconciling login StatefulSet: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -229,7 +229,7 @@ func (r SlurmClusterReconciler) ReconcileLogin(
 
 	if err := reconcileLoginImpl(); err != nil {
 		logger.Error(err, "Failed to reconcile Slurm Login")
-		return errors.Wrap(err, "reconciling Slurm Login")
+		return fmt.Errorf("reconciling Slurm Login: %w", err)
 	}
 	logger.Info("Reconciled Slurm Login")
 	return nil
@@ -257,7 +257,7 @@ func (r SlurmClusterReconciler) ValidateLogin(
 			return ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}, nil
 		}
 		logger.Error(err, "Failed to get login StatefulSet")
-		return ctrl.Result{}, errors.Wrap(err, "getting login StatefulSet")
+		return ctrl.Result{}, fmt.Errorf("getting login StatefulSet: %w", err)
 	}
 
 	targetReplicas := clusterValues.NodeLogin.StatefulSet.Replicas

--- a/internal/controller/clustercontroller/populate_job.go
+++ b/internal/controller/clustercontroller/populate_job.go
@@ -2,9 +2,9 @@ package clustercontroller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +56,7 @@ func (r SlurmClusterReconciler) ReconcilePopulateJail(
 							stepLogger.V(1).Info("Deleting")
 							if err := r.Delete(stepCtx, &desired); err != nil {
 								stepLogger.Error(err, "Failed to delete")
-								return errors.Wrap(err, "deleting Populate jail Job")
+								return fmt.Errorf("deleting Populate jail Job: %w", err)
 							}
 							stepLogger.V(1).Info("Deleted")
 							return nil
@@ -65,7 +65,7 @@ func (r SlurmClusterReconciler) ReconcilePopulateJail(
 							if isConditionNonOverwrite(cluster.Status.Conditions) {
 								if err := r.Delete(stepCtx, &desired); err != nil {
 									stepLogger.Error(err, "Failed to delete")
-									return errors.Wrap(err, "deleting Populate jail Job")
+									return fmt.Errorf("deleting Populate jail Job: %w", err)
 								}
 								stepLogger.V(1).Info("Successfully deleted Populate Jail Job")
 							}
@@ -75,7 +75,7 @@ func (r SlurmClusterReconciler) ReconcilePopulateJail(
 
 					if getErr != nil && !apierrors.IsNotFound(getErr) && !isMaintenanceStopMode {
 						stepLogger.Error(getErr, "Failed to get")
-						return errors.Wrap(getErr, "getting Populate jail Job")
+						return fmt.Errorf("getting Populate jail Job: %w", getErr)
 					}
 
 					if isMaintenanceStopMode {
@@ -98,7 +98,7 @@ func (r SlurmClusterReconciler) ReconcilePopulateJail(
 
 					if err := r.Job.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling Populate jail Job")
+						return fmt.Errorf("reconciling Populate jail Job: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -117,7 +117,7 @@ func (r SlurmClusterReconciler) ReconcilePopulateJail(
 								&job,
 							); err != nil {
 								stepLogger.Error(err, "Failed to get")
-								return false, errors.Wrap(err, "getting Populate jail Job")
+								return false, fmt.Errorf("getting Populate jail Job: %w", err)
 							}
 							stepLogger = stepLogger.WithValues(logfield.ResourceKV(&job)...)
 
@@ -131,7 +131,7 @@ func (r SlurmClusterReconciler) ReconcilePopulateJail(
 						},
 					); pollErr != nil {
 						stepLogger.Error(pollErr, "Failed to wait")
-						return errors.Wrap(pollErr, "waiting Populate jail Job")
+						return fmt.Errorf("waiting Populate jail Job: %w", pollErr)
 					}
 					stepLogger.V(1).Info("Completed")
 
@@ -143,7 +143,7 @@ func (r SlurmClusterReconciler) ReconcilePopulateJail(
 
 	if err := reconcilePopulateJailImpl(); err != nil {
 		logger.Error(err, "Failed to reconcile Populate jail Job")
-		return errors.Wrap(err, "reconciling Populate jail Job")
+		return fmt.Errorf("reconciling Populate jail Job: %w", err)
 	}
 	logger.Info("Reconciled Populate jail Job")
 

--- a/internal/controller/clustercontroller/reconcile.go
+++ b/internal/controller/clustercontroller/reconcile.go
@@ -9,7 +9,6 @@ import (
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
-	"github.com/pkg/errors"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -136,7 +135,7 @@ func (r *SlurmClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		// Error reading the object - requeue the request.
 		logger.Error(err, "Failed to get SlurmCluster")
-		return ctrl.Result{Requeue: true}, errors.Wrap(err, "getting SlurmCluster")
+		return ctrl.Result{Requeue: true}, fmt.Errorf("getting SlurmCluster: %w", err)
 	}
 
 	// If cluster marked for deletion, we have nothing to do
@@ -148,7 +147,7 @@ func (r *SlurmClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err != nil {
 		logger.Error(err, "Failed to reconcile SlurmCluster")
 		result = ctrl.Result{}
-		err = errors.Wrap(err, "reconciling SlurmCluster")
+		err = fmt.Errorf("reconciling SlurmCluster: %w", err)
 	}
 
 	statusErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -161,7 +160,7 @@ func (r *SlurmClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 			// Error reading the object - requeue the request.
 			logger.Error(innerErr, "Failed to get SlurmCluster")
-			return errors.Wrap(innerErr, "getting SlurmCluster")
+			return fmt.Errorf("getting SlurmCluster: %w", innerErr)
 		}
 
 		return r.Status().Update(ctx, cluster)
@@ -169,7 +168,7 @@ func (r *SlurmClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if statusErr != nil {
 		logger.Error(statusErr, "Failed to update SlurmCluster status")
 		result = ctrl.Result{}
-		err = errors.Wrap(statusErr, "updating SlurmCluster status")
+		err = fmt.Errorf("updating SlurmCluster status: %w", statusErr)
 	}
 
 	return result, errorsStd.Join(err, statusErr)
@@ -371,7 +370,7 @@ func (r *SlurmClusterReconciler) reconcile(ctx context.Context, cluster *slurmv1
 			default:
 				if res, err := r.ValidateControllers(ctx, cluster, clusterValues); err != nil {
 					logger.Error(err, "Failed to validate Slurm controllers")
-					return ctrl.Result{}, errors.Wrap(err, "validating Slurm controllers")
+					return ctrl.Result{}, fmt.Errorf("validating Slurm controllers: %w", err)
 				} else if res.Requeue {
 					return res, nil
 				}
@@ -395,7 +394,7 @@ func (r *SlurmClusterReconciler) reconcile(ctx context.Context, cluster *slurmv1
 			case clusterValues.NodeWorker.Size > 0:
 				if res, err := r.ValidateWorkers(ctx, cluster, clusterValues); err != nil {
 					logger.Error(err, "Failed to validate Slurm workers")
-					return ctrl.Result{}, errors.Wrap(err, "validating Slurm workers")
+					return ctrl.Result{}, fmt.Errorf("validating Slurm workers: %w", err)
 				} else if res.Requeue {
 					return res, nil
 				}
@@ -429,7 +428,7 @@ func (r *SlurmClusterReconciler) reconcile(ctx context.Context, cluster *slurmv1
 			case clusterValues.NodeLogin.Size > 0:
 				if res, err := r.ValidateLogin(ctx, cluster, clusterValues); err != nil {
 					logger.Error(err, "Failed to validate Slurm login")
-					return ctrl.Result{}, errors.Wrap(err, "validating Slurm login")
+					return ctrl.Result{}, fmt.Errorf("validating Slurm login: %w", err)
 				} else if res.Requeue {
 					return res, nil
 				}
@@ -477,7 +476,7 @@ func (r *SlurmClusterReconciler) reconcile(ctx context.Context, cluster *slurmv1
 				res, err := r.ValidateAccounting(ctx, cluster, clusterValues)
 				if err != nil {
 					logger.Error(err, "Failed to validate Slurm accounting")
-					return ctrl.Result{}, errors.Wrap(err, "validating Slurm accounting")
+					return ctrl.Result{}, fmt.Errorf("validating Slurm accounting: %w", err)
 				}
 				if res.Requeue {
 					return res, nil
@@ -593,7 +592,7 @@ func (r *SlurmClusterReconciler) patchStatus(ctx context.Context, cluster *slurm
 
 	if err := r.Status().Patch(ctx, cluster, patch); err != nil {
 		log.FromContext(ctx).Error(err, "Failed to patch Slurm cluster status")
-		return errors.Wrap(err, "patching cluster status")
+		return fmt.Errorf("patching cluster status: %w", err)
 	}
 
 	return nil

--- a/internal/controller/clustercontroller/rest.go
+++ b/internal/controller/clustercontroller/rest.go
@@ -2,8 +2,8 @@ package clustercontroller
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -63,7 +63,7 @@ func (r SlurmClusterReconciler) ReconcileREST(
 					var restNamePtr *string = nil
 					if err := r.Service.Reconcile(stepCtx, cluster, desired, restNamePtr); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling REST API service")
+						return fmt.Errorf("reconciling REST API service: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 					return nil
@@ -83,7 +83,7 @@ func (r SlurmClusterReconciler) ReconcileREST(
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")
-						return errors.Wrap(err, "rendering ConfigMap with Slurm configs")
+						return fmt.Errorf("rendering ConfigMap with Slurm configs: %w", err)
 					}
 					stepLogger = stepLogger.WithValues(logfield.ResourceKV(desired)...)
 					stepLogger.V(1).Info("Rendered")
@@ -91,14 +91,14 @@ func (r SlurmClusterReconciler) ReconcileREST(
 					deps, err := r.getRESTDeploymentDependencies(ctx, clusterValues)
 					if err != nil {
 						stepLogger.Error(err, "Failed to retrieve dependencies")
-						return errors.Wrap(err, "retrieving dependencies for REST API Deployment")
+						return fmt.Errorf("retrieving dependencies for REST API Deployment: %w", err)
 					}
 					stepLogger.V(1).Info("Retrieved dependencies")
 
 					var restNamePtr *string = nil
 					if err = r.Deployment.Reconcile(stepCtx, cluster, desired, restNamePtr, deps...); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling REST API Deployment")
+						return fmt.Errorf("reconciling REST API Deployment: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -110,7 +110,7 @@ func (r SlurmClusterReconciler) ReconcileREST(
 
 	if err := reconcileRESTImpl(); err != nil {
 		logger.Error(err, "Failed to reconcile REST resources")
-		return errors.Wrap(err, "reconciling REST resources")
+		return fmt.Errorf("reconciling REST resources: %w", err)
 	}
 	logger.Info("Reconciled REST resources")
 	return nil

--- a/internal/controller/clustercontroller/sconfigcontroller.go
+++ b/internal/controller/clustercontroller/sconfigcontroller.go
@@ -2,8 +2,8 @@ package clustercontroller
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
@@ -41,7 +41,7 @@ func (r SlurmClusterReconciler) ReconcileSConfigController(
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")
-						return errors.Wrap(err, "rendering SConfigController Deployment")
+						return fmt.Errorf("rendering SConfigController Deployment: %w", err)
 					}
 
 					stepLogger = stepLogger.WithValues(logfield.ResourceKV(desired)...)
@@ -50,7 +50,7 @@ func (r SlurmClusterReconciler) ReconcileSConfigController(
 					var sConfigControllerNamePtr *string = nil
 					if err = r.Deployment.Reconcile(stepCtx, cluster, desired, sConfigControllerNamePtr); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling SConfigController Deployment")
+						return fmt.Errorf("reconciling SConfigController Deployment: %w", err)
 					}
 
 					stepLogger.V(1).Info("Reconciled")
@@ -71,7 +71,7 @@ func (r SlurmClusterReconciler) ReconcileSConfigController(
 
 					if err := r.ServiceAccount.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling SConfigController ServiceAccount")
+						return fmt.Errorf("reconciling SConfigController ServiceAccount: %w", err)
 					}
 
 					stepLogger.V(1).Info("Reconciled")
@@ -93,7 +93,7 @@ func (r SlurmClusterReconciler) ReconcileSConfigController(
 
 					if err := r.Role.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling SConfigController Role")
+						return fmt.Errorf("reconciling SConfigController Role: %w", err)
 					}
 
 					stepLogger.V(1).Info("Reconciled")
@@ -115,7 +115,7 @@ func (r SlurmClusterReconciler) ReconcileSConfigController(
 
 					if err := r.RoleBinding.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling SConfigController RoleBinding")
+						return fmt.Errorf("reconciling SConfigController RoleBinding: %w", err)
 					}
 
 					stepLogger.V(1).Info("Reconciled")
@@ -128,7 +128,7 @@ func (r SlurmClusterReconciler) ReconcileSConfigController(
 
 	if err := reconcileSConfigControllerImpl(); err != nil {
 		logger.Error(err, "Failed to reconcile SConfigController")
-		return errors.Wrap(err, "reconciling SConfigController")
+		return fmt.Errorf("reconciling SConfigController: %w", err)
 	}
 	logger.V(1).Info("Reconciled SConfigController")
 	return nil

--- a/internal/controller/clustercontroller/worker.go
+++ b/internal/controller/clustercontroller/worker.go
@@ -2,10 +2,10 @@ package clustercontroller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,14 +45,14 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 					desired, err := worker.RenderConfigMapNCCLTopology(clusterValues)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")
-						return errors.Wrap(err, "rendering worker NCCL topology ConfigMap")
+						return fmt.Errorf("rendering worker NCCL topology ConfigMap: %w", err)
 					}
 					stepLogger = stepLogger.WithValues(logfield.ResourceKV(&desired)...)
 					stepLogger.V(1).Info("Rendered")
 
 					if err = r.ConfigMap.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling worker NCCL topology ConfigMap")
+						return fmt.Errorf("reconciling worker NCCL topology ConfigMap: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -72,7 +72,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 
 					if err := r.ConfigMap.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling worker Sysctl ConfigMap")
+						return fmt.Errorf("reconciling worker Sysctl ConfigMap: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -98,7 +98,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 
 					if err := r.ConfigMap.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling worker default SSHD ConfigMap")
+						return fmt.Errorf("reconciling worker default SSHD ConfigMap: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -123,7 +123,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 					); getErr != nil {
 						if !apierrors.IsNotFound(getErr) {
 							stepLogger.Error(getErr, "Failed to get")
-							return errors.Wrap(getErr, "getting worker SSHDKeys Secrets")
+							return fmt.Errorf("getting worker SSHDKeys Secrets: %w", getErr)
 						}
 
 						renderedDesired, err := common.RenderSSHDKeysSecret(
@@ -134,7 +134,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 						)
 						if err != nil {
 							stepLogger.Error(err, "Failed to render")
-							return errors.Wrap(err, "rendering worker SSHDKeys Secrets")
+							return fmt.Errorf("rendering worker SSHDKeys Secrets: %w", err)
 						}
 						desired = *renderedDesired.DeepCopy()
 						stepLogger.V(1).Info("Rendered")
@@ -143,7 +143,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 
 					if err := r.Secret.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling worker SSHDKeys Secrets")
+						return fmt.Errorf("reconciling worker SSHDKeys Secrets: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -163,7 +163,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 
 					if err := r.ConfigMap.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling worker security limits configmap")
+						return fmt.Errorf("reconciling worker security limits configmap: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -186,7 +186,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 
 						if err := r.ConfigMap.Reconcile(stepCtx, cluster, &desired); err != nil {
 							stepLogger.Error(err, "Failed to reconcile")
-							return errors.Wrap(err, "reconciling worker supervisord configmap")
+							return fmt.Errorf("reconciling worker supervisord configmap: %w", err)
 						}
 					} else {
 						stepLogger.V(1).Info("Use custom ConfigMap")
@@ -210,7 +210,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 
 					if err := r.Service.Reconcile(stepCtx, cluster, &desired, nil); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling worker Service")
+						return fmt.Errorf("reconciling worker Service: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -237,7 +237,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")
-						return errors.Wrap(err, "rendering worker StatefulSet")
+						return fmt.Errorf("rendering worker StatefulSet: %w", err)
 					}
 					stepLogger = stepLogger.WithValues(logfield.ResourceKV(&desired)...)
 					stepLogger.V(1).Info("Rendered")
@@ -245,13 +245,13 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 					deps, err := r.getWorkersStatefulSetDependencies(stepCtx, clusterValues)
 					if err != nil {
 						stepLogger.Error(err, "Failed to retrieve dependencies")
-						return errors.Wrap(err, "retrieving dependencies for worker StatefulSet")
+						return fmt.Errorf("retrieving dependencies for worker StatefulSet: %w", err)
 					}
 					stepLogger.V(1).Info("Retrieved dependencies")
 
 					if err = r.AdvancedStatefulSet.Reconcile(stepCtx, cluster, &desired, deps...); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling worker StatefulSet")
+						return fmt.Errorf("reconciling worker StatefulSet: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -271,7 +271,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 
 					if err := r.ServiceAccount.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling worker ServiceAccount")
+						return fmt.Errorf("reconciling worker ServiceAccount: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -292,7 +292,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 
 						if err := r.Role.Reconcile(stepCtx, cluster, &desired); err != nil {
 							stepLogger.Error(err, "Failed to reconcile")
-							return errors.Wrap(err, "reconciling worker Role")
+							return fmt.Errorf("reconciling worker Role: %w", err)
 						}
 					} else {
 						// If SendJobsEvents is set to false or nil, the Role is not necessary because we don't need the permissions.
@@ -302,7 +302,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 						stepLogger.V(1).Info("Removing")
 						if err := r.Role.Reconcile(stepCtx, cluster, nil); err != nil {
 							stepLogger.Error(err, "Failed to remove")
-							return errors.Wrap(err, "removing worker Role")
+							return fmt.Errorf("removing worker Role: %w", err)
 						}
 						stepLogger.V(1).Info("Removed")
 					}
@@ -325,7 +325,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 
 						if err := r.RoleBinding.Reconcile(stepCtx, cluster, &desired); err != nil {
 							stepLogger.Error(err, "Failed to reconcile")
-							return errors.Wrap(err, "reconciling worker RoleBinding")
+							return fmt.Errorf("reconciling worker RoleBinding: %w", err)
 						}
 					} else {
 						// If SendJobsEvents is set to false or nil, the RoleBinding is not necessary because we don't need the permissions.
@@ -335,7 +335,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 						stepLogger.V(1).Info("Removing")
 						if err := r.RoleBinding.Reconcile(stepCtx, cluster, nil); err != nil {
 							stepLogger.Error(err, "Failed to remove")
-							return errors.Wrap(err, "removing worker Role")
+							return fmt.Errorf("removing worker Role: %w", err)
 						}
 						stepLogger.V(1).Info("Removed")
 					}
@@ -349,7 +349,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 
 	if err := reconcileWorkersImpl(); err != nil {
 		logger.Error(err, "Failed to reconcile Slurm Workers")
-		return errors.Wrap(err, "reconciling Slurm Workers")
+		return fmt.Errorf("reconciling Slurm Workers: %w", err)
 	}
 	logger.Info("Reconciled Slurm Workers")
 	return nil
@@ -377,7 +377,7 @@ func (r SlurmClusterReconciler) ValidateWorkers(
 			return ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}, nil
 		}
 		logger.Error(err, "Failed to get worker StatefulSet")
-		return ctrl.Result{}, errors.Wrap(err, "getting worker StatefulSet")
+		return ctrl.Result{}, fmt.Errorf("getting worker StatefulSet: %w", err)
 	}
 
 	targetReplicas := clusterValues.NodeWorker.StatefulSet.Replicas

--- a/internal/controller/reconciler/apparmorprofile.go
+++ b/internal/controller/reconciler/apparmorprofile.go
@@ -2,8 +2,8 @@ package reconciler
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	apparmor "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 
@@ -42,7 +42,7 @@ func (r *AppArmorProfileReconciler) Reconcile(
 		log.FromContext(ctx).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile AppArmorProfile ")
-		return errors.Wrap(err, "reconciling AppArmorProfile ")
+		return fmt.Errorf("reconciling AppArmorProfile: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/reconciler/deployment.go
+++ b/internal/controller/reconciler/deployment.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +52,7 @@ func (r *DeploymentReconciler) Reconcile(
 		logger.V(1).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile Deployment ")
-		return errors.Wrap(err, "reconciling Deployment ")
+		return fmt.Errorf("reconciling Deployment: %w", err)
 	}
 	return nil
 }
@@ -73,7 +71,7 @@ func (r *DeploymentReconciler) deleteIfOwnedByController(
 	}
 
 	if err != nil {
-		return errors.Wrap(err, "getting Deployment")
+		return fmt.Errorf("getting Deployment: %w", err)
 	}
 
 	if !metav1.IsControlledBy(deployment, cluster) {
@@ -86,7 +84,7 @@ func (r *DeploymentReconciler) deleteIfOwnedByController(
 			logger.V(1).Info("Deployment already deleted")
 			return nil
 		}
-		return errors.Wrap(err, "deleting Deployment")
+		return fmt.Errorf("deleting Deployment: %w", err)
 	}
 	logger.V(1).Info("Deployment deleted")
 	return nil

--- a/internal/controller/reconciler/grant.go
+++ b/internal/controller/reconciler/grant.go
@@ -2,8 +2,7 @@ package reconciler
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 
@@ -50,7 +49,7 @@ func (r *MariaDbGrantReconciler) Reconcile(
 		logger.V(1).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile MariaDbGrant ")
-		return errors.Wrap(err, "reconciling MariaDbGrant ")
+		return fmt.Errorf("reconciling MariaDbGrant: %w", err)
 	}
 	return nil
 }
@@ -69,7 +68,7 @@ func (r *MariaDbGrantReconciler) deleteIfOwnedByController(
 	}
 
 	if err != nil {
-		return errors.Wrap(err, "getting MariaDbGrant")
+		return fmt.Errorf("getting MariaDbGrant: %w", err)
 	}
 
 	if !metav1.IsControlledBy(grant, cluster) {
@@ -78,7 +77,7 @@ func (r *MariaDbGrantReconciler) deleteIfOwnedByController(
 	}
 
 	if err := r.Client.Delete(ctx, grant); err != nil {
-		return errors.Wrap(err, "deleting MariaDbGrant")
+		return fmt.Errorf("deleting MariaDbGrant: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/reconciler/k8s_configmap.go
+++ b/internal/controller/reconciler/k8s_configmap.go
@@ -2,9 +2,9 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 	"maps"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,7 +38,7 @@ func (r *ConfigMapReconciler) Reconcile(
 		log.FromContext(ctx).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile ConfigMap")
-		return errors.Wrap(err, "reconciling ConfigMap")
+		return fmt.Errorf("reconciling ConfigMap: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/reconciler/k8s_cronjob.go
+++ b/internal/controller/reconciler/k8s_cronjob.go
@@ -2,8 +2,8 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,7 +37,7 @@ func (r *CronJobReconciler) Reconcile(
 		log.FromContext(ctx).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile CronJob")
-		return errors.Wrap(err, "reconciling CronJob")
+		return fmt.Errorf("reconciling CronJob: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/reconciler/k8s_daemonset.go
+++ b/internal/controller/reconciler/k8s_daemonset.go
@@ -2,8 +2,8 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,7 +37,7 @@ func (r *DaemonSetReconciler) Reconcile(
 		log.FromContext(ctx).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile DaemonSet")
-		return errors.Wrap(err, "reconciling DaemonSet")
+		return fmt.Errorf("reconciling DaemonSet: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/reconciler/k8s_job.go
+++ b/internal/controller/reconciler/k8s_job.go
@@ -2,8 +2,8 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,7 +37,7 @@ func (r *JobReconciler) Reconcile(
 		log.FromContext(ctx).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile Job")
-		return errors.Wrap(err, "reconciling Job")
+		return fmt.Errorf("reconciling Job: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/reconciler/k8s_role.go
+++ b/internal/controller/reconciler/k8s_role.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +45,7 @@ func (r *RoleReconciler) Reconcile(
 		logger.V(1).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile Worker Role")
-		return errors.Wrap(err, "reconciling Worker Role")
+		return fmt.Errorf("reconciling Worker Role: %w", err)
 	}
 	return nil
 }
@@ -63,7 +62,7 @@ func (r *RoleReconciler) deleteIfOwnedByController(
 	}
 
 	if err != nil {
-		return errors.Wrap(err, "getting Worker Role")
+		return fmt.Errorf("getting Worker Role: %w", err)
 	}
 
 	if !metav1.IsControlledBy(role, cluster) {
@@ -76,7 +75,7 @@ func (r *RoleReconciler) deleteIfOwnedByController(
 			logger.V(1).Info("Role not found, skipping deletion")
 			return nil
 		}
-		return errors.Wrap(err, "deleting Worker Role")
+		return fmt.Errorf("deleting Worker Role: %w", err)
 	}
 	logger.V(1).Info("Role deleted")
 	return nil

--- a/internal/controller/reconciler/k8s_rolebinging.go
+++ b/internal/controller/reconciler/k8s_rolebinging.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +45,7 @@ func (r *RoleBindingReconciler) Reconcile(
 		logger.V(1).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile RoleBinding")
-		return errors.Wrap(err, "reconciling RoleBinding")
+		return fmt.Errorf("reconciling RoleBinding: %w", err)
 	}
 	return nil
 }
@@ -62,7 +61,7 @@ func (r *RoleBindingReconciler) deleteIfOwnedByController(
 		return nil
 	}
 	if err != nil {
-		return errors.Wrap(err, "getting Worker RoleBinding")
+		return fmt.Errorf("getting Worker RoleBinding: %w", err)
 	}
 
 	if !metav1.IsControlledBy(roleBinding, cluster) {
@@ -75,7 +74,7 @@ func (r *RoleBindingReconciler) deleteIfOwnedByController(
 			logger.V(1).Info("RoleBinding is already deleted")
 			return nil
 		}
-		return errors.Wrap(err, "deleting RoleBinding")
+		return fmt.Errorf("deleting RoleBinding: %w", err)
 	}
 
 	logger.V(1).Info("RoleBinding deleted")

--- a/internal/controller/reconciler/k8s_secret.go
+++ b/internal/controller/reconciler/k8s_secret.go
@@ -2,12 +2,12 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
@@ -38,7 +38,7 @@ func (r *SecretReconciler) Reconcile(
 		log.FromContext(ctx).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile Secret")
-		return errors.Wrap(err, "reconciling Secret")
+		return fmt.Errorf("reconciling Secret: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/reconciler/k8s_service.go
+++ b/internal/controller/reconciler/k8s_service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"maps"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +50,7 @@ func (r *ServiceReconciler) Reconcile(
 		logger.V(1).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile Service")
-		return errors.Wrap(err, "reconciling Service")
+		return fmt.Errorf("reconciling Service: %w", err)
 	}
 	return nil
 }
@@ -69,7 +68,7 @@ func (r *ServiceReconciler) deleteIfOwnedByController(
 		return nil
 	}
 	if err != nil {
-		return errors.Wrap(err, "getting Service")
+		return fmt.Errorf("getting Service: %w", err)
 	}
 
 	if !metav1.IsControlledBy(service, cluster) {
@@ -78,7 +77,7 @@ func (r *ServiceReconciler) deleteIfOwnedByController(
 	}
 
 	if err := r.Delete(ctx, service); err != nil {
-		return errors.Wrap(err, "deleting Service")
+		return fmt.Errorf("deleting Service: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/reconciler/k8s_service_account.go
+++ b/internal/controller/reconciler/k8s_service_account.go
@@ -2,8 +2,8 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,7 +37,7 @@ func (r *ServiceAccountReconciler) Reconcile(
 		log.FromContext(ctx).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile ServiceAccount")
-		return errors.Wrap(err, "reconciling ServiceAccount")
+		return fmt.Errorf("reconciling ServiceAccount: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/reconciler/k8s_statefulset.go
+++ b/internal/controller/reconciler/k8s_statefulset.go
@@ -2,8 +2,8 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +38,7 @@ func (r *StatefulSetReconciler) Reconcile(
 		log.FromContext(ctx).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile StatefulSet")
-		return errors.Wrap(err, "reconciling StatefulSet")
+		return fmt.Errorf("reconciling StatefulSet: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/reconciler/k8s_statefulset_advanced.go
+++ b/internal/controller/reconciler/k8s_statefulset_advanced.go
@@ -2,8 +2,8 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,7 +39,7 @@ func (r *AdvancedStatefulSetReconciler) Reconcile(
 		log.FromContext(ctx).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile StatefulSet")
-		return errors.Wrap(err, "reconciling StatefulSet")
+		return fmt.Errorf("reconciling StatefulSet: %w", err)
 	}
 	return nil
 }

--- a/internal/controller/reconciler/mariadb.go
+++ b/internal/controller/reconciler/mariadb.go
@@ -2,8 +2,7 @@ package reconciler
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 
@@ -51,7 +50,7 @@ func (r *MariaDbReconciler) Reconcile(
 		logger.V(1).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile MariaDb ")
-		return errors.Wrap(err, "reconciling MariaDb ")
+		return fmt.Errorf("reconciling MariaDb: %w", err)
 	}
 	return nil
 }
@@ -69,7 +68,7 @@ func (r *MariaDbReconciler) deleteIfOwnedByController(
 		return nil
 	}
 	if err != nil {
-		return errors.Wrap(err, "getting MariaDb")
+		return fmt.Errorf("getting MariaDb: %w", err)
 	}
 
 	if !metav1.IsControlledBy(mariaDb, cluster) {

--- a/internal/controller/reconciler/otel.go
+++ b/internal/controller/reconciler/otel.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -48,7 +46,7 @@ func (r *OtelReconciler) Reconcile(
 		log.FromContext(ctx).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile OpenTelemetryCollector")
-		return errors.Wrap(err, "reconciling OpenTelemetryCollector")
+		return fmt.Errorf("reconciling OpenTelemetryCollector: %w", err)
 	}
 	return nil
 }
@@ -65,7 +63,7 @@ func (r *OtelReconciler) deleteIfOwnedByController(
 	}
 
 	if err != nil {
-		return errors.Wrap(err, "getting OpenTelemetryCollector")
+		return fmt.Errorf("getting OpenTelemetryCollector: %w", err)
 	}
 
 	if !metav1.IsControlledBy(otel, cluster) {
@@ -74,7 +72,7 @@ func (r *OtelReconciler) deleteIfOwnedByController(
 	}
 
 	if err := r.Delete(ctx, otel); err != nil {
-		return errors.Wrap(err, "deleting Service")
+		return fmt.Errorf("deleting Service: %w", err)
 	}
 
 	return nil

--- a/internal/controller/reconciler/pod_monitor.go
+++ b/internal/controller/reconciler/pod_monitor.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -53,7 +51,7 @@ func (r *PodMonitorReconciler) Reconcile(
 		logger.V(1).
 			WithValues(logfield.ResourceKV(desired)...).
 			Error(err, "Failed to reconcile PodMonitor")
-		return errors.Wrap(err, "reconciling PodMonitor")
+		return fmt.Errorf("reconciling PodMonitor: %w", err)
 	}
 	return nil
 }
@@ -69,7 +67,7 @@ func (r *PodMonitorReconciler) deleteIfOwnedByController(
 		return nil
 	}
 	if err != nil {
-		return errors.Wrap(err, "getting PodMonitor")
+		return fmt.Errorf("getting PodMonitor: %w", err)
 	}
 
 	if !metav1.IsControlledBy(podMonitor, cluster) {
@@ -78,7 +76,7 @@ func (r *PodMonitorReconciler) deleteIfOwnedByController(
 	}
 
 	if err := r.Delete(ctx, podMonitor); err != nil {
-		return errors.Wrap(err, "deleting PodMonitor")
+		return fmt.Errorf("deleting PodMonitor: %w", err)
 	}
 	return nil
 }
@@ -99,7 +97,7 @@ func (r *PodMonitorReconciler) getPodMonitor(ctx context.Context, cluster *slurm
 			return podMonitor, nil
 		}
 		// Other error occurred
-		return nil, errors.Wrap(err, "getting PodMonitor")
+		return nil, fmt.Errorf("getting PodMonitor: %w", err)
 	}
 	return podMonitor, nil
 }

--- a/internal/controller/soperatorchecks/activecheck_jobs_controller.go
+++ b/internal/controller/soperatorchecks/activecheck_jobs_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -206,7 +205,7 @@ func (r *ActiveCheckJobReconciler) Reconcile(
 		err = r.Status().Update(ctx, activeCheck)
 		if err != nil {
 			logger.Error(err, "Failed to reconcile ActiveCheckJob")
-			return ctrl.Result{}, errors.Wrap(err, "reconciling ActiveCheckJob")
+			return ctrl.Result{}, fmt.Errorf("reconciling ActiveCheckJob: %w", err)
 		}
 	} else if activeCheck.Spec.CheckType == "k8sJob" {
 		newStatus := slurmv1alpha1.ActiveCheckK8sJobsStatus{
@@ -236,7 +235,7 @@ func (r *ActiveCheckJobReconciler) Reconcile(
 		err = r.Status().Update(ctx, activeCheck)
 		if err != nil {
 			logger.Error(err, "Failed to reconcile ActiveCheckJob")
-			return ctrl.Result{}, errors.Wrap(err, "reconciling ActiveCheckJob")
+			return ctrl.Result{}, fmt.Errorf("reconciling ActiveCheckJob: %w", err)
 		}
 	}
 

--- a/internal/controller/soperatorchecks/serviceaccount_controller.go
+++ b/internal/controller/soperatorchecks/serviceaccount_controller.go
@@ -2,9 +2,9 @@ package soperatorchecks
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -121,11 +121,11 @@ func (r *ServiceAccountReconciler) Reconcile(
 	err = r.Get(ctx, clusterNN, cluster)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return ctrl.Result{}, errors.Wrap(err, "SlurmCluster resource not found")
+			return ctrl.Result{}, fmt.Errorf("SlurmCluster resource not found: %w", err)
 		}
 
 		logger.Error(err, "Failed to get SlurmCluster")
-		return ctrl.Result{}, errors.Wrap(err, "getting SlurmCluster")
+		return ctrl.Result{}, fmt.Errorf("getting SlurmCluster: %w", err)
 	}
 
 	reconcileServiceAccountImpl := func() error {
@@ -145,7 +145,7 @@ func (r *ServiceAccountReconciler) Reconcile(
 
 					if err := r.ServiceAccount.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling active check ServiceAccount")
+						return fmt.Errorf("reconciling active check ServiceAccount: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -165,7 +165,7 @@ func (r *ServiceAccountReconciler) Reconcile(
 
 					if err := r.Role.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling active check Role")
+						return fmt.Errorf("reconciling active check Role: %w", err)
 					}
 					stepLogger.V(1).Info("Reconciled")
 
@@ -185,7 +185,7 @@ func (r *ServiceAccountReconciler) Reconcile(
 
 					if err := r.RoleBinding.Reconcile(stepCtx, cluster, &desired); err != nil {
 						stepLogger.Error(err, "Failed to reconcile")
-						return errors.Wrap(err, "reconciling active check RoleBinding")
+						return fmt.Errorf("reconciling active check RoleBinding: %w", err)
 					}
 
 					stepLogger.V(1).Info("Reconciled")
@@ -198,7 +198,7 @@ func (r *ServiceAccountReconciler) Reconcile(
 
 	if err := reconcileServiceAccountImpl(); err != nil {
 		logger.Error(err, "Failed to reconcile ServiceAccount")
-		return ctrl.Result{}, errors.Wrap(err, "reconciling ServiceAccount")
+		return ctrl.Result{}, fmt.Errorf("reconciling ServiceAccount: %w", err)
 	}
 
 	logger.Info("Reconciled ServiceAccount")

--- a/internal/jwt/token.go
+++ b/internal/jwt/token.go
@@ -2,12 +2,12 @@ package jwt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -141,7 +141,7 @@ func (t *Token) validate() error {
 // Issue issues a signed JWT token with specified parameters.
 func (t *Token) Issue(ctx context.Context) (string, error) {
 	if err := t.validate(); err != nil {
-		return "", errors.Wrap(err, "failed to issue token")
+		return "", fmt.Errorf("failed to issue token: %w", err)
 	}
 
 	if t.registry != nil {
@@ -173,12 +173,12 @@ func (t *Token) Issue(ctx context.Context) (string, error) {
 
 	signingKey, err := t.getSigningKey(ctx)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get signing key")
+		return "", fmt.Errorf("failed to get signing key: %w", err)
 	}
 
 	signedToken, err := token.SignedString(signingKey)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to sign token")
+		return "", fmt.Errorf("failed to sign token: %w", err)
 	}
 
 	if t.registry != nil {
@@ -199,7 +199,7 @@ func (t *Token) getSigningKey(ctx context.Context) ([]byte, error) {
 		},
 		&signingKeySecret,
 	); err != nil {
-		return nil, errors.Wrap(err, "failed to get signing secret")
+		return nil, fmt.Errorf("failed to get signing secret: %w", err)
 	}
 
 	return signingKeySecret.Data[consts.SecretRESTJWTKeyFileName], nil

--- a/internal/utils/multistep_test.go
+++ b/internal/utils/multistep_test.go
@@ -2,10 +2,10 @@ package utils_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 

--- a/internal/utils/mutltistep.go
+++ b/internal/utils/mutltistep.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -55,7 +54,7 @@ func ExecuteMultiStep(ctx context.Context, name string, strategy MultiStepExecut
 
 	if err != nil {
 		logger.Error(err, "Failed to execute steps")
-		return errors.Wrap(err, "failed to execute steps")
+		return fmt.Errorf("failed to execute steps: %w", err)
 	} else {
 		logger.V(1).Info("Executed steps")
 	}
@@ -77,7 +76,7 @@ func executeFailAtFirstError(ctx context.Context, steps ...MultiStepExecutionSte
 		err := step.Func(stepCtx)
 		if err != nil {
 			stepLogger.Error(err, "Failed step. Stopping execution of the following steps")
-			return errors.Wrap(err, "multi-step execution failed at the first met error")
+			return fmt.Errorf("multi-step execution failed at the first met error: %w", err)
 		}
 	}
 	return nil

--- a/internal/values/slurm_cluster.go
+++ b/internal/values/slurm_cluster.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -51,7 +50,7 @@ func BuildSlurmClusterFrom(ctx context.Context, cluster *slurmv1.SlurmCluster) (
 	clusterType, err := consts.StringToClusterType(cluster.Spec.ClusterType)
 	if err != nil {
 		logger.Error(err, "Failed to get cluster type")
-		return nil, errors.Wrap(err, "getting cluster type")
+		return nil, fmt.Errorf("getting cluster type: %w", err)
 	}
 
 	res := &SlurmCluster{


### PR DESCRIPTION
## Summary

Replace all usage of `github.com/pkg/errors` with Go's standard library error handling using `fmt.Errorf()` and the `%w` verb, and enable `depguard` linter to prevent future usage.

Part of #680. Closes #1001.

## Changes Made

- Replaced all `errors.Wrap(err, "message")` with `fmt.Errorf("message: %w", err)`
- Removed `github.com/pkg/errors` imports from source files
- Added `depguard` linter configuration to prevent future `pkg/errors` usage
- Preserved standard library `errors.New()` usage where appropriate

## Benefits

- **Dependencies**: Reduced external dependency footprint
- **Future-proof**: Linter enforcement prevents regression to deprecated patterns
- **Compatibility**: Better integration with Go 1.13+ error handling (`errors.Is`, `errors.As`)
- **Standards**: Aligns with modern Go development best practices

## Breaking Changes

None. All error wrapping semantics are preserved through the `%w` verb.