### PR TITLE
[nccld-plugin] Make user responsible for correct rights of the output directory

### DIFF
--- a/helm/soperator-activechecks/scripts/ensure-dir-snccld-logs.sh
+++ b/helm/soperator-activechecks/scripts/ensure-dir-snccld-logs.sh
@@ -1,0 +1,4 @@
+set -ex
+
+echo "Ensuring log directory for NCCL Debug plugin (${SNCCLD_LOG_DIR_PATH})..."
+chroot /mnt/jail /bin/bash -c "mkdir -p '${SNCCLD_LOG_DIR_PATH}'; chmod 777 '${SNCCLD_LOG_DIR_PATH}'"

--- a/helm/soperator-activechecks/templates/ensure-dir-snccld-logs.yaml
+++ b/helm/soperator-activechecks/templates/ensure-dir-snccld-logs.yaml
@@ -7,6 +7,7 @@ spec:
   checkType: "k8sJob"
   name: "ensure-dir-snccld-logs"
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
+  schedule: {{ .Values.ensureDirSnccldLogs.schedule | default "15 0 * * *" | quote }}
   suspend: false
   runAfterCreation: true
   k8sJobSpec:
@@ -19,7 +20,7 @@ spec:
       image: {{ .Values.images.k8sJob | quote }}
       env:
         - name: SNCCLD_LOG_DIR_PATH
-          value: {{ .Values.ensureDirSnccldLogs.dir | quote }}
+          value: {{ .Values.ensureDirSnccldLogs.dir | default "/opt/soperator-outputs/nccl_logs" | quote }}
       volumeMounts:
 {{ toYaml .Values.jobContainer.volumeMounts | indent 8 }}
       volumes:

--- a/helm/soperator-activechecks/templates/ensure-dir-snccld-logs.yaml
+++ b/helm/soperator-activechecks/templates/ensure-dir-snccld-logs.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.ensureDirSnccldLogs.enabled -}}
+apiVersion: slurm.nebius.ai/v1alpha1
+kind: ActiveCheck
+metadata:
+  name: "ensure-dir-snccld-logs"
+spec:
+  checkType: "k8sJob"
+  name: "ensure-dir-snccld-logs"
+  slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
+  suspend: false
+  runAfterCreation: true
+  k8sJobSpec:
+    jobContainer:
+      command:
+        - bash
+        - -c
+        - |
+{{ .Files.Get "scripts/ensure-dir-snccld-logs.sh" | indent 10 }}
+      image: {{ .Values.images.k8sJob | quote }}
+      env:
+        - name: SNCCLD_LOG_DIR_PATH
+          value: {{ .Values.ensureDirSnccldLogs.dir | quote }}
+      volumeMounts:
+{{ toYaml .Values.jobContainer.volumeMounts | indent 8 }}
+      volumes:
+{{ toYaml .Values.jobContainer.volumes | indent 8 }}
+{{- end -}}

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -35,3 +35,4 @@ upgradeHealthChecker:
 ensureDirSnccldLogs:
   enabled: false
   dir: /opt/soperator-outputs/nccl_logs
+  schedule: 15 0 * * *

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -32,3 +32,6 @@ upgradeCuda:
   cudaVersion: "12.4.1-1"
 upgradeHealthChecker:
   healthCheckerVersion: "1.0.0-150.250826"
+ensureDirSnccldLogs:
+  enabled: false
+  dir: /opt/soperator-outputs/nccl_logs

--- a/helm/soperator-fluxcd/templates/slurm-cluster-storage.yaml
+++ b/helm/soperator-fluxcd/templates/slurm-cluster-storage.yaml
@@ -36,7 +36,7 @@ spec:
   {{- end }}
   valuesFrom:
   - kind: ConfigMap
-    name: terrraform-slurm-cluster-storage
+    name: terraform-slurm-cluster-storage
     optional: true
     valuesKey: values.yaml
   - kind: ConfigMap

--- a/helm/soperator-fluxcd/templates/slurm-cluster.yaml
+++ b/helm/soperator-fluxcd/templates/slurm-cluster.yaml
@@ -43,7 +43,7 @@ spec:
   {{- end }}
   valuesFrom:
   - kind: ConfigMap
-    name: terrraform-slurm-cluster
+    name: terraform-slurm-cluster
     optional: true
     valuesKey: values.yaml
   - kind: ConfigMap

