### PR TITLE
Cancel old builds when pull request is updated

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -32,6 +32,10 @@ permissions:
   attestations: write
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pre-build:
     runs-on: self-hosted


### PR DESCRIPTION
## Summary

Added concurrency configuration to the `one_job.yml` workflow to automatically cancel in-progress builds when a pull request is updated with new commits.

## Changes

- Added concurrency group using PR number for pull requests or git ref for other events
- Set `cancel-in-progress` to true only for pull request events
- Main branch, release branches, and tags will not have their builds cancelled

This prevents wasting CI resources on outdated builds while preserving important builds that should complete.