### PR TITLE
fix patch cm with empty labels

### DIFF
--- a/internal/controller/reconciler/k8s_configmap.go
+++ b/internal/controller/reconciler/k8s_configmap.go
@@ -48,6 +48,9 @@ func (r *ConfigMapReconciler) patch(existing, desired client.Object) (client.Pat
 		res := client.MergeFrom(dst.DeepCopy())
 
 		dst.Data = src.Data
+		if dst.Labels == nil {
+			dst.Labels = make(map[string]string)
+		}
 		maps.Copy(dst.Labels, src.Labels)
 
 		return res


### PR DESCRIPTION
This PR fixes a potential nil pointer dereference when patching ConfigMaps that have empty or nil labels by ensuring the Labels map is initialized before copying labels from the source.

Adds nil check and initialization for the Labels map in the ConfigMap patch operation
Prevents runtime panics when copying labels to ConfigMaps with nil Labels