### PR TITLE
Release 1.21.10/add macos support in filestore

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -86,6 +86,50 @@ jobs:
           echo "Version: $VERSION"
           echo "Unstable: $UNSTABLE"
 
+  lint:
+    runs-on: self-hosted
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install GO
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+
+      # These steps are not a matrix to avoid allocating 3 jobs on runners for something this small
+      - name: golangci-lint on linux/amd64
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
+        with:
+          version: v2.0.2 # version of golangci-lint, should be in sync with Makefile.
+        env:
+          GOEXPERIMENT: synctest
+          GOARCH: amd64
+          GOOS: linux
+      - name: golangci-lint on linux/arm64
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
+        with:
+          version: v2.0.2 # version of golangci-lint, should be in sync with Makefile.
+        env:
+          GOEXPERIMENT: synctest
+          GOARCH: arm64
+          GOOS: linux
+      - name: golangci-lint on darwin/arm64
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
+        with:
+          version: v2.0.2 # version of golangci-lint, should be in sync with Makefile.
+        env:
+          GOEXPERIMENT: synctest
+          GOARCH: arm64
+          GOOS: darwin
+
   build:
     runs-on: ${{ matrix.runner }}
     needs: pre-build
@@ -112,13 +156,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: false
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
-        with:
-          version: v2.0.2 # version of golangci-lint, should be in sync with Makefile.
-        env:
-          GOEXPERIMENT: synctest
 
       - name: Download version artifact
         uses: actions/download-artifact@v4

--- a/internal/controller/sconfigcontroller/fs_darwin.go
+++ b/internal/controller/sconfigcontroller/fs_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package sconfigcontroller
+
+import "golang.org/x/sys/unix"
+
+func renameExchange(oldPath, newPath string) error {
+	return unix.RenameatxNp(unix.AT_FDCWD, oldPath, unix.AT_FDCWD, newPath, unix.RENAME_SWAP)
+}
+
+func renameNoReplace(oldPath, newPath string) error {
+	return unix.RenameatxNp(unix.AT_FDCWD, oldPath, unix.AT_FDCWD, newPath, unix.RENAME_EXCL)
+}

--- a/internal/controller/sconfigcontroller/fs_linux.go
+++ b/internal/controller/sconfigcontroller/fs_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package sconfigcontroller
+
+import "golang.org/x/sys/unix"
+
+func renameExchange(oldPath, newPath string) error {
+	return unix.Renameat2(unix.AT_FDCWD, oldPath, unix.AT_FDCWD, newPath, unix.RENAME_EXCHANGE)
+}
+
+func renameNoReplace(oldPath, newPath string) error {
+	return unix.Renameat2(unix.AT_FDCWD, oldPath, unix.AT_FDCWD, newPath, unix.RENAME_NOREPLACE)
+}


### PR DESCRIPTION
Cherry-pick this: https://github.com/nebius/soperator/pull/1253

```
➜ git cherry-pick -x 682054e4 && git cherry-pick -x 96276584
[release-1.21.10/aff-macos-supoort-in-filestore e7f6bdec] Add macOS support in FileStore
 Author: Mikhail Cheshkov <mcheshkov@nebius.com>
 Date: Thu Jul 17 14:16:19 2025 +0200
 3 files changed, 31 insertions(+), 7 deletions(-)
 create mode 100644 internal/controller/sconfigcontroller/fs_darwin.go
 create mode 100644 internal/controller/sconfigcontroller/fs_linux.go
[release-1.21.10/aff-macos-supoort-in-filestore 7be04fc6] Setup simple lint check in CI for every interesting platform
 Author: Mikhail Cheshkov <mcheshkov@nebius.com>
 Date: Thu Jul 17 14:17:13 2025 +0200
 1 file changed, 44 insertions(+), 7 deletions(-)
```

Issue: https://github.com/nebius/soperator/issues/1289