### PR TITLE
Enhance node metrics with state labels and remove job GPU metric

### DIFF
--- a/internal/exporter/collector.go
+++ b/internal/exporter/collector.go
@@ -36,17 +36,17 @@ func NewMetricsCollector(slurmAPIClient slurmapi.Client, soperatorVersion string
 		slurmAPIClient: slurmAPIClient,
 
 		sopClusterInfo: prometheus.NewDesc("soperator_cluster_info", "Soperator cluster information", []string{}, sopClusterInfoConstLabels),
-		nodeInfo:       prometheus.NewDesc("slurm_node_info", "Slurm node info", []string{"node_name", "compute_instance_id", "base_state", "is_drain", "is_maintenance", "is_reserved", "address"}, nil),
+		nodeInfo:       prometheus.NewDesc("slurm_node_info", "Slurm node info", []string{"node_name", "instance_id", "state_base", "state_is_drain", "state_is_maintenance", "state_is_reserved", "address"}, nil),
 		jobInfo:        prometheus.NewDesc("slurm_job_info", "Slurm job detail information", []string{"job_id", "job_state", "job_state_reason", "slurm_partition", "job_name", "user_name", "standard_error", "standard_output", "array_job_id", "array_task_id"}, nil),
 		jobNode:        prometheus.NewDesc("slurm_node_job", "Slurm job node information", []string{"job_id", "node_name"}, nil),
 		nodeGPUSeconds: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "slurm_node_gpu_seconds_total",
 			Help: "Total GPU seconds on Slurm nodes",
-		}, []string{"node_name", "base_state", "is_drain", "is_maintenance", "is_reserved"}),
+		}, []string{"node_name", "state_base", "state_is_drain", "state_is_maintenance", "state_is_reserved"}),
 		nodeFails: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "slurm_node_fails_total",
 			Help: "Total number of times a node has failed (went from not down/drain to down/drain state)",
-		}, []string{"node_name", "base_state", "is_drain", "is_maintenance", "is_reserved", "reason"}),
+		}, []string{"node_name", "state_base", "state_is_drain", "state_is_maintenance", "state_is_reserved", "reason"}),
 
 		lastNodeGPUTimeUpdated: time.Now(),
 		nodes:                  make(map[string]slurmapi.Node),

--- a/internal/exporter/collector.go
+++ b/internal/exporter/collector.go
@@ -22,11 +22,9 @@ type MetricsCollector struct {
 	jobInfo        *prometheus.Desc
 	jobNode        *prometheus.Desc
 	nodeGPUSeconds *prometheus.CounterVec
-	jobGPUSeconds  *prometheus.CounterVec
 	nodeFails      *prometheus.CounterVec
 
 	lastNodeGPUTimeUpdated time.Time
-	lastJobGPUTimeUpdated  time.Time
 	nodes                  map[string]slurmapi.Node
 	stateMutex             sync.RWMutex
 }
@@ -38,24 +36,19 @@ func NewMetricsCollector(slurmAPIClient slurmapi.Client, soperatorVersion string
 		slurmAPIClient: slurmAPIClient,
 
 		sopClusterInfo: prometheus.NewDesc("soperator_cluster_info", "Soperator cluster information", []string{}, sopClusterInfoConstLabels),
-		nodeInfo:       prometheus.NewDesc("slurm_node_info", "Slurm node info", []string{"node_name", "compute_instance_id", "base_state", "is_drain", "address"}, nil),
+		nodeInfo:       prometheus.NewDesc("slurm_node_info", "Slurm node info", []string{"node_name", "compute_instance_id", "base_state", "is_drain", "is_maintenance", "is_reserved", "address"}, nil),
 		jobInfo:        prometheus.NewDesc("slurm_job_info", "Slurm job detail information", []string{"job_id", "job_state", "job_state_reason", "slurm_partition", "job_name", "user_name", "standard_error", "standard_output", "array_job_id", "array_task_id"}, nil),
 		jobNode:        prometheus.NewDesc("slurm_node_job", "Slurm job node information", []string{"job_id", "node_name"}, nil),
 		nodeGPUSeconds: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "slurm_active_node_gpu_seconds_total",
-			Help: "Total GPU seconds on active Slurm nodes (not down, not idle+drain)",
-		}, []string{"node_name"}),
-		jobGPUSeconds: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "slurm_job_alloc_gpu_seconds_total",
-			Help: "Total GPU seconds allocated to jobs in RUNNING state",
-		}, []string{}),
+			Name: "slurm_node_gpu_seconds_total",
+			Help: "Total GPU seconds on Slurm nodes",
+		}, []string{"node_name", "base_state", "is_drain", "is_maintenance", "is_reserved"}),
 		nodeFails: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "slurm_node_fails_total",
 			Help: "Total number of times a node has failed (went from not down/drain to down/drain state)",
