### PR TITLE
Implement async metrics collection for SLURM exporter

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -991,6 +991,12 @@ type SlurmExporter struct {
 	//
 	// +kubebuilder:validation:Optional
 	ExporterContainer NodeContainer `json:"exporterContainer"`
+
+	// CollectionInterval specifies how often to collect metrics from SLURM APIs
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="30s"
+	CollectionInterval prometheusv1.Duration `json:"collectionInterval,omitempty"`
 }
 
 // ExporterContainer defines the configuration for one of node containers

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -7612,6 +7612,12 @@ spec:
                     description: |
                       Exporter represents the Slurm exporter node configuration
                     properties:
+                      collectionInterval:
+                        default: 30s
+                        description: CollectionInterval specifies how often to collect
+                          metrics from SLURM APIs
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
                       customInitContainers:
                         description: CustomInitContainers represent additional init
                           containers that should be added to created Pods

--- a/docs/slurm-exporter.md
+++ b/docs/slurm-exporter.md
@@ -8,12 +8,22 @@ The exporter integrates seamlessly with the Prometheus monitoring stack and enab
 
 ### Key Features
 
+- **Asynchronous metrics collection** with configurable intervals (default: 30s)
 - **Real-time monitoring** of SLURM nodes, jobs, and controller performance
 - **Prometheus-native metrics** with standardized naming conventions
 - **Rich labeling** for detailed filtering and aggregation
 - **Controller RPC diagnostics** similar to SLURM's `sdiag` command
 - **Kubernetes-native deployment** as part of Soperator
 
+## Configuration
+
+### Command Line Flags
+
+When running the exporter directly, you can configure the collection interval with:
+
+```bash
+./soperator-exporter --collection-interval=30s
+```
 
 ## Exported Metrics
 

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -24474,6 +24474,12 @@ spec:
                     description: |
                       Exporter represents the Slurm exporter node configuration
                     properties:
+                      collectionInterval:
+                        default: 30s
+                        description: CollectionInterval specifies how often to collect
+                          metrics from SLURM APIs
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
                       customInitContainers:
                         description: CustomInitContainers represent additional init
                           containers that should be added to created Pods

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -24474,6 +24474,12 @@ spec:
                     description: |
                       Exporter represents the Slurm exporter node configuration
                     properties:
+                      collectionInterval:
+                        default: 30s
+                        description: CollectionInterval specifies how often to collect
+                          metrics from SLURM APIs
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
                       customInitContainers:
                         description: CustomInitContainers represent additional init
                           containers that should be added to created Pods

--- a/internal/exporter/collector.go
+++ b/internal/exporter/collector.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"iter"
 	"strconv"
-	"sync"
+	"sync/atomic"
 	"time"
 
