### PR TITLE
Change DCGM exporter image version

### DIFF
--- a/helm/soperator-dcgm-exporter/values.yaml
+++ b/helm/soperator-dcgm-exporter/values.yaml
@@ -18,7 +18,7 @@ daemonSet:
   nvidiaDcgmExporter:
     image:
       repository: cr.eu-north1.nebius.cloud/marketplace/nebius/nvidia-gpu-operator/image/dcgm-exporter
-      tag: 4.2.3-4.1.3-ubuntu22.04
+      tag: 3.3.9-3.6.1-ubuntu22.04
 
     env:
       dcgmExporterListen: :9400


### PR DESCRIPTION
To the last version where HPC job mapping works. It is broken after 4.x.