### PR TITLE
Add MTTR tracking to SLURM exporter with ConfigMap persistence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	GOEXPERIMENT=synctest go test ./... # TODO: remove "GOEXPERIMENT=synctest" from everywhere after upgrading to Go 1.25.
+	GOEXPERIMENT=synctest go test $(or $(TESTARGS),./...) # TODO: remove "GOEXPERIMENT=synctest" from everywhere after upgrading to Go 1.25.
 
 .PHONY: test-coverage
 test-coverage: manifests generate fmt vet envtest ## Run tests with coverage.

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -218,6 +218,7 @@ func main() {
 
 	clusterExporter := exporter.NewClusterExporter(
 		slurmAPIClient,
+		ctrlClient,
 		exporter.Params{
 			SlurmAPIServer:     flags.slurmAPIServer,
 			SlurmClusterID:     slurmClusterID,

--- a/internal/exporter/persistence.go
+++ b/internal/exporter/persistence.go
@@ -1,0 +1,145 @@
+package exporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"nebius.ai/slurm-operator/internal/slurmapi"
+)
+
+const (
+	// ConfigMapKey is the key used to store node not-usable timestamps in the ConfigMap
+	ConfigMapKey = "node-not-usable"
+)
+
+// LoadNotUsableTimestamps loads node not-usable timestamps from the ConfigMap.
+// This should be called only at exporter startup.
+func LoadNotUsableTimestamps(ctx context.Context, k8sClient client.Client, configMapName types.NamespacedName) (map[string]time.Time, error) {
+	logger := log.FromContext(ctx).WithName(ControllerName).WithValues("configmap", configMapName)
+
+	var configMap corev1.ConfigMap
+	err := k8sClient.Get(ctx, configMapName, &configMap)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("ConfigMap not found, starting with empty state")
+			return make(map[string]time.Time), nil
+		}
+		return nil, fmt.Errorf("failed to get ConfigMap: %w", err)
+	}
+
+	data, exists := configMap.Data[ConfigMapKey]
+	if !exists || data == "" {
+		logger.Info("ConfigMap exists but has no data, starting with empty state")
+		return make(map[string]time.Time), nil
+	}
+
+	var timestamps map[string]string
+	if err := json.Unmarshal([]byte(data), &timestamps); err != nil {
+		logger.Error(err, "Failed to unmarshal ConfigMap data, starting with empty state")
+		return make(map[string]time.Time), nil
+	}
+
+	result := make(map[string]time.Time, len(timestamps))
+	for nodeName, timestampStr := range timestamps {
+		timestamp, err := time.Parse(time.RFC3339, timestampStr)
+		if err != nil {
+			logger.Error(err, "Failed to parse timestamp for node, skipping", "node", nodeName, "timestamp", timestampStr)
+			continue
+		}
+		result[nodeName] = timestamp
+	}
+
+	logger.Info("Loaded node not-usable timestamps", "count", len(result))
+	return result, nil
+}
+
+// SaveNotUsableTimestamps saves node not-usable timestamps to the ConfigMap.
+// This should be called on each collection if timestamps were changed.
+// It includes cleanup logic to remove nodes that no longer exist in the cluster.
+func SaveNotUsableTimestamps(ctx context.Context, k8sClient client.Client, configMapName types.NamespacedName, timestamps map[string]time.Time, currentNodes []slurmapi.Node) error {
+	logger := log.FromContext(ctx).WithName(ControllerName).WithValues("configmap", configMapName)
+
+	// Clean up timestamps for nodes that no longer exist in the cluster
+	cleanedTimestamps := make(map[string]time.Time, len(timestamps))
+	currentNodesMap := make(map[string]struct{}, len(currentNodes))
+	for _, node := range currentNodes {
+		currentNodesMap[node.Name] = struct{}{}
+	}
+
+	cleanedCount := 0
+	for nodeName, timestamp := range timestamps {
+		if _, exists := currentNodesMap[nodeName]; exists {
+			cleanedTimestamps[nodeName] = timestamp
+		} else {
+			logger.Info("Removing timestamp for node that no longer exists", "node", nodeName)
+			cleanedCount++
+		}
+	}
+
+	if cleanedCount > 0 {
+		logger.Info("Cleaned up timestamps for non-existent nodes", "cleaned", cleanedCount)
+	}
+
+	// Convert timestamps to string format for JSON serialization
+	timestampStrs := make(map[string]string, len(cleanedTimestamps))
+	for nodeName, timestamp := range cleanedTimestamps {
+		timestampStrs[nodeName] = timestamp.Format(time.RFC3339)
+	}
+
+	data, err := json.Marshal(timestampStrs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal timestamps: %w", err)
+	}
+
+	// Try to get existing ConfigMap first
+	var existingConfigMap corev1.ConfigMap
+	err = k8sClient.Get(ctx, configMapName, &existingConfigMap)
+
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to get existing ConfigMap: %w", err)
+	}
+
+	// Check if the data has changed to avoid unnecessary updates
+	if err == nil {
+		existingData, exists := existingConfigMap.Data[ConfigMapKey]
+		if exists && existingData == string(data) {
+			// Data hasn't changed, no need to update
+			return nil
+		}
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName.Name,
+			Namespace: configMapName.Namespace,
+		},
+		Data: map[string]string{
+			ConfigMapKey: string(data),
+		},
+	}
+
+	if errors.IsNotFound(err) {
+		// ConfigMap doesn't exist, create it
+		if err := k8sClient.Create(ctx, configMap); err != nil {
+			return fmt.Errorf("failed to create ConfigMap: %w", err)
+		}
+		logger.Info("Created ConfigMap with node not-usable timestamps", "count", len(cleanedTimestamps))
+	} else {
+		// ConfigMap exists, update it
+		if err := k8sClient.Update(ctx, configMap); err != nil {
+			return fmt.Errorf("failed to update ConfigMap: %w", err)
+		}
+		logger.Info("Updated ConfigMap with node not-usable timestamps", "count", len(cleanedTimestamps))
+	}
+
+	return nil
+}