+	api "github.com/SlinkyProject/slurm-client/api/v0041"
 	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -31,14 +32,13 @@ type MetricsCollector struct {
 	rpcUserDurationSecondsTotal *prometheus.Desc
 	controllerServerThreadCount *prometheus.Desc
 
-	lastNodeGPUTimeUpdated time.Time
-	nodes                  map[string]slurmapi.Node
-	stateMutex             sync.RWMutex
+	// Atomic pointer to the current state for lock-free reads
+	state atomic.Pointer[metricsCollectorState]
 }
 
 // NewMetricsCollector creates a new MetricsCollector
 func NewMetricsCollector(slurmAPIClient slurmapi.Client) *MetricsCollector {
-	return &MetricsCollector{
+	collector := &MetricsCollector{
 		slurmAPIClient: slurmAPIClient,
 
 		nodeInfo:    prometheus.NewDesc("slurm_node_info", "Slurm node info", []string{"node_name", "instance_id", "state_base", "state_is_drain", "state_is_maintenance", "state_is_reserved", "address"}, nil),
@@ -59,10 +59,11 @@ func NewMetricsCollector(slurmAPIClient slurmapi.Client) *MetricsCollector {
 		rpcUserCallsTotal:           prometheus.NewDesc("slurm_controller_rpc_user_calls_total", "Total count of RPC calls by user", []string{"user", "user_id"}, nil),
 		rpcUserDurationSecondsTotal: prometheus.NewDesc("slurm_controller_rpc_user_duration_seconds_total", "Total time spent on user RPCs", []string{"user", "user_id"}, nil),
 		controllerServerThreadCount: prometheus.NewDesc("slurm_controller_server_thread_count", "Number of server threads", nil, nil),
-
-		lastNodeGPUTimeUpdated: time.Now(),
-		nodes:                  make(map[string]slurmapi.Node),
 	}
+
+	collector.state.Store(newMetricsCollectorState())
+
+	return collector
 }
 
 // Describe implements the prometheus.Collector interface
@@ -81,25 +82,42 @@ func (c *MetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.controllerServerThreadCount
 }
 
-// Collect implements the prometheus.Collector interface
-func (c *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
-	c.stateMutex.Lock()
-	defer c.stateMutex.Unlock()
-
-	ctx := context.Background()
-	now := time.Now()
+// updateState fetches data from SLURM APIs and atomically updates the collector state
+func (c *MetricsCollector) updateState(ctx context.Context) error {
 	logger := log.FromContext(ctx).WithName(ControllerName)
+	now := time.Now()
+
+	previousState := c.state.Load()
+	if previousState == nil {
+		previousState = newMetricsCollectorState()
+	}
+
+	newState := &metricsCollectorState{
+		lastGPUSecondsUpdate: previousState.lastGPUSecondsUpdate,
+	}
+
+	// Always update state with whatever data we successfully collect (even if partial)
+	defer func() {
+		c.state.Store(newState)
+	}()
+
 	nodes, err := c.slurmAPIClient.ListNodes(ctx)
 	if err != nil {
 		logger.Error(err, "Failed to get nodes from SLURM API")
-		return
+		return err
 	}
-	for slurmNodeMetric := range c.slurmNodeMetrics(ctx, now, nodes) {
-		ch <- slurmNodeMetric
+	newState.nodes = nodes
+
+	// Create temporary map for node failure detection
+	previousNodesMap := make(map[string]slurmapi.Node, len(previousState.nodes))
+	for _, node := range previousState.nodes {
+		previousNodesMap[node.Name] = node
 	}
 
+	// Process nodes: detect failures and update GPU seconds
 	for _, node := range nodes {
-		if existingNode, exists := c.nodes[node.Name]; exists {
+		// Check for node failures by comparing with previous state
+		if existingNode, exists := previousNodesMap[node.Name]; exists {
 			wasFailed := existingNode.IsDownState() || existingNode.IsDrainState()
 			isFailed := node.IsDownState() || node.IsDrainState()
 			if !wasFailed && isFailed {
@@ -117,34 +135,77 @@ func (c *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
 				).Inc()
 			}
 		}
-		c.nodes[node.Name] = node
+
+		// Update GPU seconds
+		tres, err := slurmapi.ParseTrackableResources(node.Tres)
+		if err != nil {
+			logger.Error(err, "Failed to parse trackable resources", "tres", node.Tres)
+		} else {
+			gpuSecondsInc := now.Sub(previousState.lastGPUSecondsUpdate).Seconds() * float64(tres.GPUCount)
+			c.nodeGPUSeconds.WithLabelValues(
+				node.Name,
+				string(node.BaseState()),
+				strconv.FormatBool(node.IsDrainState()),
+				strconv.FormatBool(node.IsMaintenanceState()),
+				strconv.FormatBool(node.IsReservedState()),
+			).Add(gpuSecondsInc)
+		}
+	}
+
+	// CRITICAL: Update lastGPUSecondsUpdate AFTER successfully calculating and adding GPU seconds increments.
+	// This timestamp is used to calculate the time delta for the next collection cycle's GPU seconds.
+	// It must only be updated after the GPU seconds metrics have been successfully updated to ensure
+	// accurate accounting of GPU utilization over time.
+	newState.lastGPUSecondsUpdate = now
+
+	jobs, err := c.slurmAPIClient.ListJobs(ctx)
+	if err != nil {
+		logger.Error(err, "Failed to get jobs from SLURM API")
+		return err
+	}
+	newState.jobs = jobs
+
+	diag, err := c.slurmAPIClient.GetDiag(ctx)
+	if err != nil {
+		logger.Error(err, "Failed to get diagnostics from SLURM API")
+		// Continue without diagnostics - other metrics should still work
+		newState.diag = nil
+	} else {
+		newState.diag = diag
+	}
+
+	logger.Info("Collected metrics", "elapsed_seconds", time.Since(now).Seconds())
+
+	return nil
+}
+
+// Collect implements the prometheus.Collector interface
+func (c *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	state := c.state.Load()
+	if state == nil {
+		return
+	}
+
+	for slurmNodeMetric := range c.slurmNodeMetrics(state.nodes) {
+		ch <- slurmNodeMetric
 	}
 
 	c.nodeGPUSeconds.Collect(ch)
 	c.nodeFails.Collect(ch)
 
-	jobs, err := c.slurmAPIClient.ListJobs(ctx)
-	if err != nil {
-		logger.Error(err, "Failed to get jobs from SLURM API")
-		return
-	}
-
-	for slurmJobMetric := range c.slurmJobMetrics(ctx, jobs) {
+	for slurmJobMetric := range c.slurmJobMetrics(ctx, state.jobs) {
 		ch <- slurmJobMetric
 	}
 
-	for rpcMetric := range c.slurmRPCMetrics(ctx) {
+	for rpcMetric := range c.slurmRPCMetrics(ctx, state.diag) {
 		ch <- rpcMetric
 	}
-
-	logger.Info("Collected metrics", "elapsed_seconds", time.Now().Sub(now).Seconds())
 }
 
-func (c *MetricsCollector) slurmNodeMetrics(
-	ctx context.Context, now time.Time, slurmNodes []slurmapi.Node,
-) iter.Seq[prometheus.Metric] {
+func (c *MetricsCollector) slurmNodeMetrics(slurmNodes []slurmapi.Node) iter.Seq[prometheus.Metric] {
 	return func(yield func(prometheus.Metric) bool) {
-		logger := log.FromContext(ctx).WithName(ControllerName)
 		for _, node := range slurmNodes {
 			labels := []string{
 				node.Name,
@@ -156,28 +217,11 @@ func (c *MetricsCollector) slurmNodeMetrics(
 				node.Address,
 			}
 			yield(prometheus.MustNewConstMetric(c.nodeInfo, prometheus.GaugeValue, 1, labels...))
-
-			tres, err := slurmapi.ParseTrackableResources(node.Tres)
-			if err != nil {
-				logger.Error(err, "Failed to parse trackable resources", "tres", node.Tres)
-				continue
-			}
-			gpuSecondsInc := now.Sub(c.lastNodeGPUTimeUpdated).Seconds() * float64(tres.GPUCount)
-			c.nodeGPUSeconds.WithLabelValues(
-				node.Name,
-				string(node.BaseState()),
-				strconv.FormatBool(node.IsDrainState()),
-				strconv.FormatBool(node.IsMaintenanceState()),
-				strconv.FormatBool(node.IsReservedState()),
-			).Add(gpuSecondsInc)
 		}
-		c.lastNodeGPUTimeUpdated = now
 	}
 }
 
-func (c *MetricsCollector) slurmJobMetrics(
-	ctx context.Context, slurmJobs []slurmapi.Job,
-) iter.Seq[prometheus.Metric] {
+func (c *MetricsCollector) slurmJobMetrics(ctx context.Context, slurmJobs []slurmapi.Job) iter.Seq[prometheus.Metric] {
 	return func(yield func(prometheus.Metric) bool) {
 		logger := log.FromContext(ctx).WithName(ControllerName)
 		for _, job := range slurmJobs {
@@ -240,15 +284,9 @@ func (c *MetricsCollector) slurmJobMetrics(
 	}
 }
 
-func (c *MetricsCollector) slurmRPCMetrics(
-	ctx context.Context,
-) iter.Seq[prometheus.Metric] {
+func (c *MetricsCollector) slurmRPCMetrics(_ context.Context, diag *api.V0041OpenapiDiagResp) iter.Seq[prometheus.Metric] {
 	return func(yield func(prometheus.Metric) bool) {
-		logger := log.FromContext(ctx).WithName(ControllerName)
-
-		diag, err := c.slurmAPIClient.GetDiag(ctx)
-		if err != nil {
-			logger.Error(err, "Failed to get diagnostics from SLURM API")
+		if diag == nil {
 			return
 		}
 

--- a/internal/exporter/state.go
+++ b/internal/exporter/state.go
@@ -2,15 +2,24 @@ package exporter
 
 import (
 	"time"
+
+	api "github.com/SlinkyProject/slurm-client/api/v0041"
+
+	"nebius.ai/slurm-operator/internal/slurmapi"
 )
 
+// metricsCollectorState holds the raw data collected from SLURM APIs
 type metricsCollectorState struct {
-	lastUpdateTime time.Time
+	lastGPUSecondsUpdate time.Time
+	nodes                []slurmapi.Node
+	jobs                 []slurmapi.Job
+	diag                 *api.V0041OpenapiDiagResp
 }
 
 // newMetricsCollectorState initializes a new metrics collector state
-func newMetricsCollectorState() metricsCollectorState {
-	return metricsCollectorState{
-		lastUpdateTime: time.Now(),
+func newMetricsCollectorState() *metricsCollectorState {
+	return &metricsCollectorState{
+		lastGPUSecondsUpdate: time.Now(),
+		nodes:                nil,
 	}
 }

--- a/internal/render/exporter/container.go
+++ b/internal/render/exporter/container.go
@@ -20,6 +20,7 @@ func renderContainerExporter(clusterValues *values.SlurmCluster) corev1.Containe
 			fmt.Sprintf("--cluster-namespace=%s", clusterValues.Namespace),
 			fmt.Sprintf("--cluster-name=%s", clusterValues.Name),
 			fmt.Sprintf("--slurm-api-server=%s", rest.GetServiceURL(clusterValues.Namespace, &clusterValues.NodeRest)),
+			fmt.Sprintf("--collection-interval=%s", clusterValues.SlurmExporter.CollectionInterval),
 		},
 		ImagePullPolicy: clusterValues.SlurmExporter.Container.ImagePullPolicy,
 		Ports: []corev1.ContainerPort{

--- a/internal/render/exporter/container_test.go
+++ b/internal/render/exporter/container_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 
+	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/values"
@@ -33,6 +34,7 @@ func TestRenderContainerExporter(t *testing.T) {
 				Image:     imageExporter,
 				Resources: resourceExporter,
 			},
+			CollectionInterval: prometheusv1.Duration("30s"),
 		},
 		NodeRest: values.SlurmREST{
 			Service: values.Service{Name: "rest-service"},
@@ -57,6 +59,7 @@ func TestRenderContainerExporter(t *testing.T) {
 			"--cluster-namespace=soperator-ns",
 			"--cluster-name=test-cluster",
 			"--slurm-api-server=http://rest-service.soperator-ns.svc:6817",
+			"--collection-interval=30s",
 		},
 	}
 

--- a/internal/values/slurm_exporter.go
+++ b/internal/values/slurm_exporter.go
@@ -1,6 +1,7 @@
 package values
 
 import (
+	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
@@ -34,6 +35,9 @@ type SlurmExporter struct {
 
 	// Container represents the main container for the Soperator Exporter.
 	Container slurmv1.NodeContainer
+
+	// CollectionInterval specifies how often to collect metrics from SLURM APIs
+	CollectionInterval prometheusv1.Duration
 }
 
 func buildSlurmExporterFrom(maintenance *consts.MaintenanceMode, exporter *slurmv1.SlurmExporter) SlurmExporter {
@@ -50,7 +54,8 @@ func buildSlurmExporterFrom(maintenance *consts.MaintenanceMode, exporter *slurm
 		VolumeJail: slurmv1.NodeVolume{
 			VolumeSourceName: ptr.To(consts.VolumeNameJail),
 		},
-		Maintenance: maintenance,
-		Container:   *exporter.ExporterContainer.DeepCopy(),
+		Maintenance:        maintenance,
+		Container:          *exporter.ExporterContainer.DeepCopy(),
+		CollectionInterval: exporter.CollectionInterval,
 	}
 }


### PR DESCRIPTION
## Summary

Implements asynchronous metrics collection for the SLURM exporter to resolve scrape timeout issues when multiple Prometheus consumers access the /metrics endpoint simultaneously.

## Changes

- Added background goroutine that collects metrics every 30 seconds (configurable via `collectionInterval`)
- Implemented atomic state management using `atomic.Pointer` for lock-free reads during scraping
- Added `CollectionInterval` field to `SlurmExporter` CRD with proper validation
- Updated `/metrics` endpoint to serve pre-collected data instead of real-time API calls

This prevents mutex contention between multiple scrapers and ensures consistent response times regardless of the number of concurrent requests.

## Tests

- [x] Unit tests work (after rewriting them too)
- [x] Tested on a production cluster, exporter works and returns legitimate metrics

Fixes #1369