### PR TITLE
Rename exporter deployment to slurm-exporter and use constants for naming

### DIFF
--- a/internal/controller/clustercontroller/soperator_exporter.go
+++ b/internal/controller/clustercontroller/soperator_exporter.go
@@ -8,9 +8,7 @@ import (
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"nebius.ai/slurm-operator/internal/check"
-	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/logfield"
-	"nebius.ai/slurm-operator/internal/naming"
 	"nebius.ai/slurm-operator/internal/render/exporter"
 	"nebius.ai/slurm-operator/internal/utils"
 	"nebius.ai/slurm-operator/internal/values"
@@ -47,7 +45,7 @@ func (r SlurmClusterReconciler) ReconcileSoperatorExporter(
 					}
 				} else {
 					debugLogger.Info("Exporter disabled, will delete ServiceAccount if exists")
-					exporterSAName := exporter.BuildExporterServiceAccountName(clusterValues.Name)
+					exporterSAName := exporter.ServiceAccountName
 					if err := r.ServiceAccount.Cleanup(stepCtx, cluster, exporterSAName); err != nil {
 						return fmt.Errorf("cleanup Exporter SA: %w", err)
 					}
@@ -71,7 +69,7 @@ func (r SlurmClusterReconciler) ReconcileSoperatorExporter(
 					}
 				} else {
 					debugLogger.Info("Exporter disabled, will delete Role if exists")
-					exporterRoleName := exporter.BuildExporterRoleName(clusterValues.Name)
+					exporterRoleName := exporter.RoleName
 					if err := r.Role.Cleanup(stepCtx, cluster, exporterRoleName); err != nil {
 						return fmt.Errorf("cleanup Exporter Role: %w", err)
 					}
@@ -95,7 +93,7 @@ func (r SlurmClusterReconciler) ReconcileSoperatorExporter(
 					}
 				} else {
 					debugLogger.Info("Exporter disabled, will delete RoleBinding if exists")
-					exporterRoleBindingName := exporter.BuildExporterRoleBindingName(clusterValues.Name)
+					exporterRoleBindingName := exporter.RoleBindingName
 					if err := r.RoleBinding.Cleanup(stepCtx, cluster, exporterRoleBindingName); err != nil {
 						return fmt.Errorf("cleanup Exporter RoleBinding: %w", err)
 					}
@@ -149,7 +147,7 @@ func (r SlurmClusterReconciler) ReconcileSoperatorExporter(
 					}
 				} else {
 					debugLogger.Info("Exporter disabled, will delete Deployment if exists")
-					exporterDeploymentName := naming.BuildDeploymentName(consts.ComponentTypeExporter)
+					exporterDeploymentName := exporter.DeploymentName
 					if err := r.Deployment.Cleanup(stepCtx, cluster, exporterDeploymentName); err != nil {
 						return fmt.Errorf("cleanup soperator exporter deployment: %w", err)
 					}

--- a/internal/render/exporter/deployment.go
+++ b/internal/render/exporter/deployment.go
@@ -11,7 +11,6 @@ import (
 
 	"nebius.ai/slurm-operator/internal/check"
 	"nebius.ai/slurm-operator/internal/consts"
-	"nebius.ai/slurm-operator/internal/naming"
 	"nebius.ai/slurm-operator/internal/render/common"
 	"nebius.ai/slurm-operator/internal/values"
 )
@@ -49,7 +48,7 @@ func RenderDeploymentExporter(clusterValues *values.SlurmCluster) (*appsv1.Deplo
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      naming.BuildDeploymentName(consts.ComponentTypeExporter),
+			Name:      DeploymentName,
 			Namespace: clusterValues.Namespace,
 			Labels:    labels,
 		},

--- a/internal/render/exporter/names.go
+++ b/internal/render/exporter/names.go
@@ -1,13 +1,8 @@
 package exporter
 
-func BuildExporterServiceAccountName(clusterName string) string {
-	return clusterName + "-exporter-sa"
-}
-
-func BuildExporterRoleName(clusterName string) string {
-	return clusterName + "-exporter-role"
-}
-
-func BuildExporterRoleBindingName(clusterName string) string {
-	return clusterName + "-exporter-role-binding"
-}
+const (
+	ServiceAccountName = "slurm-exporter-sa"
+	RoleName           = "slurm-exporter-role"
+	RoleBindingName    = "slurm-exporter-role-binding"
+	DeploymentName     = "slurm-exporter"
+)

--- a/internal/render/exporter/pod.go
+++ b/internal/render/exporter/pod.go
@@ -33,7 +33,7 @@ func renderPodTemplateSpec(
 			NodeSelector:       nodeFilter.NodeSelector,
 			InitContainers:     initContainers,
 			Containers:         []corev1.Container{renderContainerExporter(clusterValues)},
-			ServiceAccountName: BuildExporterServiceAccountName(clusterValues.Name),
+			ServiceAccountName: ServiceAccountName,
 		},
 	}
 	return result

