### PR TITLE
Release 1.21.10/fix slurm controller failover

### DIFF
--- a/internal/controller/clustercontroller/worker.go
+++ b/internal/controller/clustercontroller/worker.go
@@ -234,6 +234,7 @@ func (r SlurmClusterReconciler) ReconcileWorkers(
 						&clusterValues.NodeWorker,
 						clusterValues.SlurmTopologyConfigMapRefName,
 						clusterValues.WorkerFeatures,
+						clusterValues.NodeController.ContainerSlurmctld.Port,
 					)
 					if err != nil {
 						stepLogger.Error(err, "Failed to render")

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -56,15 +56,11 @@ func generateSlurmConfig(cluster *values.SlurmCluster, topologyConfig corev1.Con
 
 	res.AddProperty("ClusterName", cluster.Name)
 	res.AddComment("")
-	// example: SlurmctldHost=controller-0(controller-0.controller.slurm-poc.svc.cluster.local)
+	// example: SlurmctldHost=controller-0(controller-0)
+	// beause in kubernetes, dns uses the dot notation to separate the service name and the namespace
 	for i := int32(0); i < cluster.NodeController.Size; i++ {
-		hostName, hostFQDN := naming.BuildServiceHostFQDN(
-			consts.ComponentTypeController,
-			cluster.Namespace,
-			cluster.Name,
-			i,
-		)
-		res.AddProperty("SlurmctldHost", fmt.Sprintf("%s(%s)", hostName, hostFQDN))
+		svcName := fmt.Sprintf("%s-%d", cluster.NodeController.StatefulSet.Name, i)
+		res.AddProperty("SlurmctldHost", fmt.Sprintf("%s(%s)", svcName, svcName))
 	}
 	res.AddComment("")
 	res.AddProperty("AuthType", "auth/"+consts.Munge)

--- a/internal/render/controller/container.go
+++ b/internal/render/controller/container.go
@@ -33,20 +33,6 @@ func renderContainerSlurmctld(container *values.Container, customMounts []slurmv
 			Protocol:      corev1.ProtocolTCP,
 		}},
 		VolumeMounts: volumeMounts,
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{
-						"scontrol",
-						"ping",
-					},
-				},
-			},
-			TimeoutSeconds:   common.DefaultProbeTimeoutSeconds,
-			PeriodSeconds:    common.DefaultProbePeriodSeconds,
-			SuccessThreshold: common.DefaultProbeSuccessThreshold,
-			FailureThreshold: common.DefaultProbeFailureThreshold,
-		},
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -47,7 +47,7 @@ func renderContainerToolkitValidation(container *values.Container) corev1.Contai
 }
 
 // RenderContainerWaitForController renders init [corev1.Container] that waits for controller readiness
