### PR TITLE
Node deletion does not wait for the epilog to complete. #1279

### DIFF
--- a/internal/controller/soperatorchecks/slurm_nodes_controller.go
+++ b/internal/controller/soperatorchecks/slurm_nodes_controller.go
@@ -635,8 +635,12 @@ func (c *SlurmNodesController) slurmNodesFullyDrained(
 			if err != nil {
 				return false, err
 			}
+			_, completing := node.States[api.V0041NodeStateCOMPLETING]
 			logger.Info("slurm node", "nodeStates", node.States)
-			if !node.IsIdleDrained() {
+			// When prologe is running, node is in COMPLETING state and both IDLE and DRAIN states are set.
+			// Example: State=IDLE+COMPLETING+DRAIN+DYNAMIC_NORM
+			// We consider node fully drained when it is in IDLE+DRAIN+DYNAMIC_NORM states.
+			if !node.IsIdleDrained() && !completing {
 				logger.Info("slurm node is not fully drained", "nodeStates", node.States)
 				return false, nil
 			}


### PR DESCRIPTION
The state when the prolog is running.


```
root@login-0:~# scontrol show  nodes  worker-1
NodeName=worker-1 Arch=x86_64 CoresPerSocket=8 
   CPUAlloc=0 CPUEfctv=16 CPUTot=16 CPULoad=0.08
   AvailableFeatures=(null)
   ActiveFeatures=(null)
   Gres=gpu:nvidia_h100_80gb_hbm3:1(S:0)
   NodeAddr=10.0.110.38 NodeHostName=worker-1 Version=24.11.5
   OS=Linux 5.15.0-136-generic #147-Ubuntu SMP Sat Mar 15 15:53:30 UTC 2025 
   RealMemory=191356 AllocMem=0 FreeMem=161883 Sockets=1 Boards=1
   State=IDLE+DRAIN+DYNAMIC_NORM ThreadsPerCore=2 TmpDisk=0 Weight=1 Owner=N/A MCS_label=N/A
   Partitions=main,background 
   BootTime=2025-07-21 14:35:22.UTC SlurmdStartTime=2025-07-23 05:46:39.UTC
   LastBusyTime=2025-07-23 12:24:09.UTC ResumeAfterTime=None
   CfgTRES=cpu=16,mem=191356M,billing=16,gres/gpu=1
   AllocTRES=
   CurrentWatts=0 AveWatts=0
```
   
