### PR TITLE
Disable OpenTelemetry collectors by default

### DIFF
--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.observability.enabled .Values.observability.opentelemetry.enabled .Values.observability.opentelemetry.logs.values.hcOutputEnabled }}
+{{- if and .Values.observability.enabled
+            .Values.observability.opentelemetry.enabled
+            .Values.observability.opentelemetry.logs.values.hcOutputEnabled
+            .Values.observability.opentelemetry.logs.values.jailLogs.enabled }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -124,6 +124,7 @@ spec:
             - set(attributes["cluster"], "${env:CLUSTER_NAME}")
             - set(attributes["k8s.node.name"], "${env:K8S_NODE_NAME}")
       receivers:
+        {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
         filelog/nodelogs:
           include:
             - '/var/nodelogs/kern.log*'
@@ -166,6 +167,7 @@ spec:
             - type: move
               from: attributes["logtype"]
               to: resource["app.kubernetes.io/name"]
+        {{- end }}
         filelog/pods:
           exclude:
           - /var/log/pods/*/otc-container/*.log
@@ -294,7 +296,9 @@ spec:
             - batch
             receivers:
             - filelog/pods
+            {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
             - filelog/nodelogs
+            {{- end }}
           metrics: null
           traces: null
     extraEnvs:
@@ -320,9 +324,11 @@ spec:
       readOnly: true
     - mountPath: /var/lib/otelcol
       name: varlibotelcol
+    {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
     - name: node-logs
       mountPath: /var/nodelogs
       readOnly: true
+    {{- end }}
     extraVolumes:
     {{- if $hasPublicEndpoint }}
     - name: o11ytoken
@@ -332,10 +338,12 @@ spec:
     - hostPath:
         path: /var/log/pods
       name: varlogpods
+    {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
     - hostPath:
         path: /var/log
         type: Directory
       name: node-logs
+    {{- end }}
     - hostPath:
         path: /var/lib/otelcol
         type: DirectoryOrCreate
@@ -351,7 +359,11 @@ spec:
     - command:
       - sh
       - -c
+      {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
       - 'chown -R 10001: /var/lib/otelcol /var/nodelogs'
+      {{- else }}
+      - 'chown -R 10001: /var/lib/otelcol'
+      {{- end }}
       image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
       name: init-fs
       securityContext:
@@ -360,8 +372,10 @@ spec:
       volumeMounts:
       - mountPath: /var/lib/otelcol
         name: varlibotelcol
+      {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
       - name: node-logs
         mountPath: /var/nodelogs
+      {{- end }}
     mode: daemonset
     rollout:
       rollingUpdate:

--- a/helm/soperator-fluxcd/tests/component_enabled_test.yaml
+++ b/helm/soperator-fluxcd/tests/component_enabled_test.yaml
@@ -4,9 +4,23 @@ templates:
 excludeTemplates:
   - templates/helmrepository.yaml
 tests:
-  - it: should not render component when enabled=false
+  - it: should render jail logs component when jailLogs.enabled=true
     set:
       observability.opentelemetry.logs.values.jailLogs.enabled: true
     asserts:
       - hasDocuments:
           count: 1
+  - it: should render node logs when nodeLogs.enabled=true
+    set:
+      observability.opentelemetry.logs.values.nodeLogs.enabled: true
+    templates:
+      - templates/opentelemetry-collector-logs.yaml
+    asserts:
+      - exists:
+          path: spec.values.config.receivers["filelog/nodelogs"]
+  - it: should not render node logs when nodeLogs.enabled=false (default)
+    templates:
+      - templates/opentelemetry-collector-logs.yaml
+    asserts:
+      - notExists:
+          path: spec.values.config.receivers["filelog/nodelogs"]

--- a/helm/soperator-fluxcd/tests/component_enabled_test.yaml
+++ b/helm/soperator-fluxcd/tests/component_enabled_test.yaml
@@ -5,6 +5,8 @@ excludeTemplates:
   - templates/helmrepository.yaml
 tests:
   - it: should not render component when enabled=false
+    set:
+      observability.opentelemetry.logs.values.jailLogs.enabled: true
     asserts:
       - hasDocuments:
           count: 1

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -86,7 +86,10 @@ observability:
       timeout: 5m
       values:
         jailLogs:
+          enabled: false
           pollInterval: 5m
+        nodeLogs:
+          enabled: false
         hcOutputEnabled: true
         resources: {}
       overrideValues: null


### PR DESCRIPTION
Add enabled flags to control resource usage:
- `jailLogs.enabled: false` - controls jail logs collection
- `nodeLogs.enabled: false` - controls system logs (kern.log, syslog, dmesg, fabricmanager.log)

Users can enable collectors by setting respective enabled flags to true.