--- a/helm/soperator-fluxcd/templates/soperator-activechecks.yaml
+++ b/helm/soperator-fluxcd/templates/soperator-activechecks.yaml
@@ -38,7 +38,7 @@ spec:
   {{- end }}
   valuesFrom:
   - kind: ConfigMap
-    name: terrraform-soperator-activechecks
+    name: terraform-soperator-activechecks
     optional: true
     valuesKey: values.yaml
   - kind: ConfigMap

--- a/helm/soperator-fluxcd/templates/soperatorchecks.yaml
+++ b/helm/soperator-fluxcd/templates/soperatorchecks.yaml
@@ -33,7 +33,7 @@ spec:
   {{- end }}
   valuesFrom:
   - kind: ConfigMap
-    name: terrraform-soperatorchecks
+    name: terraform-soperatorchecks
     optional: true
     valuesKey: values.yaml
   - kind: ConfigMap

--- a/images/common/spank-nccl-debug/src/snccld_log.h
+++ b/images/common/spank-nccl-debug/src/snccld_log.h
@@ -71,8 +71,15 @@ enum _SNCCLD_LOG_LEVEL {
  * @param __fmt Format string.
  * @param ... Variadic arguments to fill in the format string.
  */
+#ifdef NDEBUG
 #define snccld_log_info(__fmt, ...)                                            \
     _snccld_log_impl(_SNCCLD_LOG_LEVEL_INFO, slurm_info, __fmt, ##__VA_ARGS__)
+#else // NDEBUG
+#define snccld_log_info(__fmt, ...)                                            \
+    _snccld_log_impl(                                                          \
+        _SNCCLD_LOG_LEVEL_INFO, slurm_spank_log, __fmt, ##__VA_ARGS__          \
+    )
+#endif // NDEBUG
 
 /**
  * Log error message.
@@ -80,8 +87,15 @@ enum _SNCCLD_LOG_LEVEL {
  * @param __fmt Format string.
  * @param ... Variadic arguments to fill in the format string.
  */
+#ifdef NDEBUG
 #define snccld_log_error(__fmt, ...)                                           \
     _snccld_log_impl(_SNCCLD_LOG_LEVEL_ERROR, slurm_error, __fmt, ##__VA_ARGS__)
+#else // NDEBUG
+#define snccld_log_error(__fmt, ...)                                           \
+    _snccld_log_impl(                                                          \
+        _SNCCLD_LOG_LEVEL_ERROR, slurm_spank_log, __fmt, ##__VA_ARGS__         \
+    )
+#endif // NDEBUG
 
 #ifdef NDEBUG
 #define snccld_log_debug(__fmt, ...)
@@ -94,7 +108,9 @@ enum _SNCCLD_LOG_LEVEL {
  * @param ... Variadic arguments to fill in the format string.
  */
 #define snccld_log_debug(__fmt, ...)                                           \
-    _snccld_log_impl(_SNCCLD_LOG_LEVEL_DEBUG, slurm_debug, __fmt, ##__VA_ARGS__)
+    _snccld_log_impl(                                                          \
+        _SNCCLD_LOG_LEVEL_DEBUG, slurm_spank_log, __fmt, ##__VA_ARGS__         \
+    )
 #endif // NDEBUG
 
 #endif // SNCCLD_LOG_H

--- a/images/common/spank-nccl-debug/src/snccld_state.h
+++ b/images/common/spank-nccl-debug/src/snccld_state.h
@@ -45,6 +45,12 @@ spank_err_t snccld_key_get_from(spank_t spank, snccld_state_key_t *key);
 
 /// State of the plugin for the particular job.
 typedef struct {
+    /// Job submitter GID.
+    gid_t user_gid;
+
+    /// Job submitter UID.
+    uid_t user_uid;
+
     /// Absolute path of the named pipe (FIFO).
     char fifo_path[PATH_MAX + 1];
 

--- a/images/common/spank-nccl-debug/src/snccld_util_dir_file.c
+++ b/images/common/spank-nccl-debug/src/snccld_util_dir_file.c
@@ -54,14 +54,14 @@ spank_err_t snccld_mkdir_p(
     }
 
     if (as_user) {
-        chown(path, user_uid, user_gid);
+        chown(tmp, user_uid, user_gid);
         snccld_log_debug(
-            "Chowned directory: '%s' to %d:%d", path, user_uid, user_gid
+            "Chowned directory: '%s' to %d:%d", tmp, user_uid, user_gid
         );
     } else {
-        snccld_ensure_mode(path, SNCCLD_DEFAULT_MODE);
+        snccld_ensure_mode(tmp, SNCCLD_DEFAULT_MODE);
         snccld_log_debug(
-            "Ensured directory mode: '%s':%o", path, SNCCLD_DEFAULT_MODE
+            "Ensured directory mode: '%s':%o", tmp, SNCCLD_DEFAULT_MODE
         );
     }
 

--- a/images/common/spank-nccl-debug/src/snccld_util_dir_file.c
+++ b/images/common/spank-nccl-debug/src/snccld_util_dir_file.c
@@ -47,11 +47,6 @@ spank_err_t snccld_mkdir_p(const char *path, const bool as_user) {
         }
     }
 
-    if (!as_user &&
-        snccld_ensure_mode(tmp, SNCCLD_DEFAULT_MODE) != ESPANK_SUCCESS) {
-        return ESPANK_ERROR;
-    }
-
     return ESPANK_SUCCESS;
 }
 
@@ -117,7 +112,14 @@ void snccld_ensure_file_exists(const char *path, const bool as_user) {
 }
 
 inline void snccld_ensure_dir_exists(const char *path, const bool as_user) {
-    snccld_mkdir_p(path, as_user);
+    const int ret = snccld_mkdir_p(path, as_user);
+    if (ret != ESPANK_SUCCESS) {
+        return;
+    }
+
+    if (!as_user) {
+        snccld_ensure_mode(path, SNCCLD_DEFAULT_MODE);
+    }
 }
 
 static inline bool _snccld_needs_chmod(const char *path, const mode_t mode) {

--- a/images/common/spank-nccl-debug/src/snccld_util_dir_file.h
+++ b/images/common/spank-nccl-debug/src/snccld_util_dir_file.h
@@ -22,11 +22,14 @@
  * @param path Absolute path of the directory to make on.
  *             Trailing slash is handled.
  * @param as_user Whether to create directories as user (w/o umask 0).
+ * @param user_gid User GID to set for created directories in case of as_user.
+ * @param user_uid User UID to set for created directories in case of as_user.
  *
  * @retval ESPANK_SUCCESS Successfully created the directory.
  * @retval ESPANK_ERROR Something went wrong.
  */
-spank_err_t snccld_mkdir_p(const char *path, bool as_user);
+spank_err_t
+snccld_mkdir_p(const char *path, bool as_user, gid_t user_gid, uid_t user_uid);
 
 /**
  * Check if the directory exists.
@@ -55,8 +58,12 @@ void snccld_split_file_path(const char *path, char **dir_out, char **file_out);
  *
  * @param path Path to the file to ensure its existence.
  * @param as_user Whether to create directory and file as user (w/o umask 0).
+ * @param user_gid User GID to set for created file in case of as_user.
+ * @param user_uid User UID to set for created file in case of as_user.
  */
-void snccld_ensure_file_exists(const char *path, bool as_user);
+void snccld_ensure_file_exists(
+    const char *path, bool as_user, gid_t user_gid, uid_t user_uid
+);
 
 /**
  * Ensure the directory exists.
@@ -64,8 +71,12 @@ void snccld_ensure_file_exists(const char *path, bool as_user);
  *
  * @param path Path to the directory to ensure its existence.
  * @param as_user Whether to create directory as user (w/o umask 0).
+ * @param user_gid User GID to set for created directories in case of as_user.
+ * @param user_uid User UID to set for created directories in case of as_user.
  */
-void snccld_ensure_dir_exists(const char *path, bool as_user);
+void snccld_ensure_dir_exists(
+    const char *path, bool as_user, gid_t user_gid, uid_t user_uid
+);
 
 /**
  * Ensure the directory/file has desired mode.


### PR DESCRIPTION
This PR introduces the following changes:
- **NCCL Debug plugin**:
  - Makes `mkdir_p` a recursive function to eliminate logic duplication
  - `chmod`ding while creating new directory is only applied to the created directories, not to the whole path
  - User's GID and UID are stored to be applied to files and directories in case of `as_user=true` (try best but not guaranteed - `chown`ing to `root:root` may be not permitted under other user account)
  - Log function wrappers now use different implementations based on the target mode for easier debug builds
- **Active Checks Helm chart**:
  - Active check is introduced to ensure NCCLD log directory existence and its proper rights
  - Typo in override ConfigMap names is fixed