### PR TITLE
Add controller RPC metrics export

### DIFF
--- a/internal/exporter/collector_test.go
+++ b/internal/exporter/collector_test.go
@@ -34,9 +34,8 @@ func TestMetricsCollector_Describe(t *testing.T) {
 		descriptors = append(descriptors, desc)
 	}
 
-	// Should have 3 descriptors: nodeInfo, jobInfo, jobNode
-	// Plus the nodeGPUSeconds descriptor
-	assert.GreaterOrEqual(t, len(descriptors), 3)
+	// Should have base descriptors plus RPC metrics: nodeInfo, jobInfo, jobNode + 4 RPC metrics + 1 controller metric
+	assert.GreaterOrEqual(t, len(descriptors), 8)
 
 	// Verify descriptor names
 	found := make(map[string]bool)
@@ -44,9 +43,19 @@ func TestMetricsCollector_Describe(t *testing.T) {
 		found[desc.String()] = true
 	}
 
+	// Base metrics
 	assert.Contains(t, found, `Desc{fqName: "slurm_node_info", help: "Slurm node info", constLabels: {}, variableLabels: {node_name,instance_id,state_base,state_is_drain,state_is_maintenance,state_is_reserved,address}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_job_info", help: "Slurm job detail information", constLabels: {}, variableLabels: {job_id,job_state,job_state_reason,slurm_partition,job_name,user_name,standard_error,standard_output,array_job_id,array_task_id}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_node_job", help: "Slurm job node information", constLabels: {}, variableLabels: {job_id,node_name}}`)
+
+	// RPC metrics
+	assert.Contains(t, found, `Desc{fqName: "slurm_controller_rpc_calls_total", help: "Total count of RPC calls by message type", constLabels: {}, variableLabels: {message_type}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_controller_rpc_duration_seconds_total", help: "Total time spent processing RPCs by message type", constLabels: {}, variableLabels: {message_type}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_controller_rpc_user_calls_total", help: "Total count of RPC calls by user", constLabels: {}, variableLabels: {user,user_id}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_controller_rpc_user_duration_seconds_total", help: "Total time spent on user RPCs", constLabels: {}, variableLabels: {user,user_id}}`)
+
+	// Controller metrics
+	assert.Contains(t, found, `Desc{fqName: "slurm_controller_server_thread_count", help: "Number of server threads", constLabels: {}, variableLabels: {}}`)
 }
 
 func TestMetricsCollector_Collect_Success(t *testing.T) {
@@ -81,6 +90,14 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 		}
 
 		mockClient.EXPECT().ListNodes(mock.Anything).Return(testNodes, nil)
+
+		// Mock GetDiag response with realistic data
+		serverThreadCount := int32(1)
+		mockClient.EXPECT().GetDiag(mock.Anything).Return(&slurmapispec.V0041OpenapiDiagResp{
+			Statistics: slurmapispec.V0041StatsMsg{
+				ServerThreadCount: &serverThreadCount,
+			},
+		}, nil)
 
 		arrayTaskID := int32(42)
 		// Mock successful ListJobs response
@@ -128,6 +145,7 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 			`GAUGE; slurm_job_info{array_job_id="",array_task_id="42",job_id="12345",job_name="test_job",job_state="RUNNING",job_state_reason="None",slurm_partition="gpu",standard_error="/path/to/stderr",standard_output="/path/to/stdout",user_name="testuser"} 1`,
 			`GAUGE; slurm_node_job{job_id="12345",node_name="node-1"} 1`,
 			`GAUGE; slurm_node_job{job_id="12345",node_name="node-2"} 1`,
+			`GAUGE; slurm_controller_server_thread_count 1`,
 		}
 
 		assert.ElementsMatch(t, expectedMetrics, metricsText)
@@ -192,8 +210,14 @@ func TestMetricsCollector_NodeFails(t *testing.T) {
 		},
 	}
 
+	serverThreadCount := int32(1)
 	mockClient.EXPECT().ListNodes(mock.Anything).Return(testNodes, nil)
 	mockClient.EXPECT().ListJobs(mock.Anything).Return([]slurmapi.Job{}, nil)
