### PR TITLE
Configure slurmrestd's thread count and connections

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -649,6 +649,21 @@ type SlurmRest struct {
 	// +kubebuilder:default=false
 	Enabled bool `json:"enabled,omitempty"`
 
+	// ThreadCount defines the number of threads for slurmrestd
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=2
+	// +kubebuilder:validation:Maximum=1024
+	// +kubebuilder:default=3
+	ThreadCount *int32 `json:"threadCount,omitempty"`
+
+	// MaxConnections defines the maximum number of connections for slurmrestd
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=2
+	// +kubebuilder:default=10
+	MaxConnections *int32 `json:"maxConnections,omitempty"`
+
 	// SlurmRestNode represents the Slurm REST API daemon configuration
 	//
 	// +kubebuilder:validation:Optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1159,6 +1159,16 @@ func (in *SlurmNodes) DeepCopy() *SlurmNodes {
 func (in *SlurmRest) DeepCopyInto(out *SlurmRest) {
 	*out = *in
 	in.SlurmNode.DeepCopyInto(&out.SlurmNode)
+	if in.ThreadCount != nil {
+		in, out := &in.ThreadCount, &out.ThreadCount
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MaxConnections != nil {
+		in, out := &in.MaxConnections, &out.MaxConnections
+		*out = new(int32)
+		**out = **in
+	}
 	in.SlurmRestNode.DeepCopyInto(&out.SlurmRestNode)
 }
 

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -13515,6 +13515,13 @@ spec:
                           K8sNodeFilterName defines the Kubernetes node filter name associated with the Slurm node.
                           Must correspond to the name of one of [K8sNodeFilter]
                         type: string
+                      maxConnections:
+                        default: 10
+                        description: MaxConnections defines the maximum number of
+                          connections for slurmrestd
+                        format: int32
+                        minimum: 2
+                        type: integer
                       rest:
                         description: SlurmRestNode represents the Slurm REST API daemon
                           configuration
@@ -13575,6 +13582,14 @@ spec:
                       size:
                         description: Size defines the number of node instances
                         format: int32
+                        type: integer
+                      threadCount:
+                        default: 3
+                        description: ThreadCount defines the number of threads for
+                          slurmrestd
+                        format: int32
+                        maximum: 1024
+                        minimum: 2
                         type: integer
                     required:
                     - k8sNodeFilterName

--- a/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
+++ b/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
@@ -378,6 +378,12 @@ spec:
       enabled: {{ .Values.slurmNodes.rest.enabled }}
       size: {{ required ".Values.slurmNodes.rest.size must be provided." .Values.slurmNodes.rest.size }}
       k8sNodeFilterName: {{ required ".Values.slurmNodes.rest.k8sNodeFilterName must be provided." .Values.slurmNodes.rest.k8sNodeFilterName | quote }}
+      {{- if .Values.slurmNodes.rest.threadCount }}
+      threadCount: {{ .Values.slurmNodes.rest.threadCount }}
+      {{- end }}
+      {{- if .Values.slurmNodes.rest.maxConnections }}
+      maxConnections: {{ .Values.slurmNodes.rest.maxConnections }}
+      {{- end }}
       customInitContainers: {{- default list .Values.slurmNodes.rest.customInitContainers | toYaml | nindent 10 }}
       rest:
         image: {{ required "rest image" .Values.images.slurmrestd | quote }}

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -473,16 +473,18 @@ slurmNodes:
         volumeSourceName: "jail"
   rest:
     enabled: false
-    size: 1
+    size: 2
     k8sNodeFilterName: "no-gpu"
+    threadCount: 3
+    maxConnections: 10
     rest:
       imagePullPolicy: "IfNotPresent"
       appArmorProfile: "unconfined"
       command: []
       args: []
       resources:
-        cpu: "1000m"
-        memory: "1Gi"
+        cpu: "2000m"
+        memory: "8Gi"
         ephemeralStorage: "500Mi"
     customInitContainers: []
 sConfigController:

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -30374,6 +30374,13 @@ spec:
                           K8sNodeFilterName defines the Kubernetes node filter name associated with the Slurm node.
                           Must correspond to the name of one of [K8sNodeFilter]
                         type: string
+                      maxConnections:
+                        default: 10
+                        description: MaxConnections defines the maximum number of
+                          connections for slurmrestd
+                        format: int32
+                        minimum: 2
+                        type: integer
                       rest:
                         description: SlurmRestNode represents the Slurm REST API daemon
                           configuration
@@ -30434,6 +30441,14 @@ spec:
                       size:
                         description: Size defines the number of node instances
                         format: int32
+                        type: integer
+                      threadCount:
+                        default: 3
+                        description: ThreadCount defines the number of threads for
+                          slurmrestd
+                        format: int32
+                        maximum: 1024
+                        minimum: 2
                         type: integer
                     required:
                     - k8sNodeFilterName

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -30374,6 +30374,13 @@ spec:
                           K8sNodeFilterName defines the Kubernetes node filter name associated with the Slurm node.
                           Must correspond to the name of one of [K8sNodeFilter]
                         type: string
+                      maxConnections:
+                        default: 10
+                        description: MaxConnections defines the maximum number of
+                          connections for slurmrestd
+                        format: int32
+                        minimum: 2
+                        type: integer
                       rest:
                         description: SlurmRestNode represents the Slurm REST API daemon
                           configuration
@@ -30434,6 +30441,14 @@ spec:
                       size:
                         description: Size defines the number of node instances
                         format: int32
+                        type: integer
+                      threadCount:
+                        default: 3
+                        description: ThreadCount defines the number of threads for
+                          slurmrestd
+                        format: int32
+                        maximum: 1024
+                        minimum: 2
                         type: integer
                     required:
                     - k8sNodeFilterName

--- a/images/restd/slurmrestd_entrypoint.sh
+++ b/images/restd/slurmrestd_entrypoint.sh
@@ -8,4 +8,6 @@ rm -rf /etc/slurm && ln -s /mnt/slurm-configs /etc/slurm
 chown www-data:www-data /usr/sbin/slurmrestd && chmod 500 /usr/sbin/slurmrestd
 
 echo "Start slurmrestd daemon"
-exec /usr/sbin/slurmrestd -f /etc/slurm/slurm_rest.conf -u www-data -g www-data -a rest_auth/jwt -vvvvvv :6820
+SLURMRESTD_THREAD_COUNT=${SLURMRESTD_THREAD_COUNT:-3}
+SLURMRESTD_MAX_CONNECTIONS=${SLURMRESTD_MAX_CONNECTIONS:-10}
+exec /usr/sbin/slurmrestd -f /etc/slurm/slurm_rest.conf -u www-data -g www-data -a rest_auth/jwt -vvvvvv -t ${SLURMRESTD_THREAD_COUNT} --max-connections ${SLURMRESTD_MAX_CONNECTIONS} :6820

--- a/internal/render/rest/pod.go
+++ b/internal/render/rest/pod.go
@@ -45,7 +45,7 @@ func BasePodTemplateSpec(
 			NodeSelector:   nodeFilter.NodeSelector,
 			Hostname:       consts.HostnameREST,
 			InitContainers: valuesREST.CustomInitContainers,
-			Containers:     []corev1.Container{renderContainerREST(valuesREST.ContainerREST)},
+			Containers:     []corev1.Container{renderContainerREST(valuesREST.ContainerREST, valuesREST.ThreadCount, valuesREST.MaxConnections)},
 			Volumes:        volumes,
 		},
 	}, nil

--- a/internal/values/slurm_rest.go
+++ b/internal/values/slurm_rest.go
@@ -12,6 +12,8 @@ type SlurmREST struct {
 	slurmv1.SlurmNode
 
 	Enabled              bool
+	ThreadCount          *int32
+	MaxConnections       *int32
 	ContainerREST        Container
 	CustomInitContainers []corev1.Container
 	Service              Service
@@ -30,6 +32,8 @@ func buildRestFrom(clusterName string, maintenance *consts.MaintenanceMode, rest
 	return SlurmREST{
 		SlurmNode:            *rest.SlurmNode.DeepCopy(),
 		Enabled:              rest.Enabled,
+		ThreadCount:          rest.ThreadCount,
+		MaxConnections:       rest.MaxConnections,
 		ContainerREST:        containerREST,
 		CustomInitContainers: rest.CustomInitContainers,
 		Service:              buildServiceFrom(naming.BuildServiceName(consts.ComponentTypeREST, clusterName)),


### PR DESCRIPTION
- Add threadCount and maxConnections fields to SlurmRest API
- Make slurmrestd entrypoint use environment variables
- Increase default REST replicas to 2 and memory to 8Gi
- Support configurable thread count and max connections via Helm values

Fixes issue #1118