### PR TITLE
SCHED-138: add  SOPERATOR_NODE_SETS_ON=true for static worker configuration

### DIFF
--- a/images/worker/slurmd_entrypoint.sh
+++ b/images/worker/slurmd_entrypoint.sh
@@ -36,12 +36,10 @@ evaluated_extra=$(eval echo "$SLURM_NODE_EXTRA")
 
 echo "Start slurmd daemon"
 
-# Common slurmd arguments
 slurmd_args=(
   -D
 )
 
-# Add node configuration based on SOPERATOR_NODE_SETS_ON flag
 if [ "${SOPERATOR_NODE_SETS_ON}" = "true" ]; then
   echo "Running slurmd with NodeSets configuration from slurm.conf"
 else

--- a/images/worker/slurmd_entrypoint.sh
+++ b/images/worker/slurmd_entrypoint.sh
@@ -35,11 +35,24 @@ echo "Evaluate variables in the Slurm node 'Extra' field"
 evaluated_extra=$(eval echo "$SLURM_NODE_EXTRA")
 
 echo "Start slurmd daemon"
-exec /usr/sbin/slurmd \
-  -D \
-  -Z \
-  --instance-id "${INSTANCE_ID}" \
-  --extra "${evaluated_extra}" \
-  --conf \
-  "NodeHostname=${K8S_POD_NAME} NodeAddr=${K8S_POD_NAME}.${K8S_SERVICE_NAME}.${K8S_POD_NAMESPACE}.svc.cluster.local RealMemory=${SLURM_REAL_MEMORY} Gres=${GRES} $(feature_conf)" \
-  2>&1 | tee >(multilog s100000000 n5 /var/log/slurm/multilog)
+
+# Common slurmd arguments
+slurmd_args=(
+  -D
+)
+
+# Add node configuration based on SOPERATOR_NODE_SETS_ON flag
+if [ "${SOPERATOR_NODE_SETS_ON}" = "true" ]; then
+  echo "Running slurmd with NodeSets configuration from slurm.conf"
+else
+  echo "Running slurmd with dynamic node configuration"
+  slurmd_args+=(
+    -Z
+    --instance-id "${INSTANCE_ID}"
+    --extra "${evaluated_extra}"
+    --conf
+    "NodeHostname=${K8S_POD_NAME} NodeAddr=${K8S_POD_NAME}.${K8S_SERVICE_NAME}.${K8S_POD_NAMESPACE}.svc RealMemory=${SLURM_REAL_MEMORY} Gres=${GRES} $(feature_conf)"
+  )
+fi
+
+exec /usr/sbin/slurmd "${slurmd_args[@]}" 2>&1 | tee >(multilog s100000000 n5 /var/log/slurm/multilog)


### PR DESCRIPTION
## Problem
Currently, slurmd daemon runs with dynamic node configuration using the `--conf` flag, which passes node configuration (NodeHostname, NodeAddr, RealMemory, Gres, Features) at runtime. This approach doesn't support the new structured partition configuration feature where node configuration is pre-defined in `slurm.conf` via NodeSets.

## Solution
Added conditional logic to `slurmd_entrypoint.sh` that switches between two modes based on the `SOPERATOR_NODE_SETS_ON` environment variable:
- When `SOPERATOR_NODE_SETS_ON=true`: runs slurmd without `--conf` flag, relying on node configuration from `slurm.conf` (generated by `AddNodeSetsToSlurmConfig` and `AddNodesToSlurmConfig`)
- Otherwise: maintains backward compatibility with dynamic node configuration using `--conf` flag

Refactored the script to use a bash array for slurmd arguments, eliminating code duplication and improving readability.

## Testing
- Manual testing with `SOPERATOR_NODE_SETS_ON=true` to verify slurmd starts without `--conf` flag
- Manual testing without the variable set to verify backward compatibility with existing dynamic node configuration
- Verified slurmd logs show correct startup messages for both modes

## Release Notes
Feature: Added support for structured partition configuration mode in slurmd. When `SOPERATOR_NODE_SETS_ON` environment variable is set to `true`, slurmd will use static node configuration from `slurm.conf` instead of dynamic configuration, enabling NodeSet-based partition management. This change is backward compatible - existing clusters continue to work without modifications.