-		}, []string{"node_name", "reason"}),
+		}, []string{"node_name", "base_state", "is_drain", "is_maintenance", "is_reserved", "reason"}),
 
 		lastNodeGPUTimeUpdated: time.Now(),
-		lastJobGPUTimeUpdated:  time.Now(),
 		nodes:                  make(map[string]slurmapi.Node),
 	}
 }
@@ -67,7 +60,6 @@ func (c *MetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.jobInfo
 	ch <- c.jobNode
 	c.nodeGPUSeconds.Describe(ch)
-	c.jobGPUSeconds.Describe(ch)
 	c.nodeFails.Describe(ch)
 }
 
@@ -98,7 +90,14 @@ func (c *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
 				if node.Reason != nil {
 					reason = node.Reason.Reason
 				}
-				c.nodeFails.WithLabelValues(node.Name, reason).Inc()
+				c.nodeFails.WithLabelValues(
+					node.Name,
+					string(node.BaseState()),
+					strconv.FormatBool(node.IsDrainState()),
+					strconv.FormatBool(node.IsMaintenanceState()),
+					strconv.FormatBool(node.IsReservedState()),
+					reason,
+				).Inc()
 			}
 		}
 		c.nodes[node.Name] = node
@@ -112,9 +111,6 @@ func (c *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
 		logger.Error(err, "Failed to get jobs from SLURM API")
 		return
 	}
-
-	c.calculateJobGPUSeconds(ctx, now, jobs, nodes)
-	c.jobGPUSeconds.Collect(ch)
 
 	for slurmJobMetric := range c.slurmJobMetrics(ctx, jobs) {
 		ch <- slurmJobMetric
@@ -134,6 +130,8 @@ func (c *MetricsCollector) slurmNodeMetrics(
 				node.InstanceID,
 				string(node.BaseState()),
 				strconv.FormatBool(node.IsDrainState()),
+				strconv.FormatBool(node.IsMaintenanceState()),
+				strconv.FormatBool(node.IsReservedState()),
 				node.Address,
 			}
 			yield(prometheus.MustNewConstMetric(c.nodeInfo, prometheus.GaugeValue, 1, labels...))
@@ -143,61 +141,17 @@ func (c *MetricsCollector) slurmNodeMetrics(
 				logger.Error(err, "Failed to parse trackable resources", "tres", node.Tres)
 				continue
 			}
-			if !node.IsDownState() && !node.IsIdleDrained() {
-				gpuSecondsInc := now.Sub(c.lastNodeGPUTimeUpdated).Seconds() * float64(tres.GPUCount)
-				c.nodeGPUSeconds.WithLabelValues(node.Name).Add(gpuSecondsInc)
-			}
+			gpuSecondsInc := now.Sub(c.lastNodeGPUTimeUpdated).Seconds() * float64(tres.GPUCount)
+			c.nodeGPUSeconds.WithLabelValues(
+				node.Name,
+				string(node.BaseState()),
+				strconv.FormatBool(node.IsDrainState()),
+				strconv.FormatBool(node.IsMaintenanceState()),
+				strconv.FormatBool(node.IsReservedState()),
+			).Add(gpuSecondsInc)
 		}
 		c.lastNodeGPUTimeUpdated = now
 	}
