### PR TITLE
Add node affinity to jail collector to exclude non-worker nodes

### DIFF
--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -299,6 +299,14 @@ spec:
       runAsUser: 10001
     serviceAccount:
       create: true
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: slurm.nebius.ai/nodeset
+              operator: NotIn
+              values: ["login", "accounting", "controller", "system"]
     tolerations:
     - operator: Exists
     - effect: NoExecute

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -136,6 +136,7 @@ spec:
                   - "/mnt/jail/opt/soperator-outputs/**/`name`*.out"
                 include_file_name: true
                 include_file_path: true
+                preserve_leading_whitespaces: true
                 operators:
                   - type: add
                     field: resource["worker_name"]


### PR DESCRIPTION
- Fix DaemonSet scheduling conflict where jail collector tried to deploy to all nodes
- Use node affinity with NotIn operator to exclude accounting, controller, login, system nodes
- Ensures jail collectors only deploy to worker nodesets where logs are generated
- Resolves 'Insufficient CPU' scheduling failures on accounting node
- Future-proof for any new worker nodeset types (worker-1, cpu-workers, etc.)