--- a/internal/exporter/persistence_test.go
+++ b/internal/exporter/persistence_test.go
@@ -1,0 +1,312 @@
+package exporter
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"nebius.ai/slurm-operator/internal/slurmapi"
+)
+
+func TestLoadNotUsableTimestamps_NoConfigMap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	configMapName := types.NamespacedName{
+		Name:      "test-exporter-state",
+		Namespace: "test-namespace",
+	}
+
+	timestamps, err := LoadNotUsableTimestamps(context.Background(), fakeClient, configMapName)
+
+	require.NoError(t, err)
+	assert.Empty(t, timestamps)
+}
+
+func TestLoadNotUsableTimestamps_EmptyConfigMap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-exporter-state",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+	configMapName := types.NamespacedName{
+		Name:      "test-exporter-state",
+		Namespace: "test-namespace",
+	}
+
+	timestamps, err := LoadNotUsableTimestamps(context.Background(), fakeClient, configMapName)
+
+	require.NoError(t, err)
+	assert.Empty(t, timestamps)
+}
+
+func TestLoadNotUsableTimestamps_WithData(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	testTime := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	timestampData := map[string]string{
+		"worker-0": testTime.Format(time.RFC3339),
+		"worker-1": testTime.Add(time.Hour).Format(time.RFC3339),
+	}
+	jsonData, err := json.Marshal(timestampData)
+	require.NoError(t, err)
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-exporter-state",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{
+			ConfigMapKey: string(jsonData),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+	configMapName := types.NamespacedName{
+		Name:      "test-exporter-state",
+		Namespace: "test-namespace",
+	}
+
+	timestamps, err := LoadNotUsableTimestamps(context.Background(), fakeClient, configMapName)
+
+	require.NoError(t, err)
+	assert.Len(t, timestamps, 2)
+	assert.Equal(t, testTime, timestamps["worker-0"])
+	assert.Equal(t, testTime.Add(time.Hour), timestamps["worker-1"])
+}
+
+func TestLoadNotUsableTimestamps_InvalidJSON(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-exporter-state",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{
+			ConfigMapKey: "invalid json",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+	configMapName := types.NamespacedName{
+		Name:      "test-exporter-state",
+		Namespace: "test-namespace",
+	}
+
+	timestamps, err := LoadNotUsableTimestamps(context.Background(), fakeClient, configMapName)
+
+	require.NoError(t, err)
+	assert.Empty(t, timestamps) // Should return empty map on parse error
+}
+
+func TestSaveNotUsableTimestamps_CreateNew(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	configMapName := types.NamespacedName{
+		Name:      "test-exporter-state",
+		Namespace: "test-namespace",
+	}
+
+	testTime := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	timestamps := map[string]time.Time{
+		"worker-0": testTime,
+		"worker-1": testTime.Add(time.Hour),
+	}
+
+	// Create some mock nodes for cleanup
+	nodes := []slurmapi.Node{
+		{Name: "worker-0"},
+		{Name: "worker-1"},
+	}
+
+	err := SaveNotUsableTimestamps(context.Background(), fakeClient, configMapName, timestamps, nodes)
+	require.NoError(t, err)
+
+	// Verify ConfigMap was created
+	var configMap corev1.ConfigMap
+	err = fakeClient.Get(context.Background(), configMapName, &configMap)
+	require.NoError(t, err)
+
+	assert.Contains(t, configMap.Data, ConfigMapKey)
+
+	// Verify the data is correct
+	var storedTimestamps map[string]string
+	err = json.Unmarshal([]byte(configMap.Data[ConfigMapKey]), &storedTimestamps)
+	require.NoError(t, err)
+
+	assert.Equal(t, testTime.Format(time.RFC3339), storedTimestamps["worker-0"])
+	assert.Equal(t, testTime.Add(time.Hour).Format(time.RFC3339), storedTimestamps["worker-1"])
+}
+
+func TestSaveNotUsableTimestamps_Update(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	// Create existing ConfigMap with old data
+	oldTime := time.Date(2025, 1, 14, 10, 0, 0, 0, time.UTC)
+	oldTimestampData := map[string]string{
+		"worker-0": oldTime.Format(time.RFC3339),
+	}
+	oldJsonData, err := json.Marshal(oldTimestampData)
+	require.NoError(t, err)
+
+	existingConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-exporter-state",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{
+			ConfigMapKey: string(oldJsonData),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingConfigMap).Build()
+	configMapName := types.NamespacedName{
+		Name:      "test-exporter-state",
+		Namespace: "test-namespace",
+	}
+
+	// Update with new data
+	newTime := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	timestamps := map[string]time.Time{
+		"worker-0": oldTime, // Keep old timestamp
+		"worker-1": newTime, // Add new timestamp
+	}
+
+	// Create nodes for cleanup
+	nodes := []slurmapi.Node{
+		{Name: "worker-0"},
+		{Name: "worker-1"},
+	}
+
+	err = SaveNotUsableTimestamps(context.Background(), fakeClient, configMapName, timestamps, nodes)
+	require.NoError(t, err)
+
+	// Verify ConfigMap was updated
+	var configMap corev1.ConfigMap
+	err = fakeClient.Get(context.Background(), configMapName, &configMap)
+	require.NoError(t, err)
+
+	var storedTimestamps map[string]string
+	err = json.Unmarshal([]byte(configMap.Data[ConfigMapKey]), &storedTimestamps)
+	require.NoError(t, err)
+
+	assert.Len(t, storedTimestamps, 2)
+	assert.Equal(t, oldTime.Format(time.RFC3339), storedTimestamps["worker-0"])
+	assert.Equal(t, newTime.Format(time.RFC3339), storedTimestamps["worker-1"])
+}
+
+func TestSaveNotUsableTimestamps_CleanupNonExistentNodes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	configMapName := types.NamespacedName{
+		Name:      "test-exporter-state",
+		Namespace: "test-namespace",
+	}
+
+	testTime := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	// Timestamps include a node that doesn't exist anymore
+	timestamps := map[string]time.Time{
+		"worker-0":     testTime,
+		"worker-1":     testTime.Add(time.Hour),
+		"old-worker-2": testTime.Add(2 * time.Hour), // This node no longer exists
+	}
+
+	// Current nodes only include worker-0 and worker-1
+	nodes := []slurmapi.Node{
+		{Name: "worker-0"},
+		{Name: "worker-1"},
+	}
+
+	err := SaveNotUsableTimestamps(context.Background(), fakeClient, configMapName, timestamps, nodes)
+	require.NoError(t, err)
+
+	// Verify ConfigMap was created and cleaned up
+	var configMap corev1.ConfigMap
+	err = fakeClient.Get(context.Background(), configMapName, &configMap)
+	require.NoError(t, err)
+
+	var storedTimestamps map[string]string
+	err = json.Unmarshal([]byte(configMap.Data[ConfigMapKey]), &storedTimestamps)
+	require.NoError(t, err)
+
+	// Should only contain worker-0 and worker-1, old-worker-2 should be cleaned up
+	assert.Len(t, storedTimestamps, 2)
+	assert.Equal(t, testTime.Format(time.RFC3339), storedTimestamps["worker-0"])
+	assert.Equal(t, testTime.Add(time.Hour).Format(time.RFC3339), storedTimestamps["worker-1"])
+	assert.NotContains(t, storedTimestamps, "old-worker-2")
+}
+
+func TestSaveNotUsableTimestamps_NoChangeSkipsUpdate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	testTime := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	timestampData := map[string]string{
+		"worker-0": testTime.Format(time.RFC3339),
+		"worker-1": testTime.Add(time.Hour).Format(time.RFC3339),
+	}
+	jsonData, err := json.Marshal(timestampData)
+	require.NoError(t, err)
+
+	existingConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-exporter-state",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{
+			ConfigMapKey: string(jsonData),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingConfigMap).Build()
+	configMapName := types.NamespacedName{
+		Name:      "test-exporter-state",
+		Namespace: "test-namespace",
+	}
+
+	// Save identical timestamps
+	timestamps := map[string]time.Time{
+		"worker-0": testTime,
+		"worker-1": testTime.Add(time.Hour),
+	}
+
+	nodes := []slurmapi.Node{
+		{Name: "worker-0"},
+		{Name: "worker-1"},
+	}
+
+	err = SaveNotUsableTimestamps(context.Background(), fakeClient, configMapName, timestamps, nodes)
+	require.NoError(t, err)
+
+	// Verify ConfigMap still exists with same data - function should have exited early
+	var configMap corev1.ConfigMap
+	err = fakeClient.Get(context.Background(), configMapName, &configMap)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(jsonData), configMap.Data[ConfigMapKey])
+}

