### PR TITLE
Update GitHub release workflow to support multi-branch releases

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '.github/**'
-      - '.dockerignore'
-      - '.editorconfig'
-      - '.gitignore'
+      - 'soperator-release-*'
+    paths:
+      - 'VERSION'
 
 jobs:
   tag:
@@ -24,11 +22,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get previous tag
+      - name: Get previous tag from current branch
         id: get-previous-tag
-        uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435 # v1.6.0
-        with:
-          semver_only: true
+        run: |
+          # Get the latest release tag (semantic version) that's reachable from the current commit
+          # Match tags like: 1.2.3 (without 'v' prefix)
+          PREV_TAG=$(git tag --merged HEAD^ | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "Error: No previous release tag found in current branch history"
+            echo "This is unexpected - there should be previous releases in the history"
+            exit 1
+          fi
+          echo "tag=${PREV_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "Found previous tag: ${PREV_TAG}"
 
       - name: Get version
         id: get-version
@@ -111,8 +117,7 @@ jobs:
                   "pattern": "^(other|docs|doc|dependencies|deps|feat|feature|fix|bug|test|.*)",
                   "target": "$1"
                 }
-              ],
-              "base_branches": ["dev"]
+              ]
             }
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Enable automatic GitHub releases from both `main` and `soperator-release-*` branches when VERSION file changes.

## Changes

- Multi-branch support: Releases can now be triggered from `main` and `soperator-release-*` branches
- VERSION-based trigger: Releases only occur when the VERSION file is modified  
- Improved tag detection: Uses branch-specific tag history instead of global latest tag
- Simplified changelog: Removed base_branches filter to show actual changes between versions

This allows creating hotfix releases from soperator-release branches while maintaining accurate changelogs.

## Issue
 https://github.com/nebius/soperator/issues/1289