### PR TITLE
Release 1.21.10/fix select type parameters

### DIFF
--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -128,7 +128,7 @@ func generateSlurmConfig(cluster *values.SlurmCluster, topologyConfig corev1.Con
 	res.AddComment("SCHEDULING")
 	res.AddProperty("SchedulerType", "sched/backfill")
 	res.AddProperty("SelectType", "select/cons_tres")
-	res.AddProperty("SelectTypeParameters", "CR_Core_Memory,CR_ONE_TASK_PER_CORE,CR_CORE_DEFAULT_DIST_BLOCK")
+	res.AddProperty("SelectTypeParameters", "CR_Core_Memory,CR_CORE_DEFAULT_DIST_BLOCK")
 	res.AddComment("")
 	res.AddComment("LOGGING")
 	res.AddProperty("SlurmctldDebug", consts.SlurmDefaultDebugLevel)


### PR DESCRIPTION
Cherry-pick https://github.com/nebius/soperator/pull/1306
Issue: https://github.com/nebius/soperator/issues/1289

```sh
❯ git cherry-pick -x 86ad90d86c56b12a5c2eaed9543c05df7bacef25
Auto-merging internal/render/common/configmap.go
[release-1.21.10/fix-select-type-parameters fb4ddbc5] Remove CR_ONE_TASK_PER_CORE from SelectTypeParameters
 Author: rdjjke <rdjjke@gmail.com>
 Date: Thu Jul 24 15:07:06 2025 +0200
 1 file changed, 1 insertion(+), 1 deletion(-)
```