+	mockClient.EXPECT().GetDiag(mock.Anything).Return(&slurmapispec.V0041OpenapiDiagResp{
+		Statistics: slurmapispec.V0041StatsMsg{
+			ServerThreadCount: &serverThreadCount,
+		},
+	}, nil)
 
 	// First collect - establish baseline
 	ch := make(chan prometheus.Metric, 20)
@@ -249,6 +273,11 @@ func TestMetricsCollector_NodeFails(t *testing.T) {
 
 	mockClient.EXPECT().ListNodes(mock.Anything).Return(testNodes, nil)
 	mockClient.EXPECT().ListJobs(mock.Anything).Return([]slurmapi.Job{}, nil)
+	mockClient.EXPECT().GetDiag(mock.Anything).Return(&slurmapispec.V0041OpenapiDiagResp{
+		Statistics: slurmapispec.V0041StatsMsg{
+			ServerThreadCount: &serverThreadCount,
+		},
+	}, nil)
 
 	// Second collect - trigger node fails
 	ch = make(chan prometheus.Metric, 20)
@@ -270,6 +299,288 @@ func TestMetricsCollector_NodeFails(t *testing.T) {
 	// Check that node fails metric includes all the new labels
 	expectedNodeFailsMetric := `COUNTER; slurm_node_fails_total{node_name="node-maintenance",reason="maintenance drain triggered",state_base="IDLE",state_is_drain="true",state_is_maintenance="true",state_is_reserved="false"} 1`
 	assert.Contains(t, metricsText, expectedNodeFailsMetric)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestMetricsCollector_RPCMetrics_Success(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	mockClient := &fake.MockClient{}
+	collector := NewMetricsCollector(mockClient)
+
+	// Mock successful ListNodes and ListJobs with minimal data
+	mockClient.EXPECT().ListNodes(mock.Anything).Return([]slurmapi.Node{}, nil)
+	mockClient.EXPECT().ListJobs(mock.Anything).Return([]slurmapi.Job{}, nil)
+
+	// Mock realistic RPC diagnostics data based on production output
+	serverThreadCount := int32(1)
+	rpcsByMessageType := slurmapispec.V0041StatsMsgRpcsByType{
+		{
+			MessageType: "REQUEST_NODE_INFO",
+			Count:       576,
+			TotalTime:   61410,
+		},
+		{
+			MessageType: "REQUEST_JOB_INFO",
+			Count:       288,
+			TotalTime:   30218,
+		},
+		{
+			MessageType: "REQUEST_PING",
+			Count:       414,
+			TotalTime:   14239,
+		},
+	}
+	rpcsByUser := slurmapispec.V0041StatsMsgRpcsByUser{
+		{
+			User:      "root",
+			UserId:    0,
+			Count:     2423,
+			TotalTime: 172774,
+		},
+		{
+			User:      "testuser",
+			UserId:    1000,
+			Count:     100,
+			TotalTime: 5000,
+		},
+	}
+
+	mockClient.EXPECT().GetDiag(mock.Anything).Return(&slurmapispec.V0041OpenapiDiagResp{
+		Statistics: slurmapispec.V0041StatsMsg{
+			ServerThreadCount: &serverThreadCount,
+			RpcsByMessageType: &rpcsByMessageType,
+			RpcsByUser:        &rpcsByUser,
+		},
+	}, nil)
+
+	ch := make(chan prometheus.Metric, 50)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+
+	var metricsText []string
+	for _, metric := range metrics {
+		metricsText = append(metricsText, toPrometheusLikeString(t, metric))
+	}
+
+	// Verify controller metrics
+	assert.Contains(t, metricsText, `GAUGE; slurm_controller_server_thread_count 1`)
+
+	// Verify RPC calls by message type
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_calls_total{message_type="REQUEST_NODE_INFO"} 576`)
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_calls_total{message_type="REQUEST_JOB_INFO"} 288`)
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_calls_total{message_type="REQUEST_PING"} 414`)
+
+	// Verify RPC duration by message type (converted from microseconds to seconds)
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_duration_seconds_total{message_type="REQUEST_NODE_INFO"} 0.06141`)
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_duration_seconds_total{message_type="REQUEST_JOB_INFO"} 0.030218`)
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_duration_seconds_total{message_type="REQUEST_PING"} 0.014239`)
+
+	// Verify RPC calls by user
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_user_calls_total{user="root",user_id="0"} 2423`)
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_user_calls_total{user="testuser",user_id="1000"} 100`)
+
+	// Verify RPC duration by user (converted from microseconds to seconds)
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_user_duration_seconds_total{user="root",user_id="0"} 0.172774`)
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_user_duration_seconds_total{user="testuser",user_id="1000"} 0.005`)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestMetricsCollector_RPCMetrics_EdgeCases(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	mockClient := &fake.MockClient{}
+	collector := NewMetricsCollector(mockClient)
+
+	// Mock minimal required calls
+	mockClient.EXPECT().ListNodes(mock.Anything).Return([]slurmapi.Node{}, nil)
+	mockClient.EXPECT().ListJobs(mock.Anything).Return([]slurmapi.Job{}, nil)
+
+	serverThreadCount := int32(0)
+	rpcsByMessageType := slurmapispec.V0041StatsMsgRpcsByType{
+		{
+			MessageType: "ZERO_COUNT",
+			Count:       0,
+			TotalTime:   1000,
+		},
+		{
+			MessageType: "ZERO_TIME",
+			Count:       10,
+			TotalTime:   0,
+		},
+		{
+			MessageType: "NORMAL",
+			Count:       1,
+			TotalTime:   1,
+		},
+	}
+	rpcsByUser := slurmapispec.V0041StatsMsgRpcsByUser{
+		{
+			User:      "zero_user",
+			UserId:    999,
+			Count:     0,
+			TotalTime: 5000,
+		},
+		{
+			User:      "normal_user",
+			UserId:    1001,
+			Count:     1,
+			TotalTime: 1,
+		},
+	}
+
+	mockClient.EXPECT().GetDiag(mock.Anything).Return(&slurmapispec.V0041OpenapiDiagResp{
+		Statistics: slurmapispec.V0041StatsMsg{
+			ServerThreadCount: &serverThreadCount,
+			RpcsByMessageType: &rpcsByMessageType,
+			RpcsByUser:        &rpcsByUser,
+		},
+	}, nil)
+
+	ch := make(chan prometheus.Metric, 50)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+
+	var metricsText []string
+	for _, metric := range metrics {
+		metricsText = append(metricsText, toPrometheusLikeString(t, metric))
+	}
+
+	// Should emit zero controller thread count
+	assert.Contains(t, metricsText, `GAUGE; slurm_controller_server_thread_count 0`)
+
+	for _, metricText := range metricsText {
+		if strings.Contains(metricText, `message_type="ZERO_COUNT"`) {
+			assert.Contains(t, metricText, `slurm_controller_rpc_duration_seconds_total`)
+		}
+		if strings.Contains(metricText, `user="zero_user"`) {
+			assert.Contains(t, metricText, `slurm_controller_rpc_user_duration_seconds_total`)
+		}
+	}
+
+	// Should emit non-zero metrics
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_calls_total{message_type="ZERO_TIME"} 10`)
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_calls_total{message_type="NORMAL"} 1`)
+
+	// Should NOT emit zero duration metrics
+	for _, metricText := range metricsText {
+		assert.NotContains(t, metricText, `slurm_controller_rpc_duration_seconds_total{message_type="ZERO_TIME"}`)
+	}
+
+	// Should emit very small duration
+	assert.Contains(t, metricsText, `COUNTER; slurm_controller_rpc_duration_seconds_total{message_type="NORMAL"} 1e-06`)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestMetricsCollector_GetDiag_APIError(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	mockClient := &fake.MockClient{}
+	collector := NewMetricsCollector(mockClient)
+
+	// Mock successful node and job calls
+	testNodes := []slurmapi.Node{
+		{
+			Name:       "test-node",
+			InstanceID: "test-instance",
+			States: map[slurmapispec.V0041NodeState]struct{}{
+				slurmapispec.V0041NodeStateIDLE: {},
+			},
+			Tres:    "cpu=4,mem=8000M,gres/gpu=0",
+			Address: "10.0.0.1",
+		},
+	}
+	mockClient.EXPECT().ListNodes(mock.Anything).Return(testNodes, nil)
+	mockClient.EXPECT().ListJobs(mock.Anything).Return([]slurmapi.Job{}, nil)
+
+	// Mock GetDiag failure
+	mockClient.EXPECT().GetDiag(mock.Anything).Return(nil, assert.AnError)
+
+	ch := make(chan prometheus.Metric, 50)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+
+	var metricsText []string
+	for _, metric := range metrics {
+		metricsText = append(metricsText, toPrometheusLikeString(t, metric))
+	}
+
+	// Should still have node metrics (proving other metrics continue to work)
+	assert.Contains(t, metricsText, `GAUGE; slurm_node_info{address="10.0.0.1",instance_id="test-instance",node_name="test-node",state_base="IDLE",state_is_drain="false",state_is_maintenance="false",state_is_reserved="false"} 1`)
+
+	// Should NOT have any RPC metrics due to GetDiag failure
+	for _, metricText := range metricsText {
+		assert.NotContains(t, metricText, `slurm_controller_rpc_`)
+		assert.NotContains(t, metricText, `slurm_controller_server_thread_count`)
+	}
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestMetricsCollector_GetDiag_NilFields(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	mockClient := &fake.MockClient{}
+	collector := NewMetricsCollector(mockClient)
+
+	// Mock minimal required calls
+	mockClient.EXPECT().ListNodes(mock.Anything).Return([]slurmapi.Node{}, nil)
+	mockClient.EXPECT().ListJobs(mock.Anything).Return([]slurmapi.Job{}, nil)
+
+	// Mock GetDiag response with nil fields
+	mockClient.EXPECT().GetDiag(mock.Anything).Return(&slurmapispec.V0041OpenapiDiagResp{
+		Statistics: slurmapispec.V0041StatsMsg{
+			ServerThreadCount: nil, // Should not emit metric
+			RpcsByMessageType: nil, // Should not emit metrics
+			RpcsByUser:        nil, // Should not emit metrics
+		},
+	}, nil)
+
+	ch := make(chan prometheus.Metric, 50)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+
+	var metricsText []string
+	for _, metric := range metrics {
+		metricsText = append(metricsText, toPrometheusLikeString(t, metric))
+	}
+
+	// Should NOT have any RPC metrics when all fields are nil
+	for _, metricText := range metricsText {
+		assert.NotContains(t, metricText, `slurm_controller_rpc_`)
+		assert.NotContains(t, metricText, `slurm_controller_server_thread_count`)
+	}
 
 	mockClient.AssertExpectations(t)
 }

--- a/internal/slurmapi/client.go
+++ b/internal/slurmapi/client.go
@@ -165,3 +165,18 @@ func (c *client) ListJobs(ctx context.Context) ([]Job, error) {
 
 	return jobs, nil
 }
+
+func (c *client) GetDiag(ctx context.Context) (*slurmapispec.V0041OpenapiDiagResp, error) {
+	getDiagResp, err := c.SlurmV0041GetDiagWithResponse(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get diag: %w", err)
+	}
+	if getDiagResp.JSON200 == nil {
+		return nil, fmt.Errorf("json200 field is nil")
+	}
+	if getDiagResp.JSON200.Errors != nil && len(*getDiagResp.JSON200.Errors) != 0 {
+		return nil, fmt.Errorf("get diag responded with errors: %v", *getDiagResp.JSON200.Errors)
+	}
+
+	return getDiagResp.JSON200, nil
+}

--- a/internal/slurmapi/fake/mock_client.go
+++ b/internal/slurmapi/fake/mock_client.go
@@ -258,6 +258,64 @@ func (_c *MockClient_ListNodes_Call) RunAndReturn(run func(context.Context) ([]s
 	return _c
 }
 
+// GetDiag provides a mock function with given fields: ctx
+func (_m *MockClient) GetDiag(ctx context.Context) (*v0041.V0041OpenapiDiagResp, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDiag")
+	}
+
+	var r0 *v0041.V0041OpenapiDiagResp
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*v0041.V0041OpenapiDiagResp, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) *v0041.V0041OpenapiDiagResp); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v0041.V0041OpenapiDiagResp)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClient_GetDiag_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDiag'
+type MockClient_GetDiag_Call struct {
+	*mock.Call
+}
+
+// GetDiag is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockClient_Expecter) GetDiag(ctx interface{}) *MockClient_GetDiag_Call {
+	return &MockClient_GetDiag_Call{Call: _e.mock.On("GetDiag", ctx)}
+}
+
+func (_c *MockClient_GetDiag_Call) Run(run func(ctx context.Context)) *MockClient_GetDiag_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockClient_GetDiag_Call) Return(_a0 *v0041.V0041OpenapiDiagResp, _a1 error) *MockClient_GetDiag_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClient_GetDiag_Call) RunAndReturn(run func(context.Context) (*v0041.V0041OpenapiDiagResp, error)) *MockClient_GetDiag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SlurmV0041DeleteJobWithResponse provides a mock function with given fields: ctx, jobId, params, reqEditors
 func (_m *MockClient) SlurmV0041DeleteJobWithResponse(ctx context.Context, jobId string, params *v0041.SlurmV0041DeleteJobParams, reqEditors ...v0041.RequestEditorFn) (*v0041.SlurmV0041DeleteJobResponse, error) {
 	_va := make([]interface{}, len(reqEditors))

--- a/internal/slurmapi/interface.go
+++ b/internal/slurmapi/interface.go
@@ -12,4 +12,5 @@ type Client interface {
 	GetNode(ctx context.Context, nodeName string) (Node, error)
 	GetJobsByID(ctx context.Context, jobID string) ([]Job, error)
 	ListJobs(ctx context.Context) ([]Job, error)
+	GetDiag(ctx context.Context) (*api.V0041OpenapiDiagResp, error)
 }


### PR DESCRIPTION
## Summary

Implements SLURM controller RPC metrics export functionality for monitoring controller performance.

## Changes

- **RPC Metrics by Message Type**: Exports `slurm_controller_rpc_calls_total` and `slurm_controller_rpc_duration_seconds_total` metrics with `message_type` labels
- **RPC Metrics by User**: Exports `slurm_controller_rpc_user_calls_total` and `slurm_controller_rpc_user_duration_seconds_total` metrics with `user` and `user_id` labels  
- **Controller Metrics**: Exports `slurm_controller_server_thread_count` gauge metric

## New Metrics Output

```
slurm_controller_rpc_calls_total{message_type="MESSAGE_NODE_REGISTRATION_STATUS"} 14
slurm_controller_rpc_calls_total{message_type="REQUEST_JOB_INFO"} 370
slurm_controller_rpc_calls_total{message_type="REQUEST_NODE_INFO"} 742
slurm_controller_rpc_calls_total{message_type="REQUEST_NODE_INFO_SINGLE"} 356
slurm_controller_rpc_calls_total{message_type="REQUEST_PARTITION_INFO"} 1100
slurm_controller_rpc_calls_total{message_type="REQUEST_PING"} 536
slurm_controller_rpc_calls_total{message_type="REQUEST_STATS_INFO"} 4

slurm_controller_rpc_duration_seconds_total{message_type="MESSAGE_NODE_REGISTRATION_STATUS"} 0.001678
slurm_controller_rpc_duration_seconds_total{message_type="REQUEST_JOB_INFO"} 0.03879
slurm_controller_rpc_duration_seconds_total{message_type="REQUEST_NODE_INFO"} 0.077907
slurm_controller_rpc_duration_seconds_total{message_type="REQUEST_NODE_INFO_SINGLE"} 0.020751
slurm_controller_rpc_duration_seconds_total{message_type="REQUEST_PARTITION_INFO"} 0.062916
slurm_controller_rpc_duration_seconds_total{message_type="REQUEST_PING"} 0.018569
slurm_controller_rpc_duration_seconds_total{message_type="REQUEST_STATS_INFO"} 0.00024

slurm_controller_rpc_user_calls_total{user="root",user_id="0"} 3122
slurm_controller_rpc_user_duration_seconds_total{user="root",user_id="0"} 0.220851

slurm_controller_server_thread_count 1
```

Resolves #1027