### PR TITLE
Reorganize log directory structure by worker node

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -271,7 +271,7 @@ type PluginConfigNcclDebug struct {
 
 	// OutputToFile defines whether to additionally redirect `NCCL_DEBUG` outputs to the output file.
 	// Output filename will have the following format:
-	//  <WORKER_NAME>.<JOB_ID>.<STEP_ID>.out
+	//  <JOB_ID>.<STEP_ID>.out
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=true
@@ -292,7 +292,7 @@ type PluginConfigNcclDebug struct {
 	// If the path does not exist, it will be created by the plugin.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="/opt/soperator-outputs/nccl_logs"
+	// +kubebuilder:default="/opt/soperator-outputs/%h/nccl_logs"
 	OutputDirectory string `json:"outputDirectory,omitempty"`
 }
 

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -1357,7 +1357,7 @@ spec:
                         - TRACE
                         type: string
                       outputDirectory:
-                        default: /opt/soperator-outputs/nccl_logs
+                        default: /opt/soperator-outputs/%h/nccl_logs
                         description: |-
                           OutputDirectory defines a directory path where OutputToFile has to be created.
 
@@ -1371,7 +1371,7 @@ spec:
                         description: |-
                           OutputToFile defines whether to additionally redirect `NCCL_DEBUG` outputs to the output file.
                           Output filename will have the following format:
-                           <WORKER_NAME>.<JOB_ID>.<STEP_ID>.out
+                           <JOB_ID>.<STEP_ID>.out
                         type: boolean
                       outputToStdOut:
                         default: false

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -18216,7 +18216,7 @@ spec:
                         - TRACE
                         type: string
                       outputDirectory:
-                        default: /opt/soperator-outputs/nccl_logs
+                        default: /opt/soperator-outputs/%h/nccl_logs
                         description: |-
                           OutputDirectory defines a directory path where OutputToFile has to be created.
 
@@ -18230,7 +18230,7 @@ spec:
                         description: |-
                           OutputToFile defines whether to additionally redirect `NCCL_DEBUG` outputs to the output file.
                           Output filename will have the following format:
-                           <WORKER_NAME>.<JOB_ID>.<STEP_ID>.out
+                           <JOB_ID>.<STEP_ID>.out
                         type: boolean
                       outputToStdOut:
                         default: false

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -133,7 +133,7 @@ spec:
               rule: type == "pod" && name matches "worker-"
               config:
                 include: 
-                  - "/mnt/jail/opt/soperator-outputs/**/`name`*.out"
+                  - "/mnt/jail/opt/soperator-outputs/`name`/**/*.out"
                 include_file_name: true
                 include_file_path: true
                 preserve_leading_whitespaces: true
@@ -145,7 +145,7 @@ spec:
                   - id: extract_content_from_filename
                     type: regex_parser
                     parse_from: attributes["log.file.name"]
-                    regex: ^`name`\.(?P<content>.+)\.out$
+                    regex: ^(?P<content>.+)\.out$
                   - id: extract_directory
                     type: regex_parser
                     parse_from: attributes["log.file.path"]

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -18216,7 +18216,7 @@ spec:
                         - TRACE
                         type: string
                       outputDirectory:
-                        default: /opt/soperator-outputs/nccl_logs
+                        default: /opt/soperator-outputs/%h/nccl_logs
                         description: |-
                           OutputDirectory defines a directory path where OutputToFile has to be created.
 
@@ -18230,7 +18230,7 @@ spec:
                         description: |-
                           OutputToFile defines whether to additionally redirect `NCCL_DEBUG` outputs to the output file.
                           Output filename will have the following format:
-                           <WORKER_NAME>.<JOB_ID>.<STEP_ID>.out
+                           <JOB_ID>.<STEP_ID>.out
                         type: boolean
                       outputToStdOut:
                         default: false

--- a/images/common/spank-nccl-debug/src/snccld_args.h
+++ b/images/common/spank-nccl-debug/src/snccld_args.h
@@ -161,11 +161,11 @@ typedef struct {
 
 /// Per-job plugin config initialized with default values.
 static snccld_config_t snccld_config = {
-    .enabled    = SNCCLD_ARG_ENABLED_DEFAULT,
-    .log_level  = SNCCLD_ARG_LOG_LEVEL_DEFAULT,
-    .out_dir    = SNCCLD_ARG_OUT_DIR_DEFAULT,
-    .out_file   = SNCCLD_ARG_OUT_FILE_DEFAULT,
-    .out_stdout = SNCCLD_ARG_OUT_STDOUT_DEFAULT,
+    .enabled          = SNCCLD_ARG_ENABLED_DEFAULT,
+    .log_level        = SNCCLD_ARG_LOG_LEVEL_DEFAULT,
+    .out_dir          = SNCCLD_ARG_OUT_DIR_DEFAULT,
+    .out_file         = SNCCLD_ARG_OUT_FILE_DEFAULT,
+    .out_stdout       = SNCCLD_ARG_OUT_STDOUT_DEFAULT,
 };
 
 /**

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -305,7 +305,7 @@ func generateSpankConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
 				fmt.Sprintf("enabled=%d", utils.Ternary(opts.Enabled, 1, 0)),
 				fmt.Sprintf("log-level=%s", utils.Ternary(opts.LogLevel != "", opts.LogLevel, "INFO")),
 				fmt.Sprintf("out-file=%d", utils.Ternary(opts.OutputToFile, 1, 0)),
-				fmt.Sprintf("out-dir=%s", utils.Ternary(opts.OutputDirectory != "", opts.OutputDirectory, "/opt/soperator-outputs/nccl_logs")),
+				fmt.Sprintf("out-dir=%s", utils.Ternary(opts.OutputDirectory != "", opts.OutputDirectory, "/opt/soperator-outputs/%h/nccl_logs")),
 				fmt.Sprintf("out-stdout=%d", utils.Ternary(opts.OutputToStdOut, 1, 0)),
 			},
 			" ",

--- a/internal/render/common/configmap_test.go
+++ b/internal/render/common/configmap_test.go
@@ -279,7 +279,7 @@ func TestRenderPlugstack(t *testing.T) {
 			},
 		}).Render()
 		assert.NotEmpty(t, result)
-		assert.Contains(t, result, "optional spanknccldebug.so enabled=0 log-level=INFO out-file=0 out-dir=/opt/soperator-outputs/nccl_logs out-stdout=0")
+		assert.Contains(t, result, "optional spanknccldebug.so enabled=0 log-level=INFO out-file=0 out-dir=/opt/soperator-outputs/%h/nccl_logs out-stdout=0")
 	})
 
 	t.Run("NCCL options", func(t *testing.T) {


### PR DESCRIPTION
This change implements a worker-separated directory structure for logs
to reduce filesystem contention on the shared jail storage.

## Changes:
- NCCL logs: `/opt/soperator-outputs/%h/nccl_logs/` (using Slurm `%h` substitution)
- Remove worker name prefix from filenames (redundant with directory structure)
- Update OpenTelemetry collector to read from worker-specific directories
- Update documentation to reflect new layout
- Add hostname substitution support to NCCL plugin for `%h` replacement
- Update CRD documentation for new filename format

## Benefits:
- Eliminates cross-worker filesystem contention
- Enables parallel log collection
- Simplifies filename patterns
- Improves shared filesystem performance
