### PR TITLE
Standalone Slurm exporter - No Kubernetes needed

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -183,7 +183,7 @@ func main() {
 
 	// choose issuer: k8s → jwt; else static-token; else none
 	var issuer interface {
-		Issue(context.Context) (string, error)
+		Issue(ctx context.Context) (string, error)
 	}
 	switch {
 	case ctrlClient != nil:

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -14,6 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -27,6 +43,8 @@ import (
 
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -45,17 +63,22 @@ type Flags struct {
 	clusterNamespace   string
 	clusterName        string
 	collectionInterval string
+
+	// modes
+	kubeconfigPath string 
+	standalone     bool
+
+	// auth
+	staticToken string
 }
 
 func getZapOpts(logFormat, logLevel string) []zap.Opts {
 	var zapOpts []zap.Opts
-
 	if logFormat == "json" {
 		zapOpts = append(zapOpts, zap.UseDevMode(false))
 	} else {
 		zapOpts = append(zapOpts, zap.UseDevMode(true))
 	}
-
 	var level zapcore.Level
 	switch logLevel {
 	case "debug":
@@ -82,7 +105,6 @@ func getZapOpts(logFormat, logLevel string) []zap.Opts {
 func parseFlags() Flags {
 	var flags Flags
 
-	// flagConfig represents configuration for a single flag/env var pair
 	type flagConfig struct {
 		flagName   string
 		envName    string
@@ -90,127 +112,115 @@ func parseFlags() Flags {
 		usage      string
 		target     *string
 	}
-
 	configs := []flagConfig{
-		{
-			flagName:   "log-format",
-			envName:    "SLURM_EXPORTER_LOG_FORMAT",
-			defaultVal: "json",
-			usage:      "Log format: plain or json",
-			target:     &flags.logFormat,
-		},
-		{
-			flagName:   "log-level",
-			envName:    "SLURM_EXPORTER_LOG_LEVEL",
-			defaultVal: "debug",
-			usage:      "Log level: debug, info, warn, error, dpanic, panic, fatal",
-			target:     &flags.logLevel,
-		},
-		{
-			flagName:   "metrics-bind-address",
-			envName:    "SLURM_EXPORTER_METRICS_BIND_ADDRESS",
-			defaultVal: ":8080",
-			usage:      "The address the metric endpoint binds to.",
-			target:     &flags.metricsAddr,
-		},
-		{
-			flagName:   "monitoring-bind-address",
-			envName:    "SLURM_EXPORTER_MONITORING_BIND_ADDRESS",
-			defaultVal: ":8081",
-			usage:      "The address the monitoring endpoint binds to.",
-			target:     &flags.monitoringAddr,
-		},
-		{
-			flagName:   "slurm-api-server",
-			envName:    "SLURM_EXPORTER_SLURM_API_SERVER",
-			defaultVal: "http://localhost:6820",
-			usage:      "The address of the Slurm REST API server.",
-			target:     &flags.slurmAPIServer,
-		},
-		{
-			flagName:   "cluster-namespace",
-			envName:    "SLURM_EXPORTER_CLUSTER_NAMESPACE",
-			defaultVal: "soperator",
-			usage:      "The namespace of the Slurm cluster",
-			target:     &flags.clusterNamespace,
-		},
-		{
-			flagName:   "cluster-name",
-			envName:    "SLURM_EXPORTER_CLUSTER_NAME",
-			defaultVal: "",
-			usage:      "The name of the Slurm cluster (required)",
-			target:     &flags.clusterName,
-		},
-		{
-			flagName:   "collection-interval",
-			envName:    "SLURM_EXPORTER_COLLECTION_INTERVAL",
-			defaultVal: "30s",
-			usage:      "How often to collect metrics from SLURM APIs",
-			target:     &flags.collectionInterval,
-		},
+		{"log-format", "SLURM_EXPORTER_LOG_FORMAT", "json", "Log format: plain or json", &flags.logFormat},
+		{"log-level", "SLURM_EXPORTER_LOG_LEVEL", "debug", "Log level", &flags.logLevel},
+		{"metrics-bind-address", "SLURM_EXPORTER_METRICS_BIND_ADDRESS", ":8080", "The address the metric endpoint binds to.", &flags.metricsAddr},
+		{"monitoring-bind-address", "SLURM_EXPORTER_MONITORING_BIND_ADDRESS", ":8081", "The address the monitoring endpoint binds to.", &flags.monitoringAddr},
+		{"slurm-api-server", "SLURM_EXPORTER_SLURM_API_SERVER", "http://localhost:6820", "The address of the Slurm REST API server.", &flags.slurmAPIServer},
+		{"cluster-namespace", "SLURM_EXPORTER_CLUSTER_NAMESPACE", "soperator", "The namespace of the Slurm cluster", &flags.clusterNamespace},
+		{"cluster-name", "SLURM_EXPORTER_CLUSTER_NAME", "", "The name of the Slurm cluster (required)", &flags.clusterName},
+		{"collection-interval", "SLURM_EXPORTER_COLLECTION_INTERVAL", "30s", "How often to collect metrics from SLURM APIs", &flags.collectionInterval},
 	}
 
 	for _, cfg := range configs {
 		flag.StringVar(cfg.target, cfg.flagName, cfg.defaultVal, cfg.usage)
 	}
+	flag.StringVar(&flags.kubeconfigPath, "kubeconfig-path", "", "Path to a kubeconfig for out-of-cluster use (optional)")
+	flag.BoolVar(&flags.standalone, "standalone", false, "Run without Kubernetes (skip k8s client/JWT)")
 
-	flag.Parse()
+	// NEW: static token; if empty we will also check SLURM_JWT env var
+	flag.StringVar(&flags.staticToken, "static-token", "", "Static JWT to send in X-SLURM-USER-TOKEN (use with rest_auth/jwt)")
 
-	// Build a set of flags that were explicitly passed on the command line
 	passedFlags := make(map[string]struct{})
-	flag.Visit(func(f *flag.Flag) {
-		passedFlags[f.Name] = struct{}{}
-	})
+    flag.Visit(func(f *flag.Flag) {
+        passedFlags[f.Name] = struct{}{}
+    })
 
-	// Apply environment variables if CLI flags were not explicitly set
-	// Priority: CLI flag > Environment variable > Default value
-	for _, cfg := range configs {
-		if _, passed := passedFlags[cfg.flagName]; !passed {
-			if envVal := os.Getenv(cfg.envName); envVal != "" {
-				*cfg.target = envVal
-			}
+    // Apply environment variables if CLI flags were not explicitly set
+    // Priority: CLI flag > Environment variable > Default value
+    for _, cfg := range configs {
+        if _, passed := passedFlags[cfg.flagName]; !passed {
+            if envVal := os.Getenv(cfg.envName); envVal != "" {
+                *cfg.target = envVal
+            }
+        }
+    }
+	// env fallback for non-passed flags
+	if flags.staticToken == "" {
+      if v := os.Getenv("SLURM_EXPORTER_TOKEN"); v != "" {
+        flags.staticToken = v
+    } else if v := os.Getenv("SLURM_JWT"); v != "" { // legacy compat
+        flags.staticToken = v
+      }
+    }
+
+	// static-token also from env if not provided as flag
+	if flags.staticToken == "" {
+		if v := os.Getenv("SLURM_JWT"); v != "" {
+			flags.staticToken = v
 		}
 	}
 
 	if flags.clusterName == "" {
-		_, _ = fmt.Fprintf(os.Stderr, "Error: cluster-name is required (set via --cluster-name flag or SLURM_EXPORTER_CLUSTER_NAME env var)\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Error: --cluster-name (or SLURM_EXPORTER_CLUSTER_NAME) is required\n")
 		flag.Usage()
 		os.Exit(1)
 	}
-
 	return flags
 }
+
+// simple issuer that returns a fixed token
+type staticIssuer struct{ tok string }
+func (s staticIssuer) Issue(_ context.Context) (string, error) { return s.tok, nil }
 
 func main() {
 	flags := parseFlags()
 	opts := getZapOpts(flags.logFormat, flags.logLevel)
-
 	ctrl.SetLogger(zap.New(opts...))
 	log := ctrl.Log.WithName("soperator-exporter")
 
-	slurmClusterID := types.NamespacedName{
-		Namespace: flags.clusterNamespace,
-		Name:      flags.clusterName,
+	slurmClusterID := types.NamespacedName{Namespace: flags.clusterNamespace, Name: flags.clusterName}
+
+	// optional k8s
+	var cfg *rest.Config
+	var err error
+	if !flags.standalone {
+		cfg, err = rest.InClusterConfig()
+		if err != nil && flags.kubeconfigPath != "" {
+			cfg, err = clientcmd.BuildConfigFromFlags("", flags.kubeconfigPath)
+			if err != nil {
+				cfg = nil
+			}
+		}
+	}
+	var ctrlClient client.Client
+	if cfg != nil {
+		ctrlClient, err = client.New(cfg, client.Options{})
+		if err != nil {
+			log.Error(err, "Failed to create Kubernetes client, continuing in standalone mode")
+			ctrlClient = nil
+		}
 	}
 
-	config := ctrl.GetConfigOrDie()
-
-	ctrlClient, err := client.New(config, client.Options{})
-	if err != nil {
-		log.Error(err, "Failed to create Kubernetes client")
-		os.Exit(1)
+	// choose issuer: k8s → jwt; else static-token; else none
+	var issuer interface{ Issue(context.Context) (string, error) }
+	switch {
+	case ctrlClient != nil:
+		issuer = jwt.NewToken(ctrlClient).For(slurmClusterID, "root").WithRegistry(jwt.NewTokenRegistry().Build())
+	case flags.staticToken != "":
+		issuer = staticIssuer{tok: flags.staticToken}
+	default:
+		issuer = nil
 	}
 
-	jwtTokenIssuer := jwt.NewToken(ctrlClient).For(slurmClusterID, "root").WithRegistry(
-		jwt.NewTokenRegistry().Build())
-
-	slurmAPIClient, err := slurmapi.NewClient(flags.slurmAPIServer, jwtTokenIssuer, slurmapi.DefaultHTTPClient())
+	slurmAPIClient, err := slurmapi.NewClient(flags.slurmAPIServer, issuer, slurmapi.DefaultHTTPClient())
 	if err != nil {
 		log.Error(err, "Failed to initialize Slurm API client")
 		os.Exit(1)
 	}
 
-	collectionInterval, err := time.ParseDuration(flags.collectionInterval)
+	interval, err := time.ParseDuration(flags.collectionInterval)
 	if err != nil {
 		log.Error(err, "Failed to parse collection interval")
 		os.Exit(1)
@@ -221,11 +231,10 @@ func main() {
 		exporter.Params{
 			SlurmAPIServer:     flags.slurmAPIServer,
 			SlurmClusterID:     slurmClusterID,
-			CollectionInterval: collectionInterval,
+			CollectionInterval: interval,
 		},
 	)
 
-	// Handle graceful shutdown
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -233,7 +242,6 @@ func main() {
 		log.Error(err, "Failed to start metrics exporter")
 		os.Exit(1)
 	}
-
 	if err := clusterExporter.StartMonitoring(ctx, flags.monitoringAddr); err != nil {
 		log.Error(err, "Failed to start monitoring server")
 		os.Exit(1)
@@ -247,6 +255,5 @@ func main() {
 	if err := clusterExporter.Stop(stopCtx); err != nil {
 		log.Error(err, "Failed to stop metrics exporter")
 	}
-
 	log.Info("Metrics exporter stopped gracefully")
 }

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -49,7 +49,7 @@ type Flags struct {
 	collectionInterval string
 
 	// modes
-	kubeconfigPath string 
+	kubeconfigPath string
 	standalone     bool
 
 	// auth
@@ -143,6 +143,7 @@ func parseFlags() Flags {
 
 // simple issuer that returns a fixed token
 type staticIssuer struct{ tok string }
+
 func (s staticIssuer) Issue(_ context.Context) (string, error) { return s.tok, nil }
 
 func main() {
@@ -157,20 +158,20 @@ func main() {
 	var cfg *rest.Config
 	var err error
 	if !flags.standalone {
-      cfg, err = rest.InClusterConfig()
-      if err != nil && flags.kubeconfigPath != "" {
-          log.Info("Failed to get in-cluster config, trying kubeconfig file", "kubeconfig", flags.kubeconfigPath, "error", err)
-          cfg, err = clientcmd.BuildConfigFromFlags("", flags.kubeconfigPath)
-          if err != nil {
-              log.Info("Failed to load kubeconfig file, continuing without Kubernetes client", "kubeconfig", flags.kubeconfigPath, "error", err)
-              cfg = nil
-          } else {
-              log.Info("Successfully loaded kubeconfig file")
-          }
-      } else if err != nil {
-          log.Info("Failed to get in-cluster config, continuing without Kubernetes client", "error", err)
-        }
-    }
+		cfg, err = rest.InClusterConfig()
+		if err != nil && flags.kubeconfigPath != "" {
+			log.Info("Failed to get in-cluster config, trying kubeconfig file", "kubeconfig", flags.kubeconfigPath, "error", err)
+			cfg, err = clientcmd.BuildConfigFromFlags("", flags.kubeconfigPath)
+			if err != nil {
+				log.Info("Failed to load kubeconfig file, continuing without Kubernetes client", "kubeconfig", flags.kubeconfigPath, "error", err)
+				cfg = nil
+			} else {
+				log.Info("Successfully loaded kubeconfig file")
+			}
+		} else if err != nil {
+			log.Info("Failed to get in-cluster config, continuing without Kubernetes client", "error", err)
+		}
+	}
 	var ctrlClient client.Client
 	if cfg != nil {
 		ctrlClient, err = client.New(cfg, client.Options{})
@@ -181,7 +182,9 @@ func main() {
 	}
 
 	// choose issuer: k8s → jwt; else static-token; else none
-	var issuer interface{ Issue(context.Context) (string, error) }
+	var issuer interface {
+		Issue(context.Context) (string, error)
+	}
 	switch {
 	case ctrlClient != nil:
 		issuer = jwt.NewToken(ctrlClient).For(slurmClusterID, "root").WithRegistry(jwt.NewTokenRegistry().Build())

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -157,20 +157,20 @@ func main() {
 	var cfg *rest.Config
 	var err error
 	if !flags.standalone {
-    cfg, err = rest.InClusterConfig()
-    if err != nil && flags.kubeconfigPath != "" {
-        log.Info("Failed to get in-cluster config, trying kubeconfig file", "kubeconfig", flags.kubeconfigPath, "error", err)
-        cfg, err = clientcmd.BuildConfigFromFlags("", flags.kubeconfigPath)
-        if err != nil {
-            log.Info("Failed to load kubeconfig file, continuing without Kubernetes client", "kubeconfig", flags.kubeconfigPath, "error", err)
-            cfg = nil
-        } else {
-            log.Info("Successfully loaded kubeconfig file")
+      cfg, err = rest.InClusterConfig()
+      if err != nil && flags.kubeconfigPath != "" {
+          log.Info("Failed to get in-cluster config, trying kubeconfig file", "kubeconfig", flags.kubeconfigPath, "error", err)
+          cfg, err = clientcmd.BuildConfigFromFlags("", flags.kubeconfigPath)
+          if err != nil {
+              log.Info("Failed to load kubeconfig file, continuing without Kubernetes client", "kubeconfig", flags.kubeconfigPath, "error", err)
+              cfg = nil
+          } else {
+              log.Info("Successfully loaded kubeconfig file")
+          }
+      } else if err != nil {
+          log.Info("Failed to get in-cluster config, continuing without Kubernetes client", "error", err)
         }
-    } else if err != nil {
-        log.Info("Failed to get in-cluster config, continuing without Kubernetes client", "error", err)
     }
-}
 	var ctrlClient client.Client
 	if cfg != nil {
 		ctrlClient, err = client.New(cfg, client.Options{})


### PR DESCRIPTION
## Summary
Add a minimal, backward-compatible path to run the exporter against a **standalone Slurm cluster** (`slurmrestd` with `rest_auth/jwt`)—no Kubernetes required.

## Changes
- **New Flags**
  - `--standalone`: skip k8s client/JWT flow.
  - `--static-token` (optional): alternative to env; CLI still has highest precedence.
- **Auth**
  - Prefer **`SLURM_EXPORTER_TOKEN`** from the environment for REST calls.
  - Do **not** rely on `SLURM_JWT` (kept out to avoid collisions with Slurm internals).
- **HTTP client**
  - Use `Header.Set` instead of `Header.Add` for `X-SLURM-USER-TOKEN` (and `Content-Type`) to avoid duplicate headers on retries.
- **Docs**
  - README section describing standalone mode usage, and troubleshooting.

## Testing
- Verified with Slurm 24.05.x + `slurmrestd` **v0.0.40**.