### PR TITLE
Fix worker startup race conditions with controller readiness check

### DIFF
--- a/images/worker/slurmd.dockerfile
+++ b/images/worker/slurmd.dockerfile
@@ -192,8 +192,12 @@ COPY images/worker/slurmd_entrypoint.sh /opt/bin/slurm/
 # Copy supervisord entrypoint script
 COPY images/worker/supervisord_entrypoint.sh /opt/bin/slurm/
 
+# Copy wait-for-controller script
+COPY images/worker/wait-for-controller.sh /opt/bin/slurm/
+
 RUN chmod +x /opt/bin/slurm/slurmd_entrypoint.sh && \
-    chmod +x /opt/bin/slurm/supervisord_entrypoint.sh
+    chmod +x /opt/bin/slurm/supervisord_entrypoint.sh && \
+    chmod +x /opt/bin/slurm/wait-for-controller.sh
 
 # Start supervisord that manages both slurmd and sshd as child processes
 ENTRYPOINT ["/opt/bin/slurm/supervisord_entrypoint.sh"]

--- a/images/worker/wait-for-controller.sh
+++ b/images/worker/wait-for-controller.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+echo "Waiting for Slurm controller to be ready..."
+controller_service="${CONTROLLER_SERVICE}"
+max_attempts=60
+attempt=0
+
+# Create symlink to slurm configs (same as worker entrypoint)
+echo "Creating symlink to slurm configs..."
+rm -rf /etc/slurm && ln -s /mnt/jail/slurm /etc/slurm
+
+# Wait for controller service to be resolvable via DNS
+echo "Checking controller service DNS resolution..."
+attempt=0
+while [ $attempt -lt $max_attempts ]; do
+	if nslookup "$controller_service" >/dev/null 2>&1; then
+		echo "Controller service is resolvable via DNS"
+		break
+	fi
+	echo "Attempt $((attempt + 1))/$max_attempts: Waiting for controller service DNS..."
+	attempt=$((attempt + 1))
+	sleep 5
+done
+
+if ! nslookup "$controller_service" >/dev/null 2>&1; then
+	echo "ERROR: Controller service DNS not resolvable after $max_attempts attempts"
+	exit 1
+fi
+
+# Now try to ping the controller using scontrol
+echo "Checking slurmctld readiness..."
+attempt=0
+while [ $attempt -lt $max_attempts ]; do
+	echo "Attempt $((attempt + 1))/$max_attempts: Checking controller readiness..."
+
+	# Try to ping the controller using scontrol
+	echo "Running: scontrol ping"
+	if scontrol_output=$(scontrol ping 2>&1); then
+		echo "Controller is ready!"
+		echo "scontrol ping output: $scontrol_output"
+		exit 0
+	else
+		echo "scontrol ping failed with output: $scontrol_output"
+	fi
+
+	attempt=$((attempt + 1))
+	sleep 5
+done
+
+echo "ERROR: Controller did not become ready after $max_attempts attempts"
+exit 1

--- a/internal/consts/container.go
+++ b/internal/consts/container.go
@@ -8,6 +8,7 @@ const (
 	ContainerNameREST              = Slurmrestd
 	ContainerNameSshd              = SshdName
 	ContainerNameToolkitValidation = "toolkit-validation"
+	ContainerNameWaitForController = "wait-for-controller"
 	ContainerNameNCCLBenchmark     = ncclBenchmark
 	ContainerNamePopulateJail      = populateJail
 	ContainerNameExporter          = Exporter

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -46,6 +46,30 @@ func renderContainerToolkitValidation(container *values.Container) corev1.Contai
 	}
 }
 
