### PR TITLE
Add self-monitoring metrics on separate port 8081

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -40,6 +40,7 @@ type Flags struct {
 	logFormat          string
 	logLevel           string
 	metricsAddr        string
+	monitoringAddr     string
 	slurmAPIServer     string
 	clusterNamespace   string
 	clusterName        string
@@ -84,6 +85,7 @@ func parseFlags() Flags {
 	flag.StringVar(&flags.logFormat, "log-format", "json", "Log format: plain or json")
 	flag.StringVar(&flags.logLevel, "log-level", "debug", "Log level: debug, info, warn, error, dpanic, panic, fatal")
 	flag.StringVar(&flags.metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&flags.monitoringAddr, "monitoring-bind-address", ":8081", "The address the monitoring endpoint binds to.")
 	flag.StringVar(&flags.slurmAPIServer, "slurm-api-server", "http://localhost:6820", "The address of the Slurm REST API server.")
 	flag.StringVar(&flags.clusterNamespace, "cluster-namespace", "soperator", "The namespace of the Slurm cluster")
 	flag.StringVar(&flags.clusterName, "cluster-name", "", "The name of the Slurm cluster (required)")
@@ -149,6 +151,11 @@ func main() {
 
 	if err := clusterExporter.Start(ctx, flags.metricsAddr); err != nil {
 		log.Error(err, "Failed to start metrics exporter")
+		os.Exit(1)
+	}
+
+	if err := clusterExporter.StartMonitoring(ctx, flags.monitoringAddr); err != nil {
+		log.Error(err, "Failed to start monitoring server")
 		os.Exit(1)
 	}
 

--- a/docs/slurm-exporter.md
+++ b/docs/slurm-exporter.md
@@ -19,11 +19,18 @@ The exporter integrates seamlessly with the Prometheus monitoring stack and enab
 
 ### Command Line Flags
 
-When running the exporter directly, you can configure the collection interval with:
+When running the exporter directly, you can configure various settings:
 
 ```bash
-./soperator-exporter --collection-interval=30s
+./soperator-exporter \
+  --collection-interval=30s \
+  --metrics-bind-address=:8080 \
+  --monitoring-bind-address=:8081
 ```
+
+- `--collection-interval`: How often to collect metrics from SLURM APIs (default: 30s)
+- `--metrics-bind-address`: Address for the main metrics endpoint (default: :8080)
+- `--monitoring-bind-address`: Address for the self-monitoring metrics endpoint (default: :8081)
 
 ## Exported Metrics
 
@@ -209,6 +216,69 @@ slurm_controller_rpc_user_duration_seconds_total{user="researcher",user_id="1000
 **Example:**
 ```prometheus
 slurm_controller_server_thread_count 1
+```
+
+### Self-Monitoring Metrics (Port 8081)
+
+The exporter provides self-monitoring metrics to track its own health and performance.
+These metrics are available on a separate endpoint (default port 8081) to avoid mixing operational metrics with business metrics.
+
+#### Gauge `slurm_exporter_collection_duration_seconds`
+
+**Description:** Duration of the most recent metrics collection from SLURM APIs
+
+**Example:**
+```prometheus
+slurm_exporter_collection_duration_seconds 0.34
+```
+
+#### Counter `slurm_exporter_collection_attempts_total`
+
+**Description:** Total number of metrics collection attempts
+
+**Example:**
+```prometheus
+slurm_exporter_collection_attempts_total 150
+```
+
+#### Counter `slurm_exporter_collection_failures_total`
+
+**Description:** Total number of failed metrics collection attempts
+
+**Example:**
+```prometheus
+slurm_exporter_collection_failures_total 3
+```
+
+#### Counter `slurm_exporter_metrics_requests_total`
+
+**Description:** Total number of requests to the `/metrics` endpoint
+
+**Example:**
+```prometheus
+slurm_exporter_metrics_requests_total 245
+```
+
+#### Gauge `slurm_exporter_metrics_exported`
+
+**Description:** Number of metrics exported in the last scrape
+
+**Example:**
+```prometheus
+slurm_exporter_metrics_exported 127
+```
+
+### Accessing Self-Monitoring Metrics
+
+To access self-monitoring metrics:
+
+```bash
+# Default monitoring port
+curl http://localhost:8081/metrics
+
+# Or with custom monitoring address
+./soperator-exporter --monitoring-bind-address=:9090
+curl http://localhost:9090/metrics
 ```
 
 ## Grafana Dashboard Example

--- a/internal/consts/container.go
+++ b/internal/consts/container.go
@@ -22,4 +22,9 @@ const (
 	ContainerPortExporter     = 8080
 	ContainerPathExporter     = "/metrics"
 	ContainerSchemeExporter   = "http"
+
+	ContainerPortNameMonitoring = "monitoring"
+	ContainerPortMonitoring     = 8081
+	ContainerPathMonitoring     = "/metrics"
+	ContainerSchemeMonitoring   = "http"
 )

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -42,19 +42,28 @@ type Exporter struct {
 	httpServer *http.Server
 	// stopCh is used to signal the exporter to stop
 	stopCh chan struct{}
+	// monitoringRegistry is the Prometheus registry for self-monitoring metrics
+	monitoringRegistry *prometheus.Registry
+	// monitoringMetrics contains self-monitoring metrics
+	monitoringMetrics *MonitoringMetrics
+	// monitoringServer is the HTTP server for the monitoring endpoint
+	monitoringServer *http.Server
 }
 
 // NewClusterExporter creates a new SLURM cluster exporter
 func NewClusterExporter(slurmAPIClient slurmapi.Client, params Params) *Exporter {
 	registry := prometheus.NewRegistry()
+	monitoringRegistry := prometheus.NewRegistry()
 	collector := NewMetricsCollector(slurmAPIClient)
 
 	return &Exporter{
-		params:         params,
-		slurmAPIClient: slurmAPIClient,
-		registry:       registry,
-		collector:      collector,
-		stopCh:         make(chan struct{}),
+		params:             params,
+		slurmAPIClient:     slurmAPIClient,
+		registry:           registry,
+		collector:          collector,
+		stopCh:             make(chan struct{}),
+		monitoringRegistry: monitoringRegistry,
+		monitoringMetrics:  collector.Monitoring,
 	}
 }
 
@@ -62,15 +71,12 @@ func NewClusterExporter(slurmAPIClient slurmapi.Client, params Params) *Exporter
 func (e *Exporter) Start(ctx context.Context, addr string) error {
 	logger := log.FromContext(ctx).WithName(ControllerName)
 
-	//if err := prometheus.Register(e.collector); err != nil {
-	//	return fmt.Errorf("failed to register metrics: %w", err)
-	//}
 	if err := e.registry.Register(e.collector); err != nil {
 		return fmt.Errorf("failed to register metrics: %w", err)
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.HandlerFor(e.registry, promhttp.HandlerOpts{}))
+	mux.Handle("/metrics", e.instrumentedMetricsHandler())
 	mux.HandleFunc("/health", e.healthHandler)
 
 	e.httpServer = &http.Server{
@@ -128,16 +134,57 @@ func (e *Exporter) Stop(ctx context.Context) error {
 	shutdownCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
+	var errs []error
+
 	if err := e.httpServer.Shutdown(shutdownCtx); err != nil {
-		return fmt.Errorf("failed to shutdown HTTP server: %w", err)
+		errs = append(errs, fmt.Errorf("failed to shutdown HTTP server: %w", err))
 	}
 
-	logger.Info("Metrics exporter stopped")
-	return nil
+	if e.monitoringServer != nil {
+		if err := e.monitoringServer.Shutdown(shutdownCtx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to shutdown monitoring server: %w", err))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // healthHandler handles health check requests
 func (e *Exporter) healthHandler(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("healthy"))
+}
+
+// instrumentedMetricsHandler wraps the metrics handler to track requests
+func (e *Exporter) instrumentedMetricsHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		e.monitoringMetrics.RecordMetricsRequest()
+		promhttp.HandlerFor(e.registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+	})
+}
+
+// StartMonitoring starts the monitoring server on a separate port
+func (e *Exporter) StartMonitoring(ctx context.Context, addr string) error {
+	logger := log.FromContext(ctx).WithName(ControllerName)
+
+	if err := e.monitoringMetrics.Register(e.monitoringRegistry); err != nil {
+		return fmt.Errorf("failed to register monitoring metrics: %w", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(e.monitoringRegistry, promhttp.HandlerOpts{}))
+
+	e.monitoringServer = &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	go func() {
+		logger.Info("Starting monitoring server", "addr", addr)
+		if err := e.monitoringServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error(err, "Failed to start monitoring server")
+		}
+	}()
+
+	return nil
 }

--- a/internal/exporter/monitoring.go
+++ b/internal/exporter/monitoring.go
@@ -1,0 +1,78 @@
+package exporter
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MonitoringMetrics contains self-monitoring metrics for the exporter
+type MonitoringMetrics struct {
+	collectionDuration prometheus.Gauge
+	collectionAttempts prometheus.Counter
+	collectionFailures prometheus.Counter
+	metricsRequests    prometheus.Counter
+	metricsExported    prometheus.Gauge
+}
+
+// NewMonitoringMetrics creates a new set of monitoring metrics
+func NewMonitoringMetrics() *MonitoringMetrics {
+	return &MonitoringMetrics{
+		collectionDuration: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "slurm_exporter_collection_duration_seconds",
+			Help: "Duration of the most recent metrics collection from SLURM APIs",
+		}),
+		collectionAttempts: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "slurm_exporter_collection_attempts_total",
+			Help: "Total number of metrics collection attempts",
+		}),
+		collectionFailures: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "slurm_exporter_collection_failures_total",
+			Help: "Total number of failed metrics collection attempts",
+		}),
+		metricsRequests: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "slurm_exporter_metrics_requests_total",
+			Help: "Total number of requests to /metrics endpoint",
+		}),
+		metricsExported: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "slurm_exporter_metrics_exported",
+			Help: "Number of metrics exported in the last scrape",
+		}),
+	}
+}
+
+// Register registers all monitoring metrics with the given registry
+func (m *MonitoringMetrics) Register(registry *prometheus.Registry) error {
+	collectors := []prometheus.Collector{
+		m.collectionDuration,
+		m.collectionAttempts,
+		m.collectionFailures,
+		m.metricsRequests,
+		m.metricsExported,
+	}
+
+	for _, collector := range collectors {
+		if err := registry.Register(collector); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RecordCollection records a collection attempt with its duration and success/failure
+func (m *MonitoringMetrics) RecordCollection(duration float64, err error) {
+	m.collectionAttempts.Inc()
+	m.collectionDuration.Set(duration)
+	if err != nil {
+		m.collectionFailures.Inc()
+	}
+}
+
+// RecordMetricsRequest increments the metrics request counter
+func (m *MonitoringMetrics) RecordMetricsRequest() {
+	m.metricsRequests.Inc()
+}
+
+// RecordMetricsExported updates the number of exported metrics
+func (m *MonitoringMetrics) RecordMetricsExported(count float64) {
+	m.metricsExported.Set(count)
+}

--- a/internal/exporter/monitoring_test.go
+++ b/internal/exporter/monitoring_test.go
@@ -1,0 +1,138 @@
+package exporter
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonitoringMetrics_Register(t *testing.T) {
+	metrics := NewMonitoringMetrics()
+	registry := prometheus.NewRegistry()
+
+	err := metrics.Register(registry)
+	assert.NoError(t, err)
+
+	// Verify all metrics are registered
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	expectedMetrics := map[string]bool{
+		"slurm_exporter_collection_duration_seconds": false,
+		"slurm_exporter_collection_attempts_total":   false,
+		"slurm_exporter_collection_failures_total":   false,
+		"slurm_exporter_metrics_requests_total":      false,
+		"slurm_exporter_metrics_exported":            false,
+	}
+
+	for _, mf := range metricFamilies {
+		if _, ok := expectedMetrics[*mf.Name]; ok {
+			expectedMetrics[*mf.Name] = true
+		}
+	}
+
+	for metric, found := range expectedMetrics {
+		assert.True(t, found, "Expected metric %s not found", metric)
+	}
+}
+
+func TestMonitoringMetrics_RecordCollection(t *testing.T) {
+	metrics := NewMonitoringMetrics()
+	registry := prometheus.NewRegistry()
+	require.NoError(t, metrics.Register(registry))
+
+	// Test successful collection
+	metrics.RecordCollection(1.5, nil)
+
+	// Test failed collection
+	metrics.RecordCollection(0.5, errors.New("collection failed"))
+
+	// Gather metrics
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	var attemptsTotal, failuresTotal, durationValue float64
+
+	for _, mf := range metricFamilies {
+		switch *mf.Name {
+		case "slurm_exporter_collection_attempts_total":
+			attemptsTotal = *mf.Metric[0].Counter.Value
+		case "slurm_exporter_collection_failures_total":
+			failuresTotal = *mf.Metric[0].Counter.Value
+		case "slurm_exporter_collection_duration_seconds":
+			durationValue = *mf.Metric[0].Gauge.Value
+		}
+	}
+
+	assert.Equal(t, float64(2), attemptsTotal, "Expected 2 collection attempts")
+	assert.Equal(t, float64(1), failuresTotal, "Expected 1 collection failure")
+	assert.Equal(t, float64(0.5), durationValue, "Expected duration to be set to the last collection (0.5s)")
+}
+
+func TestMonitoringMetrics_RecordMetricsRequest(t *testing.T) {
+	metrics := NewMonitoringMetrics()
+	registry := prometheus.NewRegistry()
+	require.NoError(t, metrics.Register(registry))
+
+	// Record multiple requests
+	metrics.RecordMetricsRequest()
+	metrics.RecordMetricsRequest()
+	metrics.RecordMetricsRequest()
+
+	// Gather metrics
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	var requestsTotal float64
+	for _, mf := range metricFamilies {
+		if *mf.Name == "slurm_exporter_metrics_requests_total" {
+			requestsTotal = *mf.Metric[0].Counter.Value
+			break
+		}
+	}
+
+	assert.Equal(t, float64(3), requestsTotal, "Expected 3 metrics requests")
+}
+
+func TestMonitoringMetrics_RecordMetricsExported(t *testing.T) {
+	metrics := NewMonitoringMetrics()
+	registry := prometheus.NewRegistry()
+	require.NoError(t, metrics.Register(registry))
+
+	// Record exported metrics count
+	metrics.RecordMetricsExported(150)
+	metrics.RecordMetricsExported(200) // Should override previous value
+
+	// Gather metrics
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	var exportedCount float64
+	for _, mf := range metricFamilies {
+		if *mf.Name == "slurm_exporter_metrics_exported" {
+			exportedCount = *mf.Metric[0].Gauge.Value
+			break
+		}
+	}
+
+	assert.Equal(t, float64(200), exportedCount, "Expected 200 exported metrics")
+}
+
+func getMetricValue(families []*dto.MetricFamily, name string, metricType string) float64 {
+	for _, mf := range families {
+		if *mf.Name == name && len(mf.Metric) > 0 {
+			metric := mf.Metric[0]
+			switch metricType {
+			case "counter":
+				return *metric.Counter.Value
+			case "gauge":
+				return *metric.Gauge.Value
+			}
+		}
+	}
+	return 0
+}

--- a/internal/render/exporter/container.go
+++ b/internal/render/exporter/container.go
@@ -28,6 +28,10 @@ func renderContainerExporter(clusterValues *values.SlurmCluster) corev1.Containe
 				Name:          consts.ContainerPortNameExporter,
 				ContainerPort: consts.ContainerPortExporter,
 			},
+			{
+				Name:          consts.ContainerPortNameMonitoring,
+				ContainerPort: consts.ContainerPortMonitoring,
+			},
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: clusterValues.SlurmExporter.Container.Resources,

--- a/internal/render/exporter/pod_monitor.go
+++ b/internal/render/exporter/pod_monitor.go
@@ -42,6 +42,15 @@ func RenderPodMonitor(
 					MetricRelabelConfigs: metricRelabelConfigs,
 					RelabelConfigs:       pmConfig.RelabelConfig,
 				},
+				{
+					Interval:             pmConfig.Interval,
+					ScrapeTimeout:        pmConfig.ScrapeTimeout,
+					Path:                 consts.ContainerPathMonitoring,
+					Port:                 ptr.To(consts.ContainerPortNameMonitoring),
+					Scheme:               consts.ContainerSchemeMonitoring,
+					MetricRelabelConfigs: metricRelabelConfigs,
+					RelabelConfigs:       pmConfig.RelabelConfig,
+				},
 			},
 		},
 	}

