### PR TITLE
Detect stable builds by version tag instead of VERSION file

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -6,7 +6,7 @@ on:
       - main
       - soperator-release-*
     tags:
-      - 'build**'  # Trigger on tags starting with "build"
+      - '**'  # Trigger on any tag
     paths-ignore:
       - 'docs/**'
       - 'CODEOWNERS'
@@ -53,15 +53,11 @@ jobs:
       - name: Generate version file
         run: |
           UNSTABLE="true"
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ ^refs/heads/soperator-release- ]]; then
-            CHANGED_FILES=$(git diff --name-only HEAD^ HEAD) || {
-              echo "Error: git diff failed with exit code $?"
-              exit 1
-            }
-
-            if echo "$CHANGED_FILES" | grep -q "^VERSION$"; then
-              UNSTABLE="false"
-            fi
+          if [[ "${{ github.ref }}" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Detected semantic version tag - building stable release"
+            UNSTABLE="false"
+          else
+            echo "Building unstable version"
           fi
 
           make get-version UNSTABLE=${UNSTABLE} >> version.txt


### PR DESCRIPTION
Changes the stable build detection mechanism in CI to use semantic version tags instead of VERSION file change detection.

## Changes

- Trigger builds on all tags (not just `build*` tags)
- Stable builds (UNSTABLE=false) are now created only when building from semantic version tags (e.g., `1.22.0`)
- All other builds (branches, non-semantic tags) create unstable builds
- Removed complex VERSION file change detection logic

This approach provides better visibility as stable builds are clearly identifiable in GitHub Actions UI - they only occur on release tags created by the release workflow.