### PR TITLE
Use ADD to build populate_jail image instead of COPY + RUN + second stage

### DIFF
--- a/images/populate_jail/populate_jail.dockerfile
+++ b/images/populate_jail/populate_jail.dockerfile
@@ -1,17 +1,6 @@
 ARG BASE_IMAGE=cr.eu-north1.nebius.cloud/soperator/ubuntu:noble
 ARG TARGETARCH
 
-# First stage: untap jail_rootfs.tar
-FROM $BASE_IMAGE AS untaped
-
-ARG TARGETARCH
-
-COPY images/jail_rootfs_${TARGETARCH}.tar /jail_rootfs.tar
-RUN mkdir /jail && \
-    tar -xvf /jail_rootfs.tar -C /jail && \
-    rm /jail_rootfs.tar
-
-# Second stage: copy untaped jail environment to the target
 FROM $BASE_IMAGE AS populate_jail
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -20,7 +9,7 @@ RUN apt update && \
     apt install -y rclone rsync && \
     apt clean
 
-COPY --from=untaped /jail /jail
+ADD --link images/jail_rootfs_${TARGETARCH}.tar /jail/
 
 COPY images/populate_jail/populate_jail_entrypoint.sh .
 RUN chmod +x ./populate_jail_entrypoint.sh


### PR DESCRIPTION
`ADD` command can unpack local tarballs directly as an image layer. It should even be a little bit better, because cache can be tracked more precisely
See https://docs.docker.com/reference/dockerfile/#adding-local-tar-archives