### PR TITLE
[slurmcluster] maxUnavalaible for workes and support pre install images

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"nebius.ai/slurm-operator/internal/consts"
 
@@ -793,6 +794,16 @@ type SlurmNodeControllerVolumes struct {
 // SlurmNodeWorker defines the configuration for the Slurm worker node
 type SlurmNodeWorker struct {
 	SlurmNode `json:",inline"`
+
+	// The maximum number of worker pods that can be unavailable during the update.
+	// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+	// Absolute number is calculated from percentage by rounding down.
+	// Also, maxUnavailable can just be allowed to work with Parallel podManagementPolicy.
+	// Defaults to 20%.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="20%"
+	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 
 	// Slurmd represents the Slurm daemon service configuration
 	//

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"nebius.ai/slurm-operator/internal/consts"
 )
 
@@ -1007,6 +1008,11 @@ func (in *SlurmNodeLoginVolumes) DeepCopy() *SlurmNodeLoginVolumes {
 func (in *SlurmNodeWorker) DeepCopyInto(out *SlurmNodeWorker) {
 	*out = *in
 	in.SlurmNode.DeepCopyInto(&out.SlurmNode)
+	if in.MaxUnavailable != nil {
+		in, out := &in.MaxUnavailable, &out.MaxUnavailable
+		*out = new(intstr.IntOrString)
+		**out = **in
+	}
 	in.Slurmd.DeepCopyInto(&out.Slurmd)
 	in.Munge.DeepCopyInto(&out.Munge)
 	if in.WorkerAnnotations != nil {

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -14953,6 +14953,18 @@ spec:
                           K8sNodeFilterName defines the Kubernetes node filter name associated with the Slurm node.
                           Must correspond to the name of one of [K8sNodeFilter]
                         type: string
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 20%
+                        description: |-
+                          The maximum number of worker pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          Also, maxUnavailable can just be allowed to work with Parallel podManagementPolicy.
+                          Defaults to 20%.
+                        x-kubernetes-int-or-string: true
                       munge:
                         description: Munge represents the Slurm munge configuration
                         properties:

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -31815,6 +31815,18 @@ spec:
                           K8sNodeFilterName defines the Kubernetes node filter name associated with the Slurm node.
                           Must correspond to the name of one of [K8sNodeFilter]
                         type: string
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 20%
+                        description: |-
+                          The maximum number of worker pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          Also, maxUnavailable can just be allowed to work with Parallel podManagementPolicy.
+                          Defaults to 20%.
+                        x-kubernetes-int-or-string: true
                       munge:
                         description: Munge represents the Slurm munge configuration
                         properties:

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -31815,6 +31815,18 @@ spec:
                           K8sNodeFilterName defines the Kubernetes node filter name associated with the Slurm node.
                           Must correspond to the name of one of [K8sNodeFilter]
                         type: string
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 20%
+                        description: |-
+                          The maximum number of worker pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          Also, maxUnavailable can just be allowed to work with Parallel podManagementPolicy.
+                          Defaults to 20%.
+                        x-kubernetes-int-or-string: true
                       munge:
                         description: Munge represents the Slurm munge configuration
                         properties:

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"maps"
 
+	appspub "github.com/openkruise/kruise-api/apps/pub"
 	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,6 +78,11 @@ func RenderStatefulSet(
 	}
 
 	spec := corev1.PodSpec{
+		ReadinessGates: []corev1.PodReadinessGate{
+			{
+				ConditionType: appspub.InPlaceUpdateReady,
+			},
+		},
 		PriorityClassName:  worker.PriorityClass,
 		ServiceAccountName: naming.BuildServiceAccountWorkerName(clusterName),
 		Affinity:           nodeFilter.Affinity,
@@ -117,7 +124,7 @@ func RenderStatefulSet(
 				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: &kruisev1b1.RollingUpdateStatefulSetStrategy{
 					MaxUnavailable:  &worker.StatefulSet.MaxUnavailable,
-					PodUpdatePolicy: kruisev1b1.RecreatePodUpdateStrategyType,
+					PodUpdatePolicy: kruisev1b1.InPlaceIfPossiblePodUpdateStrategyType,
 					Partition:       ptr.To(int32(0)),
 					MinReadySeconds: ptr.To(int32(0)),
 				},

--- a/internal/values/slurm_worker.go
+++ b/internal/values/slurm_worker.go
@@ -85,9 +85,10 @@ func buildSlurmWorkerFrom(
 		SupervisordConfigMapName:    supervisordConfigName,
 		WorkerAnnotations:           worker.WorkerAnnotations,
 		Service:                     buildServiceFrom(naming.BuildServiceName(consts.ComponentTypeWorker, clusterName)),
-		StatefulSet: buildStatefulSetFrom(
+		StatefulSet: buildStatefulSetWithMaxUnavailableFrom(
 			naming.BuildStatefulSetName(consts.ComponentTypeWorker),
 			worker.SlurmNode.Size,
+			worker.MaxUnavailable,
 		),
 		VolumeSpool:               *worker.Volumes.Spool.DeepCopy(),
 		VolumeJail:                *worker.Volumes.Jail.DeepCopy(),


### PR DESCRIPTION
Added the ability to specify the maximum number of `maxUnavailable` pods during a rolling upgrade, and, if possible, to preload the image and patch the pod spec with the new image without needing to recreate the pod.



Fixes #1390