### PR TITLE
Add observability pipeline documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ It includes, among other things:
 - The [full list of features](docs/features.md) that this solution provides comparing to typical Slurm installations.
 - A more complete description of the existing [limitations](docs/limitations.md).
 - The [release process](docs/releases.md) for both soperator and nebius-solutions-library repositories.
+- [Metrics collection and processing](docs/metrics-pipeline.md) documentation.
+- [Logs collection and aggregation](docs/logs-pipeline.md) pipeline guide.
 
 
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -103,62 +103,14 @@ this information on the dashboards we provide as well.
 
 At the moment, the following information is gathered and can be viewed by users:
 - Logs for all K8s pods + K8s events.
-- **Centralized Slurm workload logs**: Structured collection of job outputs with automatic categorization.
+- Centralized Slurm workload logs: Structured collection of job outputs with automatic categorization.
 - K8s cluster metrics: node states, stateful set & deployment sizes, etc.
 - K8s node metrics: CPU, memory, network, disk usage, etc.
 - K8s pod resource metrics: resource usage by pods & containers.
 - NVIDIA GPU metrics: GPU utilization, power, temperature, etc.
-- Slurm metrics: comprehensive monitoring of nodes, jobs, and controller performance. See [SLURM Exporter](slurm-exporter.md) for detailed metrics documentation.
+- Slurm metrics: comprehensive monitoring of nodes, jobs, and controller performance.
 
-
-### Centralized Logging Scheme
-
-Soperator implements a centralized logging system that automatically collects and categorizes Slurm workload outputs. Logs are organized by type and processed by OpenTelemetry collectors for centralized analysis.
-
-#### Directory Structure
-
-Logs are organized in a flat structure by log type:
-
-```
-/opt/soperator-outputs/
-├── nccl_logs/      # NCCL debug outputs from all workers
-├── slurm_jobs/     # Slurm job outputs from all workers
-└── slurm_scripts/  # Script outputs (prolog, epilog, health checks) from all workers
-```
-
-#### Logging Schema
-
-Log files include the worker name at the beginning of the filename for easy identification:
-
-**NCCL Logs:**
-```
-worker_name.job_id.job_step_id.out
-Example: worker-0.12345.67890.out
-```
-
-**Slurm Jobs:**
-```
-worker_name.job_name.job_id[.array_id].out
-Examples:
-- worker-1.benchmark.12345.out
-- worker-2.training.12345.1.out (array job)
-```
-
-**Slurm Scripts:**
-```
-worker_name.script_name.context.out
-Examples:
-- worker-0.health_checker.prolog.out
-- worker-3.cleanup_enroot.epilog.out
-```
-
-#### Generated Labels
-
-The logging system automatically extracts metadata from filenames and creates the following labels:
-
-- `slurm_node_name`: Slurm worker node identifier extracted from filename (e.g., "worker-0", "worker-1")
-- `log_type`: Category (nccl_logs, slurm_jobs, slurm_scripts)
-- `job_id`, `job_step_id`: For NCCL logs
-- `job_name`, `job_array_id`: For Slurm job logs
-- `slurm_script_name`, `slurm_script_context`: For script logs
-
+For more details, see the following documents:
+- [Logs Pipeline](logs-pipeline.md): Overview of the centralized logging architecture, including log collection and processing.
+- [Metrics Pipeline](metrics-pipeline.md): Overview of the metrics collection and processing architecture.
+- [SLURM Exporter](slurm-exporter.md): Detailed documentation of the SLURM exporter, including metrics and usage examples.

