### PR TITLE
Fix E2E test scheduler workflow failure for hours 08 and 09

### DIFF
--- a/.github/workflows/e2e_test_scheduler.yml
+++ b/.github/workflows/e2e_test_scheduler.yml
@@ -21,7 +21,7 @@ jobs:
           # Configuration
           RELEASE_BRANCH="soperator-release-1.21"
 
-          HOUR=$(date -u +%H)
+          HOUR=$(date -u +%-H)  # %-H removes leading zeros to avoid octal interpretation
           if [ $((HOUR % 2)) -eq 0 ]; then
             echo "ref=main" >> $GITHUB_OUTPUT
             echo "terraform_ref=main" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The E2E test scheduler workflow was failing when run at hours 08 or 09 UTC with the error:
`09: value too great for base (error token is "09")`

This happened because bash interprets numbers with leading zeros as octal, and 08/09 are invalid octal numbers.

Fixed by using `date -u +%-H` instead of `date -u +%H` to get hours without leading zeros.