--- a/internal/render/exporter/pod_monitor_test.go
+++ b/internal/render/exporter/pod_monitor_test.go
@@ -50,6 +50,13 @@ func Test_RenderPodMonitor(t *testing.T) {
 					Port:          ptr.To(consts.ContainerPortNameExporter),
 					Scheme:        consts.ContainerSchemeExporter,
 				},
+				{
+					Interval:      prometheusv1.Duration(interval),
+					ScrapeTimeout: prometheusv1.Duration(scrapeTimeout),
+					Path:          consts.ContainerPathMonitoring,
+					Port:          ptr.To(consts.ContainerPortNameMonitoring),
+					Scheme:        consts.ContainerSchemeMonitoring,
+				},
 			},
 		},
 	}
@@ -59,16 +66,31 @@ func Test_RenderPodMonitor(t *testing.T) {
 	assert.Equal(t, expected.Namespace, result.Namespace)
 	assert.Equal(t, expected.Spec.Selector, result.Spec.Selector)
 	assert.Equal(t, expected.Spec.JobLabel, result.Spec.JobLabel)
+	// Verify we have both endpoints
+	assert.Len(t, result.Spec.PodMetricsEndpoints, 2)
+
+	// Check exporter endpoint (first)
 	assert.Equal(t, expected.Spec.PodMetricsEndpoints[0].Interval, result.Spec.PodMetricsEndpoints[0].Interval)
 	assert.Equal(t, expected.Spec.PodMetricsEndpoints[0].ScrapeTimeout, result.Spec.PodMetricsEndpoints[0].ScrapeTimeout)
 	assert.Equal(t, expected.Spec.PodMetricsEndpoints[0].Path, result.Spec.PodMetricsEndpoints[0].Path)
 	assert.Equal(t, expected.Spec.PodMetricsEndpoints[0].Port, result.Spec.PodMetricsEndpoints[0].Port)
 	assert.Equal(t, expected.Spec.PodMetricsEndpoints[0].Scheme, result.Spec.PodMetricsEndpoints[0].Scheme)
 
-	// Verify default MetricRelabelConfigs are added
+	// Check monitoring endpoint (second)
+	assert.Equal(t, expected.Spec.PodMetricsEndpoints[1].Interval, result.Spec.PodMetricsEndpoints[1].Interval)
+	assert.Equal(t, expected.Spec.PodMetricsEndpoints[1].ScrapeTimeout, result.Spec.PodMetricsEndpoints[1].ScrapeTimeout)
+	assert.Equal(t, expected.Spec.PodMetricsEndpoints[1].Path, result.Spec.PodMetricsEndpoints[1].Path)
+	assert.Equal(t, expected.Spec.PodMetricsEndpoints[1].Port, result.Spec.PodMetricsEndpoints[1].Port)
+	assert.Equal(t, expected.Spec.PodMetricsEndpoints[1].Scheme, result.Spec.PodMetricsEndpoints[1].Scheme)
+
+	// Verify default MetricRelabelConfigs are added to both endpoints
 	assert.Len(t, result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs, 1)
 	assert.Equal(t, "labeldrop", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[0].Action)
 	assert.Equal(t, "pod|instance|container", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[0].Regex)
+
+	assert.Len(t, result.Spec.PodMetricsEndpoints[1].MetricRelabelConfigs, 1)
+	assert.Equal(t, "labeldrop", result.Spec.PodMetricsEndpoints[1].MetricRelabelConfigs[0].Action)
+	assert.Equal(t, "pod|instance|container", result.Spec.PodMetricsEndpoints[1].MetricRelabelConfigs[0].Regex)
 }
 
 func Test_RenderPodMonitor_WithUserMetricRelabelConfigs(t *testing.T) {
@@ -97,14 +119,21 @@ func Test_RenderPodMonitor_WithUserMetricRelabelConfigs(t *testing.T) {
 
 	result := exporter.RenderPodMonitor(defaultNameCluster, defaultNamespace, slurmExporter)
 
-	// Verify defaults are added first, then user configs
+	// Verify defaults are added first, then user configs on both endpoints
 	assert.Len(t, result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs, 2)
+	assert.Len(t, result.Spec.PodMetricsEndpoints[1].MetricRelabelConfigs, 2)
 
-	// Check default config (should come first)
+	// Check default config (should come first) for exporter endpoint
 	assert.Equal(t, "labeldrop", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[0].Action)
 	assert.Equal(t, "pod|instance|container", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[0].Regex)
 
-	// Check user config (should come last)
+	// Check user config (should come last) for exporter endpoint
 	assert.Equal(t, "replace", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[1].Action)
 	assert.Equal(t, "custom-regex", result.Spec.PodMetricsEndpoints[0].MetricRelabelConfigs[1].Regex)
+
+	// Check same configs are applied to monitoring endpoint
+	assert.Equal(t, "labeldrop", result.Spec.PodMetricsEndpoints[1].MetricRelabelConfigs[0].Action)
+	assert.Equal(t, "pod|instance|container", result.Spec.PodMetricsEndpoints[1].MetricRelabelConfigs[0].Regex)
+	assert.Equal(t, "replace", result.Spec.PodMetricsEndpoints[1].MetricRelabelConfigs[1].Action)
+	assert.Equal(t, "custom-regex", result.Spec.PodMetricsEndpoints[1].MetricRelabelConfigs[1].Regex)
 }


### PR DESCRIPTION
Add self-monitoring capabilities:

- New monitoring server on port 8081 with 5 Prometheus metrics (`slurm_exporter_` prefix)
- Collection performance tracking: duration, attempts, failures, request counts  
- Separate HTTP endpoint to isolate operational metrics from business metrics
- Single PodMonitor with dual endpoints for efficient Kubernetes resource usage
- Added `--monitoring-bind-address` flag and comprehensive documentation

This enables monitoring of the exporter's own health and performance separate from SLURM business metrics.