### PR TITLE
Reduce OpenTelemetry jail collector polling frequency

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - dev
+    tags:
+      - 'build**'  # Trigger on tags starting with "build"
     paths-ignore:
       - 'docs/**'
       - 'CODEOWNERS'

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -137,6 +137,7 @@ spec:
                 include_file_name: true
                 include_file_path: true
                 preserve_leading_whitespaces: true
+                poll_interval: 10s
                 operators:
                   - type: add
                     field: resource["worker_name"]


### PR DESCRIPTION
- Set poll_interval to 10s for jail log collector to reduce filesystem I/O
- Add CI trigger for tags starting with 'build' for on-demand builds