### PR TITLE
SCHED-137: add  --instance-id and --extra both static and dynamic config

### DIFF
--- a/images/worker/slurmd_entrypoint.sh
+++ b/images/worker/slurmd_entrypoint.sh
@@ -38,7 +38,6 @@ echo "Start slurmd daemon"
 
 slurmd_args=(
   -D
-  -Z
   --instance-id "${INSTANCE_ID}"
   --extra "${evaluated_extra}"
 )
@@ -48,6 +47,7 @@ if [ "${SOPERATOR_NODE_SETS_ON}" = "true" ]; then
 else
   echo "Running slurmd with dynamic node configuration"
   slurmd_args+=(
+    -Z
     --conf
     "NodeHostname=${K8S_POD_NAME} NodeAddr=${K8S_POD_NAME}.${K8S_SERVICE_NAME}.${K8S_POD_NAMESPACE}.svc RealMemory=${SLURM_REAL_MEMORY} Gres=${GRES} $(feature_conf)"
   )

--- a/images/worker/slurmd_entrypoint.sh
+++ b/images/worker/slurmd_entrypoint.sh
@@ -38,6 +38,9 @@ echo "Start slurmd daemon"
 
 slurmd_args=(
   -D
+  -Z
+  --instance-id "${INSTANCE_ID}"
+  --extra "${evaluated_extra}"
 )
 
 if [ "${SOPERATOR_NODE_SETS_ON}" = "true" ]; then
@@ -45,9 +48,6 @@ if [ "${SOPERATOR_NODE_SETS_ON}" = "true" ]; then
 else
   echo "Running slurmd with dynamic node configuration"
   slurmd_args+=(
-    -Z
-    --instance-id "${INSTANCE_ID}"
-    --extra "${evaluated_extra}"
     --conf
     "NodeHostname=${K8S_POD_NAME} NodeAddr=${K8S_POD_NAME}.${K8S_SERVICE_NAME}.${K8S_POD_NAMESPACE}.svc RealMemory=${SLURM_REAL_MEMORY} Gres=${GRES} $(feature_conf)"
   )

--- a/internal/render/common/configmap_test.go
+++ b/internal/render/common/configmap_test.go
@@ -425,7 +425,7 @@ func TestAddNodesToSlurmConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: "NodeName=nodeA-0 NodeHostname=nodeA-0 NodeAddr=nodeA-0.soperator.svc RealMemory=2048 Gres=gpu:nvidia-a100:4 NodeCPUs=64 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=1",
+			expected: "NodeName=nodeA-0 NodeHostname=nodeA-0 NodeAddr=nodeA-0.nodeA.soperator.svc RealMemory=2048 Gres=gpu:nvidia-a100:4 NodeCPUs=64 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=1",
 		},
 		{
 			name: "Single nodeset with multiple replicas",
@@ -456,9 +456,9 @@ func TestAddNodesToSlurmConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: "NodeName=nodeB-0 NodeHostname=nodeB-0 NodeAddr=nodeB-0.soperator.svc RealMemory=4096 Gres=gpu:nvidia-a100:8 NodeCPUs=128 Boards=1 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
-				"NodeName=nodeB-1 NodeHostname=nodeB-1 NodeAddr=nodeB-1.soperator.svc RealMemory=4096 Gres=gpu:nvidia-a100:8 NodeCPUs=128 Boards=1 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
-				"NodeName=nodeB-2 NodeHostname=nodeB-2 NodeAddr=nodeB-2.soperator.svc RealMemory=4096 Gres=gpu:nvidia-a100:8 NodeCPUs=128 Boards=1 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1",
+			expected: "NodeName=nodeB-0 NodeHostname=nodeB-0 NodeAddr=nodeB-0.nodeB.soperator.svc RealMemory=4096 Gres=gpu:nvidia-a100:8 NodeCPUs=128 Boards=1 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
+				"NodeName=nodeB-1 NodeHostname=nodeB-1 NodeAddr=nodeB-1.nodeB.soperator.svc RealMemory=4096 Gres=gpu:nvidia-a100:8 NodeCPUs=128 Boards=1 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
+				"NodeName=nodeB-2 NodeHostname=nodeB-2 NodeAddr=nodeB-2.nodeB.soperator.svc RealMemory=4096 Gres=gpu:nvidia-a100:8 NodeCPUs=128 Boards=1 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1",
 		},
 		{
 			name: "Multiple nodesets with varying replicas",
@@ -506,9 +506,9 @@ func TestAddNodesToSlurmConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: "NodeName=nodeC-0 NodeHostname=nodeC-0 NodeAddr=nodeC-0.soperator.svc RealMemory=8192 Gres=gpu:nvidia-a100:16 NodeCPUs=256 Boards=2 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
-				"NodeName=nodeC-1 NodeHostname=nodeC-1 NodeAddr=nodeC-1.soperator.svc RealMemory=8192 Gres=gpu:nvidia-a100:16 NodeCPUs=256 Boards=2 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
-				"NodeName=nodeD-0 NodeHostname=nodeD-0 NodeAddr=nodeD-0.soperator.svc RealMemory=16384 Gres=gpu:nvidia-a100:32 NodeCPUs=512 Boards=4 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1",
+			expected: "NodeName=nodeC-0 NodeHostname=nodeC-0 NodeAddr=nodeC-0.nodeC.soperator.svc RealMemory=8192 Gres=gpu:nvidia-a100:16 NodeCPUs=256 Boards=2 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
+				"NodeName=nodeC-1 NodeHostname=nodeC-1 NodeAddr=nodeC-1.nodeC.soperator.svc RealMemory=8192 Gres=gpu:nvidia-a100:16 NodeCPUs=256 Boards=2 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
+				"NodeName=nodeD-0 NodeHostname=nodeD-0 NodeAddr=nodeD-0.nodeD.soperator.svc RealMemory=16384 Gres=gpu:nvidia-a100:32 NodeCPUs=512 Boards=4 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1",
 		},
 		{
 			name: "Nodeset with zero replicas",


### PR DESCRIPTION
## Problem
Dynamic update of instance ID and extra parameters at slurmd startup, with static configuration.

## Solution
- Updated worker entrypoint

## Testing
-  manual testing feature when `SOPERATOR_NODE_SETS_ON=true`: slurmd uses static configuration from `slurm.conf`

## Release Notes
**Feature:** Updated worker entrypoint