### PR TITLE
Drop CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Global code owners (applies to the whole repo)
-* @dstaroff @asteny @rdjjke @Uburro @itechdima @theyoprst @ChessProfessor @ali-sattari @MeenaAlfons


### PR DESCRIPTION
CODEOWNERS makes little sense: it requires team's approve, although each team member has admin rights in the repository, so they can commit anything without an approve, or even a PR.

The huge downside of CODEOWNERS: it summons the whole team to review any PR, creating a huge amount of spam for everyone from GitHub.
