### PR TITLE
Add time metrics to slurm_job_info metric for comprehensive job monitoring

### DIFF
--- a/docs/slurm-exporter.md
+++ b/docs/slurm-exporter.md
@@ -88,10 +88,13 @@ slurm_node_fails_total{node_name="worker-2",state_base="DOWN",state_is_drain="tr
 - `standard_output`: Path to stdout file
 - `array_job_id`: Array job ID (if applicable)
 - `array_task_id`: Array task ID (if applicable)
+- `submit_time`: When the job was submitted (Unix timestamp seconds, empty if not available)
+- `start_time`: When the job started execution (Unix timestamp seconds, empty if not available)
+- `end_time`: When the job completed (Unix timestamp seconds, empty if not available)
 
 **Example:**
 ```prometheus
-slurm_job_info{job_id="12345",job_state="RUNNING",job_state_reason="None",slurm_partition="gpu",job_name="training_job",user_name="researcher",user_id="1000",standard_error="/home/researcher/job.err",standard_output="/home/researcher/job.out",array_job_id="",array_task_id=""} 1
+slurm_job_info{job_id="12345",job_state="RUNNING",job_state_reason="None",slurm_partition="gpu",job_name="training_job",user_name="researcher",user_id="1000",standard_error="/home/researcher/job.err",standard_output="/home/researcher/job.out",array_job_id="",array_task_id="",submit_time="1722697200",start_time="1722697230",end_time=""} 1
 ```
 
 #### Gauge `slurm_node_job`

--- a/internal/slurmapi/job.go
+++ b/internal/slurmapi/job.go
@@ -28,6 +28,7 @@ type Job struct {
 	ArrayJobID     *int32
 	ArrayTaskID    *int32
 	SubmitTime     *metav1.Time
+	StartTime      *metav1.Time
 	EndTime        *metav1.Time
 }
 
@@ -91,6 +92,7 @@ func JobFromAPI(apiJob api.V0041JobInfo) (Job, error) {
 	job.ArrayJobID = convertToInt(apiJob.ArrayJobId)
 	job.ArrayTaskID = convertToInt(apiJob.ArrayTaskId)
 	job.SubmitTime = convertToMetav1Time(apiJob.SubmitTime)
+	job.StartTime = convertToMetav1Time(apiJob.StartTime)
 	job.EndTime = convertToMetav1Time(apiJob.EndTime)
 
 	return job, nil


### PR DESCRIPTION
## Summary

Added `submit_time`, `start_time`, and `end_time` labels to `slurm_job_info` metric as Unix timestamps to enable better job lifecycle tracking and dashboard visualization.

## Changes

- Enhanced `slurm_job_info` metric with three new time labels (Unix timestamp format)
- Added `StartTime` field to Job struct and updated API mapping
- Updated documentation with examples showing the new time metrics

Resolves #1299