-}
-
-func (c *MetricsCollector) calculateJobGPUSeconds(
-	ctx context.Context, now time.Time, jobs []slurmapi.Job, nodes []slurmapi.Node,
-) {
-	logger := log.FromContext(ctx).WithName(ControllerName)
-
-	nodeMap := make(map[string]slurmapi.Node, len(nodes))
-	for _, node := range nodes {
-		nodeMap[node.Name] = node
-	}
-
-	var totalRunningJobGPUs int
-	for _, job := range jobs {
-		if job.State != "RUNNING" {
-			continue
-		}
-
-		nodeList, err := job.GetNodeList()
-		if err != nil {
-			logger.Error(err, "Failed to parse node list for job", "job_id", job.GetIDString(), "nodes", job.Nodes)
-			continue
-		}
-
-		for _, nodeName := range nodeList {
-			node, exists := nodeMap[nodeName]
-			if !exists {
-				logger.Error(nil, "Job references unknown node", "job_id", job.GetIDString(), "node_name", nodeName)
-				continue
-			}
-
-			tres, err := slurmapi.ParseTrackableResources(node.Tres)
-			if err != nil {
-				logger.Error(err, "Failed to parse trackable resources for job node", "job_id", job.GetIDString(), "node_name", nodeName, "tres", node.Tres)
-				continue
-			}
-
-			totalRunningJobGPUs += tres.GPUCount
-		}
-	}
-
-	if totalRunningJobGPUs > 0 {
-		timeDelta := now.Sub(c.lastJobGPUTimeUpdated).Seconds()
-		gpuSecondsInc := timeDelta * float64(totalRunningJobGPUs)
-		c.jobGPUSeconds.WithLabelValues().Add(gpuSecondsInc)
-	}
-
-	c.lastJobGPUTimeUpdated = now
 }
 
 func (c *MetricsCollector) slurmJobMetrics(

--- a/internal/exporter/collector_test.go
+++ b/internal/exporter/collector_test.go
@@ -45,7 +45,7 @@ func TestMetricsCollector_Describe(t *testing.T) {
 	}
 
 	assert.Contains(t, found, `Desc{fqName: "soperator_cluster_info", help: "Soperator cluster information", constLabels: {soperator_version="test-version"}, variableLabels: {}}`)
-	assert.Contains(t, found, `Desc{fqName: "slurm_node_info", help: "Slurm node info", constLabels: {}, variableLabels: {node_name,compute_instance_id,base_state,is_drain,is_maintenance,is_reserved,address}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_info", help: "Slurm node info", constLabels: {}, variableLabels: {node_name,instance_id,state_base,state_is_drain,state_is_maintenance,state_is_reserved,address}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_job_info", help: "Slurm job detail information", constLabels: {}, variableLabels: {job_id,job_state,job_state_reason,slurm_partition,job_name,user_name,standard_error,standard_output,array_job_id,array_task_id}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_node_job", help: "Slurm job node information", constLabels: {}, variableLabels: {job_id,node_name}}`)
 }