-func RenderContainerWaitForController(container *values.Container, clusterName string) corev1.Container {
+func RenderContainerWaitForController(container *values.Container, controllerPort int32) corev1.Container {
 	return corev1.Container{
 		Name:            consts.ContainerNameWaitForController,
 		Image:           container.Image,
@@ -58,7 +58,11 @@ func RenderContainerWaitForController(container *values.Container, clusterName s
 		Env: []corev1.EnvVar{
 			{
 				Name:  "CONTROLLER_SERVICE",
-				Value: naming.BuildServiceName(consts.ComponentTypeController, clusterName),
+				Value: fmt.Sprintf("%s-%d", consts.ComponentTypeController, 0),
+			},
+			{
+				Name:  "CONTROLLER_PORT",
+				Value: strconv.FormatInt(int64(controllerPort), 10),
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -30,6 +30,7 @@ func RenderStatefulSet(
 	worker *values.SlurmWorker,
 	slurmTopologyConfigMapRefName string,
 	workerFeatures []slurmv1.WorkerFeature,
+	controllerPort int32,
 ) (kruisev1b1.StatefulSet, error) {
 	labels := common.RenderLabels(consts.ComponentTypeWorker, clusterName)
 	matchLabels := common.RenderMatchLabels(consts.ComponentTypeWorker, clusterName)
@@ -52,7 +53,7 @@ func RenderStatefulSet(
 		common.RenderContainerMunge(&worker.ContainerMunge),
 	}
 	if worker.WaitForController != nil && *worker.WaitForController {
-		initContainers = append(initContainers, RenderContainerWaitForController(&worker.ContainerSlurmd, clusterName))
+		initContainers = append(initContainers, RenderContainerWaitForController(&worker.ContainerSlurmd, controllerPort))
 	}
 	if clusterType == consts.ClusterTypeGPU {
 		initContainers = append(initContainers, renderContainerToolkitValidation(&worker.ContainerToolkitValidation))

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -52,6 +52,7 @@ func Test_RenderStatefulSet(t *testing.T) {
 			},
 		},
 	}
+	controllerPort := int32(6817)
 
 	createWorker := func() *values.SlurmWorker {
 		return &values.SlurmWorker{
@@ -129,7 +130,9 @@ func Test_RenderStatefulSet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := worker.RenderStatefulSet(testNamespace, testCluster, tt.clusterType, nodeFilter, tt.secrets, volumeSource, tt.worker, testTopologyConfig, nil)
+			result, err := worker.RenderStatefulSet(
+				testNamespace, testCluster, tt.clusterType, nodeFilter, tt.secrets, volumeSource, tt.worker, testTopologyConfig, nil, controllerPort,
+			)
 			assert.NoError(t, err)
 
 			assert.Equal(t, consts.ContainerNameSlurmd, result.Spec.Template.Spec.Containers[0].Name)
@@ -166,7 +169,7 @@ func Test_RenderStatefulSet(t *testing.T) {
 }
 
 func Test_RenderContainerWaitForController(t *testing.T) {
-	testCluster := "test-cluster"
+	controllerPort := int32(6817)
 	container := &values.Container{
 		NodeContainer: slurmv1.NodeContainer{
 			Image:           "test-image",
@@ -174,15 +177,17 @@ func Test_RenderContainerWaitForController(t *testing.T) {
 		},
 	}
 
-	result := worker.RenderContainerWaitForController(container, testCluster)
+	result := worker.RenderContainerWaitForController(container, controllerPort)
 
 	assert.Equal(t, consts.ContainerNameWaitForController, result.Name)
 	assert.Equal(t, container.Image, result.Image)
 	assert.Equal(t, container.ImagePullPolicy, result.ImagePullPolicy)
 	assert.Equal(t, []string{"/opt/bin/slurm/wait-for-controller.sh"}, result.Command)
-	assert.Equal(t, 1, len(result.Env))
+	assert.Equal(t, 2, len(result.Env))
 	assert.Equal(t, "CONTROLLER_SERVICE", result.Env[0].Name)
-	assert.Contains(t, result.Env[0].Value, "controller")
+	assert.Equal(t, "controller-0", result.Env[0].Value)
+	assert.Equal(t, "CONTROLLER_PORT", result.Env[1].Name)
+	assert.Equal(t, "6817", result.Env[1].Value)
 	assert.Equal(t, 2, len(result.VolumeMounts))
 
 	// Verify exact volume mount values and no unexpected mounts


### PR DESCRIPTION
Cherry-picked two pull requests:
1. https://github.com/nebius/soperator/pull/1273
2. https://github.com/nebius/soperator/pull/1276

```
➜ git cherry-pick -x 30c0597f
Auto-merging internal/controller/clustercontroller/controller.go
Auto-merging internal/render/common/configmap.go
[soperator-release-1.21 b1dedc8d] Fix Slurm controller failover #1268 (#1273)
 Author: Grigorii Rochev <31252905+Uburro@users.noreply.github.com>
 Date: Tue Jul 22 11:30:43 2025 +0200
 4 files changed, 57 insertions(+), 42 deletions(-)

➜ git cherry-pick -x 3587482d
Auto-merging internal/controller/clustercontroller/worker.go
Auto-merging internal/render/worker/container.go
Auto-merging internal/render/worker/statefulset.go
Auto-merging internal/render/worker/statefulset_test.go
CONFLICT (content): Merge conflict in internal/render/worker/statefulset_test.go
error: could not apply 3587482d... fix wait for controller for new scheme failover (#1276)
hint: After resolving the conflicts, mark them with
hint: "git add/rm <pathspec>", then run
hint: "git cherry-pick --continue".
hint: You can instead skip this commit with "git cherry-pick --skip".
hint: To abort and get back to the state before "git cherry-pick",
hint: run "git cherry-pick --abort".
hint: Disable this message with "git config advice.mergeConflict false"
```

Issue: https://github.com/nebius/soperator/issues/1289