### PR TITLE
Fix E2E test scheduler workflow gh CLI error

### DIFF
--- a/.github/workflows/e2e_test_scheduler.yml
+++ b/.github/workflows/e2e_test_scheduler.yml
@@ -32,6 +32,9 @@ jobs:
             echo "Odd hour ($HOUR UTC) - Testing $RELEASE_BRANCH branch with terraform $RELEASE_BRANCH"
           fi
 
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Trigger E2E test workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add repository checkout step to E2E test scheduler workflow to fix gh CLI error.

The workflow was failing with "fatal: not a git repository" error because the gh CLI requires git repository context when running `gh workflow run` command.
