### PR TITLE
Drop pod and instance labels from PodMonitor metrics by default

### DIFF
--- a/internal/render/exporter/pod_monitor_test.go
+++ b/internal/render/exporter/pod_monitor_test.go
@@ -64,4 +64,47 @@ func Test_RenderPodMonitor(t *testing.T) {
 	assert.Equal(t, expected.Spec.PodMetricsEndpoints[0].Path, result.Spec.PodMetricsEndpoints[0].Path)
 	assert.Equal(t, expected.Spec.PodMetricsEndpoints[0].Port, result.Spec.PodMetricsEndpoints[0].Port)
 	assert.Equal(t, expected.Spec.PodMetricsEndpoints[0].Scheme, result.Spec.PodMetricsEndpoints[0].Scheme)
+
+	// Verify default MetricRelabelConfigs are added
+	assert.Len(t, result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs, 1)
+	assert.Equal(t, "labeldrop", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[0].Action)
+	assert.Equal(t, "pod|instance|container", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[0].Regex)
+}
+
+func Test_RenderPodMonitor_WithUserMetricRelabelConfigs(t *testing.T) {
+	jobLabel := "slurm-exporter-test"
+	interval := "1m"
+	scrapeTimeout := "30m"
+
+	// User-provided MetricRelabelConfigs
+	userConfigs := []prometheusv1.RelabelConfig{
+		{
+			Action: "replace",
+			Regex:  "custom-regex",
+		},
+	}
+
+	slurmExporter := values.SlurmExporter{
+		Enabled: true,
+		PodMonitorConfig: slurmv1.PodMonitorConfig{
+			JobLabel:             jobLabel,
+			Interval:             prometheusv1.Duration(interval),
+			ScrapeTimeout:        prometheusv1.Duration(scrapeTimeout),
+			MetricRelabelConfigs: userConfigs,
+			RelabelConfig:        []prometheusv1.RelabelConfig{},
+		},
+	}
+
+	result := exporter.RenderPodMonitor(defaultNameCluster, defaultNamespace, slurmExporter)
+
+	// Verify defaults are added first, then user configs
+	assert.Len(t, result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs, 2)
+
+	// Check default config (should come first)
+	assert.Equal(t, "labeldrop", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[0].Action)
+	assert.Equal(t, "pod|instance|container", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[0].Regex)
+
+	// Check user config (should come last)
+	assert.Equal(t, "replace", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[1].Action)
+	assert.Equal(t, "custom-regex", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[1].Regex)
 }


### PR DESCRIPTION
## Summary

This PR automatically drops the `pod`, `instance`, and `container` labels from PodMonitor-collected metrics to improve continuity of long-lasting counter metrics across pod restarts.

## Problem

Counter metrics like `slurm_node_gpu_seconds_total` were dropping to 0 whenever the exporter pod restarted because they included the `pod` label (e.g., `pod='slurm-exporter-c568cb944-pwv4l'`). When pods restart with new names, the time series breaks continuity.

## Solution

Added default `metricRelabelConfigs` with `labeldrop` action using regex `pod|instance|container` to the PodMonitor rendering. User-provided metric relabel configs are merged with defaults for backward compatibility.

Counter metrics now maintain continuity across pod restarts, providing accurate cumulative values over time.