### PR TITLE
Fix apt install nvslurm-plugin-pyxis

### DIFF
--- a/images/login/sshd.dockerfile
+++ b/images/login/sshd.dockerfile
@@ -108,7 +108,7 @@ RUN chown 0:0 /etc/enroot/enroot.conf && chmod 644 /etc/enroot/enroot.conf
 
 # Install slurm pyxis plugin
 RUN apt-get update && \
-    apt -y install nvslurm-plugin-pyxis=${SLURM_VERSION}-${PYXIS_VERSION}-1 && \
+    apt -y install nvslurm-plugin-pyxis=${PYXIS_VERSION}-1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/nccl_benchmark/nccl_benchmark.dockerfile
+++ b/images/nccl_benchmark/nccl_benchmark.dockerfile
@@ -73,7 +73,7 @@ RUN chown 0:0 /etc/enroot/enroot.conf && chmod 644 /etc/enroot/enroot.conf
 
 # Install slurm pyxis plugin \
 RUN apt-get update && \
-    apt -y install nvslurm-plugin-pyxis=${SLURM_VERSION}-${PYXIS_VERSION}-1 && \
+    apt -y install nvslurm-plugin-pyxis=${PYXIS_VERSION}-1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/slurm_check_job/slurm_check_job.dockerfile
+++ b/images/slurm_check_job/slurm_check_job.dockerfile
@@ -83,7 +83,7 @@ RUN chown 0:0 /etc/enroot/enroot.conf && chmod 644 /etc/enroot/enroot.conf
 
 # Install slurm pyxis plugin \
 RUN apt-get update && \
-    apt -y install nvslurm-plugin-pyxis=${SLURM_VERSION}-${PYXIS_VERSION}-1 && \
+    apt -y install nvslurm-plugin-pyxis=${PYXIS_VERSION}-1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/worker/slurmd.dockerfile
+++ b/images/worker/slurmd.dockerfile
@@ -134,7 +134,7 @@ RUN chown 0:0 /etc/enroot/enroot.conf && chmod 644 /etc/enroot/enroot.conf
 
 # Install slurm pyxis plugin
 RUN apt-get update && \
-    apt -y install nvslurm-plugin-pyxis=${SLURM_VERSION}-${PYXIS_VERSION}-1 && \
+    apt -y install nvslurm-plugin-pyxis=${PYXIS_VERSION}-1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Part of release preps: https://github.com/nebius/soperator/issues/1289

```
#17 4.433 E: Version '24.11.5-0.21.0-1' for 'nvslurm-plugin-pyxis' was not found
```