### PR TITLE
Fix CI workflow to trigger on release branches and build stable releases only on VERSION changes

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - soperator-release-*
     tags:
       - 'build**'  # Trigger on tags starting with "build"
     paths-ignore:
@@ -57,7 +58,15 @@ jobs:
 
       - name: Generate version file
         run: |
-          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+          # Check if VERSION file was changed in this push
+          VERSION_CHANGED="false"
+          if [ "${{ github.event_name }}" == "push" ]; then
+            # Get the list of changed files
+            git diff --name-only HEAD^ HEAD | grep -q "^VERSION$" && VERSION_CHANGED="true"
+          fi
+
+          # Build stable releases only on main/release branches when VERSION changes
+          if [[ ("${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" =~ "^refs/heads/soperator-release-") && "$VERSION_CHANGED" == "true" ]]; then
             make get-version UNSTABLE=false >> version.txt
             echo "false" >> version.txt
           else


### PR DESCRIPTION
## Summary
- Add `soperator-release-*` branches to CI workflow triggers
- Build stable releases only when VERSION file changes on main or release branches
- All other builds remain unstable to avoid unnecessary stable builds on every commit

## Issue
https://github.com/nebius/soperator/issues/1289