+// RenderContainerWaitForController renders init [corev1.Container] that waits for controller readiness
+func RenderContainerWaitForController(container *values.Container, clusterName string) corev1.Container {
+	return corev1.Container{
+		Name:            consts.ContainerNameWaitForController,
+		Image:           container.Image,
+		ImagePullPolicy: container.ImagePullPolicy,
+		Command: []string{
+			"/opt/bin/slurm/wait-for-controller.sh",
+		},
+		Env: []corev1.EnvVar{
+			{
+				Name:  "CONTROLLER_SERVICE",
+				Value: naming.BuildServiceName(consts.ComponentTypeController, clusterName),
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			common.RenderVolumeMountJail(),
+			common.RenderVolumeMountMungeSocket(),
+		},
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+	}
+}
+
 // renderContainerSlurmd renders [corev1.Container] for slurmd
 func renderContainerSlurmd(
 	container *values.Container,

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -50,6 +50,7 @@ func RenderStatefulSet(
 	// Since 1.29 is native sidecar support, we can use the native restart policy
 	initContainers := []corev1.Container{
 		common.RenderContainerMunge(&worker.ContainerMunge),
+		RenderContainerWaitForController(&worker.ContainerSlurmd, clusterName),
 	}
 	if clusterType == consts.ClusterTypeGPU {
 		initContainers = append(initContainers, renderContainerToolkitValidation(&worker.ContainerToolkitValidation))

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -98,7 +98,7 @@ func Test_RenderStatefulSet(t *testing.T) {
 			secrets:        secret,
 			clusterType:    consts.ClusterTypeCPU,
 			expectedEnvVar: "",
-			expectedInitCt: 1,
+			expectedInitCt: 2,
 		},
 		{
 			name:           "CGROUP V1 GPU",
@@ -106,7 +106,7 @@ func Test_RenderStatefulSet(t *testing.T) {
 			secrets:        secret,
 			clusterType:    consts.ClusterTypeGPU,
 			expectedEnvVar: "",
-			expectedInitCt: 2,
+			expectedInitCt: 3,
 		},
 		{
 			name:           "CGROUP V2",
@@ -114,7 +114,7 @@ func Test_RenderStatefulSet(t *testing.T) {
 			secrets:        secret,
 			clusterType:    consts.ClusterTypeCPU,
 			expectedEnvVar: consts.CGroupV2Env,
-			expectedInitCt: 1,
+			expectedInitCt: 2,
 		},
 		{
 			name:           "CGROUP V2 GPU",
@@ -122,7 +122,7 @@ func Test_RenderStatefulSet(t *testing.T) {
 			secrets:        secret,
 			clusterType:    consts.ClusterTypeGPU,
 			expectedEnvVar: consts.CGroupV2Env,
-			expectedInitCt: 2,
+			expectedInitCt: 3,
 		},
 	}
 
@@ -132,11 +132,69 @@ func Test_RenderStatefulSet(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, consts.ContainerNameSlurmd, result.Spec.Template.Spec.Containers[0].Name)
-			if tt.clusterType == consts.ClusterTypeGPU {
-				assert.Equal(t, consts.ContainerNameToolkitValidation, result.Spec.Template.Spec.InitContainers[1].Name)
-			}
 			assert.Equal(t, tt.expectedInitCt, len(result.Spec.Template.Spec.InitContainers))
 			assert.Equal(t, consts.ContainerNameMunge, result.Spec.Template.Spec.InitContainers[0].Name)
+			assert.Equal(t, consts.ContainerNameWaitForController, result.Spec.Template.Spec.InitContainers[1].Name)
+			if tt.clusterType == consts.ClusterTypeGPU {
+				assert.Equal(t, consts.ContainerNameToolkitValidation, result.Spec.Template.Spec.InitContainers[2].Name)
+			}
+
+			// Verify core expected volumes are present and no slurm-configs volume
+			volumes := result.Spec.Template.Spec.Volumes
+			var hasJail, hasMungeKey, hasMungeSocket, hasSlurmConfigs bool
+
+			for _, volume := range volumes {
+				switch volume.Name {
+				case consts.VolumeNameJail:
+					hasJail = true
+				case consts.VolumeNameMungeKey:
+					hasMungeKey = true
+				case consts.VolumeNameMungeSocket:
+					hasMungeSocket = true
+				case consts.VolumeNameSlurmConfigs:
+					hasSlurmConfigs = true
+				}
+			}
+
+			assert.True(t, hasJail, "Worker StatefulSet should have jail volume")
+			assert.True(t, hasMungeKey, "Worker StatefulSet should have munge-key volume")
+			assert.True(t, hasMungeSocket, "Worker StatefulSet should have munge-socket volume")
+			assert.False(t, hasSlurmConfigs, "Worker StatefulSet should NOT have slurm-configs volume")
 		})
+	}
+}
+
+func Test_RenderContainerWaitForController(t *testing.T) {
+	testCluster := "test-cluster"
+	container := &values.Container{
+		NodeContainer: slurmv1.NodeContainer{
+			Image:           "test-image",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+		},
+	}
+
+	result := worker.RenderContainerWaitForController(container, testCluster)
+
+	assert.Equal(t, consts.ContainerNameWaitForController, result.Name)
+	assert.Equal(t, container.Image, result.Image)
+	assert.Equal(t, container.ImagePullPolicy, result.ImagePullPolicy)
+	assert.Equal(t, []string{"/opt/bin/slurm/wait-for-controller.sh"}, result.Command)
+	assert.Equal(t, 1, len(result.Env))
+	assert.Equal(t, "CONTROLLER_SERVICE", result.Env[0].Name)
+	assert.Contains(t, result.Env[0].Value, "controller")
+	assert.Equal(t, 2, len(result.VolumeMounts))
+
+	// Verify exact volume mount values and no unexpected mounts
+	expectedMounts := map[string]string{
+		consts.VolumeNameJail:        consts.VolumeMountPathJail,
+		consts.VolumeNameMungeSocket: consts.VolumeMountPathMungeSocket,
+	}
+
+	assert.Equal(t, len(expectedMounts), len(result.VolumeMounts))
+
+	for _, mount := range result.VolumeMounts {
+		expectedPath, exists := expectedMounts[mount.Name]
+		assert.True(t, exists, "Unexpected volume mount: %s", mount.Name)
+		assert.Equal(t, expectedPath, mount.MountPath, "Wrong mount path for volume %s", mount.Name)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes race conditions during cluster startup where worker nodes fail to start due to empty slurm.conf files, causing DNS SRV lookup errors.

[#1148](https://github.com/nebius/soperator/issues/1148)

## Changes

- **Added wait-for-controller init container** that runs before the main slurmd container
- **Implemented three-stage verification**:
  1. Wait for `slurm.conf` to be available and non-empty
  2. Wait for controller service DNS resolution
  3. Verify slurmctld daemon responds to ping

## Problem Solved

Workers previously started before SConfigController had written slurm configuration files to the jail volume, causing:
- Empty slurm.conf files
- DNS SRV lookup failures
- Worker startup failures requiring manual intervention

The new init container ensures workers only start after the controller is fully operational, eliminating the race condition and ensuring reliable cluster startup.