### PR TITLE
Preinstall Soperator utility scripts to jail

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -85,7 +85,7 @@ type SlurmClusterSpec struct {
 	// SlurmConfig represents the Slurm configuration in slurm.conf. Not all options are supported.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={defMemPerNode: 1228800, defCpuPerGPU: 16, completeWait: 5, debugFlags: "Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs", epilog: "", prolog: "", taskPluginParam: "", maxJobCount: 10000, minJobAge: 86400}
+	// +kubebuilder:default={defMemPerNode: 1228800, defCpuPerGPU: 16, completeWait: 5, debugFlags: "Cgroup,CPU_Bind,Gres,JobComp,Priority,Script,SelectType,Steps,TraceJobs", epilog: "", prolog: "", taskPluginParam: "Autobind=Cores", maxJobCount: 10000, minJobAge: 86400}
 	SlurmConfig SlurmConfig `json:"slurmConfig,omitempty"`
 
 	// CustomSlurmConfig represents the raw Slurm configuration from slurm.conf.
@@ -172,7 +172,7 @@ type SlurmConfig struct {
 	// Additional parameters for the task plugin
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=""
+	// +kubebuilder:default="Autobind=Cores"
 	// +kubebuilder:validation:Pattern="^(|((None|Cores|Sockets|Threads|SlurmdOffSpec|OOMKillStep|Verbose|Autobind)(,)?)+)$"
 	TaskPluginParam *string `json:"taskPluginParam,omitempty"`
 	// Keep N last jobs in controller memory

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -3190,7 +3190,7 @@ spec:
                   maxJobCount: 10000
                   minJobAge: 86400
                   prolog: ""
-                  taskPluginParam: ""
+                  taskPluginParam: Autobind=Cores
                 description: SlurmConfig represents the Slurm configuration in slurm.conf.
                   Not all options are supported.
                 properties:
@@ -3246,7 +3246,7 @@ spec:
                       starts. Default value is no prolog
                     type: string
                   taskPluginParam:
-                    default: ""
+                    default: Autobind=Cores
                     description: Additional parameters for the task plugin
                     pattern: ^(|((None|Cores|Sockets|Threads|SlurmdOffSpec|OOMKillStep|Verbose|Autobind)(,)?)+)$
                     type: string

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -20049,7 +20049,7 @@ spec:
                   maxJobCount: 10000
                   minJobAge: 86400
                   prolog: ""
-                  taskPluginParam: ""
+                  taskPluginParam: Autobind=Cores
                 description: SlurmConfig represents the Slurm configuration in slurm.conf.
                   Not all options are supported.
                 properties:
@@ -20105,7 +20105,7 @@ spec:
                       starts. Default value is no prolog
                     type: string
                   taskPluginParam:
-                    default: ""
+                    default: Autobind=Cores
                     description: Additional parameters for the task plugin
                     pattern: ^(|((None|Cores|Sockets|Threads|SlurmdOffSpec|OOMKillStep|Verbose|Autobind)(,)?)+)$
                     type: string

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -20049,7 +20049,7 @@ spec:
                   maxJobCount: 10000
                   minJobAge: 86400
                   prolog: ""
-                  taskPluginParam: ""
+                  taskPluginParam: Autobind=Cores
                 description: SlurmConfig represents the Slurm configuration in slurm.conf.
                   Not all options are supported.
                 properties:
@@ -20105,7 +20105,7 @@ spec:
                       starts. Default value is no prolog
                     type: string
                   taskPluginParam:
-                    default: ""
+                    default: Autobind=Cores
                     description: Additional parameters for the task plugin
                     pattern: ^(|((None|Cores|Sockets|Threads|SlurmdOffSpec|OOMKillStep|Verbose|Autobind)(,)?)+)$
                     type: string

--- a/images/jail/jail.dockerfile
+++ b/images/jail/jail.dockerfile
@@ -274,6 +274,11 @@ RUN chmod +x /usr/bin/docker
 COPY images/jail/scripts/nvidia_smi_hostpid.sh /usr/bin/nvidia-smi-hostpid
 RUN chmod +x /usr/bin/nvidia-smi-hostpid
 
+# Copy Soperator utility scripts
+COPY images/jail/scripts/soperator_instance_login.sh /opt/soperator_utils/soperator_instance_login.sh
+COPY images/jail/scripts/slurm_task_info.sh /opt/soperator_utils/slurm_task_info.sh
+RUN chmod -R 755 /opt/soperator_utils
+
 # Create directory for pivoting host's root
 RUN mkdir -m 555 /mnt/host
 

--- a/images/jail/scripts/createuser.sh
+++ b/images/jail/scripts/createuser.sh
@@ -17,7 +17,8 @@ ADDUSER_ARGS=()
 for arg in "${ARGS[@]}"; do
     if [[ "$arg" != "--with-password" ]] && \
        [[ "$arg" != "--without-sudo" ]] && \
-       [[ "$arg" != "--without-docker" ]]; then
+       [[ "$arg" != "--without-docker" ]] && \
+       [[ "$arg" != "--without-internal-ssh" ]]; then
         ADDUSER_ARGS+=("$arg")
     fi
 done
@@ -81,7 +82,9 @@ if [ -n "$ssh_public_key" ]; then
     echo "$ssh_public_key" >> "$authorized_keys"
 fi
 
-echo "Generating an internal SSH key pair ..."
-ssh-keygen -t ecdsa -f "$internal_key" -N ''
-chown "$username:$username" "$internal_key" "$internal_key.pub"
-cat "$internal_key.pub" >> "$authorized_keys"
+if [[ "$*" != *"--without-internal-ssh"* ]]; then
+    echo "Generating an internal SSH key pair ..."
+    ssh-keygen -t ecdsa -f "$internal_key" -N ''
+    chown "$username:$username" "$internal_key" "$internal_key.pub"
+    cat "$internal_key.pub" >> "$authorized_keys"
+fi

--- a/images/jail/scripts/slurm_task_info.sh
+++ b/images/jail/scripts/slurm_task_info.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script prints various details about the resources the Slurm task is bound to.
+# Intended to be used as a Slurm task prolog: srun --task-prolog=<path_to_this_script>
+
+printf "print SLURM_TASK_INFO node=%s rank=%s cpu=%s gpu=%s cuda_dev=%s\n" \
+    "$SLURMD_NODENAME" \
+    "$SLURM_PROCID" \
+    "$(cat /proc/self/status | grep "Cpus_allowed_list:" | sed "s/Cpus_allowed_list:\t//g")" \
+    "$(nvidia-smi --query-gpu=pci.bus_id --format=csv,noheader | tr -d 0:. | paste -sd,)" \
+    "$CUDA_VISIBLE_DEVICES"

--- a/images/jail/scripts/soperator_instance_login.sh
+++ b/images/jail/scripts/soperator_instance_login.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e # Exit immediately if any command returns a non-zero error code
+
+usage() {
+    echo "Run an interactive login shell on the instance associated with a specific worker node." >&2
+    echo "" >&2
+    echo "usage: ${0} [-w worker_name] [-i instance_id] [-h]" >&2
+    echo "       (either -w or -i must be set)"
+    exit 1
+}
+
+while getopts w:i:h flag
+do
+    case "${flag}" in
+        w) worker_name=${OPTARG};;
+        i) instance_id=${OPTARG};;
+        h) usage;;
+        *) usage;;
+    esac
+done
+
+if [ -z "$worker_name" ] && [ -z "$instance_id" ]; then
+    usage
+fi
+
+if [ -z "$worker_name" ] && [ -n "$instance_id" ]; then
+    worker_name=$(scontrol show nodes --json | jq -r ".nodes[] | select(.instance_id == \"${instance_id}\") | .name")
+fi
+
+ssh -t "${worker_name}" sudo chroot /run/nvidia/driver nsenter -t 1 -m -u -i -n systemd-run --pty /bin/bash -l

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -137,7 +137,7 @@ func generateSlurmConfig(cluster *values.SlurmCluster, topologyConfig corev1.Con
 	res.AddComment("SCHEDULING")
 	res.AddProperty("SchedulerType", "sched/backfill")
 	res.AddProperty("SelectType", "select/cons_tres")
-	res.AddProperty("SelectTypeParameters", "CR_Core_Memory,CR_CORE_DEFAULT_DIST_BLOCK") // TODO: Make it configurable
+	res.AddProperty("SelectTypeParameters", "CR_Core_Memory,CR_ONE_TASK_PER_CORE,CR_CORE_DEFAULT_DIST_BLOCK")
 	res.AddComment("")
 	res.AddComment("LOGGING")
 	res.AddProperty("SlurmctldDebug", consts.SlurmDefaultDebugLevel)


### PR DESCRIPTION
Here’s a summary of the changes made in the PR:

**1. Default Values for Slurm Configuration**
- The default value for the field taskPluginParam in SlurmConfig is changed from an empty string ("") to Autobind=Cores in:
  - Go struct tags (api/v1/slurmcluster_types.go)
  - The generated CRD YAMLs (config/crd/bases/slurm.nebius.ai_slurmclusters.yaml, helm/soperator-crds/templates/slurmcluster-crd.yaml, helm/soperator/crds/slurmcluster-crd.yaml)

**2. Slurm Scheduler Configuration**
- Added CR_ONE_TASK_PER_CORE to the SelectTypeParameters in the Slurm config generation (internal/render/common/configmap.go) to improve core allocation granularity.

**3. Jail Docker Image Enhancements**
- Two utility scripts are added to /opt/soperator_utils in the jail container:
  - soperator_instance_login.sh: Script to SSH/chroot into the systemd namespace of a worker node.
  - slurm_task_info.sh: Prints Slurm task resource bindings (node, rank, CPU, GPU, CUDA devices).

**4. User Creation Script Update**
- createuser.sh now supports a --without-internal-ssh flag to skip generating an internal SSH key pair.

**5. New Utility Scripts**
- images/jail/scripts/slurm_task_info.sh: Prints details about Slurm task resource bindings.
- images/jail/scripts/soperator_instance_login.sh: Allows logging into the instance associated with a specific worker node or instance ID.

**Summary:**  
The PR sets Autobind=Cores as the default for Slurm’s taskPluginParam, tweaks Slurm core scheduling, adds two admin/diagnostic scripts to the jail image, and enhances user creation with an option to skip internal SSH key generation.