### PR TITLE
Add root switch to ensure single tree topology structure

### DIFF
--- a/internal/controller/topologyconfcontroller/topology_graph.go
+++ b/internal/controller/topologyconfcontroller/topology_graph.go
@@ -51,6 +51,8 @@ func (g TopologyGraph) ensureSingleRoot() {
 
 	// If there are multiple parentless switches, add them under "root"
 	if len(rootChildren) > 1 {
+		// Sort children for consistent output
+		slices.Sort(rootChildren)
 		for _, child := range rootChildren {
 			g.AddEdge("root", child)
 		}

--- a/internal/controller/topologyconfcontroller/topology_graph.go
+++ b/internal/controller/topologyconfcontroller/topology_graph.go
@@ -31,6 +31,32 @@ func (g TopologyGraph) AddEdge(parent, child string) {
 	g.children[parent][child] = struct{}{}
 }
 
+// ensureSingleRoot adds all parentless switches as children of a single "root" switch
+func (g TopologyGraph) ensureSingleRoot() {
+	// Find all nodes that have parents
+	hasParent := make(map[string]bool)
+	for _, children := range g.children {
+		for child := range children {
+			hasParent[child] = true
+		}
+	}
+
+	// Collect all parentless switches (except "root" itself)
+	var rootChildren []string
+	for switch_ := range g.children {
+		if !hasParent[switch_] && switch_ != "root" {
+			rootChildren = append(rootChildren, switch_)
+		}
+	}
+
+	// If there are multiple parentless switches, add them under "root"
+	if len(rootChildren) > 1 {
+		for _, child := range rootChildren {
+			g.AddEdge("root", child)
+		}
+	}
+}
+
 // RenderConfigLines renders the topology graph as a list of configuration lines.
 // Each line represents a vertex in the graph, with list of its children.
 // The format is:
@@ -95,6 +121,9 @@ func BuildTopologyGraph(
 			graph.AddEdge(unknownSwitchName, worker)
 		}
 	}
+
+	// Ensure all top-level switches are under a single root
+	graph.ensureSingleRoot()
 
 	return graph
 }

--- a/internal/controller/topologyconfcontroller/topology_graph_test.go
+++ b/internal/controller/topologyconfcontroller/topology_graph_test.go
@@ -30,6 +30,7 @@ func TestRenderTopologyConfig(t *testing.T) {
 				"":      {"pod5", "pod6"},
 			},
 			expected: []string{
+				"SwitchName=root Switches=spine1,spine2,spine3,unknown",
 				"SwitchName=spine1 Switches=switch1",
 				"SwitchName=spine2 Switches=switch2",
 				"SwitchName=spine3 Switches=switch1",
@@ -51,6 +52,7 @@ func TestRenderTopologyConfig(t *testing.T) {
 				"node3": {"pod4"},
 			},
 			expected: []string{
+				"SwitchName=root Switches=spine1,spine2,spine3",
 				"SwitchName=spine1 Switches=switch1",
 				"SwitchName=spine2 Switches=switch2",
 				"SwitchName=spine3 Switches=switch1",
@@ -73,6 +75,7 @@ func TestRenderTopologyConfig(t *testing.T) {
 				"node4": {"node4"},
 			},
 			expected: []string{
+				"SwitchName=root Switches=spine1,spine3",
 				"SwitchName=leaf1 Switches=switch0,switch1",
 				"SwitchName=leaf2 Switches=switch2",
 				"SwitchName=leaf3 Switches=switch3",
@@ -95,6 +98,7 @@ func TestRenderTopologyConfig(t *testing.T) {
 				"node2": {"node2"},
 			},
 			expected: []string{
+				"SwitchName=root Switches=switch1,switch2",
 				"SwitchName=switch1 Nodes=node1",
 				"SwitchName=switch2 Nodes=node2",
 			},
@@ -118,6 +122,7 @@ func TestRenderTopologyConfig(t *testing.T) {
 				"node3": {"node3"},
 			},
 			expected: []string{
+				"SwitchName=root Switches=spine1,spine2",
 				"SwitchName=spine1 Switches=switch1,switch2",
 				"SwitchName=spine2 Switches=switch3",
 				"SwitchName=switch1 Nodes=node1",
@@ -138,6 +143,7 @@ func TestRenderTopologyConfig(t *testing.T) {
 				"node3": {"node3"},
 			},
 			expected: []string{
+				"SwitchName=root Switches=core1,core2",
 				"SwitchName=core1 Switches=spine1",
 				"SwitchName=core2 Switches=spine2",
 				"SwitchName=leaf1 Switches=switch1,switch2",
@@ -164,6 +170,7 @@ func TestRenderTopologyConfig(t *testing.T) {
 				"node4": {"node4"},
 			},
 			expected: []string{
+				"SwitchName=root Switches=spine1,switch3,unknown",
 				"SwitchName=leaf1 Switches=switch1,switch2",
 				"SwitchName=spine1 Switches=leaf1",
 				"SwitchName=switch1 Nodes=node1",
@@ -207,6 +214,7 @@ func TestRenderTopologyConfig(t *testing.T) {
 				"node5": {"node5"},
 			},
 			expected: []string{
+				"SwitchName=root Switches=leaf1,leaf2,leaf3",
 				"SwitchName=leaf1 Switches=switch1,switch4",
 				"SwitchName=leaf2 Switches=switch2,switch5",
 				"SwitchName=leaf3 Switches=switch3",
@@ -258,6 +266,7 @@ func TestRenderTopologyConfig(t *testing.T) {
 				"node3": {"node3"},
 			},
 			expected: []string{
+				"SwitchName=root Switches=a-leaf,m-leaf,z-leaf",
 				"SwitchName=a-leaf Switches=a-switch",
 				"SwitchName=a-switch Nodes=node2",
 				"SwitchName=m-leaf Switches=m-switch",
@@ -278,6 +287,7 @@ func TestRenderTopologyConfig(t *testing.T) {
 				"":      {"pod6"},
 			},
 			expected: []string{
+				"SwitchName=root Switches=spine1,unknown",
 				"SwitchName=spine1 Switches=switch1,switch2",
 				"SwitchName=switch1 Nodes=pod1,pod2,pod3",
 				"SwitchName=switch2 Nodes=pod4,pod5",


### PR DESCRIPTION
## Summary

This PR modifies the topology functionality to ensure all switches form a single tree with a common root switch.

### Changes

- Added `ensureSingleRoot()` method to `TopologyGraph` that creates a "root" switch when there are multiple parentless switches
- All top-level switches (including "unknown") now become children of the "root" switch
- This ensures SLURM topology always has a single tree structure instead of a forest

### Implementation

The solution adds a post-processing step after building the topology graph:
1. Identifies all switches without parents (top-level switches)
2. If there are multiple parentless switches, creates a "root" switch
3. Adds all parentless switches as children of "root"

This maintains backward compatibility while ensuring a unified topology tree structure.