--- a/docs/logs-pipeline.md
+++ b/docs/logs-pipeline.md
@@ -1,0 +1,171 @@
+# Logs Pipeline Documentation
+
+## Overview
+
+The Soperator logs pipeline collects, stores, and provides search capabilities for logs from SLURM jobs, system components, and Kubernetes events. It uses VictoriaLogs for storage and OpenTelemetry collectors for log collection.
+
+## Architecture
+
+```
+┌────────────────────────────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│          Jail Filesystem               │     │   K8s Nodes     │     │  K8s Events     │
+│ ┌─────────────┐ ┌────────┐ ┌─────────┐ │     │ ┌─────────────┐ │     │ ┌─────────────┐ │
+│ │ NCCL Logs   │ │ SLURM  │ │ SLURM   │ │     │ │ System Logs │ │     │ │ K8s Events  │ │
+│ │             │ │ Jobs   │ │ Scripts │ │     │ │             │ │     │ │             │ │
+│ └─────────────┘ └────────┘ └─────────┘ │     │ └─────────────┘ │     │ └─────────────┘ │
+└────────────────────┬───────────────────┘     └────────┬────────┘     └────────┬────────┘
+                     │                                  │                       │
+         ┌───────────▼───────────┐         ┌────────────▼────────┐   ┌──────────▼────────┐
+         │  OTel Collector       │         │  OTel Collector     │   │  OTel Collector   │
+         │  (Jail Logs)          │         │  (System Logs)      │   │  (Events)         │
+         │  Single Deployment    │         │  DaemonSet          │   │  Deployment       │
+         └───────────┬───────────┘         └────────────┬────────┘   └─────────┬─────────┘
+                     │                                  │                      │
+                     └──────────────────────────────────┴──────────────────────┘
+                                                        │
+                     ┌──────────────────────────────────┴──────────────────┐
+                     │                                                     │
+         ┌───────────▼─────────────┐                           ┌───────────▼─────────────┐
+         │    VictoriaLogs         │                           │  Nebius Cloud Logging   │
+         │    (Local Storage)      │                           │  (OTLP Ingestion)       │
+         │    :9428                │                           │  write.logging.*.       │
+         │                         │                           │  nebius.cloud:443       │
+         └─────────────────────────┘                           └─────────────────────────┘
+```
+
+## Cloud Delivery
+
+Logs are delivered to both local VictoriaLogs and Nebius Cloud Logging (when `publicEndpointEnabled: true`), providing immediate local access and long-term cloud storage.
+
+- Local: VictoriaLogs at port 9428 for direct API queries
+- Cloud: Nebius Cloud Logging via OTLP/gRPC with bearer token authentication
+
+## Components
+
+### Log Collection
+
+#### 1. OpenTelemetry Collector - Jail Logs
+- Purpose: Collects logs from the jail filesystem
+- Deployment: Single pod deployment on system nodes
+- Log Sources: See Centralized Logging Scheme below
+- Poll Interval: 30s (configurable)
+
+#### 2. OpenTelemetry Collector - System Logs
+- Purpose: Collects system logs from nodes
+- Deployment: DaemonSet (disabled by default)
+- Log Sources: Node system logs
+- When to Enable: For debugging node-level issues
+
+#### 3. OpenTelemetry Collector - Events
+- Purpose: Collects Kubernetes events
+- Deployment: Single pod deployment
+
+### Log Storage
+
+#### VictoriaLogs
+- Purpose: Log storage and search engine
+- Port: 9428
+- Storage: 30Gi persistent volume
+- Query Language: LogsQL
+- Features: Fast full-text search with direct HTTP API access
+
+### Log Querying
+
+#### Direct VictoriaLogs API Access
+VictoriaLogs provides a direct HTTP API for log queries using LogsQL syntax:
+
+Connection and Query Examples:
+```bash
+# Port-forward to VictoriaLogs
+kubectl port-forward -n logs-system svc/vm-logs-victoria-logs-single-server 9428:9428
+
+# Search by namespace
+curl "http://localhost:9428/select/logsql/query?query=k8s.namespace.name:soperator-system"
+
+# Search with text pattern
+curl "http://localhost:9428/select/logsql/query?query=failed"
+
+# Search by pod name
+curl "http://localhost:9428/select/logsql/query?query=k8s.pod.name:controller-0"
+
+# Time range query
+curl "http://localhost:9428/select/logsql/query?query=level:error&start=2024-01-01T00:00:00Z&end=2026-01-01T01:00:00Z"
+```
+
+## Centralized Logging Scheme
+
+Soperator implements a centralized logging system that automatically collects and categorizes Slurm workload outputs. Logs are organized by type and processed by OpenTelemetry collectors for centralized analysis.
+
+### Directory Structure
+
+Logs are organized in a flat structure by log type:
+
+```
+/opt/soperator-outputs/
+├── nccl_logs/      # NCCL debug outputs from all workers
+├── slurm_jobs/     # Active check jobs (all-reduce-perf-nccl) from all workers
+└── slurm_scripts/  # SLURM hook outputs (prolog, epilog, HealthCheckProgram) from all workers
+```
+
+### Logging Schema
+
+Log files include the worker name at the beginning of the filename for easy identification:
+
+**NCCL Logs:**
+```
+worker_name.job_id.job_step_id.out
+Example: worker-0.12345.67890.out
+```
+
+**Active Check Jobs:**
+```
+worker_name.job_name.job_id[.array_id].out
+Examples:
+- worker-1.all-reduce-perf-nccl.12345.out
+- worker-2.enroot-cleanup.12345.1.out (array job)
+```
+
+**Slurm Scripts:**
+```
+worker_name.script_name.context.out
+Examples:
+- worker-0.health_checker.prolog.out
+- worker-3.cleanup_enroot.epilog.out
+```
+
+### Generated Labels
+
+The logging system automatically extracts metadata from filenames and creates the following labels:
+
+- `slurm_node_name`: Slurm worker node identifier extracted from filename (e.g., "worker-0", "worker-1")
+- `log_type`: Category (nccl_logs, slurm_jobs, slurm_scripts)
+- `job_id`, `job_step_id`: For NCCL logs
+- `job_name`, `job_array_id`: For Slurm job logs
+- `slurm_script_name`, `slurm_script_context`: For script logs
+
+
+## Configuration
+
+```yaml
+observability:
+  # Cloud delivery
+  publicEndpointEnabled: true  # Enable/disable cloud export
+  projectId: "your-nebius-project-id"
+  region: "eu-north1"
+  
+  # Storage
+  vmLogs:
+    values:
+      persistentVolume:
+        enabled: true
+        size: 30Gi  # Adjust based on log volume
+```
+
+## Log Retention
+
+VictoriaLogs retention is controlled by disk space (30Gi by default) and optional time-based policies.
+
+Check storage usage:
+```bash
+kubectl exec -n logs-system statefulset/vm-logs-victoria-logs-single-server -- df -h /storage
+```

