### PR TITLE
Replace automatic release trigger with manual workflow dispatch

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,15 +1,25 @@
 name: "Create GitHub release with automatic changelog"
 
 on:
-  push:
-    branches:
-      - 'soperator-release-*'
-    paths:
-      - 'VERSION'
+  workflow_dispatch:  # Manual trigger via GitHub UI
 
 jobs:
+  # First, build the stable release
+  build:
+    name: Build stable release
+    uses: ./.github/workflows/one_job.yml
+    with:
+      unstable: false
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
   tag:
     name: Push new tag
+    needs: build  # Wait for build to complete successfully
 
     permissions:
       contents: write

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -1,6 +1,14 @@
 name: Build All in one job
 
 on:
+  workflow_call:
+    inputs:
+      unstable:
+        description: 'Build unstable version'
+        type: boolean
+        required: false
+        default: true
+
   push:
     branches:
       - main
@@ -57,9 +65,9 @@ jobs:
       - name: Generate version file
         run: |
           UNSTABLE="true"
-          if [[ "${{ github.ref }}" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Detected semantic version tag - building stable release"
-            UNSTABLE="false"
+          if [[ "${{ github.event_name }}" == "workflow_call" ]]; then
+            UNSTABLE="${{ inputs.unstable }}"
+            echo "Called from workflow_call with unstable=${UNSTABLE}"
           else
             echo "Building unstable version"
           fi


### PR DESCRIPTION
## Summary
- Modified release workflow to use manual trigger instead of automatic trigger on VERSION file changes
- Added workflow_call support to one_job.yml with configurable stable/unstable builds
- Stable releases now only built when manually triggered via GitHub Actions UI

## Changes
The release process now works as follows:
1. Navigate to Actions tab → "Create GitHub release with automatic changelog" workflow
2. Click "Run workflow" button to manually trigger a release
3. The workflow builds stable images (unstable=false), creates tag, and generates release

This gives full control over when releases happen while maintaining the existing CI/CD pipeline for development builds.