### PR TITLE
[FIX] Replace `kebabcase` with custom function

### DIFF
--- a/helm/slurm-cluster-storage/templates/_helpers.tpl
+++ b/helm/slurm-cluster-storage/templates/_helpers.tpl
@@ -1,6 +1,23 @@
+{{/* Works as the sprig/kebabcase without putting dash before the first digit in the word */}}
+{{- define "mashedkebab" -}}
+    {{- /* CamelCase -> kebab */ -}}
+    {{- $s := regexReplaceAll "([a-z])([A-Z])" . "${1}-${2}" -}}
+    {{- $s = regexReplaceAll "([A-Z])([A-Z][a-z])" $s "${1}-${2}" -}}
+    {{- /* Lower uppercases */ -}}
+    {{- $s = lower $s -}}
+    {{- /* Turn alphanumericals into dash */ -}}
+    {{- $s = regexReplaceAll "[^a-z0-9]+" $s "-" -}}
+    {{- /* Compress sequence of dashes into one dash */ -}}
+    {{- regexReplaceAll "-{2,}" $s "-" -}}
+{{- end }}
+
+{{/*
+---
+*/}}
+
 {{/* Local storage class */}}
 {{- define "slurm-cluster-storage.class.local.name" -}}
-    {{- required "Local storage class name is required." .Values.storageClass.local.name | trim | kebabcase | quote -}}
+    {{- required "Local storage class name is required." .Values.storageClass.local.name | trim | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/*
@@ -9,22 +26,22 @@
 
 {{/* Jail volume */}}
 {{- define "slurm-cluster-storage.volume.jail.name" -}}
-    {{- required "Jail volume name is required." .Values.volume.jail.name | trim | kebabcase -}}
+    {{- required "Jail volume name is required." .Values.volume.jail.name | trim | include "mashedkebab" -}}
 {{- end }}
 
 {{/* Jail PVC name */}}
 {{- define "slurm-cluster-storage.volume.jail.pvc" -}}
-    {{- cat (include "slurm-cluster-storage.volume.jail.name" .) "pvc" | kebabcase | quote -}}
+    {{- cat (include "slurm-cluster-storage.volume.jail.name" .) "pvc" | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/* Jail PV name */}}
 {{- define "slurm-cluster-storage.volume.jail.pv" -}}
-    {{- cat (include "slurm-cluster-storage.volume.jail.name" .) "pv" | kebabcase | quote -}}
+    {{- cat (include "slurm-cluster-storage.volume.jail.name" .) "pv" | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/* Jail mount name */}}
 {{- define "slurm-cluster-storage.volume.jail.mount" -}}
-    {{- cat (include "slurm-cluster-storage.volume.jail.name" .) "mount" | kebabcase | quote -}}
+    {{- cat (include "slurm-cluster-storage.volume.jail.name" .) "mount" | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/* Jail storage class name */}}
@@ -48,7 +65,7 @@
 {{/* Jail filestore device name */}}
 {{- define "slurm-cluster-storage.volume.jail.device" -}}
     {{- if eq .Values.volume.jail.type "filestore" -}}
-        {{- required "Jail volume filestore device name is required." .Values.volume.jail.filestoreDeviceName | trim | kebabcase -}}
+        {{- required "Jail volume filestore device name is required." .Values.volume.jail.filestoreDeviceName | trim | include "mashedkebab" -}}
     {{- else }}
         {{- "" -}}
     {{- end }}
@@ -57,7 +74,7 @@
 {{/* Jail GlusterFS host name */}}
 {{- define "slurm-cluster-storage.volume.jail.hostname" -}}
     {{- if eq .Values.volume.jail.type "glusterfs" -}}
-        {{- required "Jail volume GlusterFS hostname is required." .Values.volume.jail.glusterfsHostName | trim | kebabcase -}}
+        {{- required "Jail volume GlusterFS hostname is required." .Values.volume.jail.glusterfsHostName | trim | include "mashedkebab" -}}
     {{- else }}
         {{- "" -}}
     {{- end }}
@@ -69,22 +86,22 @@
 
 {{/* Controller spool volume */}}
 {{- define "slurm-cluster-storage.volume.controller-spool.name" -}}
-    {{- required "Controller spool volume name is required." .Values.volume.controllerSpool.name | trim | kebabcase -}}
+    {{- required "Controller spool volume name is required." .Values.volume.controllerSpool.name | trim | include "mashedkebab" -}}
 {{- end }}
 
 {{/* Controller spool PVC name */}}
 {{- define "slurm-cluster-storage.volume.controller-spool.pvc" -}}
-    {{- cat (include "slurm-cluster-storage.volume.controller-spool.name" .) "pvc" | kebabcase | quote -}}
+    {{- cat (include "slurm-cluster-storage.volume.controller-spool.name" .) "pvc" | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/* Controller spool PV name */}}
 {{- define "slurm-cluster-storage.volume.controller-spool.pv" -}}
-    {{- cat (include "slurm-cluster-storage.volume.controller-spool.name" .) "pv" | kebabcase | quote -}}
+    {{- cat (include "slurm-cluster-storage.volume.controller-spool.name" .) "pv" | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/* Controller spool mount name */}}
 {{- define "slurm-cluster-storage.volume.controller-spool.mount" -}}
