### PR TITLE
Remove soperator_cluster_info metric and --soperator-version flag

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -43,7 +43,6 @@ type Flags struct {
 	slurmAPIServer   string
 	clusterNamespace string
 	clusterName      string
-	soperatorVersion string
 }
 
 func getZapOpts(logFormat, logLevel string) []zap.Opts {
@@ -87,7 +86,6 @@ func parseFlags() Flags {
 	flag.StringVar(&flags.slurmAPIServer, "slurm-api-server", "http://localhost:6820", "The address of the Slurm REST API server.")
 	flag.StringVar(&flags.clusterNamespace, "cluster-namespace", "soperator", "The namespace of the Slurm cluster")
 	flag.StringVar(&flags.clusterName, "cluster-name", "", "The name of the Slurm cluster (required)")
-	flag.StringVar(&flags.soperatorVersion, "soperator-version", "", "Version of the soperator")
 	flag.Parse()
 
 	if flags.clusterName == "" {
@@ -131,9 +129,8 @@ func main() {
 	clusterExporter := exporter.NewClusterExporter(
 		slurmAPIClient,
 		exporter.Params{
-			SlurmAPIServer:   flags.slurmAPIServer,
-			SlurmClusterID:   slurmClusterID,
-			SoperatorVersion: flags.soperatorVersion,
+			SlurmAPIServer: flags.slurmAPIServer,
+			SlurmClusterID: slurmClusterID,
 		},
 	)
 

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -24,8 +24,6 @@ type Params struct {
 	SlurmAPIServer string
 	// SlurmClusterID is the namespaced name of the SlurmCluster resource
 	SlurmClusterID types.NamespacedName
-	// SoperatorVersion is the version the soperator's custom resource.
-	SoperatorVersion string
 }
 
 // Exporter collects metrics from a SLURM cluster and exports them in Prometheus format
@@ -47,7 +45,7 @@ type Exporter struct {
 // NewClusterExporter creates a new SLURM cluster exporter
 func NewClusterExporter(slurmAPIClient slurmapi.Client, params Params) *Exporter {
 	registry := prometheus.NewRegistry()
-	collector := NewMetricsCollector(slurmAPIClient, params.SoperatorVersion)
+	collector := NewMetricsCollector(slurmAPIClient)
 
 	return &Exporter{
 		params:         params,

--- a/internal/render/exporter/container.go
+++ b/internal/render/exporter/container.go
@@ -20,7 +20,6 @@ func renderContainerExporter(clusterValues *values.SlurmCluster) corev1.Containe
 			fmt.Sprintf("--cluster-namespace=%s", clusterValues.Namespace),
 			fmt.Sprintf("--cluster-name=%s", clusterValues.Name),
 			fmt.Sprintf("--slurm-api-server=%s", rest.GetServiceURL(clusterValues.Namespace, &clusterValues.NodeRest)),
-			fmt.Sprintf("--soperator-version=%s", clusterValues.CRVersion),
 		},
 		ImagePullPolicy: clusterValues.SlurmExporter.Container.ImagePullPolicy,
 		Ports: []corev1.ContainerPort{

--- a/internal/render/exporter/container_test.go
+++ b/internal/render/exporter/container_test.go
@@ -57,7 +57,6 @@ func TestRenderContainerExporter(t *testing.T) {
 			"--cluster-namespace=soperator-ns",
 			"--cluster-name=test-cluster",
 			"--slurm-api-server=http://rest-service.soperator-ns.svc:6817",
-			"--soperator-version=1.0.0",
 		},
 	}
 


### PR DESCRIPTION
## Summary

This PR removes the `soperator_cluster_info` metric and all associated `--soperator-version` flag usage from the soperator exporter.

## Changes

- **Metric removal**: Removed `soperator_cluster_info` metric from the exporter collector
- **CLI flag removal**: Removed `--soperator-version` flag from the exporter binary  
- **Container configuration**: Removed `--soperator-version` from container args in Kubernetes deployments
- **Test updates**: Updated all tests to reflect the removal of the metric and flag
- **Code cleanup**: Removed unused fields and parameters throughout the codebase

## Rationale

The `soperator_cluster_info` metric provided operator version information, but this functionality will be superseded by [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) in the future. Rather than maintaining duplicate functionality, we're removing this metric to simplify the exporter and avoid redundancy.