### PR TITLE
Optimize Docker build cache with shared go-base image

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -184,6 +184,9 @@ jobs:
           echo "Updating CRDs & auto-generated code (included in test step) & run tests"
           make test-coverage UNSTABLE="${UNSTABLE}"
           
+          echo "Building shared Go base image"
+          make docker-build-go-base DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS}"
+
           echo "Building image of the rebooter ${OPERATOR_IMAGE_TAG}-${ARCH}"
           make docker-build DOCKER_BUILD_ARGS="${DOCKER_BUILD_ARGS}" UNSTABLE="${UNSTABLE}" IMAGE_NAME=rebooter DOCKERFILE=rebooter/rebooter.dockerfile IMAGE_VERSION="${OPERATOR_IMAGE_TAG}-${ARCH}"
           echo "Pushing image of the rebooter ${OPERATOR_IMAGE_TAG}-${ARCH}"

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -157,9 +157,6 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
       - name: Log in to the Github Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
@@ -295,9 +292,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Log in to the Github Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,10 @@ build: manifests generate fmt vet ## Build manager binary with native toolchain.
 run: manifests generate fmt vet ## Run a controller from your host with native toolchain.
 	go run ./cmd/main.go
 
+.PHONY: docker-build-go-base
+docker-build-go-base: ## Build shared Go base image
+	docker build $(DOCKER_BUILD_ARGS) --tag go-base:latest --target go-base ${DOCKER_IGNORE_CACHE} -f images/common/go-base.dockerfile .
+
 .PHONY: docker-build
 docker-build: ## Build docker image
 ifndef IMAGE_NAME

--- a/images/common/go-base.dockerfile
+++ b/images/common/go-base.dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.24 AS go-base
+
+WORKDIR /build
+
+# Layer 1: Go modules (changes rarely)
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Layer 2: Shared code (changes moderately)
+COPY api api
+COPY internal internal
+COPY pkg pkg

--- a/images/rebooter/rebooter.dockerfile
+++ b/images/rebooter/rebooter.dockerfile
@@ -1,28 +1,19 @@
-FROM golang:1.24 AS rebooter_builder
+FROM go-base AS rebooter_builder
 
 ARG GO_LDFLAGS=""
 ARG BUILD_TIME
 ARG CGO_ENABLED=0
 ARG GOOS=linux
 
-WORKDIR /operator
-
-# Copy only the necessary files to build the binary.
-COPY api api
-COPY cmd cmd
-COPY internal internal
-COPY pkg pkg
-COPY go.mod go.sum ./
-
-RUN go mod download
-
-RUN GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
+COPY cmd/rebooter cmd/rebooter
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
     go build -o rebooter ./cmd/rebooter
 
 #######################################################################################################################
 FROM alpine:latest@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS rebooter
 
-COPY --from=rebooter_builder /operator/rebooter /usr/bin/
+COPY --from=rebooter_builder /build/rebooter /usr/bin/
 
 RUN addgroup -S -g 1001 rebooter && \
     adduser -S -u 1001 rebooter -G rebooter rebooter && \

--- a/images/sconfigcontroller/sconfigcontroller.dockerfile
+++ b/images/sconfigcontroller/sconfigcontroller.dockerfile
@@ -1,28 +1,19 @@
-FROM golang:1.24 AS sconfigcontroller_builder
+FROM go-base AS sconfigcontroller_builder
 
 ARG GO_LDFLAGS=""
 ARG BUILD_TIME
 ARG CGO_ENABLED=0
 ARG GOOS=linux
 
-WORKDIR /operator
-
-# Copy only the necessary files to build the binary.
-COPY api api
-COPY cmd cmd
-COPY internal internal
-COPY pkg pkg
-COPY go.mod go.sum ./
-
-RUN go mod download
-
-RUN GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
+COPY cmd/sconfigcontroller cmd/sconfigcontroller
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
     go build -o sconfigcontroller ./cmd/sconfigcontroller
 
 #######################################################################################################################
 FROM alpine:latest@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS sconfigcontroller
 
-COPY --from=sconfigcontroller_builder /operator/sconfigcontroller /usr/bin/
+COPY --from=sconfigcontroller_builder /build/sconfigcontroller /usr/bin/
 
 RUN addgroup -S -g 1001 sconfigcontroller && \
     adduser -S -u 1001 sconfigcontroller -G sconfigcontroller sconfigcontroller && \

