### PR TITLE
Set `out-stdout=1` if user provided `NCCL_DEBUG` on their own

### DIFF
--- a/images/common/spank-nccl-debug/README.md
+++ b/images/common/spank-nccl-debug/README.md
@@ -63,6 +63,10 @@ Ensures every rank runs with the same level you requested.
 
 `--nccld-out-stdout=0` (or `SNCCLD_OUT_STDOUT=0`) stops NCCL logs from going to your job’s standard output.
 
+> [!IMPORTANT]
+> If the user submitting a job already has env variable `NCCL_DEBUG` set to some value,
+> outputting the NCCL logs to the stdout will be forced no matter the arguments.
+
 ### Toggle file output
 
 `--nccld-out-file=0` (or `SNCCLD_OUT_FILE=0`) disables writing NCCL output to the dedicated files,

--- a/images/common/spank-nccl-debug/src/snccld.c
+++ b/images/common/spank-nccl-debug/src/snccld.c
@@ -268,6 +268,23 @@ int slurm_spank_user_init(spank_t spank, int argc, char **argv) {
         goto user_init_exit;
     }
 
+    {
+        char       user_debug[8] = "";
+        const bool user_set_debug =
+            (spank_getenv(
+                 spank, SNCCLD_NCCL_ENV_DEBUG, user_debug, sizeof(user_debug)
+             ) == ESPANK_SUCCESS &&
+             strlen(user_debug) > 0);
+        snccld_log_debug("user_set_debug=%u", user_set_debug);
+        if (user_set_debug) {
+            snccld_log_info(
+                "Enabling output to stdout as user set %s on their own.",
+                SNCCLD_NCCL_ENV_DEBUG
+            );
+            snccld_config.out_stdout = true;
+        }
+    }
+
     // Set forced debug level.
     snccld_log_info(
         "Setting %s=%s", SNCCLD_NCCL_ENV_DEBUG, snccld_config.log_level

--- a/images/common/spank-nccl-debug/src/snccld.c
+++ b/images/common/spank-nccl-debug/src/snccld.c
@@ -51,15 +51,17 @@ char *_snccld_get_executable_name(pid_t pid) {
  * @param hostname The hostname to substitute for %h.
  * @param output Buffer to store the result (must be PATH_MAX + 1 bytes).
  */
-static void snccld_substitute_hostname(const char *path, const char *hostname, char *output) {
-    const char *p = path;
-    char *out = output;
-    
+static void snccld_substitute_hostname(
+    const char *path, const char *hostname, char *output
+) {
+    const char *p   = path;
+    char       *out = output;
+
     while (*p && (out - output) < PATH_MAX) {
         if (*p == '%' && *(p + 1) == 'h') {
             // Replace %h with hostname
             out += snprintf(out, PATH_MAX - (out - output), "%s", hostname);
-            p += 2; // Skip %h
+            p   += 2; // Skip %h
         } else {
             *out++ = *p++;
         }
@@ -298,8 +300,10 @@ int slurm_spank_user_init(spank_t spank, int argc, char **argv) {
 
     if (snccld_config.out_file) {
         char resolved_out_dir[PATH_MAX + 1];
-        snccld_substitute_hostname(snccld_config.out_dir, hostname, resolved_out_dir);
-        
+        snccld_substitute_hostname(
+            snccld_config.out_dir, hostname, resolved_out_dir
+        );
+
         snprintf(
             state->log_path,
             sizeof(state->log_path),
@@ -437,7 +441,9 @@ int slurm_spank_task_init_privileged(spank_t spank, int argc, char **argv) {
 
     if (snccld_config.out_file) {
         char resolved_out_dir[PATH_MAX + 1];
-        snccld_substitute_hostname(snccld_config.out_dir, hostname, resolved_out_dir);
+        snccld_substitute_hostname(
+            snccld_config.out_dir, hostname, resolved_out_dir
+        );
         snccld_log_debug("Ensuring '%s' exists.", resolved_out_dir);
         snccld_ensure_dir_exists(resolved_out_dir);
     }
@@ -518,7 +524,9 @@ int slurm_spank_task_init_privileged(spank_t spank, int argc, char **argv) {
             mounts[dir_mount_count++] = strdup(SNCCLD_SYSTEM_DIR);
             if (snccld_config.out_file) {
                 char resolved_out_dir[PATH_MAX + 1];
-                snccld_substitute_hostname(snccld_config.out_dir, hostname, resolved_out_dir);
+                snccld_substitute_hostname(
+                    snccld_config.out_dir, hostname, resolved_out_dir
+                );
                 mounts[dir_mount_count++] = strdup(resolved_out_dir);
             }
 

--- a/images/common/spank-nccl-debug/src/snccld_args.h
+++ b/images/common/spank-nccl-debug/src/snccld_args.h
@@ -161,11 +161,11 @@ typedef struct {
 
 /// Per-job plugin config initialized with default values.
 static snccld_config_t snccld_config = {
-    .enabled          = SNCCLD_ARG_ENABLED_DEFAULT,
-    .log_level        = SNCCLD_ARG_LOG_LEVEL_DEFAULT,
-    .out_dir          = SNCCLD_ARG_OUT_DIR_DEFAULT,
-    .out_file         = SNCCLD_ARG_OUT_FILE_DEFAULT,
-    .out_stdout       = SNCCLD_ARG_OUT_STDOUT_DEFAULT,
+    .enabled    = SNCCLD_ARG_ENABLED_DEFAULT,
+    .log_level  = SNCCLD_ARG_LOG_LEVEL_DEFAULT,
+    .out_dir    = SNCCLD_ARG_OUT_DIR_DEFAULT,
+    .out_file   = SNCCLD_ARG_OUT_FILE_DEFAULT,
+    .out_stdout = SNCCLD_ARG_OUT_STDOUT_DEFAULT,
 };
 
 /**


### PR DESCRIPTION
This PR ensures that if the user has already set the `NCCL_DEBUG` environment variable, we automatically enable stdout logging (`out-stdout=1`), updates some function formatting, and documents the new behaviour.

- Detect and force `out_stdout` when `NCCL_DEBUG` is set in `slurm_spank_user_init`
- Reformat `snccld_substitute_hostname` calls with `clang-format`
- Add an important note in `README.md` about forced stdout when `NCCL_DEBUG` is user-provided