--- a/internal/exporter/state.go
+++ b/internal/exporter/state.go
@@ -10,16 +10,18 @@ import (
 
 // metricsCollectorState holds the raw data collected from SLURM APIs
 type metricsCollectorState struct {
-	lastGPUSecondsUpdate time.Time
-	nodes                []slurmapi.Node
-	jobs                 []slurmapi.Job
-	diag                 *api.V0041OpenapiDiagResp
+	lastGPUSecondsUpdate    time.Time
+	nodes                   []slurmapi.Node
+	jobs                    []slurmapi.Job
+	diag                    *api.V0041OpenapiDiagResp
+	nodeNotUsableTimestamps map[string]time.Time // tracks when each node entered not-usable state
 }
 
 // newMetricsCollectorState initializes a new metrics collector state
 func newMetricsCollectorState() *metricsCollectorState {
 	return &metricsCollectorState{
-		lastGPUSecondsUpdate: time.Now(),
-		nodes:                nil,
+		lastGPUSecondsUpdate:    time.Now(),
+		nodes:                   nil,
+		nodeNotUsableTimestamps: make(map[string]time.Time),
 	}
 }

--- a/internal/slurmapi/node.go
+++ b/internal/slurmapi/node.go
@@ -114,6 +114,35 @@ func (n *Node) IsDownState() bool {
 	return exists
 }
 
+func (n *Node) IsFailState() bool {
+	_, exists := n.States[api.V0041NodeStateFAIL]
+	return exists
+}
+
+// IsNotUsable returns true if the node is in a not usable state.
+// A node is considered not usable when in state DOWN+*, IDLE+DRAIN+*, or IDLE+FAIL+* (where * represents any additional flags).
+// Note: RUNNING+DRAIN is not considered not usable until the job completes and base state changes to IDLE.
+func (n *Node) IsNotUsable() bool {
+	baseState := n.BaseState()
+
+	// DOWN+* is always not usable
+	if baseState == api.V0041NodeStateDOWN {
+		return true
+	}
+
+	// IDLE+DRAIN+* is not usable
+	if baseState == api.V0041NodeStateIDLE && n.IsDrainState() {
+		return true
+	}
+
+	// IDLE+FAIL+* is not usable
+	if baseState == api.V0041NodeStateIDLE && n.IsFailState() {
+		return true
+	}
+
+	return false
+}
+
 var baseStates = []api.V0041NodeState{
 	api.V0041NodeStateUNKNOWN,
 	api.V0041NodeStateDOWN,


### PR DESCRIPTION
Implements Mean Time To Restore metric for tracking node recovery times. Nodes in not-usable states (DOWN+*, IDLE+DRAIN+*, IDLE+FAIL+*) are tracked with timestamps persisted to ConfigMap across pod restarts. Histogram metric records restore durations when nodes return to usable state.