### PR TITLE
Fix empty user_name labels in job_info metric

### DIFF
--- a/docs/slurm-exporter.md
+++ b/docs/slurm-exporter.md
@@ -83,6 +83,7 @@ slurm_node_fails_total{node_name="worker-2",state_base="DOWN",state_is_drain="tr
 - `slurm_partition`: SLURM partition name
 - `job_name`: User-defined job name
 - `user_name`: Username who submitted the job
+- `user_id`: Numeric user ID who submitted the job
 - `standard_error`: Path to stderr file
 - `standard_output`: Path to stdout file
 - `array_job_id`: Array job ID (if applicable)
@@ -90,7 +91,7 @@ slurm_node_fails_total{node_name="worker-2",state_base="DOWN",state_is_drain="tr
 
 **Example:**
 ```prometheus
-slurm_job_info{job_id="12345",job_state="RUNNING",job_state_reason="None",slurm_partition="gpu",job_name="training_job",user_name="researcher",standard_error="/home/researcher/job.err",standard_output="/home/researcher/job.out",array_job_id="",array_task_id=""} 1
+slurm_job_info{job_id="12345",job_state="RUNNING",job_state_reason="None",slurm_partition="gpu",job_name="training_job",user_name="researcher",user_id="1000",standard_error="/home/researcher/job.err",standard_output="/home/researcher/job.out",array_job_id="",array_task_id=""} 1
 ```
 
 #### Gauge `slurm_node_job`

--- a/images/restd/slurmrestd_entrypoint.sh
+++ b/images/restd/slurmrestd_entrypoint.sh
@@ -2,6 +2,14 @@
 
 set -e # Exit immediately if any command returns a non-zero error code
 
+echo "Link users from jail"
+for file in passwd group shadow gshadow; do
+  rm -f /etc/$file
+  ln -s /mnt/jail/etc/$file /etc/$file
+done
+
+chown -h 0:42 /etc/{shadow,gshadow}
+
 echo "Symlink slurm configs from K8S config map"
 rm -rf /etc/slurm && ln -s /mnt/slurm-configs /etc/slurm
 

--- a/internal/controller/clustercontroller/rest.go
+++ b/internal/controller/clustercontroller/rest.go
@@ -80,6 +80,7 @@ func (r SlurmClusterReconciler) ReconcileREST(
 						clusterValues.Namespace,
 						&clusterValues.NodeRest,
 						clusterValues.NodeFilters,
+						clusterValues.VolumeSources,
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")

--- a/internal/exporter/collector.go
+++ b/internal/exporter/collector.go
@@ -40,7 +40,7 @@ func NewMetricsCollector(slurmAPIClient slurmapi.Client) *MetricsCollector {
 		slurmAPIClient: slurmAPIClient,
 
 		nodeInfo: prometheus.NewDesc("slurm_node_info", "Slurm node info", []string{"node_name", "instance_id", "state_base", "state_is_drain", "state_is_maintenance", "state_is_reserved", "address"}, nil),
-		jobInfo:  prometheus.NewDesc("slurm_job_info", "Slurm job detail information", []string{"job_id", "job_state", "job_state_reason", "slurm_partition", "job_name", "user_name", "standard_error", "standard_output", "array_job_id", "array_task_id"}, nil),
+		jobInfo:  prometheus.NewDesc("slurm_job_info", "Slurm job detail information", []string{"job_id", "job_state", "job_state_reason", "slurm_partition", "job_name", "user_name", "user_id", "standard_error", "standard_output", "array_job_id", "array_task_id"}, nil),
 		jobNode:  prometheus.NewDesc("slurm_node_job", "Slurm job node information", []string{"job_id", "node_name"}, nil),
 		nodeGPUSeconds: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "slurm_node_gpu_seconds_total",
@@ -177,6 +177,11 @@ func (c *MetricsCollector) slurmJobMetrics(
 	return func(yield func(prometheus.Metric) bool) {
 		logger := log.FromContext(ctx).WithName(ControllerName)
 		for _, job := range slurmJobs {
+			userID := ""
+			if job.UserID != nil {
+				userID = strconv.Itoa(int(*job.UserID))
+			}
+
 			jobLabels := []string{
 				job.GetIDString(),
 				job.State,
@@ -184,6 +189,7 @@ func (c *MetricsCollector) slurmJobMetrics(
 				job.Partition,
 				job.Name,
 				job.UserName,
+				userID,
 				job.StandardError,
 				job.StandardOutput,
 				job.GetArrayJobIDString(),

--- a/internal/exporter/collector_test.go
+++ b/internal/exporter/collector_test.go
@@ -45,7 +45,7 @@ func TestMetricsCollector_Describe(t *testing.T) {
 
 	// Base metrics
 	assert.Contains(t, found, `Desc{fqName: "slurm_node_info", help: "Slurm node info", constLabels: {}, variableLabels: {node_name,instance_id,state_base,state_is_drain,state_is_maintenance,state_is_reserved,address}}`)
-	assert.Contains(t, found, `Desc{fqName: "slurm_job_info", help: "Slurm job detail information", constLabels: {}, variableLabels: {job_id,job_state,job_state_reason,slurm_partition,job_name,user_name,standard_error,standard_output,array_job_id,array_task_id}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_job_info", help: "Slurm job detail information", constLabels: {}, variableLabels: {job_id,job_state,job_state_reason,slurm_partition,job_name,user_name,user_id,standard_error,standard_output,array_job_id,array_task_id}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_node_job", help: "Slurm job node information", constLabels: {}, variableLabels: {job_id,node_name}}`)
 
 	// RPC metrics
@@ -100,6 +100,7 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 		}, nil)
 
 		arrayTaskID := int32(42)
+		userID := int32(1000)
 		// Mock successful ListJobs response
 		testJobs := []slurmapi.Job{
 			{
@@ -109,6 +110,7 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 				StateReason:    "None",
 				Partition:      "gpu",
 				UserName:       "testuser",
+				UserID:         &userID,
 				StandardError:  "/path/to/stderr",
 				StandardOutput: "/path/to/stdout",
 				Nodes:          "node-[1,2]",
@@ -142,7 +144,7 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 			`GAUGE; slurm_node_info{address="10.0.0.2",instance_id="instance-2",node_name="node-2",state_base="IDLE",state_is_drain="true",state_is_maintenance="false",state_is_reserved="false"} 1`,
 			`COUNTER; slurm_node_gpu_seconds_total{node_name="node-1",state_base="ALLOCATED",state_is_drain="false",state_is_maintenance="false",state_is_reserved="false"} 20`,
 			`COUNTER; slurm_node_gpu_seconds_total{node_name="node-2",state_base="IDLE",state_is_drain="true",state_is_maintenance="false",state_is_reserved="false"} 10`,
-			`GAUGE; slurm_job_info{array_job_id="",array_task_id="42",job_id="12345",job_name="test_job",job_state="RUNNING",job_state_reason="None",slurm_partition="gpu",standard_error="/path/to/stderr",standard_output="/path/to/stdout",user_name="testuser"} 1`,
+			`GAUGE; slurm_job_info{array_job_id="",array_task_id="42",job_id="12345",job_name="test_job",job_state="RUNNING",job_state_reason="None",slurm_partition="gpu",standard_error="/path/to/stderr",standard_output="/path/to/stdout",user_id="1000",user_name="testuser"} 1`,
 			`GAUGE; slurm_node_job{job_id="12345",node_name="node-1"} 1`,
 			`GAUGE; slurm_node_job{job_id="12345",node_name="node-2"} 1`,
 			`GAUGE; slurm_controller_server_thread_count 1`,

--- a/internal/render/common/volume.go
+++ b/internal/render/common/volume.go
@@ -174,6 +174,15 @@ func RenderVolumeMountJail() corev1.VolumeMount {
 	}
 }
 
+// RenderVolumeMountJailReadOnly renders [corev1.VolumeMount] defining the mounting path for jail contents in read-only mode
+func RenderVolumeMountJailReadOnly() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      consts.VolumeNameJail,
+		MountPath: consts.VolumeMountPathJail,
+		ReadOnly:  true,
+	}
+}
+
 // endregion Jail
 
 // region JailSnapshot

--- a/internal/render/exporter/container.go
+++ b/internal/render/exporter/container.go
@@ -32,5 +32,6 @@ func renderContainerExporter(clusterValues *values.SlurmCluster) corev1.Containe
 			Requests: clusterValues.SlurmExporter.Container.Resources,
 			Limits:   common.CopyNonCPUResources(clusterValues.SlurmExporter.Container.Resources),
 		},
+		VolumeMounts: []corev1.VolumeMount{},
 	}
 }

--- a/internal/render/exporter/pod.go
+++ b/internal/render/exporter/pod.go
@@ -34,6 +34,7 @@ func renderPodTemplateSpec(
 			InitContainers:     initContainers,
 			Containers:         []corev1.Container{renderContainerExporter(clusterValues)},
 			ServiceAccountName: ServiceAccountName,
+			Volumes:            []corev1.Volume{},
 		},
 	}
 	return result

--- a/internal/render/exporter/pod_test.go
+++ b/internal/render/exporter/pod_test.go
@@ -7,8 +7,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
+	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/values"
 )
 
@@ -26,6 +28,9 @@ func TestRenderPodTemplateSpec(t *testing.T) {
 			Container: slurmv1.NodeContainer{
 				Image: "exporter-image:latest",
 			},
+			VolumeJail: slurmv1.NodeVolume{
+				VolumeSourceName: ptr.To(consts.VolumeNameJail),
+			},
 		},
 		NodeFilters: []slurmv1.K8sNodeFilter{
 			{
@@ -36,6 +41,14 @@ func TestRenderPodTemplateSpec(t *testing.T) {
 			},
 		},
 		NodeRest: values.SlurmREST{},
+		VolumeSources: []slurmv1.VolumeSource{
+			{
+				Name: consts.VolumeNameJail,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		},
 	}
 	initContainers := []corev1.Container{}
 	matchLabels := map[string]string{"app": "slurm-exporter"}

--- a/internal/render/rest/container.go
+++ b/internal/render/rest/container.go
@@ -46,6 +46,7 @@ func renderContainerREST(containerParams values.Container, threadCount *int32, m
 		}},
 		VolumeMounts: []corev1.VolumeMount{
 			common.RenderVolumeMountSlurmConfigs(),
+			common.RenderVolumeMountJailReadOnly(),
 		},
 		// TODO: Http check?
 		LivenessProbe: &corev1.Probe{

--- a/internal/render/rest/pod.go
+++ b/internal/render/rest/pod.go
@@ -17,9 +17,13 @@ func BasePodTemplateSpec(
 	clusterName string,
 	valuesREST *values.SlurmREST,
 	nodeFilters []slurmv1.K8sNodeFilter,
+	volumeSources []slurmv1.VolumeSource,
 	matchLabels map[string]string,
 ) (*corev1.PodTemplateSpec, error) {
-	volumes := []corev1.Volume{common.RenderVolumeSlurmConfigs(clusterName)}
+	volumes := []corev1.Volume{
+		common.RenderVolumeSlurmConfigs(clusterName),
+		common.RenderVolumeJailFromSource(volumeSources, *valuesREST.VolumeJail.VolumeSourceName),
+	}
 
 	nodeFilter, err := utils.GetBy(
 		nodeFilters,

--- a/internal/render/rest/rest.go
+++ b/internal/render/rest/rest.go
@@ -20,6 +20,7 @@ func RenderDeploymentREST(
 	namespace string,
 	valuesREST *values.SlurmREST,
 	nodeFilter []slurmv1.K8sNodeFilter,
+	volumeSources []slurmv1.VolumeSource,
 ) (deployment *appsv1.Deployment, err error) {
 	if valuesREST == nil || !valuesREST.Enabled {
 		return nil, errors.New("REST API is not enabled")
@@ -35,6 +36,7 @@ func RenderDeploymentREST(
 		clusterName,
 		valuesREST,
 		nodeFilter,
+		volumeSources,
 		matchLabels,
 	)
 	if err != nil {

--- a/internal/slurmapi/job.go
+++ b/internal/slurmapi/job.go
@@ -18,6 +18,7 @@ type Job struct {
 	StateReason    string
 	Partition      string
 	UserName       string
+	UserID         *int32
 	StandardError  string
 	StandardOutput string
 	Nodes          string
@@ -53,6 +54,10 @@ func JobFromAPI(apiJob api.V0041JobInfo) (Job, error) {
 
 	if apiJob.Partition != nil {
 		job.Partition = *apiJob.Partition
+	}
+
+	if apiJob.UserId != nil {
+		job.UserID = apiJob.UserId
 	}
 
 	if apiJob.UserName != nil {

--- a/internal/values/slurm_exporter.go
+++ b/internal/values/slurm_exporter.go
@@ -25,8 +25,9 @@ type SlurmExporter struct {
 
 	CustomInitContainers []corev1.Container
 
-	// VolumeJail is a volume that is used to mount the jail directory for the Slurm Exporter.
-	// Deprecated: will be removed when Slurm Exporter will be replaced with Soperator Exporter.
+	// VolumeJail is a volume that is used to mount the jail directory for the Soperator Exporter.
+	//
+	// Deprecated: not required anymore.
 	VolumeJail slurmv1.NodeVolume
 
 	Maintenance *consts.MaintenanceMode

--- a/internal/values/slurm_rest.go
+++ b/internal/values/slurm_rest.go
@@ -2,6 +2,8 @@ package values
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/naming"
@@ -17,6 +19,7 @@ type SlurmREST struct {
 	ContainerREST        Container
 	CustomInitContainers []corev1.Container
 	Service              Service
+	VolumeJail           slurmv1.NodeVolume
 	Maintenance          *consts.MaintenanceMode
 }
 
@@ -38,5 +41,8 @@ func buildRestFrom(clusterName string, maintenance *consts.MaintenanceMode, rest
 		CustomInitContainers: rest.CustomInitContainers,
 		Service:              buildServiceFrom(naming.BuildServiceName(consts.ComponentTypeREST, clusterName)),
 		Maintenance:          maintenance,
+		VolumeJail: slurmv1.NodeVolume{
+			VolumeSourceName: ptr.To(consts.VolumeNameJail),
+		},
 	}
 }


### PR DESCRIPTION
## Summary
- Add user_id label to job_info metric in soperator exporter for fallback when user_name is empty
- Enable REST container to access jail passwd files for username resolution

Closes https://github.com/nebius/soperator/issues/1238
