### PR TITLE
[nccl-debug] Use chmod instead of umask

### DIFF
--- a/images/common/spank-nccl-debug/src/snccld.c
+++ b/images/common/spank-nccl-debug/src/snccld.c
@@ -261,7 +261,7 @@ int slurm_spank_user_init(spank_t spank, int argc, char **argv) {
     }
 
     // Ensure `user_init` ran once per worker.
-    snccld_ensure_dir_exists(SNCCLD_SYSTEM_DIR);
+    snccld_ensure_dir_exists(SNCCLD_SYSTEM_DIR, false);
     if (!snccld_acquire_lock(
             key->job_id, key->step_id, SNCCLD_OPLOCK_OP_USER_INIT, hostname
         )) {
@@ -463,11 +463,11 @@ int slurm_spank_task_init_privileged(spank_t spank, int argc, char **argv) {
             snccld_config.out_dir, hostname, resolved_out_dir
         );
         snccld_log_debug("Ensuring '%s' exists.", resolved_out_dir);
-        snccld_ensure_dir_exists(resolved_out_dir);
+        snccld_ensure_dir_exists(resolved_out_dir, true);
     }
     if (strlen(state->user_log_path) > 0) {
         snccld_log_debug("Ensuring '%s' exists.", state->user_log_path);
-        snccld_ensure_file_exists(state->user_log_path);
+        snccld_ensure_file_exists(state->user_log_path, true);
     }
 
     // Create Enroot bind mounts for the state and log files.

--- a/images/common/spank-nccl-debug/src/snccld.c
+++ b/images/common/spank-nccl-debug/src/snccld.c
@@ -501,15 +501,17 @@ int slurm_spank_task_init_privileged(spank_t spank, int argc, char **argv) {
         // Write config once.
         int lock_fd;
         {
-            const mode_t old_mask = umask(0);
             lock_fd =
                 open(lock_filename, O_CREAT | O_WRONLY, SNCCLD_DEFAULT_MODE);
             if (lock_fd < 0) {
                 snccld_log_error("Cannot open %s: %m", lock_filename);
-                umask(old_mask);
                 goto mount_config_end;
             }
-            umask(old_mask);
+            if (fchmod(lock_fd, SNCCLD_DEFAULT_MODE) != 0) {
+                snccld_log_error("Cannot chmod %s: %m", lock_filename);
+                close(lock_fd);
+                goto mount_config_end;
+            }
 
             if (flock(lock_fd, LOCK_EX | LOCK_NB) == -1) {
                 snccld_log_error("Cannot flock %s: %m", lock_filename);
@@ -518,16 +520,18 @@ int slurm_spank_task_init_privileged(spank_t spank, int argc, char **argv) {
             }
         }
 
-        const mode_t old_mask        = umask(0);
-        const int    mount_config_fd = open(
+        const int mount_config_fd = open(
             mount_config_filename, O_CREAT | O_WRONLY, SNCCLD_DEFAULT_MODE
         );
         if (mount_config_fd < 0) {
             snccld_log_error("Cannot open %s: %m", mount_config_filename);
-            umask(old_mask);
             goto mount_config_unflock;
         }
-        umask(old_mask);
+        if (fchmod(mount_config_fd, SNCCLD_DEFAULT_MODE) != 0) {
+            snccld_log_error("Cannot chmod %s: %m", mount_config_filename);
+            close(mount_config_fd);
+            goto mount_config_unflock;
+        }
 
         FILE *mount_config_f = fdopen(mount_config_fd, "w");
         if (mount_config_f == NULL) {

--- a/images/common/spank-nccl-debug/src/snccld_util_dir_file.c
+++ b/images/common/spank-nccl-debug/src/snccld_util_dir_file.c
@@ -112,7 +112,8 @@ void snccld_ensure_file_exists(const char *path, const bool as_user) {
 
     int fd;
     if (as_user) {
-        fd = open(path_absolute, O_CREAT | O_WRONLY | O_TRUNC);
+        const int user_file_mode = 0666;
+        fd = open(path_absolute, O_CREAT | O_WRONLY | O_TRUNC, user_file_mode);
     } else {
         fd = open(
             path_absolute, O_CREAT | O_WRONLY | O_TRUNC, SNCCLD_DEFAULT_MODE

--- a/images/common/spank-nccl-debug/src/snccld_util_dir_file.h
+++ b/images/common/spank-nccl-debug/src/snccld_util_dir_file.h
@@ -21,12 +21,12 @@
  *
  * @param path Absolute path of the directory to make on.
  *             Trailing slash is handled.
- * @param mode Directory mode.
+ * @param as_user Whether to create directories as user (w/o umask 0).
  *
  * @retval ESPANK_SUCCESS Successfully created the directory.
  * @retval ESPANK_ERROR Something went wrong.
  */
-spank_err_t snccld_mkdir_p(const char *path, mode_t mode);
+spank_err_t snccld_mkdir_p(const char *path, bool as_user);
 
 /**
  * Check if the directory exists.
@@ -54,15 +54,17 @@ void snccld_split_file_path(const char *path, char **dir_out, char **file_out);
  * If it doesn't exist, it will be created.
  *
  * @param path Path to the file to ensure its existence.
+ * @param as_user Whether to create directory and file as user (w/o umask 0).
  */
-void snccld_ensure_file_exists(const char *path);
+void snccld_ensure_file_exists(const char *path, bool as_user);
 
 /**
  * Ensure the directory exists.
  * If it doesn't exist, it will be created.
  *
  * @param path Path to the directory to ensure its existence.
+ * @param as_user Whether to create directory as user (w/o umask 0).
  */
-void snccld_ensure_dir_exists(const char *path);
+void snccld_ensure_dir_exists(const char *path, bool as_user);
 
 #endif // SNCCLD_UTIL_DIR_FILE_H


### PR DESCRIPTION
Using umask is too broad and error-prone to umask not being returned to the previous mask.
This PR replaces the umask set/return logic with dedicated chmod calls for particular files and folders along with support of file/directory creation as root/user.