--- a/docs/metrics-pipeline.md
+++ b/docs/metrics-pipeline.md
@@ -1,0 +1,191 @@
+# Metrics Pipeline Documentation
+
+## Overview
+
+The Soperator metrics pipeline provides observability for SLURM clusters running on Kubernetes.
+It collects metrics from various sources, stores them in VictoriaMetrics, and provides visualization through Grafana.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│                      System Nodes                          │     │   GPU Nodes     │     │ All K8s Nodes   │
+│ ┌─────────────┐ ┌──────────────┐ ┌──────────────────────┐  │     │ ┌─────────────┐ │     │ ┌─────────────┐ │
+│ │   SLURM     │ │  Soperator   │ │   Kube-state         │  │     │ │    DCGM     │ │     │ │    Node     │ │
+│ │  Exporter   │ │  Controller  │ │   metrics            │  │     │ │  Exporter   │ │     │ │  Exporter   │ │
+│ │   :8080     │ │    :8443     │ │     :8081            │  │     │ │   :9400     │ │     │ │   :9100     │ │
+│ └─────────────┘ └──────────────┘ └──────────────────────┘  │     │ └─────────────┘ │     │ └─────────────┘ │
+└────────────────────────────┬───────────────────────────────┘     └────────┬────────┘     └────────┬────────┘
+                             │                                              │                       │
+                             └──────────────────────────────────────────────┴───────────────────────┘
+                                                             │
+                                                ┌────────────▼────────────┐
+                                                │   VictoriaMetrics       │
+                                                │   Agent (VMAgent)       │
+                                                │   Scrapes & Forwards    │
+                                                └────────────┬────────────┘
+                                                             │
+                                            ┌────────────────┴───────────────┐
+                                            │                                │
+                                 ┌──────────▼──────────┐          ┌──────────▼──────────┐
+                                 │ VictoriaMetrics     │          │ Nebius Cloud        │
+                                 │ Single (VMSingle)   │          │ Monitoring          │
+                                 │ Local Storage       │          │ (Remote Write)      │
+                                 └──────────┬──────────┘          └─────────────────────┘
+                                            │
+                                 ┌──────────▼──────────┐
+                                 │      Grafana        │
+                                 │   Visualization     │
+                                 └─────────────────────┘
+```
+
+## Components
+
+### Metrics Collection
+
+#### 1. Soperator Exporter (slurm-exporter)
+- Purpose: Exports SLURM-specific metrics
+- Port: 8080
+- Metrics: SLURM nodes state, jobs, controller RPC diagnostics
+- Deployment: Runs on system nodes (`slurm.nebius.ai/nodeset=system`)
+- Namespace: `soperator` (in the SLURM cluster namespace)
+- Scrape Interval: 30s (default)
+- Label Processing: Automatic removal of Kubernetes metadata labels (`pod`, `instance`, `container`)
+- Documentation: [slurm-exporter.md](slurm-exporter.md)
+
+Connection Example:
+```bash
+kubectl port-forward -n soperator deployment/slurm-exporter 8080:8080
+curl http://localhost:8080/metrics
+```
+
+The exporter applies metric relabeling to drop volatile Kubernetes labels (`pod`, `instance`, `container`) for counter continuity across restarts.
+
+#### 2. DCGM Exporter
+- Purpose: Exports NVIDIA GPU metrics
+- Port: 9400
+- Metrics: GPU temperature, power, utilization, memory, errors
+- Scrape Interval: 15s
+- DaemonSet: Runs on nodes with `nvidia.com/gpu.deploy.dcgm-exporter=true`
+
+Connection Example:
+```bash
+# Port-forward to a DCGM exporter pod
+kubectl port-forward -n soperator deployment/nvidia-dcgm-exporter 9400:9400
+curl http://localhost:9400/metrics
+```
+
+#### 3. Node Exporter
+- Purpose: Exports node/system metrics
+- Port: 9100
+- Metrics: CPU, memory, disk, network statistics
+- Part of: Prometheus Operator stack
+
+#### 4. Kubelet Metrics
+- Purpose: Collects node and container metrics from kubelet
+- Endpoints:
+  - `/metrics` - Core kubelet metrics
+  - `/metrics/cadvisor` - Container and cgroup metrics
+  - `/metrics/probes` - Liveness and readiness probe metrics
+  - `/metrics/resource` - Pod resource metrics
+- Scrape Method: VMScrapes targeting node endpoints directly
+- Scrape Interval: 30s
+
+Key Metrics:
+- `container_memory_usage_bytes` - Container memory usage
+- `container_cpu_usage_seconds_total` - Container CPU usage
+- `kubelet_pod_start_duration_seconds` - Pod startup latency
+- `kubelet_running_pods` - Number of running pods per node
+
+#### 5. Kube-state-metrics
+- Purpose: Exports Kubernetes object metrics
+- Ports:
+  - 8080 - Main metrics endpoint (Kubernetes object state)
+  - 8081 - Telemetry endpoint (self-monitoring)
+- Metrics: Pod state metrics (filtered subset)
+- Deployment: Single replica deployment in `monitoring-system` namespace
+- Configuration: `--resources=pods` with metric allowlist filtering
+
+Connection Example:
+```bash
+# Port-forward to main metrics endpoint
+kubectl port-forward -n monitoring-system svc/metrics-kube-state-metrics 8080:8080
+curl http://localhost:8080/metrics
+```
+
+Note: Port 8080 provides Kubernetes object metrics, while port 8081 provides self-monitoring metrics. VMServiceScrape targets port 8080 for cluster monitoring.
+
+#### 6. Soperator Controller Metrics
+- Purpose: Exports controller runtime metrics
+- Port: 8443 (through kube-rbac-proxy)
+- Metrics: Reconciliation metrics, controller health
+- Deployment: Runs on system nodes with the controller manager
+- Namespace: `soperator-system`
+- Access: Protected by RBAC proxy, requires proper authentication
+
+Connection Example:
+```bash
+# Port-forward to controller (bypasses RBAC)
+kubectl port-forward -n soperator-system deployment/soperator-controller-manager 8080:8080
+curl http://localhost:8080/metrics
+```
+
+Note: Production scraping requires a ServiceMonitor with proper RBAC authentication.
+
+### Metrics Processing & Storage
+
+#### VictoriaMetrics Agent (VMAgent)
+- Purpose: Scrapes metrics from exporters and forwards to storage
+- Features:
+  - Service discovery via Kubernetes API
+  - Label filtering and relabeling
+  - Remote write to multiple destinations
+  - Stream parsing for efficiency
+
+VMAgent exposes operational metrics on port 8429 for monitoring and debugging.
+
+#### VictoriaMetrics Single (VMSingle)
+- Purpose: Time-series database for metrics storage
+- Port: 8429
+- Retention: 30 days
+- Storage: 30Gi persistent volume
+- API: Prometheus-compatible query API
+
+Connection Example:
+```bash
+# Port-forward to VMSingle
+kubectl port-forward -n monitoring-system svc/vmsingle-metrics-victoria-metrics-k8s-stack 8429:8429
+
+# Query metrics
+curl "http://localhost:8429/api/v1/query?query=up"
+```
+
+#### Remote Write to Nebius Cloud
+- Endpoint: `https://write.monitoring.{region}.nebius.cloud/projects/{projectId}/buckets/soperator/prometheus`
+- Authentication: Bearer token from `/mnt/cloud-metadata/tsa-token`
+- When: Enabled with `publicEndpointEnabled: true`
+
+### Visualization
+
+#### Grafana
+- Purpose: Metrics visualization and dashboards
+- Port: 80
+- Authentication: Anonymous access enabled (Editor role)
+- Features:
+  - Pre-configured dashboards
+  - VictoriaMetrics datasource
+  - Dashboard discovery from ConfigMaps
+  - Loki/VictoriaLogs integration
+
+Connection Example:
+```bash
+# Port-forward to Grafana
+kubectl port-forward -n monitoring-system svc/metrics-grafana 3000:80
+# Access in browser: http://localhost:3000
+```
+
+Pre-configured Dashboards:
+- Victoria Metrics K8s Stack: Grafana, Kubelet, Kubernetes system, Node Exporter, VictoriaMetrics health
+- Soperator Custom: Cluster health, Jobs overview, Workers stats and overview
+
+Dashboards are auto-discovered from ConfigMaps with label `grafana_dashboard: "1"` in monitored namespaces.


### PR DESCRIPTION
## Summary
- Created **logs-pipeline.md** with VictoriaLogs setup, configuration and analysis
- Created **metrics-pipeline.md** with VictoriaMetrics stack and label management  
- Added cross-references to pipeline docs in README.md and features.md

Provides complete documentation for setting up and managing observability pipelines in Soperator clusters.