### PR TITLE
Fix Slurm controller failover #1268

### DIFF
--- a/internal/controller/clustercontroller/controller.go
+++ b/internal/controller/clustercontroller/controller.go
@@ -1,6 +1,7 @@
 package clustercontroller
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"strings"
@@ -63,11 +64,7 @@ func (r SlurmClusterReconciler) ReconcileControllers(
 					stepLogger := log.FromContext(stepCtx)
 					stepLogger.V(1).Info("Reconciling")
 
-					replicas := int32(1)
-					if clusterValues.NodeController.StatefulSet.Replicas > 0 {
-						replicas = clusterValues.NodeController.StatefulSet.Replicas
-					}
-
+					replicas := cmp.Or(clusterValues.NodeController.StatefulSet.Replicas, 1)
 					createdServices := map[string]bool{}
 
 					for i := int32(0); i < replicas; i++ {

--- a/internal/controller/clustercontroller/controller.go
+++ b/internal/controller/clustercontroller/controller.go
@@ -72,7 +72,7 @@ func (r SlurmClusterReconciler) ReconcileControllers(
 
 					for i := int32(0); i < replicas; i++ {
 						svcName := fmt.Sprintf("%s-%d", clusterValues.NodeController.StatefulSet.Name, i)
-						desired := controller.RenderService(clusterValues.Namespace, svcName, &clusterValues.NodeController,
+						desired := controller.RenderService(clusterValues.Namespace, clusterValues.Name, svcName, &clusterValues.NodeController,
 							map[string]string{
 								"statefulset.kubernetes.io/pod-name": fmt.Sprintf("controller-%d", i),
 							})

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -56,7 +56,8 @@ func generateSlurmConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
 
 	res.AddProperty("ClusterName", cluster.Name)
 	res.AddComment("")
-	// example: SlurmctldHost=controller-0(controller-0.controller.slurm-poc.svc.cluster.local)
+	// example: SlurmctldHost=controller-0(controller-0)
+	// beause in kubernetes, dns uses the dot notation to separate the service name and the namespace
 	for i := int32(0); i < cluster.NodeController.Size; i++ {
 		svcName := fmt.Sprintf("%s-%d", cluster.NodeController.StatefulSet.Name, i)
 		res.AddProperty("SlurmctldHost", fmt.Sprintf("%s(%s)", svcName, svcName))

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -58,13 +58,8 @@ func generateSlurmConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
 	res.AddComment("")
 	// example: SlurmctldHost=controller-0(controller-0.controller.slurm-poc.svc.cluster.local)
 	for i := int32(0); i < cluster.NodeController.Size; i++ {
-		hostName, hostFQDN := naming.BuildServiceHostFQDN(
-			consts.ComponentTypeController,
-			cluster.Namespace,
-			cluster.Name,
-			i,
-		)
-		res.AddProperty("SlurmctldHost", fmt.Sprintf("%s(%s)", hostName, hostFQDN))
+		svcName := fmt.Sprintf("%s-%d", cluster.NodeController.StatefulSet.Name, i)
+		res.AddProperty("SlurmctldHost", fmt.Sprintf("%s(%s)", svcName, svcName))
 	}
 	res.AddComment("")
 	res.AddProperty("AuthType", "auth/"+consts.Munge)

--- a/internal/render/controller/container.go
+++ b/internal/render/controller/container.go
@@ -33,20 +33,6 @@ func renderContainerSlurmctld(container *values.Container, customMounts []slurmv
 			Protocol:      corev1.ProtocolTCP,
 		}},
 		VolumeMounts: volumeMounts,
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{
-						"scontrol",
-						"ping",
-					},
-				},
-			},
-			TimeoutSeconds:   common.DefaultProbeTimeoutSeconds,
-			PeriodSeconds:    common.DefaultProbePeriodSeconds,
-			SuccessThreshold: common.DefaultProbeSuccessThreshold,
-			FailureThreshold: common.DefaultProbeFailureThreshold,
-		},
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{

--- a/internal/render/controller/service.go
+++ b/internal/render/controller/service.go
@@ -23,7 +23,7 @@ func RenderService(namespace, clusterName, svcName string, controller *values.Sl
 
 	return corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterName,
+			Name:      svcName,
 			Namespace: namespace,
 			Labels:    labels,
 		},

--- a/internal/render/controller/service.go
+++ b/internal/render/controller/service.go
@@ -11,12 +11,13 @@ import (
 )
 
 // RenderService renders new [corev1.Service] serving Slurm controllers
-func RenderService(namespace, clusterName string, controller *values.SlurmController, podLabels ...map[string]string) corev1.Service {
+func RenderService(namespace, clusterName, svcName string, controller *values.SlurmController, podLabels ...map[string]string) corev1.Service {
 	labels := common.RenderLabels(consts.ComponentTypeController, clusterName)
 
+	selector := common.RenderMatchLabels(consts.ComponentTypeController, clusterName)
 	for _, additionalLabels := range podLabels {
 		for k, v := range additionalLabels {
-			labels[k] = v
+			selector[k] = v
 		}
 	}
 
@@ -27,16 +28,8 @@ func RenderService(namespace, clusterName string, controller *values.SlurmContro
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
-			Type: controller.Service.Type,
-			Selector: func() map[string]string {
-				selector := map[string]string{}
-				for _, additionalLabels := range podLabels {
-					for k, v := range additionalLabels {
-						selector[k] = v
-					}
-				}
-				return selector
-			}(),
+			Type:     controller.Service.Type,
+			Selector: selector,
 			Ports: []corev1.ServicePort{{
 				Protocol:   controller.Service.Protocol,
 				Port:       controller.ContainerSlurmctld.Port,


### PR DESCRIPTION
Here’s a summary of the changes in this pull request:

**internal/controller/clustercontroller/controller.go**
- Refactors the reconciliation logic for controller services to create a separate Kubernetes Service for each controller pod (per-pod services) based on the number of replicas.
- Adds logic to clean up excess services that are no longer needed.
- Removes repetitive error logging statements (error logging is now mostly handled by returning errors).
- Updates usage of the Service rendering function to support per-pod labels and naming.

**internal/render/common/configmap.go**
- Changes how SlurmctldHost entries are generated in config files:
  - Uses the pattern `<statefulset-name>-<index>` for both host and FQDN, instead of relying on the previous `naming.BuildServiceHostFQDN` function.

**internal/render/controller/container.go**
- Removes the readiness probe from the Slurmctld container definition.

**internal/render/controller/service.go**
- Updates the `RenderService` function to allow custom labels and selectors for per-pod services.
- Service names now use the provided name parameter (for per-pod differentiation).
- Selectors and labels can include additional data for targeting specific pods.

**In summary:**  
This PR refactors the controller Service logic to create individual Kubernetes Services for each controller pod, adjusts config rendering to match the new naming scheme, removes redundant error logs, and enables more flexible service labeling and selection. The readiness probe for controller containers is also removed.

#1268
