### PR TITLE
Add `kube_node_labels` metric

### DIFF
--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -91,6 +91,8 @@ spec:
           - '--metric-allowlist=kube_node_status_condition'
           - '--metric-allowlist=kube_node_info'
           - '--metric-allowlist=kube_customresource_.*'
+          - '--metric-allowlist=kube_node_labels'
+          - '--metric-labels-allowlist=nodes=[nebius.com/driverful,nebius.com/gpu,nebius.com/node-group-id,slurm.nebius.ai/nodeset,slurm.nebius.ai/workload]'
         rbac:
           extraRules:
             - apiGroups:


### PR DESCRIPTION
This adds a new metric to connect nodes to node-groups.
To be used later in alerts to compare healthy nodes to total nodes.