### PR TITLE
fix issue with metadata.resourceVersion: Invalid value: 0x0: must be specified for an Patch in ASTS

### DIFF
--- a/internal/controller/reconciler/k8s_statefulset.go
+++ b/internal/controller/reconciler/k8s_statefulset.go
@@ -45,7 +45,9 @@ func (r *StatefulSetReconciler) Reconcile(
 
 func (r *StatefulSetReconciler) patch(existing, desired client.Object) (client.Patch, error) {
 	patchImpl := func(dst, src *appsv1.StatefulSet) client.Patch {
-		res := client.MergeFrom(dst.DeepCopy())
+		original := dst.DeepCopy()
+
+		res := client.MergeFrom(original)
 
 		dst.Spec.Template.ObjectMeta.Labels = src.Spec.Template.ObjectMeta.Labels
 		// Copy annotations from the desired StatefulSet to the existing StatefulSet

--- a/internal/controller/reconciler/reconciler.go
+++ b/internal/controller/reconciler/reconciler.go
@@ -141,6 +141,11 @@ func (r Reconciler) EnsureUpdated(
 			return fmt.Errorf("setting controller reference: %w", err)
 		}
 
+		// Copy essential metadata from existing resource to desired resource
+		// This is required for the Update operation to work correctly
+		desired.SetResourceVersion(existing.GetResourceVersion())
+		desired.SetUID(existing.GetUID())
+
 		if err = r.Update(ctx, desired); err != nil {
 			logger.Error(err, "Failed to update resource")
 			return fmt.Errorf("updating resource: %w", err)


### PR DESCRIPTION
Fix StatefulSet update error by ensuring resourceVersion is preserved

Resolves the "metadata.resourceVersion: Invalid value: 0x0: must be specified for an update" error when reconciling StatefulSets by properly handling the resourceVersion field during updates.

#[#1417](https://github.com/nebius/soperator/issues/1417)