### PR TITLE
Add alternating branch E2E test scheduler

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,9 +1,6 @@
 name: E2E test soperator
 
 on:
-  schedule:
-    # Every hour
-    - cron: '0 */1 * * *'
   workflow_dispatch:
     inputs:
       terraform_repo:

--- a/.github/workflows/e2e_test_scheduler.yml
+++ b/.github/workflows/e2e_test_scheduler.yml
@@ -1,0 +1,48 @@
+name: E2E Test Scheduler
+
+on:
+  schedule:
+    # Every hour - alternates between main and release branches
+    - cron: '0 */1 * * *'
+  workflow_dispatch:  # Allow manual trigger for testing
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  trigger-e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Determine branch and terraform ref
+        id: select_params
+        run: |
+          # Configuration
+          RELEASE_BRANCH="soperator-release-1.21"
+
+          HOUR=$(date -u +%H)
+          if [ $((HOUR % 2)) -eq 0 ]; then
+            echo "ref=main" >> $GITHUB_OUTPUT
+            echo "terraform_ref=main" >> $GITHUB_OUTPUT
+            echo "Even hour ($HOUR UTC) - Testing main branch with terraform main"
+          else
+            echo "ref=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
+            echo "terraform_ref=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
+            echo "Odd hour ($HOUR UTC) - Testing $RELEASE_BRANCH branch with terraform $RELEASE_BRANCH"
+          fi
+
+      - name: Trigger E2E test workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REF="${{ steps.select_params.outputs.ref }}"
+          TERRAFORM_REF="${{ steps.select_params.outputs.terraform_ref }}"
+
+          echo "Triggering E2E test on branch: $REF"
+          echo "With terraform ref: $TERRAFORM_REF"
+
+          gh workflow run e2e_test.yml \
+            --ref "$REF" \
+            -f terraform_repo_ref="$TERRAFORM_REF"
+          echo "E2E test workflow triggered successfully"


### PR DESCRIPTION
This PR adds a scheduler workflow that alternates E2E tests between main and release branches.

## Changes
- Removed the hourly schedule from the main e2e_test.yml workflow
- Created a new e2e_test_scheduler.yml that triggers E2E tests:
  - Even hours: tests main branch with terraform main
  - Odd hours: tests release branch with matching terraform branch
- The scheduler uses the GitHub CLI to trigger the existing E2E test workflow

This ensures both main and release branches receive regular automated testing coverage.