### PR TITLE
Ensure healthy nodes check

### DIFF
--- a/api/v1alpha1/activecheck_types.go
+++ b/api/v1alpha1/activecheck_types.go
@@ -21,6 +21,8 @@ type ActiveCheckSpec struct {
 	// DependsOn specifies dependency on another active checks that should be completed
 	// before running this one.
 	// Name of another checks in the same namespace.
+	// Note: All checks that the current one depends on must have runAfterCreation: true;
+	// otherwise, the dependency relationship won’t be respected.
 	// +kubebuilder:validation:Optional
 	DependsOn []string `json:"dependsOn"`
 

--- a/config/crd/bases/slurm.nebius.ai_activechecks.yaml
+++ b/config/crd/bases/slurm.nebius.ai_activechecks.yaml
@@ -995,6 +995,8 @@ spec:
                   DependsOn specifies dependency on another active checks that should be completed
                   before running this one.
                   Name of another checks in the same namespace.
+                  Note: All checks that the current one depends on must have runAfterCreation: true;
+                  otherwise, the dependency relationship won’t be respected.
                 items:
                   type: string
                 type: array

--- a/helm/soperator-activechecks/scripts/ensure-healthy-nodes.sh
+++ b/helm/soperator-activechecks/scripts/ensure-healthy-nodes.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH --deadline="now+4hours"
+#SBATCH --time=5:00
+
+set -euo pipefail
+
+json=$(scontrol show nodes --json)
+bad_nodes=$(echo "$json" | jq -r '
+  .nodes[]
+  | select(
+      (.reason // "") != "" 
+      or (.comment // "") != "" 
+      or ((.state? // "") | tostring | test("DOWN|DRAIN|FAIL"))
+    )
+  | {name, reason: (.reason // ""), comment: (.comment // ""), state: .state}
+')
+
+if [[ -n "$bad_nodes" ]]; then
+  echo "Found non-healthy nodes: $bad_nodes"
+  exit 1
+else
+  echo "All nodes are healthy"
+fi

--- a/helm/soperator-activechecks/templates/ensure-healthy-nodes.yaml
+++ b/helm/soperator-activechecks/templates/ensure-healthy-nodes.yaml
@@ -1,0 +1,32 @@
+apiVersion: slurm.nebius.ai/v1alpha1
+kind: ActiveCheck
+metadata:
+  name: "ensure-healthy-nodes"
+spec:
+  checkType: "slurmJob"
+  name: "ensure-healthy-nodes"
+  dependsOn:
+  - "all-reduce-perf-nccl-with-ib"
+  - "all-reduce-perf-nccl-without-ib"
+  - "cuda-samples"
+  - "dcgmi-diag-r2"
+  - "dcgmi-diag-r3"
+  - "gpu-fryer"
+  - "ib-perf"
+  - "mem-perf"
+  slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
+  suspend: {{ .Values.checks.ensureHealthyNodes.suspend }}
+  runAfterCreation: {{ .Values.checks.ensureHealthyNodes.runAfterCreation }}
+  slurmJobSpec:
+    sbatchScript: |
+{{ tpl (.Files.Get "scripts/ensure-healthy-nodes.sh") . | indent 6 }}
+    jobContainer:
+      image: {{ .Values.images.slurmJob | quote }}
+      env:
+{{ toYaml .Values.jobContainer.env | indent 8 }}
+      volumeMounts:
+{{ toYaml .Values.jobContainer.volumeMounts | indent 8 }}
+      volumes:
+{{ toYaml .Values.jobContainer.volumes | indent 8 }}
+    mungeContainer:
+      image: {{ .Values.images.munge | quote }}

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -57,6 +57,10 @@ checks:
     enabled: false
     dir: /opt/soperator-outputs/nccl_logs
     schedule: 15 0 * * *
+  ensureHealthyNodes:
+    suspend: false
+    runAfterCreation: true
+    enabled: true
   extensiveCheck:
     suspend: true
     runAfterCreation: false

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -994,6 +994,8 @@ spec:
                   DependsOn specifies dependency on another active checks that should be completed
                   before running this one.
                   Name of another checks in the same namespace.
+                  Note: All checks that the current one depends on must have runAfterCreation: true;
+                  otherwise, the dependency relationship won’t be respected.
                 items:
                   type: string
                 type: array

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -994,6 +994,8 @@ spec:
                   DependsOn specifies dependency on another active checks that should be completed
                   before running this one.
                   Name of another checks in the same namespace.
+                  Note: All checks that the current one depends on must have runAfterCreation: true;
+                  otherwise, the dependency relationship won’t be respected.
                 items:
                   type: string
                 type: array

--- a/internal/controller/soperatorchecks/activecheck_controller.go
+++ b/internal/controller/soperatorchecks/activecheck_controller.go
@@ -367,6 +367,14 @@ func (r *ActiveCheckReconciler) dependenciesReady(
 			return false, fmt.Errorf("failed to get prerequisite ActiveCheck: %w", err)
 		}
 
+		if prerequisiteCheck.Spec.RunAfterCreation == nil || !*prerequisiteCheck.Spec.RunAfterCreation {
+			logger.Info(fmt.Sprintf(
+				"Prerequisite ActiveCheck %s runAfterCreation == false, skipping",
+				prerequisiteCheck.Name,
+			))
+			continue
+		}
+
 		// TODO: common status?
 		switch prerequisiteCheck.Spec.CheckType {
 		case "k8sJob": // TODO: const


### PR DESCRIPTION
## Problem
After cluster is provisioned and all checks run we do not check states of nodes.

## Solution
Add new ActiveCheck that would check nodes after all checks run.

## Testing
Dev cluster

## Release Notes
New `ensure-healthy-nodes` AcitveCheck that would run after all checks during cluster provisioning.
