### PR TITLE
Create releases only in soperator-release branches

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -3,12 +3,9 @@ name: "Create GitHub release with automatic changelog"
 on:
   push:
     branches:
-      - main
-    paths-ignore:
-      - '.github/**'
-      - '.dockerignore'
-      - '.editorconfig'
-      - '.gitignore'
+      - 'soperator-release-*'
+    paths:
+      - 'VERSION'
 
 jobs:
   tag:
@@ -24,11 +21,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get previous tag
+      - name: Get previous tag from current branch
         id: get-previous-tag
-        uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435 # v1.6.0
-        with:
-          semver_only: true
+        run: |
+          # Get the latest release tag (semantic version) that's reachable from the current commit
+          # Match tags like: 1.2.3 (without 'v' prefix)
+          PREV_TAG=$(git tag --merged HEAD^ | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "Error: No previous release tag found in current branch history"
+            echo "This is unexpected - there should be previous releases in the history"
+            exit 1
+          fi
+          echo "tag=${PREV_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "Found previous tag: ${PREV_TAG}"
 
       - name: Get version
         id: get-version
@@ -111,8 +116,7 @@ jobs:
                   "pattern": "^(other|docs|doc|dependencies|deps|feat|feature|fix|bug|test|.*)",
                   "target": "$1"
                 }
-              ],
-              "base_branches": ["dev"]
+              ]
             }
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - soperator-release-*
     tags:
       - 'build**'  # Trigger on tags starting with "build"
     paths-ignore:
@@ -41,6 +42,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0  # Fetch git history for the VERSION file changes detection
 
       - name: Install GO
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
@@ -50,13 +53,20 @@ jobs:
 
       - name: Generate version file
         run: |
-          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            make get-version UNSTABLE=false >> version.txt
-            echo "false" >> version.txt
-          else
-            make get-version UNSTABLE=true >> version.txt
-            echo "true" >> version.txt
+          UNSTABLE="true"
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ ^refs/heads/soperator-release- ]]; then
+            CHANGED_FILES=$(git diff --name-only HEAD^ HEAD) || {
+              echo "Error: git diff failed with exit code $?"
+              exit 1
+            }
+
+            if echo "$CHANGED_FILES" | grep -q "^VERSION$"; then
+              UNSTABLE="false"
+            fi
           fi
+
+          make get-version UNSTABLE=${UNSTABLE} >> version.txt
+          echo "${UNSTABLE}" >> version.txt
 
       - name: Upload version file
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Updates GitHub Actions workflows to implement the new release process where releases are only created from `soperator-release-*` branches.

## Changes

- Modified `github_release.yml` to trigger only on `soperator-release-*` branches when VERSION file changes
- Updated `one_job.yml` to support `soperator-release-*` branches and build stable releases only when VERSION file is modified
- Improved previous tag detection to use branch-specific history instead of global tags
- Added proper git history fetching and error handling for VERSION file change detection

## Issue
https://github.com/nebius/soperator/issues/1324
