### PR TITLE
Fix topology generation to exclude nodes without pod assignments

### DIFF
--- a/internal/controller/topologyconfcontroller/topology_graph.go
+++ b/internal/controller/topologyconfcontroller/topology_graph.go
@@ -108,11 +108,14 @@ func BuildTopologyGraph(
 		workers := podsByNode[node]
 		delete(podsByNode, node)
 
-		for _, worker := range workers {
-			graph.AddEdge(pathToRoot[0], worker)
-		}
-		for i := range len(pathToRoot) - 1 {
-			graph.AddEdge(pathToRoot[i+1], pathToRoot[i])
+		// Only create topology edges if this node has workers
+		if len(workers) > 0 {
+			for _, worker := range workers {
+				graph.AddEdge(pathToRoot[0], worker)
+			}
+			for i := range len(pathToRoot) - 1 {
+				graph.AddEdge(pathToRoot[i+1], pathToRoot[i])
+			}
 		}
 	}
 

--- a/internal/controller/topologyconfcontroller/topology_graph_test.go
+++ b/internal/controller/topologyconfcontroller/topology_graph_test.go
@@ -294,6 +294,25 @@ func TestRenderTopologyConfig(t *testing.T) {
 				"SwitchName=unknown Nodes=pod6",
 			},
 		},
+		{
+			name: "Nodes with missing pod assignments should not create invalid switches",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "leaf-A", "tier-2": "spine-X"},
+				"node2": {"tier-1": "leaf-B", "tier-2": "spine-X"},
+				"node3": {"tier-1": "leaf-C", "tier-2": "spine-X"}, // This node has no pods!
+			},
+			podsByNode: map[string][]string{
+				"node1": {"worker-1"},
+				"node2": {"worker-2"},
+				// "node3" is missing - this should not create invalid topology
+			},
+			expected: []string{
+				// This is what SHOULD be generated (without leaf-C):
+				"SwitchName=leaf-A Nodes=worker-1",
+				"SwitchName=leaf-B Nodes=worker-2",
+				"SwitchName=spine-X Switches=leaf-A,leaf-B", // Should NOT include leaf-C
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes a critical topology generation bug that was causing Slurm to reject configurations.

## Changes

**Fix topology generation to exclude nodes without pod assignments**
- Resolves Slurm errors: `Switch configuration X has invalid child (Y)`
- Only creates topology edges for nodes that actually have worker pods
- Adds regression test to prevent this issue from recurring

## Context

The bug occurred when nodes had topology labels but no corresponding pod assignments, causing Slurm to reject the entire topology configuration with "invalid child" errors.