### PR TITLE
add delete-not-ready-nodes=true by default in helm

### DIFF
--- a/helm/soperator/values.yaml
+++ b/helm/soperator/values.yaml
@@ -30,7 +30,7 @@ controllerManager:
       - --reconcile-timeout=3m
       - --max-concurrent-reconciles=1
       - --cache-sync-timeout=2m
-      - --enable-node-replacement=true
+      - --enable-node-replacement=false
       - --not-ready-timeout=15m
       - --delete-not-ready-nodes=true
     containerSecurityContext:

--- a/helm/soperator/values.yaml
+++ b/helm/soperator/values.yaml
@@ -25,6 +25,14 @@ controllerManager:
       - --metrics-bind-address=127.0.0.1:8080
       - --enable-topology-controller=true
       - --leader-elect
+      - --log-format=json
+      - --log-level=warn
+      - --reconcile-timeout=3m
+      - --max-concurrent-reconciles=1
+      - --cache-sync-timeout=2m
+      - --enable-node-replacement=true
+      - --not-ready-timeout=15m
+      - --delete-not-ready-nodes=true
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/helm/soperator/values.yaml
+++ b/helm/soperator/values.yaml
@@ -25,14 +25,6 @@ controllerManager:
       - --metrics-bind-address=127.0.0.1:8080
       - --enable-topology-controller=true
       - --leader-elect
-      - --log-format=json
-      - --log-level=warn
-      - --reconcile-timeout=3m
-      - --max-concurrent-reconciles=1
-      - --cache-sync-timeout=2m
-      - --enable-node-replacement=false
-      - --not-ready-timeout=15m
-      - --delete-not-ready-nodes=true
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/helm/soperatorchecks/values.yaml
+++ b/helm/soperatorchecks/values.yaml
@@ -23,7 +23,7 @@ checks:
     args:
       - --enable-node-replacement=false
       - --log-format=json
-      - --log-level=warn
+      - --log-level=info
       - --reconcile-timeout=3m
       - --max-concurrent-reconciles=1
       - --cache-sync-timeout=2m

--- a/helm/soperatorchecks/values.yaml
+++ b/helm/soperatorchecks/values.yaml
@@ -22,6 +22,14 @@ checks:
   manager:
     args:
       - --enable-node-replacement=false
+      - --log-format=json
+      - --log-level=warn
+      - --reconcile-timeout=3m
+      - --max-concurrent-reconciles=1
+      - --cache-sync-timeout=2m
+      - --enable-node-replacement=false
+      - --not-ready-timeout=15m
+      - --delete-not-ready-nodes=true
       - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

The soperator controller was missing configurable command-line flags for key operational parameters like logging, reconciliation timeouts, and node management behavior. This made it difficult to tune the controller's behavior for different environments and requirements without rebuilding the image.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

Added comprehensive command-line flags to the soperator controller with sensible defaults:
- `--log-format` and `--log-level` for logging configuration
- `--reconcile-timeout` and `--max-concurrent-reconciles` for performance tuning
- `--cache-sync-timeout` for cache synchronization control
- `--enable-node-replacement` for node replacement controller toggle
- `--not-ready-timeout` and `--delete-not-ready-nodes` for automated node cleanup

These flags are now exposed in the Helm chart values.yaml, allowing operators to configure the controller behavior during deployment without code changes.


## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->

This function allows deleting a node if the kubelet remains in the **NodeReady** state for N minutes. In this PR, we enable it by default in the Helm chart.
