### PR TITLE
Node deletion does not wait for the epilog to complete. #1279 (#1288)

### DIFF
--- a/internal/controller/soperatorchecks/slurm_nodes_controller.go
+++ b/internal/controller/soperatorchecks/slurm_nodes_controller.go
@@ -632,8 +632,12 @@ func (c *SlurmNodesController) slurmNodesFullyDrained(
 			if err != nil {
 				return false, err
 			}
+			_, isCompleting := node.States[api.V0041NodeStateCOMPLETING]
 			logger.Info("slurm node", "nodeStates", node.States)
-			if !node.IsIdleDrained() {
+			// When epilog is running, node is in COMPLETING state and both IDLE and DRAIN states are set.
+			// Example: State=IDLE+COMPLETING+DRAIN+DYNAMIC_NORM
+			// We consider node fully drained when it is in IDLE+DRAIN+DYNAMIC_NORM states.
+			if !node.IsIdleDrained() || isCompleting {
 				logger.Info("slurm node is not fully drained", "nodeStates", node.States)
 				return false, nil
 			}


### PR DESCRIPTION
Cherry-pick https://github.com/nebius/soperator/pull/1288
Issue: https://github.com/nebius/soperator/issues/1289

```sh
➜ git cherry-pick -x 09ddd12c
Auto-merging internal/controller/soperatorchecks/slurm_nodes_controller.go
[release-1.21.10/want-for-epilog-complete b7100ad3] Node deletion does not wait for the epilog to complete. #1279 (#1288)
 Author: Grigorii Rochev <31252905+Uburro@users.noreply.github.com>
 Date: Wed Jul 23 15:15:59 2025 +0200
 1 file changed, 5 insertions(+), 1 deletion(-)
```