### PR TITLE
Disable bash IB healthchecks on B200

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/hc_program.sh
+++ b/helm/slurm-cluster/slurm_scripts/hc_program.sh
@@ -18,20 +18,21 @@ chroot /mnt/jail /bin/bash -s <<-'EOF'
         health_checker
     )
 
-    GPU_COUNT=$(nvidia-smi --list-gpus 2>/dev/null | wc -l || echo 0)
-    echo "Found ${GPU_COUNT} GPUs"
-
-    # Only add hc_* checks if we have exactly 8 GPUs
-    if [[ "${GPU_COUNT}" -eq 8 ]]; then
+    gpus_on_node=$(nvidia-smi --query-gpu=name --format=csv,noheader | sort | uniq -c)
+    if [[ "${gpus_on_node}" == *"8 NVIDIA"* ]]; then
         checks+=(
             hc_host_service
             hc_xid
-            hc_ib_link_state
             hc_ib_counters
-            hc_ib_pkey
         )
+        if [[ "${gpus_on_node}" == *"8 NVIDIA H100"* ]] || [[ "${gpus_on_node}" == *"8 NVIDIA H200"* ]]; then
+            checks+=(
+                hc_ib_link_state
+                hc_ib_pkey
+            )
+        fi
     else
-        echo "Skipping hc_* checks because GPU_COUNT=${GPU_COUNT} (need 8)"
+        echo "Skipping hc_* checks because there are no 8 GPUs"
     fi
 
     pushd /opt/slurm_scripts || exit 0

--- a/helm/slurm-cluster/slurm_scripts/prolog.sh
+++ b/helm/slurm-cluster/slurm_scripts/prolog.sh
@@ -20,20 +20,21 @@ if [ -n "$SLURM_JOB_GPUS" ]; then
             health_checker
         )
 
-        GPU_COUNT=$(nvidia-smi --list-gpus 2>/dev/null | wc -l || echo 0)
-        echo "Found ${GPU_COUNT} GPUs"
-
-        # Only add hc_* checks if we have exactly 8 GPUs
-        if [[ "${GPU_COUNT}" -eq 8 ]]; then
+        gpus_on_node=$(nvidia-smi --query-gpu=name --format=csv,noheader | sort | uniq -c)
+        if [[ "${gpus_on_node}" == *"8 NVIDIA"* ]]; then
             checks+=(
                 hc_host_service
                 hc_xid
-                hc_ib_link_state
                 hc_ib_counters
-                hc_ib_pkey
             )
+            if [[ "${gpus_on_node}" == *"8 NVIDIA H100"* ]] || [[ "${gpus_on_node}" == *"8 NVIDIA H200"* ]]; then
+                checks+=(
+                    hc_ib_link_state
+                    hc_ib_pkey
+                )
+            fi
         else
-            echo "Skipping hc_* checks because GPU_COUNT=${GPU_COUNT} (need 8)"
+            echo "Skipping hc_* checks because there are no 8 GPUs"
         fi
 
         pushd /opt/slurm_scripts || exit 0


### PR DESCRIPTION
Cherry-pick of https://github.com/nebius/soperator/pull/1283
For new release https://github.com/nebius/soperator/issues/1289

```
❯ git cherry-pick -x 232a7c96c1bcd29c62d47332d570bf2b2b1289fe
[release-1.21.10/fix-bash-hc-for-b200/0 f06a02fc] Disable bash IB healthchecks on B200
 Author: rdjjke <rdjjke@gmail.com>
 Date: Wed Jul 23 12:29:19 2025 +0200
 3 files changed, 27 insertions(+), 24 deletions(-)
```