@@ -123,10 +123,10 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 
 		expectedMetrics := []string{
 			`GAUGE; soperator_cluster_info{soperator_version="test-version"} 1`,
-			`GAUGE; slurm_node_info{address="10.0.0.1",base_state="ALLOCATED",compute_instance_id="instance-1",is_drain="false",is_maintenance="false",is_reserved="false",node_name="node-1"} 1`,
-			`GAUGE; slurm_node_info{address="10.0.0.2",base_state="IDLE",compute_instance_id="instance-2",is_drain="true",is_maintenance="false",is_reserved="false",node_name="node-2"} 1`,
-			`COUNTER; slurm_node_gpu_seconds_total{base_state="ALLOCATED",is_drain="false",is_maintenance="false",is_reserved="false",node_name="node-1"} 20`,
-			`COUNTER; slurm_node_gpu_seconds_total{base_state="IDLE",is_drain="true",is_maintenance="false",is_reserved="false",node_name="node-2"} 10`,
+			`GAUGE; slurm_node_info{address="10.0.0.1",instance_id="instance-1",node_name="node-1",state_base="ALLOCATED",state_is_drain="false",state_is_maintenance="false",state_is_reserved="false"} 1`,
+			`GAUGE; slurm_node_info{address="10.0.0.2",instance_id="instance-2",node_name="node-2",state_base="IDLE",state_is_drain="true",state_is_maintenance="false",state_is_reserved="false"} 1`,
+			`COUNTER; slurm_node_gpu_seconds_total{node_name="node-1",state_base="ALLOCATED",state_is_drain="false",state_is_maintenance="false",state_is_reserved="false"} 20`,
+			`COUNTER; slurm_node_gpu_seconds_total{node_name="node-2",state_base="IDLE",state_is_drain="true",state_is_maintenance="false",state_is_reserved="false"} 10`,
 			`GAUGE; slurm_job_info{array_job_id="",array_task_id="42",job_id="12345",job_name="test_job",job_state="RUNNING",job_state_reason="None",slurm_partition="gpu",standard_error="/path/to/stderr",standard_output="/path/to/stdout",user_name="testuser"} 1`,
 			`GAUGE; slurm_node_job{job_id="12345",node_name="node-1"} 1`,
 			`GAUGE; slurm_node_job{job_id="12345",node_name="node-2"} 1`,
@@ -216,8 +216,8 @@ func TestMetricsCollector_NodeFails(t *testing.T) {
 
 	// Check specific state combinations for node info metrics
 	expectedNodeMetrics := []string{
-		`GAUGE; slurm_node_info{address="10.0.0.3",base_state="IDLE",compute_instance_id="instance-maintenance",is_drain="false",is_maintenance="true",is_reserved="false",node_name="node-maintenance"} 1`,
-		`GAUGE; slurm_node_info{address="10.0.0.4",base_state="IDLE",compute_instance_id="instance-reserved",is_drain="false",is_maintenance="false",is_reserved="true",node_name="node-reserved"} 1`,
+		`GAUGE; slurm_node_info{address="10.0.0.3",instance_id="instance-maintenance",node_name="node-maintenance",state_base="IDLE",state_is_drain="false",state_is_maintenance="true",state_is_reserved="false"} 1`,
+		`GAUGE; slurm_node_info{address="10.0.0.4",instance_id="instance-reserved",node_name="node-reserved",state_base="IDLE",state_is_drain="false",state_is_maintenance="false",state_is_reserved="true"} 1`,
 	}
 
 	for _, expected := range expectedNodeMetrics {
@@ -228,10 +228,10 @@ func TestMetricsCollector_NodeFails(t *testing.T) {
 	foundMaintenanceGPU := false
 	foundReservedGPU := false
 	for _, metric := range metricsText {
-		if strings.Contains(metric, `slurm_node_gpu_seconds_total{base_state="IDLE",is_drain="false",is_maintenance="true",is_reserved="false",node_name="node-maintenance"}`) {
+		if strings.Contains(metric, `slurm_node_gpu_seconds_total{node_name="node-maintenance",state_base="IDLE",state_is_drain="false",state_is_maintenance="true",state_is_reserved="false"}`) {
 			foundMaintenanceGPU = true
 		}
-		if strings.Contains(metric, `slurm_node_gpu_seconds_total{base_state="IDLE",is_drain="false",is_maintenance="false",is_reserved="true",node_name="node-reserved"}`) {
+		if strings.Contains(metric, `slurm_node_gpu_seconds_total{node_name="node-reserved",state_base="IDLE",state_is_drain="false",state_is_maintenance="false",state_is_reserved="true"}`) {
 			foundReservedGPU = true
 		}
 	}
@@ -270,7 +270,7 @@ func TestMetricsCollector_NodeFails(t *testing.T) {
 	}
 
 	// Check that node fails metric includes all the new labels
-	expectedNodeFailsMetric := `COUNTER; slurm_node_fails_total{base_state="IDLE",is_drain="true",is_maintenance="true",is_reserved="false",node_name="node-maintenance",reason="maintenance drain triggered"} 1`
+	expectedNodeFailsMetric := `COUNTER; slurm_node_fails_total{node_name="node-maintenance",reason="maintenance drain triggered",state_base="IDLE",state_is_drain="true",state_is_maintenance="true",state_is_reserved="false"} 1`
 	assert.Contains(t, metricsText, expectedNodeFailsMetric)
 
 	mockClient.AssertExpectations(t)
@@ -278,7 +278,7 @@ func TestMetricsCollector_NodeFails(t *testing.T) {
 
 // toPrometheusLikeString returns metric text representation like Prometheus does, with some extra additions.
 // E.g.:
-// GAUGE; slurm_node_info{base_state="idle",compute_instance_id="computeinstance-xyz",is_drain="false",node_name="worker-0",reason=""} 1
+// GAUGE; slurm_node_info{address="10.0.0.1",instance_id="computeinstance-xyz",node_name="worker-0",state_base="idle",state_is_drain="false",state_is_maintenance="false",state_is_reserved="false"} 1
 func toPrometheusLikeString(t *testing.T, metric prometheus.Metric) string {
 	var pb dto.Metric
 	if err := metric.Write(&pb); err != nil {

--- a/internal/slurmapi/node.go
+++ b/internal/slurmapi/node.go
@@ -94,13 +94,23 @@ func (n *Node) IsIdleDrained() bool {
 }
 
 func (n *Node) IsDrainState() bool {
-	_, drained := n.States[slurmapispec.V0041NodeStateDRAIN]
-	return drained
+	_, exists := n.States[slurmapispec.V0041NodeStateDRAIN]
+	return exists
+}
+
+func (n *Node) IsMaintenanceState() bool {
+	_, exists := n.States[slurmapispec.V0041NodeStateMAINTENANCE]
+	return exists
+}
+
+func (n *Node) IsReservedState() bool {
+	_, exists := n.States[slurmapispec.V0041NodeStateRESERVED]
+	return exists
 }
 
 func (n *Node) IsDownState() bool {
-	_, down := n.States[slurmapispec.V0041NodeStateDOWN]
-	return down
+	_, exists := n.States[slurmapispec.V0041NodeStateDOWN]
+	return exists
 }
 
 var baseStates = []slurmapispec.V0041NodeState{


### PR DESCRIPTION
## Labels renamed
- Rename state labels to use consistent state_ prefix:
  - base_state -> state_base
  - is_drain -> state_is_drain
  - is_maintenance -> state_is_maintenance
  - is_reserved -> state_is_reserved
- Rename compute_instance_id -> instance_id to be consistent with Slurm terms

## GPU-time and failure-related metrics were redesigned:
- Add state labels to slurm_node_fails_total
- Rename slurm_active_node_gpu_seconds_total -> slurm_node_gpu_seconds_total and add the state labels
- Remove slurm_job_alloc_gpu_seconds_total metric entirely (will slurm_node_gpu_seconds_total with proper states instead)