--- a/images/soperator-exporter/soperator-exporter.dockerfile
+++ b/images/soperator-exporter/soperator-exporter.dockerfile
@@ -1,28 +1,19 @@
-FROM golang:1.24 AS exporter-builder
+FROM go-base AS exporter-builder
 
 ARG GO_LDFLAGS=""
 ARG BUILD_TIME
 ARG CGO_ENABLED=0
 ARG GOOS=linux
 
-WORKDIR /exporter
-
-# Copy only the necessary files to build the binary.
-COPY api api
-COPY cmd cmd
-COPY internal internal
-COPY pkg pkg
-COPY go.mod go.sum ./
-
-RUN go mod download
-
-RUN GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
+COPY cmd/exporter cmd/exporter
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
     go build -o exporter ./cmd/exporter
 
 #######################################################################################################################
 FROM alpine:latest@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS soperator-exporter
 
-COPY --from=exporter-builder /exporter/exporter /usr/bin/
+COPY --from=exporter-builder /build/exporter /usr/bin/
 
 RUN addgroup -S -g 1001 exporter && \
     adduser -S -u 1001 exporter -G exporter exporter && \

--- a/images/soperator/Dockerfile
+++ b/images/soperator/Dockerfile
@@ -1,28 +1,19 @@
-FROM golang:1.24 AS operator_builder
+FROM go-base AS operator_builder
 
 ARG GO_LDFLAGS=""
 ARG BUILD_TIME
 ARG CGO_ENABLED=0
 ARG GOOS=linux
 
-WORKDIR /operator
-
-# Copy only the necessary files to build the binary.
-COPY api api
 COPY cmd cmd
-COPY internal internal
-COPY pkg pkg
-COPY go.mod go.sum ./
-
-RUN go mod download
-
-RUN GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
     go build -o slurm_operator ./cmd/
 
 #######################################################################################################################
 FROM alpine:latest@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS slurm-operator
 
-COPY --from=operator_builder /operator/slurm_operator /usr/bin/
+COPY --from=operator_builder /build/slurm_operator /usr/bin/
 
 RUN addgroup -S -g 1001 operator && \
     adduser -S -u 1001 operator -G operator operator && \

--- a/images/soperatorchecks/soperatorchecks.dockerfile
+++ b/images/soperatorchecks/soperatorchecks.dockerfile
@@ -1,28 +1,19 @@
-FROM golang:1.24 AS soperatorchecks_builder
+FROM go-base AS soperatorchecks_builder
 
 ARG GO_LDFLAGS=""
 ARG BUILD_TIME
 ARG CGO_ENABLED=0
 ARG GOOS=linux
 
-WORKDIR /operator
-
-# Copy only the necessary files to build the binary.
-COPY api api
-COPY cmd cmd
-COPY internal internal
-COPY pkg pkg
-COPY go.mod go.sum ./
-
-RUN go mod download
-
-RUN GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
+COPY cmd/soperatorchecks cmd/soperatorchecks
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
     go build -o soperatorchecks ./cmd/soperatorchecks
 
 #######################################################################################################################
 FROM alpine:latest@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS soperatorchecks
 
-COPY --from=soperatorchecks_builder /operator/soperatorchecks /usr/bin/
+COPY --from=soperatorchecks_builder /build/soperatorchecks /usr/bin/
 
 RUN addgroup -S -g 1001 soperatorchecks && \
     adduser -S -u 1001 soperatorchecks -G soperatorchecks soperatorchecks && \


### PR DESCRIPTION
## Summary

Optimizes Docker build performance by implementing a shared base image strategy and removing unnecessary Docker Buildx setup steps.

### Key Changes

- Created `go-base.dockerfile` with shared Go dependencies and source code layers
- Added build cache mounts for faster incremental builds
- Removed redundant Docker Buildx setup steps from CI workflows
- Added explicit go-base image build step in CI pipeline

### Benefits

- Reduces Docker layer duplication across services
- Enables better layer caching for Go dependencies and shared code
- Simplified CI pipeline by removing unnecessary setup steps
- Centralized Go base configuration for easier maintenance

Affects main soperator controller, rebooter, config controller, operator checks, and metrics exporter services.