-    {{- cat (include "slurm-cluster-storage.volume.controller-spool.name" .) "mount" | kebabcase | quote -}}
+    {{- cat (include "slurm-cluster-storage.volume.controller-spool.name" .) "mount" | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/* Controller spool storage class name */}}
@@ -99,7 +116,7 @@
 
 {{/* Controller spool device name */}}
 {{- define "slurm-cluster-storage.volume.controller-spool.device" -}}
-    {{- required "Controller spool Filestore device name is required." .Values.volume.controllerSpool.filestoreDeviceName | trim | kebabcase -}}
+    {{- required "Controller spool Filestore device name is required." .Values.volume.controllerSpool.filestoreDeviceName | trim | include "mashedkebab" -}}
 {{- end }}
 
 {{/*
@@ -108,17 +125,17 @@
 
 {{/* Accounting database volume */}}
 {{- define "slurm-cluster-storage.volume.accounting.name" -}}
-    {{- required "Accounting volume name is required." .Values.volume.accounting.name | trim | kebabcase -}}
+    {{- required "Accounting volume name is required." .Values.volume.accounting.name | trim | include "mashedkebab" -}}
 {{- end }}
 
 {{/* Accounting database  PV name */}}
 {{- define "slurm-cluster-storage.volume.accounting.pv" -}}
-    {{- cat (include "slurm-cluster-storage.volume.accounting.name" .) "pv" | kebabcase | quote -}}
+    {{- cat (include "slurm-cluster-storage.volume.accounting.name" .) "pv" | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/* Accounting database  mount name */}}
 {{- define "slurm-cluster-storage.volume.accounting.mount" -}}
-    {{- cat (include "slurm-cluster-storage.volume.accounting.name" .) "mount" | kebabcase | quote -}}
+    {{- cat (include "slurm-cluster-storage.volume.accounting.name" .) "mount" | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/* Accounting database  storage class name */}}
@@ -133,7 +150,7 @@
 
 {{/* Accounting database  device name */}}
 {{- define "slurm-cluster-storage.volume.accounting.device" -}}
-    {{- required "Accounting Filestore device name is required." .Values.volume.accounting.filestoreDeviceName | trim | kebabcase -}}
+    {{- required "Accounting Filestore device name is required." .Values.volume.accounting.filestoreDeviceName | trim | include "mashedkebab" -}}
 {{- end }}
 
 {{/*
@@ -142,22 +159,22 @@
 
 {{/* Jail submount volume */}}
 {{- define "slurm-cluster-storage.volume.jail-submount.name" -}}
-    {{- cat "jail-submount" (required "Jail submount name is required." .name) | trim | kebabcase -}}
+    {{- cat "jail-submount" (required "Jail submount name is required." .name) | trim | include "mashedkebab" -}}
 {{- end }}
 
 {{/* Jail submount PVC name */}}
 {{- define "slurm-cluster-storage.volume.jail-submount.pvc" -}}
-  {{- cat (include "slurm-cluster-storage.volume.jail-submount.name" .) "pvc" | kebabcase | quote -}}
+  {{- cat (include "slurm-cluster-storage.volume.jail-submount.name" .) "pvc" | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/* Jail submount PV name */}}
 {{- define "slurm-cluster-storage.volume.jail-submount.pv" -}}
-    {{- cat (include "slurm-cluster-storage.volume.jail-submount.name" .) "pv" | kebabcase | quote -}}
+    {{- cat (include "slurm-cluster-storage.volume.jail-submount.name" .) "pv" | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/* Jail submount mount name */}}
 {{- define "slurm-cluster-storage.volume.jail-submount.mount" -}}
-    {{- cat (include "slurm-cluster-storage.volume.jail-submount.name" .) "mount" | kebabcase | quote -}}
+    {{- cat (include "slurm-cluster-storage.volume.jail-submount.name" .) "mount" | include "mashedkebab" | quote -}}
 {{- end }}
 
 {{/* Jail submount storage class name */}}
@@ -172,5 +189,5 @@
 
 {{/* Jail submount device name */}}
 {{- define "slurm-cluster-storage.volume.jail-submount.device" -}}
-    {{- required "Jail submount Filestore device name is required." .filestoreDeviceName | trim | kebabcase -}}
+    {{- required "Jail submount Filestore device name is required." .filestoreDeviceName | trim | include "mashedkebab" -}}
 {{- end }}

--- a/helm/slurm-cluster-storage/templates/jail-mount-daemonset.yaml
+++ b/helm/slurm-cluster-storage/templates/jail-mount-daemonset.yaml
@@ -18,7 +18,7 @@ spec:
       hostIPC: true
 {{- end }}
       containers:
-        - name: {{ cat "mount-jail" (include "slurm-cluster-storage.volume.jail.type" .) | kebabcase }}
+        - name: {{ cat "mount-jail" (include "slurm-cluster-storage.volume.jail.type" .) | include "mashedkebab" }}
 {{- if eq (include "slurm-cluster-storage.volume.jail.type" .) "filestore" }}
           image: cr.eu-north1.nebius.cloud/soperator/busybox
 {{- else }}


### PR DESCRIPTION
Otherwise, kebabcase turns something like `slurm-k9` to `slurm-k-9`