### PR TITLE
Scale soperator-exporter to zero when disabled

### DIFF
--- a/internal/controller/clustercontroller/soperator_exporter.go
+++ b/internal/controller/clustercontroller/soperator_exporter.go
@@ -25,10 +25,6 @@ func (r SlurmClusterReconciler) ReconcileSoperatorExporter(
 		logger.V(1).Info("Prometheus Operator CRD is not installed, skipping reconciliation")
 		return nil
 	}
-	if !clusterValues.SlurmExporter.Enabled {
-		logger.V(1).Info("Soperator exporter is not enabled, skipping reconciliation")
-		return nil
-	}
 	if clusterValues.SlurmExporter.ExporterContainer.Image != "" {
 		logger.V(1).Info("Slurm exporter image is set, skipping Soperator exporter reconciliation")
 		return nil


### PR DESCRIPTION
When exporter.enabled is set to false, the soperator-exporter deployment now scales to 0 replicas instead of being skipped during reconciliation. This ensures pods are terminated and resources are freed while keeping RBAC and monitoring resources available for fast re-enabling.