### PR TITLE
add scrape node conditions and pod termination reasons metrics from ksm 

### DIFF
--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -95,6 +95,7 @@ spec:
           enabled: true
         collectors:
           - pods
+          - nodes
         vmServiceScrape:
           spec:
             endpoints:


### PR DESCRIPTION

This PR adds monitoring capabilities for Kubernetes cluster health by enabling additional metrics from kube-state-metrics (KSM). The changes focus on collecting pod termination reasons and node condition metrics to improve observability of cluster issues.

Adds metrics for pod container termination reasons and signals
Adds metrics for node status conditions and information