### PR TITLE
Improve sconfigcontroller FileStore.Add: catch close errors and switch files atomically

### DIFF
--- a/internal/controller/sconfigcontroller/file_store.go
+++ b/internal/controller/sconfigcontroller/file_store.go
@@ -82,6 +82,15 @@ func (s *FileStore) Add(name, content, subPath string) (err error) {
 		return err
 	}
 
+	// os.CreateTemp uses 600 & umask by default, and os.Create uses o666 & umask
+	// For now fixed 644 should be fine
+	// TODO make this configurable
+	err = os.Chmod(tempFileName, 0o644)
+	if err != nil {
+		err = fmt.Errorf("chmod temp file: %w", err)
+		return err
+	}
+
 	err = os.Rename(tempFileName, filePath)
 	if err != nil {
 		err = fmt.Errorf("rename temp file: %w", err)

--- a/internal/controller/sconfigcontroller/file_store.go
+++ b/internal/controller/sconfigcontroller/file_store.go
@@ -34,12 +34,13 @@ func ensureDir(dirPath string) error {
 
 func (s *FileStore) Add(name, content, subPath string) (err error) {
 	dirPath := filepath.Join(s.path, subPath)
+	filePath := filepath.Join(dirPath, name)
 
 	if err = ensureDir(dirPath); err != nil {
 		return err
 	}
 
-	file, err := os.Create(fmt.Sprintf("%s/%s", dirPath, name))
+	file, err := os.Create(filePath)
 	if err != nil {
 		err = fmt.Errorf("open file: %w", err)
 		return err


### PR DESCRIPTION
1. Errors coming from `file.Close()` were ignored, and for NFS they can really matter.
2. Writing to file directly with `Create`-`Write`-`Close` sequence can lead to observable empty file (between create and write), so instead it uses temp file, and renames it in place of old file