### PR TITLE
Make docker manifest create idempotent.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,10 +378,10 @@ docker-manifest: ## Create and push docker manifest for multiple image architect
 ifndef IMAGE_NAME
 	$(error IMAGE_NAME is not set, docker manifest can not be pushed)
 endif
-	docker manifest create $(AMEND) "$(IMAGE_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}" "$(IMAGE_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}-arm64" "$(IMAGE_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}-amd64"
+	docker manifest create --amend "$(IMAGE_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}" "$(IMAGE_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}-arm64" "$(IMAGE_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}-amd64"
 	docker manifest push "$(IMAGE_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}"
 ifeq ($(UNSTABLE), false)
-	docker manifest create $(AMEND) "$(GITHUB_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}" "$(GITHUB_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}-arm64" "$(GITHUB_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}-amd64"
+	docker manifest create --amend "$(GITHUB_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}" "$(GITHUB_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}-arm64" "$(GITHUB_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}-amd64"
 	docker manifest push "$(GITHUB_REPO)/${IMAGE_NAME}:${IMAGE_VERSION}"
 endif
 


### PR DESCRIPTION
## Problem

When a Docker image (manifest) has already been built, any subsequent restart of the build for the same commit will always fail: the manifest already exists, and the `docker manifest create` command fails.

## Solution

Use the `--amend` option to fetch the existing manifest first and update it.

## Testing

- Restarting the CI build succeeds
- In the manifest, only some hashes are updated after the restart
- The cluster runs correctly on the new Docker images
