### PR TITLE
Rename createuser to soperator-createuser to avoid PostgreSQL conflict

### DIFF
--- a/helm/soperator-activechecks/scripts/create-user-soperatorchecks.sh
+++ b/helm/soperator-activechecks/scripts/create-user-soperatorchecks.sh
@@ -3,7 +3,7 @@ set -ex
 echo "Creating soperatorchecks user..."
 chroot /mnt/jail /bin/bash -s <<'EOF'
 
-id "soperatorchecks" || echo "" | createuser soperatorchecks --home /opt/soperator-home/soperatorchecks --gecos ""
+id "soperatorchecks" || echo "" | soperator-createuser soperatorchecks --home /opt/soperator-home/soperatorchecks --gecos ""
 
 if [ ! -f /opt/soperator-home/soperatorchecks/.ssh/soperatorchecks_id_ecdsa ]; then
   echo "Generating ssh key..."

--- a/helm/soperator-activechecks/scripts/create-user.sh
+++ b/helm/soperator-activechecks/scripts/create-user.sh
@@ -5,7 +5,7 @@ echo "Creating ${USER_NAME} user..."
 retry -d 2 -t 10 -- ssh -i /mnt/jail/opt/soperator-home/soperatorchecks/.ssh/soperatorchecks_id_ecdsa \
     -o StrictHostKeyChecking=no \
     soperatorchecks@login-0.soperator-login-headless-svc.soperator.svc.cluster.local \
-    "id '${USER_NAME}' || echo '' | sudo createuser '${USER_NAME}' --gecos '' --home /opt/soperator-home/'${USER_NAME}'"
+    "id '${USER_NAME}' || echo '' | sudo soperator-createuser '${USER_NAME}' --gecos '' --home /opt/soperator-home/'${USER_NAME}'"
 
 # Because of the bug in filestore ssh is unavailable for ~15 sec after new user creation.
 echo "Wait for ssh availability 20 sec..."

--- a/images/jail/jail.dockerfile
+++ b/images/jail/jail.dockerfile
@@ -210,9 +210,10 @@ RUN chmod 755 /etc/skel/.ssh && \
 RUN rm -rf -- /root/..?* /root/.[!.]* /root/* && \
     cp -a /etc/skel/. /root/
 
-# Copy createuser utility script
-COPY images/jail/scripts/createuser.py /usr/bin/createuser
-RUN chmod +x /usr/bin/createuser
+# Copy soperator-createuser utility script
+COPY images/jail/scripts/soperator-createuser.py /usr/bin/soperator-createuser
+RUN chmod +x /usr/bin/soperator-createuser && \
+    ln -sf /usr/bin/soperator-createuser /usr/bin/createuser
 
 # Replace SSH "message of the day" scripts
 RUN rm -rf /etc/update-motd.d/*

--- a/images/jail/scripts/soperator-createuser.py
+++ b/images/jail/scripts/soperator-createuser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-createuser: a thin wrapper around Ubuntu/Debian `adduser` with sane defaults.
+soperator-createuser: a thin wrapper around Ubuntu/Debian `adduser` with sane defaults.
 
 Defaults:
 - Uses `--disabled-password` unless --with-password is given or caller overrides.
@@ -86,7 +86,7 @@ def add_to_group(username: str, group: str):
 
 def parse_args():
   p = argparse.ArgumentParser(
-    prog="createuser",
+    prog="soperator-createuser",
     formatter_class=argparse.RawTextHelpFormatter,
     description="Wrapper around `adduser` with safe defaults and SSH setup.",
   )


### PR DESCRIPTION
## Problem
The createuser script conflicted with PostgreSQL's createuser client utility. 

## Solution
Renamed createuser to soperator-createuser with backward-compatible symlink for existing scripts.

## Testing
Manual testing: deployed the cluster, run the script, created a user.

## Release Notes
Renamed `createuser` command to `soperator-createuser`. It is recommended to use the new command, although the old one is till available if not overwritten by PostgreSQL.