### PR TITLE
Use soperator exporter by default.

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -14,7 +14,6 @@ on:
       - 'README.md'
       - 'SECURITY.md'
       - 'images/worker/gpubench/**'
-      - 'helm/**'
 
   # pull_request are defined separately to allow to run CI from forks.
   pull_request:
@@ -30,7 +29,6 @@ on:
       - 'README.md'
       - 'SECURITY.md'
       - 'images/worker/gpubench/**'
-      - 'helm/**'
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ sync-version: yq ## Sync versions from file
 	@$(YQ) -i ".images.sshd = \"$(IMAGE_REPO)/login_sshd:$(IMAGE_VERSION)\"" "helm/slurm-cluster/values.yaml"
 	@$(YQ) -i ".images.munge = \"$(IMAGE_REPO)/munge:$(IMAGE_VERSION)\"" "helm/slurm-cluster/values.yaml"
 	@$(YQ) -i ".images.populateJail = \"$(IMAGE_REPO)/populate_jail:$(IMAGE_VERSION)\"" "helm/slurm-cluster/values.yaml"
-	@$(YQ) -i ".images.exporter = \"$(IMAGE_REPO)/exporter:$(IMAGE_VERSION)\"" "helm/slurm-cluster/values.yaml"
+	@$(YQ) -i ".images.soperatorExporter = \"$(IMAGE_REPO)/soperator-exporter:$(IMAGE_VERSION)\"" "helm/slurm-cluster/values.yaml"
 	@$(YQ) -i ".images.sConfigController = \"$(IMAGE_REPO)/sconfigcontroller:$(OPERATOR_IMAGE_TAG)\"" "helm/slurm-cluster/values.yaml"
 	@$(YQ) -i ".images.mariaDB = \"docker-registry1.mariadb.com/library/mariadb:11.4.3\"" "helm/slurm-cluster/values.yaml"
 	@# endregion helm/slurm-cluster/values.yaml

--- a/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
+++ b/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
@@ -320,34 +320,10 @@ spec:
       enabled: {{ .Values.slurmNodes.exporter.enabled }}
       size: {{ required ".Values.slurmNodes.exporter.size must be provided." .Values.slurmNodes.exporter.size }}
       k8sNodeFilterName: {{ required ".Values.slurmNodes.exporter.k8sNodeFilterName must be provided." .Values.slurmNodes.exporter.k8sNodeFilterName | quote }}
-      exporter:
-        image: {{ required "exporter image" .Values.images.exporter | quote }}
+      exporterContainer:
+        image: {{ required "soperator exporter image" .Values.images.soperatorExporter | quote }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.slurmNodes.exporter.imagePullPolicy | quote }}
         appArmorProfile: {{ default "unconfined" .Values.slurmNodes.exporter.appArmorProfile | quote }}
-        {{- if .Values.slurmNodes.exporter.exporter.command }}
-        command: {{- .Values.slurmNodes.exporter.exporter.command | toYaml | nindent 8 }}
-        {{- end }}
-        {{- if .Values.slurmNodes.exporter.exporter.args }}
-        args: {{- .Values.slurmNodes.exporter.exporter.args | toYaml | nindent 8 }}
-        {{- end }}
-      munge:
-        image: {{ required "munge image" .Values.images.munge | quote }}
-        imagePullPolicy: {{ default "IfNotPresent" .Values.slurmNodes.exporter.munge.imagePullPolicy | quote }}
-        appArmorProfile: {{ default "unconfined" .Values.slurmNodes.exporter.munge.appArmorProfile | quote }}
-        {{- if .Values.slurmNodes.exporter.munge.command }}
-        command: {{- .Values.slurmNodes.exporter.munge.command | toYaml | nindent 8 }}
-        {{- end }}
-        {{- if .Values.slurmNodes.exporter.munge.args }}
-        args: {{- .Values.slurmNodes.exporter.munge.args | toYaml | nindent 8 }}
-        {{- end }}
-        resources:
-          cpu: {{ required ".Values.slurmNodes.controller.munge.resources.cpu must be provided." .Values.slurmNodes.controller.munge.resources.cpu | quote}}
-          memory: {{ required ".Values.slurmNodes.controller.munge.resources.memory must be provided." .Values.slurmNodes.controller.munge.resources.memory | quote}}
-          ephemeral-storage: {{ required ".Values.slurmNodes.controller.munge.resources.ephemeralStorage must be provided." .Values.slurmNodes.controller.munge.resources.ephemeralStorage | quote}}
-      customInitContainers: {{- default list .Values.slurmNodes.exporter.customInitContainers | toYaml | nindent 10 }}
-      volumes:
-        jail:
-          {{- required ".Values.slurmNodes.exporter.volumes.jail must be provided." .Values.slurmNodes.exporter.volumes.jail | toYaml | nindent 10 }}
     rest:
       enabled: {{ .Values.slurmNodes.rest.enabled }}
       size: {{ required ".Values.slurmNodes.rest.size must be provided." .Values.slurmNodes.rest.size }}

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -493,6 +493,6 @@ images:
   populateJail: "cr.eu-north1.nebius.cloud/soperator/populate_jail:1.20.1-jammy-slurm24.05.7"
   ncclBenchmark: "cr.eu-north1.nebius.cloud/soperator/nccl_benchmark:1.20.1-jammy-slurm24.05.7"
   slurmdbd: "cr.eu-north1.nebius.cloud/soperator/controller_slurmdbd:1.20.1-jammy-slurm24.05.7"
-  exporter: "cr.eu-north1.nebius.cloud/soperator/exporter:1.20.1-jammy-slurm24.05.7"
+  soperatorExporter: "cr.eu-north1.nebius.cloud/soperator/soperator-exporter:1.20.1-jammy-slurm24.05.7"
   sConfigController: cr.eu-north1.nebius.cloud/soperator/sconfigcontroller:1.20.1
   mariaDB: docker-registry1.mariadb.com/library/mariadb:11.4.3


### PR DESCRIPTION
This change enables the soperator exporter by default to provide Prometheus metrics collection out of the box. 
Together with changing the dashboard (https://github.com/nebius/nebius-solutions-library/pull/357), users will now see new dashboard in new installations.

Addresses this issue: https://github.com/nebius/soperator/issues/994