--- a/internal/render/exporter/pod_test.go
+++ b/internal/render/exporter/pod_test.go
@@ -45,7 +45,7 @@ func TestRenderPodTemplateSpec(t *testing.T) {
 			Labels: map[string]string{"app": "slurm-exporter"},
 		},
 		Spec: corev1.PodSpec{
-			ServiceAccountName: "test-cluster-exporter-sa",
+			ServiceAccountName: ServiceAccountName,
 			NodeSelector:       map[string]string{"node": "exporter"},
 			Tolerations:        []corev1.Toleration{{Key: "test", Value: "true"}},
 			InitContainers:     []corev1.Container{},

--- a/internal/render/exporter/role.go
+++ b/internal/render/exporter/role.go
@@ -13,7 +13,7 @@ func RenderRole(clusterNamespace, clusterName string) rbacv1.Role {
 
 	return rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      BuildExporterRoleName(clusterName),
+			Name:      RoleName,
 			Namespace: clusterNamespace,
 			Labels:    labels,
 		},

--- a/internal/render/exporter/role_binding.go
+++ b/internal/render/exporter/role_binding.go
@@ -13,20 +13,20 @@ func RenderExporterRoleBinding(clusterNamespace, clusterName string) rbacv1.Role
 
 	return rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      BuildExporterRoleBindingName(clusterName),
+			Name:      RoleBindingName,
 			Namespace: clusterNamespace,
 			Labels:    labels,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      rbacv1.ServiceAccountKind,
-				Name:      BuildExporterServiceAccountName(clusterName),
+				Name:      ServiceAccountName,
 				Namespace: clusterNamespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "Role",
-			Name:     BuildExporterRoleName(clusterName),
+			Name:     RoleName,
 			APIGroup: rbacv1.GroupName,
 		},
 	}

--- a/internal/render/exporter/service_account.go
+++ b/internal/render/exporter/service_account.go
@@ -13,7 +13,7 @@ func RenderServiceAccount(clusterNamespace, clusterName string) corev1.ServiceAc
 
 	return corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      BuildExporterServiceAccountName(clusterName),
+			Name:      ServiceAccountName,
 			Namespace: clusterNamespace,
 			Labels:    labels,
 		},


### PR DESCRIPTION
## Summary

This PR renames the soperator exporter deployment and simplifies its resource naming to prevent clashing with existing exporter deployments in existing clusters.

## Changes

- **Deployment Renaming**: Changed deployment name from `"exporter"` to `"slurm-exporter"`
- **RBAC Simplification**: Removed cluster name prefix from RBAC resources:
  - ServiceAccount: `{clusterName}-exporter-sa` → `slurm-exporter-sa`
  - Role: `{clusterName}-exporter-role` → `slurm-exporter-role`
  - RoleBinding: `{clusterName}-exporter-role-binding` → `slurm-exporter-role-binding`
- **Code Optimization**: Converted naming functions to constants for better maintainability

## Benefits

- Prevents naming conflicts with existing exporter deployments in clusters
- More descriptive and unique naming for the new soperator exporter
- Simplified resource management without cluster name dependencies