### PR TITLE
Make jail log collector great again

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -105,7 +105,7 @@ type SlurmClusterSpec struct {
 	// PlugStackConfig represents the Plugin stack configurations in `plugstack.conf`.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={ pyxis: { required: true, containerImageSave: "/var/cache/enroot-container-images/" }, ncclDebug: { required: false, enabled: false, logLevel: "INFO", outputToFile: true, outputToStdOut: false, outputDirectory: "/opt/soperator-outputs/%h/nccl_logs" } }
+	// +kubebuilder:default={ pyxis: { required: true, containerImageSave: "/var/cache/enroot-container-images/" }, ncclDebug: { required: false, enabled: false, logLevel: "INFO", outputToFile: true, outputToStdOut: false, outputDirectory: "/opt/soperator-outputs/nccl_logs" } }
 	PlugStackConfig PlugStackConfig `json:"plugStackConfig,omitempty"`
 
 	// SlurmTopologyConfigMapRefName is the name of the slurm topology config.
@@ -215,7 +215,7 @@ type PlugStackConfig struct {
 	// NcclDebug represents the 'NCCL Debug' SPANK plugin configuration.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={ required: false, enabled: false, logLevel: "INFO", outputToFile: true, outputToStdOut: false, outputDirectory: "/opt/soperator-outputs/%h/nccl_logs" }
+	// +kubebuilder:default={ required: false, enabled: false, logLevel: "INFO", outputToFile: true, outputToStdOut: false, outputDirectory: "/opt/soperator-outputs/nccl_logs" }
 	NcclDebug PluginConfigNcclDebug `json:"ncclDebug,omitempty"`
 
 	// PluginConfigCustom represents a configuration of custom SPANK plugins.
@@ -271,7 +271,7 @@ type PluginConfigNcclDebug struct {
 
 	// OutputToFile defines whether to additionally redirect `NCCL_DEBUG` outputs to the output file.
 	// Output filename will have the following format:
-	//  <JOB_ID>.<STEP_ID>.out
+	//  <WORKER_NAME>.<JOB_ID>.<STEP_ID>.out
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=true
@@ -292,7 +292,7 @@ type PluginConfigNcclDebug struct {
 	// If the path does not exist, it will be created by the plugin.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="/opt/soperator-outputs/%h/nccl_logs"
+	// +kubebuilder:default="/opt/soperator-outputs/nccl_logs"
 	OutputDirectory string `json:"outputDirectory,omitempty"`
 }
 

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -1292,7 +1292,7 @@ spec:
                   ncclDebug:
                     enabled: false
                     logLevel: INFO
-                    outputDirectory: /opt/soperator-outputs/%h/nccl_logs
+                    outputDirectory: /opt/soperator-outputs/nccl_logs
                     outputToFile: true
                     outputToStdOut: false
                     required: false
@@ -1336,7 +1336,7 @@ spec:
                     default:
                       enabled: false
                       logLevel: INFO
-                      outputDirectory: /opt/soperator-outputs/%h/nccl_logs
+                      outputDirectory: /opt/soperator-outputs/nccl_logs
                       outputToFile: true
                       outputToStdOut: false
                       required: false
@@ -1357,7 +1357,7 @@ spec:
                         - TRACE
                         type: string
                       outputDirectory:
-                        default: /opt/soperator-outputs/%h/nccl_logs
+                        default: /opt/soperator-outputs/nccl_logs
                         description: |-
                           OutputDirectory defines a directory path where OutputToFile has to be created.
 
@@ -1371,7 +1371,7 @@ spec:
                         description: |-
                           OutputToFile defines whether to additionally redirect `NCCL_DEBUG` outputs to the output file.
                           Output filename will have the following format:
-                           <JOB_ID>.<STEP_ID>.out
+                           <WORKER_NAME>.<JOB_ID>.<STEP_ID>.out
                         type: boolean
                       outputToStdOut:
                         default: false

--- a/helm/slurm-cluster/slurm_scripts/epilog.sh
+++ b/helm/slurm-cluster/slurm_scripts/epilog.sh
@@ -3,7 +3,7 @@
 set -eox pipefail
 
 export JAIL_DIR="/mnt/jail"
-export LOGS_OUTPUT_DIR="/opt/soperator-outputs/${SLURMD_NODENAME}/slurm_scripts"
+export LOGS_OUTPUT_DIR="/opt/soperator-outputs/slurm_scripts"
 export SCRIPT_CONTEXT="epilog"
 
 (umask 000; mkdir -p ${JAIL_DIR}${LOGS_OUTPUT_DIR})
@@ -21,7 +21,7 @@ if [ -n "$SLURM_JOB_GPUS" ]; then
         pushd /opt/slurm_scripts || exit 0
         for check in "${checks[@]}"; do
             script="${check}.sh"
-            log="${LOGS_OUTPUT_DIR}/${check}.${SCRIPT_CONTEXT}.out"
+            log="${LOGS_OUTPUT_DIR}/${SLURMD_NODENAME}.${check}.${SCRIPT_CONTEXT}.out"
 
             # Run the current script and:
             # - write its fd 1 and 2 (stderr+stdout) to the $log file
@@ -53,7 +53,7 @@ EOF
 fi
 
 echo "Unmap the Slurm job with DCGM metrics"
-log="${JAIL_DIR}${LOGS_OUTPUT_DIR}/unmap_job_dcgm.${SCRIPT_CONTEXT}.out"
+log="${JAIL_DIR}${LOGS_OUTPUT_DIR}/${SLURMD_NODENAME}.unmap_job_dcgm.${SCRIPT_CONTEXT}.out"
 bash /mnt/jail/opt/slurm_scripts/unmap_job_dcgm.sh > "$log" 2>&1 || true
 
 exit 0

--- a/helm/slurm-cluster/slurm_scripts/hc_program.sh
+++ b/helm/slurm-cluster/slurm_scripts/hc_program.sh
@@ -3,7 +3,7 @@
 set -eox pipefail
 
 export JAIL_DIR="/mnt/jail"
-export LOGS_OUTPUT_DIR="/opt/soperator-outputs/${SLURMD_NODENAME}/slurm_scripts"
+export LOGS_OUTPUT_DIR="/opt/soperator-outputs/slurm_scripts"
 export SCRIPT_CONTEXT="hc_program"
 
 (umask 000; mkdir -p ${JAIL_DIR}${LOGS_OUTPUT_DIR})
@@ -21,7 +21,7 @@ chroot /mnt/jail /bin/bash -s <<-'EOF'
     pushd /opt/slurm_scripts || exit 0
     for check in "${checks[@]}"; do
         script="${check}.sh"
-        log="${LOGS_OUTPUT_DIR}/${check}.${SCRIPT_CONTEXT}.out"
+        log="${LOGS_OUTPUT_DIR}/${SLURMD_NODENAME}.${check}.${SCRIPT_CONTEXT}.out"
 
         # Run the current script and:
         # - write its fd 1 and 2 (stderr+stdout) to the $log file

--- a/helm/slurm-cluster/slurm_scripts/prolog.sh
+++ b/helm/slurm-cluster/slurm_scripts/prolog.sh
@@ -3,7 +3,7 @@
 set -eox pipefail
 
 export JAIL_DIR="/mnt/jail"
-export LOGS_OUTPUT_DIR="/opt/soperator-outputs/${SLURMD_NODENAME}/slurm_scripts"
+export LOGS_OUTPUT_DIR="/opt/soperator-outputs/slurm_scripts"
 export SCRIPT_CONTEXT="prolog"
 
 (umask 000; mkdir -p ${JAIL_DIR}${LOGS_OUTPUT_DIR})
@@ -23,7 +23,7 @@ if [ -n "$SLURM_JOB_GPUS" ]; then
         pushd /opt/slurm_scripts || exit 0
         for check in "${checks[@]}"; do
             script="${check}.sh"
-            log="${LOGS_OUTPUT_DIR}/${check}.${SCRIPT_CONTEXT}.out"
+            log="${LOGS_OUTPUT_DIR}/${SLURMD_NODENAME}.${check}.${SCRIPT_CONTEXT}.out"
 
             # Run the current script and:
             # - write its fd 1 and 2 (stderr+stdout) to the $log file
@@ -59,11 +59,11 @@ EOF
 fi
 
 echo "Cleanup leftover enroot containers"
-log="${JAIL_DIR}${LOGS_OUTPUT_DIR}/cleanup_enroot.${SCRIPT_CONTEXT}.out"
+log="${JAIL_DIR}${LOGS_OUTPUT_DIR}/${SLURMD_NODENAME}.cleanup_enroot.${SCRIPT_CONTEXT}.out"
 bash /mnt/jail/opt/slurm_scripts/cleanup_enroot.sh  > "$log" 2>&1 || true
 
 echo "Map the Slurm job with DCGM metrics"
-log="${JAIL_DIR}${LOGS_OUTPUT_DIR}/map_job_dcgm.${SCRIPT_CONTEXT}.out"
+log="${JAIL_DIR}${LOGS_OUTPUT_DIR}/${SLURMD_NODENAME}.map_job_dcgm.${SCRIPT_CONTEXT}.out"
 bash /mnt/jail/opt/slurm_scripts/map_job_dcgm.sh > "$log" 2>&1 || true
 
 exit 0

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -175,7 +175,7 @@ plugStackConfig:
     logLevel: "INFO"
     outputToFile: true
     outputToStdOut: false
-    outputDirectory: "/opt/soperator-outputs/%h/nccl_logs"
+    outputDirectory: "/opt/soperator-outputs/nccl_logs"
 #  pyxis:
 #    required: true
 #    containerImageSave: "/var/cache/enroot-container-images/"

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -18151,7 +18151,7 @@ spec:
                   ncclDebug:
                     enabled: false
                     logLevel: INFO
-                    outputDirectory: /opt/soperator-outputs/%h/nccl_logs
+                    outputDirectory: /opt/soperator-outputs/nccl_logs
                     outputToFile: true
                     outputToStdOut: false
                     required: false
@@ -18195,7 +18195,7 @@ spec:
                     default:
                       enabled: false
                       logLevel: INFO
-                      outputDirectory: /opt/soperator-outputs/%h/nccl_logs
+                      outputDirectory: /opt/soperator-outputs/nccl_logs
                       outputToFile: true
                       outputToStdOut: false
                       required: false
@@ -18216,7 +18216,7 @@ spec:
                         - TRACE
                         type: string
                       outputDirectory:
-                        default: /opt/soperator-outputs/%h/nccl_logs
+                        default: /opt/soperator-outputs/nccl_logs
                         description: |-
                           OutputDirectory defines a directory path where OutputToFile has to be created.
 
@@ -18230,7 +18230,7 @@ spec:
                         description: |-
                           OutputToFile defines whether to additionally redirect `NCCL_DEBUG` outputs to the output file.
                           Output filename will have the following format:
-                           <JOB_ID>.<STEP_ID>.out
+                           <WORKER_NAME>.<JOB_ID>.<STEP_ID>.out
                         type: boolean
                       outputToStdOut:
                         default: false

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -1,6 +1,5 @@
 {{- if and .Values.observability.enabled
             .Values.observability.opentelemetry.enabled
-            .Values.observability.opentelemetry.logs.values.hcOutputEnabled
             .Values.observability.opentelemetry.logs.values.jailLogs.enabled }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -49,8 +48,132 @@ spec:
         - watch
         - list
     config:
+      receivers:
+        filelog:
+          include:
+            - "/mnt/jail/opt/soperator-outputs/*/*.out"
+          include_file_name: true  # Adds attributes["log.file.name"]
+          include_file_path: true  # Adds attributes["log.file.path"]
+          preserve_leading_whitespaces: true
+          poll_interval: {{ .Values.observability.opentelemetry.logs.values.jailLogs.pollInterval | default "5s" }}
+          operators:
+            - id: extract_base_name_and_pod
+              type: regex_parser
+              parse_from: attributes["log.file.name"]
+              regex: ^(?P<slurm_node_name>[^.]+)\.(?P<base_name>.+)\.out$
+            - type: copy
+              from: attributes.slurm_node_name
+              to: resource["slurm_node_name"]
+            - type: move
+              from: attributes.slurm_node_name
+              to: resource["k8s.pod.name"]
+            - type: add
+              field: resource["k8s.namespace.name"]
+              value: {{ .Values.slurmCluster.namespace | default "soperator" | quote }}
+            - id: extract_directory
+              type: regex_parser
+              parse_from: attributes["log.file.path"]
+              regex: ^.*/(?P<log_directory>nccl_logs|slurm_jobs|slurm_scripts)/.*$
+            - type: move
+              from: attributes.log_directory
+              to: resource["log_type"]
+            - id: parse_nccl_log_base_name
+              type: regex_parser
+              parse_from: attributes.base_name
+              regex: ^(?P<job_id>\d+)\.(?P<job_step_id>\d+)$
+              if: resource["log_type"] == "nccl_logs"
+            - type: move
+              from: attributes.job_id
+              to: resource["job_id"]
+              if: resource["log_type"] == "nccl_logs" and attributes["job_id"] != nil
+            - type: move
+              from: attributes.job_step_id
+              to: resource["job_step_id"]
+              if: resource["log_type"] == "nccl_logs" and attributes["job_step_id"] != nil
+            - id: parse_slurm_job_log_base_name
+              type: regex_parser
+              parse_from: attributes.base_name
+              regex: ^(?P<job_name>[^.]+)\.(?P<job_id>\d+)(?:\.(?P<job_array_id>\d+))?$
+              if: resource["log_type"] == "slurm_jobs"
+            - type: move
+              from: attributes.job_name
+              to: resource["job_name"]
+              if: resource["log_type"] == "slurm_jobs" and attributes["job_name"] != nil
+            - type: move
+              from: attributes.job_id
+              to: resource["job_id"]
+              if: resource["log_type"] == "slurm_jobs" and attributes["job_id"] != nil
+            - type: move
+              from: attributes.job_array_id
+              to: resource["job_array_id"]
+              if: resource["log_type"] == "slurm_jobs" and attributes["job_array_id"] != nil
+            - id: parse_script_log_base_name
+              type: regex_parser
+              parse_from: attributes.base_name
+              regex: ^(?P<script_name>[^.]+)\.(?P<script_context>[^.]+)$
+              if: resource["log_type"] == "slurm_scripts"
+            - type: move
+              from: attributes.script_name
+              to: resource["slurm_script_name"]
+              if: resource["log_type"] == "slurm_scripts" and attributes["script_name"] != nil
+            - type: move
+              from: attributes.script_context
+              to: resource["slurm_script_context"]
+              if: resource["log_type"] == "slurm_scripts" and attributes["script_context"] != nil
+            - type: remove
+              field: attributes.base_name
+          retry_on_failure:
+            enabled: true
+          start_at: end  # Start reading from the end of the file on startup.
+          storage: file_storage  # Storage for the state (file offsets).
+        # Disable irrelevant receivers that might be added by valuesFrom ConfigMap:
+        zipkin: null
+        jaeger: null
+        otlp: null
+        prometheus: null
+      processors:
+        batch:
+          send_batch_max_size: 700
+          send_batch_size: 250
+        k8sattributes:
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+          extract:
+            labels:  # Copy labels for the managed solution.
+            - from: pod
+              key: external-o11y
+              tag_name: external_o11y
+            - from: namespace
+              key: o11y_resource_id
+              tag_name: resource_id
+            - from: namespace
+              key: o11y_service_provider
+              tag_name: service_provider
+            metadata:
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.pod.start_time
+          passthrough: false
+          wait_for_metadata: true  # Wait for k8s metadata on startup.
+          wait_for_metadata_timeout: 30s
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 25
+        transform:
+          log_statements:
+          - context: log
+            error_mode: ignore
+            statements:
+            - set(attributes["cluster"], {{ .Values.observability.clusterName | quote }})
       exporters:
-        otlphttp/victoriametrics:
+        otlphttp/victorialogs:
           compression: gzip
           encoding: proto
           logs_endpoint: http://vm-logs-victoria-logs-single-server:9428/insert/opentelemetry/v1/logs
@@ -71,8 +194,6 @@ spec:
             authenticator: bearertokenauth
         {{- end }}
       extensions:
-        k8s_observer:
-          node: ${env:K8S_NODE_NAME}
         file_storage:
           directory: /var/lib/otelcol-jail
         health_check:
@@ -81,135 +202,6 @@ spec:
         bearertokenauth:
           filename: "/o11ytoken/accessToken"
         {{- end }}
-      processors:
-        batch:
-          send_batch_max_size: 700
-          send_batch_size: 250
-        k8sattributes:
-          extract:
-            labels:
-            - from: pod
-              key: external-o11y
-              tag_name: external_o11y
-            - from: namespace
-              key: o11y_resource_id
-              tag_name: resource_id
-            - from: namespace
-              key: o11y_service_provider
-              tag_name: service_provider
-            metadata:
-            - k8s.namespace.name
-            - k8s.node.name
-            - k8s.pod.name
-            - k8s.pod.uid
-            - k8s.pod.start_time
-          filter:
-            node_from_env_var: K8S_NODE_NAME
-          passthrough: false
-          pod_association:
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.ip
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.uid
-          - sources:
-            - from: connection
-          wait_for_metadata: true
-          wait_for_metadata_timeout: 30s
-        memory_limiter:
-          check_interval: 5s
-          limit_percentage: 80
-          spike_limit_percentage: 25
-        transform:
-          log_statements:
-          - context: log
-            error_mode: ignore
-            statements:
-            - set(attributes["cluster"], "${env:CLUSTER_NAME}")
-            - set(attributes["k8s.node.name"], "${env:K8S_NODE_NAME}")
-      receivers:
-        filelog:
-          include:
-            - "/mnt/jail/opt/soperator-outputs/*/*.out"
-          include_file_name: true
-          include_file_path: true
-          preserve_leading_whitespaces: true
-          poll_interval: {{ .Values.observability.opentelemetry.logs.values.jailLogs.pollInterval | default "5s" }}
-          operators:
-            - id: extract_content_from_filename
-              type: regex_parser
-              parse_from: attributes["log.file.name"]
-              regex: ^(?P<content>.+)\.out$
-            - id: extract_directory
-              type: regex_parser
-              parse_from: attributes["log.file.path"]
-              regex: ^.*/(?P<log_directory>nccl_logs|slurm_jobs|slurm_scripts)/.*$
-            - type: move
-              from: attributes.log_directory
-              to: resource["log_type"]
-            - id: parse_nccl_content
-              type: regex_parser
-              parse_from: attributes.content
-              regex: ^(?P<node_name>[^.]+)\.(?P<job_id>\d+)\.(?P<job_step_id>\d+)$
-              if: resource["log_type"] == "nccl_logs"
-            - type: move
-              from: attributes.job_id
-              to: resource["job_id"]
-              if: resource["log_type"] == "nccl_logs" and attributes["job_id"] != nil
-            - type: move
-              from: attributes.job_step_id
-              to: resource["job_step_id"]
-              if: resource["log_type"] == "nccl_logs" and attributes["job_step_id"] != nil
-            - type: move
-              from: attributes.node_name
-              to: resource["node_name"]
-              if: resource["log_type"] == "nccl_logs" and attributes["node_name"] != nil
-            - id: parse_slurm_job_content
-              type: regex_parser
-              parse_from: attributes.content
-              regex: ^(?P<node_name>[^.]+)\.(?P<job_name>[^.]+)\.(?P<job_id>\d+)(?:\.(?P<job_array_id>\d+))?$
-              if: resource["log_type"] == "slurm_jobs"
-            - type: move
-              from: attributes.job_name
-              to: resource["job_name"]
-              if: resource["log_type"] == "slurm_jobs" and attributes["job_name"] != nil
-            - type: move
-              from: attributes.job_id
-              to: resource["job_id"]
-              if: resource["log_type"] == "slurm_jobs" and attributes["job_id"] != nil
-            - type: move
-              from: attributes.job_array_id
-              to: resource["job_array_id"]
-              if: resource["log_type"] == "slurm_jobs" and attributes["job_array_id"] != nil
-            - type: move
-              from: attributes.node_name
-              to: resource["node_name"]
-              if: resource["log_type"] == "slurm_jobs" and attributes["node_name"] != nil
-            - id: parse_script_content
-              type: regex_parser
-              parse_from: attributes.content
-              regex: ^(?P<node_name>[^.]+)\.(?P<script_name>[^.]+)\.(?P<script_context>[^.]+)$
-              if: resource["log_type"] == "slurm_scripts"
-            - type: move
-              from: attributes.script_name
-              to: resource["slurm_script_name"]
-              if: resource["log_type"] == "slurm_scripts" and attributes["script_name"] != nil
-            - type: move
-              from: attributes.script_context
-              to: resource["slurm_script_context"]
-              if: resource["log_type"] == "slurm_scripts" and attributes["script_context"] != nil
-            - type: move
-              from: attributes.node_name
-              to: resource["node_name"]
-              if: resource["log_type"] == "slurm_scripts" and attributes["node_name"] != nil
-            - type: remove
-              field: attributes.content
-          retry_on_failure:
-            enabled: true
-          start_at: end
-          storage: file_storage
-        zipkin: null
       service:
         extensions:
         - health_check
@@ -217,30 +209,23 @@ spec:
         {{- if $hasPublicEndpoint }}
         - bearertokenauth
         {{- end }}
-        - k8s_observer
         pipelines:
           logs:
-            exporters:
-            - otlphttp/victoriametrics
-            {{- if $hasPublicEndpoint }}
-            - otlp
-            {{- end }}
+            receivers:
+            - filelog
             processors:
             - k8sattributes
             - transform
             - memory_limiter
             - batch
-            receivers:
-            - filelog
+            exporters:
+            - otlphttp/victorialogs
+            {{- if $hasPublicEndpoint }}
+            - otlp
+            {{- end }}
           metrics: null
           traces: null
     extraEnvs:
-    - name: K8S_NODE_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    - name: CLUSTER_NAME
-      value: {{ .Values.observability.clusterName | quote }}
     - name: GOMAXPROCS
       value: "1"
     extraVolumeMounts:
@@ -260,10 +245,10 @@ spec:
       secret:
         secretName: o11y-writer-sa-token
     {{- end }}
-    - hostPath:
+    - name: soperator-outputs
+      hostPath:
         path: /mnt/jail/opt/soperator-outputs
         type: Directory
-      name: soperator-outputs
     - hostPath:
         path: /var/lib/otelcol-jail
         type: DirectoryOrCreate
@@ -285,8 +270,19 @@ spec:
       volumeMounts:
       - mountPath: /var/lib/otelcol-jail
         name: varlibotelcol
-    mode: daemonset
-    ports:
+    mode: deployment  # Single deployment on system nodes instead of DaemonSet on all workers
+    replicaCount: 1   # Only one replica to avoid file lock conflicts on shared storage and prevent log duplication
+    rollout:
+      strategy: Recreate  # Ensure old pod terminates before new one starts to maintain max one pod running
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: slurm.nebius.ai/nodeset
+                  operator: In
+                  values: ["system"]
+    ports:  # Disable all network receivers since this collector only reads files
       jaeger-compact:
         enabled: false
       jaeger-grpc:
@@ -299,52 +295,16 @@ spec:
         enabled: false
       zipkin:
         enabled: false
-    rollout:
-      rollingUpdate:
-        maxUnavailable: 50%
-      strategy: RollingUpdate
     securityContext:
       runAsGroup: 0
       runAsUser: 10001
+    service:  # No external access needed - this collector only reads files and sends to Victoria Logs
+      enabled: false
     serviceAccount:
       create: true
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-          - matchExpressions:
-            - key: slurm.nebius.ai/nodeset
-              operator: NotIn
-              values: ["login", "accounting", "controller", "system"]
-    tolerations:
-    - operator: Exists
-    - effect: NoExecute
-      key: node.kubernetes.io/not-ready
-      operator: Exists
-    - effect: NoExecute
-      key: node.kubernetes.io/unreachable
-      operator: Exists
-    - effect: NoSchedule
-      key: node.kubernetes.io/disk-pressure
-      operator: Exists
-    - effect: NoSchedule
-      key: node.kubernetes.io/memory-pressure
-      operator: Exists
-    - effect: NoSchedule
-      key: node.kubernetes.io/pid-pressure
-      operator: Exists
-    - effect: NoSchedule
-      key: node.kubernetes.io/unschedulable
-      operator: Exists
-    - effect: NoSchedule
-      key: node.kubernetes.io/network-unavailable
-      operator: Exists
-    - effect: NoSchedule
-      key: node.cilium.io/agent-not-ready
-      operator: Exists
     useGOMEMLIMIT: {{ .Values.observability.opentelemetry.logs.values.useGOMEMLIMIT | default true }}
-    {{- if and .Values.observability.opentelemetry.logs.values .Values.observability.opentelemetry.logs.values.resources }}
-    resources: {{- toYaml .Values.observability.opentelemetry.logs.values.resources | nindent 6 }}
+    {{- if .Values.observability.opentelemetry.logs.values.jailLogs.resources }}
+    resources: {{- toYaml .Values.observability.opentelemetry.logs.values.jailLogs.resources | nindent 6 }}
     {{- end }}
   {{- end }}
   valuesFrom:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -129,82 +129,86 @@ spec:
             - set(attributes["cluster"], "${env:CLUSTER_NAME}")
             - set(attributes["k8s.node.name"], "${env:K8S_NODE_NAME}")
       receivers:
-        receiver_creator:
-          watch_observers: [k8s_observer]
-          receivers:
-            filelog:
-              rule: type == "pod" && name matches "worker-"
-              config:
-                include: 
-                  - "/mnt/jail/opt/soperator-outputs/`name`/**/*.out"
-                include_file_name: true
-                include_file_path: true
-                preserve_leading_whitespaces: true
-                poll_interval: {{ .Values.observability.opentelemetry.logs.values.jailLogs.pollInterval | default "5m" }}
-                operators:
-                  - type: add
-                    field: resource["worker_name"]
-                    value: "`name`"
-                  - id: extract_content_from_filename
-                    type: regex_parser
-                    parse_from: attributes["log.file.name"]
-                    regex: ^(?P<content>.+)\.out$
-                  - id: extract_directory
-                    type: regex_parser
-                    parse_from: attributes["log.file.path"]
-                    regex: ^.*/(?P<log_directory>nccl_logs|slurm_jobs|slurm_scripts)/.*$
-                  - type: move
-                    from: attributes.log_directory
-                    to: resource["log_type"]
-                  - id: parse_nccl_content
-                    type: regex_parser
-                    parse_from: attributes.content
-                    regex: ^(?P<job_id>\d+)\.(?P<job_step_id>\d+)$
-                    if: resource["log_type"] == "nccl_logs"
-                  - type: move
-                    from: attributes.job_id
-                    to: resource["job_id"]
-                    if: resource["log_type"] == "nccl_logs" and attributes["job_id"] != nil
-                  - type: move
-                    from: attributes.job_step_id
-                    to: resource["job_step_id"]
-                    if: resource["log_type"] == "nccl_logs" and attributes["job_step_id"] != nil
-                  - id: parse_slurm_job_content
-                    type: regex_parser
-                    parse_from: attributes.content
-                    regex: ^(?P<job_name>[^.]+)\.(?P<job_id>\d+)(?:\.(?P<job_array_id>\d+))?$
-                    if: resource["log_type"] == "slurm_jobs"
-                  - type: move
-                    from: attributes.job_name
-                    to: resource["job_name"]
-                    if: resource["log_type"] == "slurm_jobs" and attributes["job_name"] != nil
-                  - type: move
-                    from: attributes.job_id
-                    to: resource["job_id"]
-                    if: resource["log_type"] == "slurm_jobs" and attributes["job_id"] != nil
-                  - type: move
-                    from: attributes.job_array_id
-                    to: resource["job_array_id"]
-                    if: resource["log_type"] == "slurm_jobs" and attributes["job_array_id"] != nil
-                  - id: parse_script_content
-                    type: regex_parser
-                    parse_from: attributes.content
-                    regex: ^(?P<script_name>[^.]+)(?:\.(?P<script_context>[^.]+))?$
-                    if: resource["log_type"] == "slurm_scripts"
-                  - type: move
-                    from: attributes.script_name
-                    to: resource["slurm_script_name"]
-                    if: resource["log_type"] == "slurm_scripts" and attributes["script_name"] != nil
-                  - type: move
-                    from: attributes.script_context
-                    to: resource["slurm_script_context"]
-                    if: resource["log_type"] == "slurm_scripts" and attributes["script_context"] != nil
-                  - type: remove
-                    field: attributes.content
-                retry_on_failure:
-                  enabled: true
-                start_at: end
-                storage: file_storage
+        filelog:
+          include:
+            - "/mnt/jail/opt/soperator-outputs/*/*.out"
+          include_file_name: true
+          include_file_path: true
+          preserve_leading_whitespaces: true
+          poll_interval: {{ .Values.observability.opentelemetry.logs.values.jailLogs.pollInterval | default "5s" }}
+          operators:
+            - id: extract_content_from_filename
+              type: regex_parser
+              parse_from: attributes["log.file.name"]
+              regex: ^(?P<content>.+)\.out$
+            - id: extract_directory
+              type: regex_parser
+              parse_from: attributes["log.file.path"]
+              regex: ^.*/(?P<log_directory>nccl_logs|slurm_jobs|slurm_scripts)/.*$
+            - type: move
+              from: attributes.log_directory
+              to: resource["log_type"]
+            - id: parse_nccl_content
+              type: regex_parser
+              parse_from: attributes.content
+              regex: ^(?P<node_name>[^.]+)\.(?P<job_id>\d+)\.(?P<job_step_id>\d+)$
+              if: resource["log_type"] == "nccl_logs"
+            - type: move
+              from: attributes.job_id
+              to: resource["job_id"]
+              if: resource["log_type"] == "nccl_logs" and attributes["job_id"] != nil
+            - type: move
+              from: attributes.job_step_id
+              to: resource["job_step_id"]
+              if: resource["log_type"] == "nccl_logs" and attributes["job_step_id"] != nil
+            - type: move
+              from: attributes.node_name
+              to: resource["node_name"]
+              if: resource["log_type"] == "nccl_logs" and attributes["node_name"] != nil
+            - id: parse_slurm_job_content
+              type: regex_parser
+              parse_from: attributes.content
+              regex: ^(?P<node_name>[^.]+)\.(?P<job_name>[^.]+)\.(?P<job_id>\d+)(?:\.(?P<job_array_id>\d+))?$
+              if: resource["log_type"] == "slurm_jobs"
+            - type: move
+              from: attributes.job_name
+              to: resource["job_name"]
+              if: resource["log_type"] == "slurm_jobs" and attributes["job_name"] != nil
+            - type: move
+              from: attributes.job_id
+              to: resource["job_id"]
+              if: resource["log_type"] == "slurm_jobs" and attributes["job_id"] != nil
+            - type: move
+              from: attributes.job_array_id
+              to: resource["job_array_id"]
+              if: resource["log_type"] == "slurm_jobs" and attributes["job_array_id"] != nil
+            - type: move
+              from: attributes.node_name
+              to: resource["node_name"]
+              if: resource["log_type"] == "slurm_jobs" and attributes["node_name"] != nil
+            - id: parse_script_content
+              type: regex_parser
+              parse_from: attributes.content
+              regex: ^(?P<node_name>[^.]+)\.(?P<script_name>[^.]+)\.(?P<script_context>[^.]+)$
+              if: resource["log_type"] == "slurm_scripts"
+            - type: move
+              from: attributes.script_name
+              to: resource["slurm_script_name"]
+              if: resource["log_type"] == "slurm_scripts" and attributes["script_name"] != nil
+            - type: move
+              from: attributes.script_context
+              to: resource["slurm_script_context"]
+              if: resource["log_type"] == "slurm_scripts" and attributes["script_context"] != nil
+            - type: move
+              from: attributes.node_name
+              to: resource["node_name"]
+              if: resource["log_type"] == "slurm_scripts" and attributes["node_name"] != nil
+            - type: remove
+              field: attributes.content
+          retry_on_failure:
+            enabled: true
+          start_at: end
+          storage: file_storage
         zipkin: null
       service:
         extensions:
@@ -227,7 +231,7 @@ spec:
             - memory_limiter
             - batch
             receivers:
-            - receiver_creator
+            - filelog
           metrics: null
           traces: null
     extraEnvs:

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -89,11 +89,11 @@ observability:
       timeout: 5m
       values:
         jailLogs:
-          enabled: false
-          pollInterval: 5m
+          enabled: true
+          pollInterval: 30s
+          resources: {}
         nodeLogs:
           enabled: false
-        hcOutputEnabled: true
         resources: {}
       overrideValues: null
     events:

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -18151,7 +18151,7 @@ spec:
                   ncclDebug:
                     enabled: false
                     logLevel: INFO
-                    outputDirectory: /opt/soperator-outputs/%h/nccl_logs
+                    outputDirectory: /opt/soperator-outputs/nccl_logs
                     outputToFile: true
                     outputToStdOut: false
                     required: false
@@ -18195,7 +18195,7 @@ spec:
                     default:
                       enabled: false
                       logLevel: INFO
-                      outputDirectory: /opt/soperator-outputs/%h/nccl_logs
+                      outputDirectory: /opt/soperator-outputs/nccl_logs
                       outputToFile: true
                       outputToStdOut: false
                       required: false
@@ -18216,7 +18216,7 @@ spec:
                         - TRACE
                         type: string
                       outputDirectory:
-                        default: /opt/soperator-outputs/%h/nccl_logs
+                        default: /opt/soperator-outputs/nccl_logs
                         description: |-
                           OutputDirectory defines a directory path where OutputToFile has to be created.
 
@@ -18230,7 +18230,7 @@ spec:
                         description: |-
                           OutputToFile defines whether to additionally redirect `NCCL_DEBUG` outputs to the output file.
                           Output filename will have the following format:
-                           <JOB_ID>.<STEP_ID>.out
+                           <WORKER_NAME>.<JOB_ID>.<STEP_ID>.out
                         type: boolean
                       outputToStdOut:
                         default: false

--- a/images/common/spank-nccl-debug/src/snccld.c
+++ b/images/common/spank-nccl-debug/src/snccld.c
@@ -324,8 +324,9 @@ int slurm_spank_user_init(spank_t spank, int argc, char **argv) {
         snprintf(
             state->log_path,
             sizeof(state->log_path),
-            "%s/%u.%u.out",
+            "%s/%s.%u.%u.out",
             resolved_out_dir,
+            hostname,
             key->job_id,
             key->step_id
         );

--- a/images/slurm_check_job/slurm_check_job_entrypoint.sh
+++ b/images/slurm_check_job/slurm_check_job_entrypoint.sh
@@ -21,20 +21,15 @@ rm -rf /etc/slurm && ln -s /mnt/jail/slurm /etc/slurm
 echo "Bind-mount /opt/bin/sbatch.sh script"
 mount --bind /opt/bin/sbatch.sh opt/bin/sbatch.sh
 
-echo "Create directory for slurm job outputs for every node"
-NODES=$(sinfo -N --noheader -o "%N" | sort -u)
-BASE_DIR="/mnt/jail/opt/soperator-outputs"
-for NODE in $NODES; do
-    DIR="${BASE_DIR}/${NODE}/slurm_jobs"
-    (umask 000; mkdir -p "$DIR")
-done
+echo "Create directory for slurm job outputs"
+(umask 000; mkdir -p "/mnt/jail/opt/soperator-outputs/slurm_jobs")
 
 if [[ "$EACH_WORKER_JOB_ARRAY" == "true" ]]; then
     echo "Submitting job using slurm_submit_array_job.sh..."
     SLURM_JOB_ID=$(/opt/bin/slurm/slurm_submit_array_job.sh | tail -n 1)
 else
     echo "Submitting regular Slurm job..."
-    OUT_PATTERN='/opt/soperator-outputs/%N/slurm_jobs/%x.%j.out'
+    OUT_PATTERN='/opt/soperator-outputs/slurm_jobs/%N.%x.%j.out'
     # Here we use env variables instead of --output and --error because they do not support %N (node name) parameter.
     SLURM_OUTPUT=$(
       SBATCH_OUTPUT="$OUT_PATTERN" \

--- a/images/slurm_check_job/slurm_submit_array_job.sh
+++ b/images/slurm_check_job/slurm_submit_array_job.sh
@@ -16,7 +16,7 @@ done
 echo "Submitting Slurm array job..."
 HOSTS_NUM=$(sinfo -N --noheader -o "%N" | wc -l)
 export SLURM_PROLOG="/slurm/activecheck-prolog.sh"
-OUT_PATTERN='/opt/soperator-outputs/%N/slurm_jobs/%x.%j.%A.out'
+OUT_PATTERN='/opt/soperator-outputs/slurm_jobs/%N.%x.%j.%A.out'
 # Here we use env variables instead of --output and --error because they do not support %N (node name) parameter.
 SLURM_OUTPUT=$(
     SBATCH_OUTPUT="$OUT_PATTERN" \

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -305,7 +305,7 @@ func generateSpankConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
 				fmt.Sprintf("enabled=%d", utils.Ternary(opts.Enabled, 1, 0)),
 				fmt.Sprintf("log-level=%s", utils.Ternary(opts.LogLevel != "", opts.LogLevel, "INFO")),
 				fmt.Sprintf("out-file=%d", utils.Ternary(opts.OutputToFile, 1, 0)),
-				fmt.Sprintf("out-dir=%s", utils.Ternary(opts.OutputDirectory != "", opts.OutputDirectory, "/opt/soperator-outputs/%h/nccl_logs")),
+				fmt.Sprintf("out-dir=%s", utils.Ternary(opts.OutputDirectory != "", opts.OutputDirectory, "/opt/soperator-outputs/nccl_logs")),
 				fmt.Sprintf("out-stdout=%d", utils.Ternary(opts.OutputToStdOut, 1, 0)),
 			},
 			" ",

--- a/internal/render/common/configmap_test.go
+++ b/internal/render/common/configmap_test.go
@@ -279,7 +279,7 @@ func TestRenderPlugstack(t *testing.T) {
 			},
 		}).Render()
 		assert.NotEmpty(t, result)
-		assert.Contains(t, result, "optional spanknccldebug.so enabled=0 log-level=INFO out-file=0 out-dir=/opt/soperator-outputs/%h/nccl_logs out-stdout=0")
+		assert.Contains(t, result, "optional spanknccldebug.so enabled=0 log-level=INFO out-file=0 out-dir=/opt/soperator-outputs/nccl_logs out-stdout=0")
 	})
 
 	t.Run("NCCL options", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reverts worker-separated directory structure introduced in PRs #1106, #1107, #1108, and #1111.
- Migrates jail log collector from DaemonSet to Deployment running on system nodes
- Re-enables jail logs collection by default

## Changes

1. Simplified logging structure: Removed /worker-X/ subdirectories, keeping only type-based directories (/nccl_logs/, /slurm_jobs/, /slurm_scripts/)
2. Node info in filenames: Node information now included in filenames using %N pattern instead of directory paths
3. Deployment optimization: Jail log collector now runs as a single Deployment on system nodes instead of DaemonSet on all nodes
4. Default configuration: Jail logs collection enabled by default in values.yaml

## Rationale

Performance optimization: A single collector scanning 3 directories (/nccl_logs/, /slurm_jobs/, /slurm_scripts/) is much more cost-efficient than scanning O(count of workers) directories. This significantly reduces I/O operations and improves collector performance at scale.

Issue: #1119 
