### PR TITLE
Fix REST deployment to respect configured replica count from CRD

### DIFF
--- a/internal/render/rest/container.go
+++ b/internal/render/rest/container.go
@@ -60,13 +60,7 @@ func renderContainerREST(containerParams values.Container, threadCount *int32, m
 			SuccessThreshold:    1,
 			TimeoutSeconds:      1,
 		},
-		SecurityContext: &corev1.SecurityContext{
-			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{
-					consts.ContainerSecurityContextCapabilitySysAdmin,
-				},
-			},
-		},
+		SecurityContext: &corev1.SecurityContext{},
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: *containerParams.Resources.Memory(),

--- a/internal/render/rest/container.go
+++ b/internal/render/rest/container.go
@@ -62,9 +62,7 @@ func renderContainerREST(containerParams values.Container, threadCount *int32, m
 		},
 		SecurityContext: &corev1.SecurityContext{},
 		Resources: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: *containerParams.Resources.Memory(),
-			},
+			Limits:   common.CopyNonCPUResources(containerParams.Resources),
 			Requests: containerParams.Resources,
 		},
 	}

--- a/internal/render/rest/rest.go
+++ b/internal/render/rest/rest.go
@@ -41,10 +41,7 @@ func RenderDeploymentREST(
 		return nil, err
 	}
 
-	// in Deployment mode replicas should be 1.
-	// in StatefulSet mode replicas should be more than 1.
-	// Because of munge container use pvcs, we can't use template pvc for munge in Deployment mode.
-	replicas := ptr.To(int32(1))
+	replicas := ptr.To(valuesREST.Size)
 	if check.IsMaintenanceActive(valuesREST.Maintenance) {
 		replicas = ptr.To(consts.ZeroReplicas)
 	}


### PR DESCRIPTION
## Summary

This PR fixes multiple configuration issues with the REST component.

## Changes

- **Fix replica scaling**: REST deployment now respects the `size` field from SlurmCluster CRD instead of being hardcoded to 1 replica
- **Remove unnecessary privilege**: Removed `SYS_ADMIN` capability from REST container security context  
- **Fix resource limits**: Added ephemeral-storage limits to prevent unlimited disk usage and align with other components

## Context

The REST component is stateless and these changes align its configuration with established patterns while improving security and resource management.

#1137