### PR TITLE
del readeness probe from worker

### DIFF
--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -98,21 +98,6 @@ func renderContainerSlurmd(
 			Protocol:      corev1.ProtocolTCP,
 		}},
 		VolumeMounts: volumeMounts,
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{
-						"scontrol",
-						"show",
-						"slurmd",
-					},
-				},
-			},
-			PeriodSeconds:    1,
-			TimeoutSeconds:   common.DefaultProbeTimeoutSeconds,
-			SuccessThreshold: common.DefaultProbeSuccessThreshold,
-			FailureThreshold: common.DefaultProbeFailureThreshold,
-		},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: ptr.To(true),
 			Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
We don’t do anything and have no automation in place for when this probe fails. But we’re getting a lot of spam in the events. That’s why the useless probe is being removed.
