### PR TITLE
[DEP] Update controller-gen to 0.19.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -445,7 +445,7 @@ MOCKERY        ?= $(LOCALBIN)/mockery
 
 ## Tool Versions
 KUSTOMIZE_VERSION        ?= v5.5.0
-CONTROLLER_TOOLS_VERSION ?= v0.16.4
+CONTROLLER_TOOLS_VERSION ?= v0.19.0
 ENVTEST_VERSION          ?= release-0.17
 GOLANGCI_LINT_VERSION    ?= v2.5.0  # Should be in sync with the github CI step.
 HELMIFY_VERSION          ?= 0.4.13

--- a/config/crd/bases/slurm.nebius.ai_activechecks.yaml
+++ b/config/crd/bases/slurm.nebius.ai_activechecks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: activechecks.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai

--- a/config/crd/bases/slurm.nebius.ai_jailedconfigs.yaml
+++ b/config/crd/bases/slurm.nebius.ai_jailedconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: jailedconfigs.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai

--- a/config/crd/bases/slurm.nebius.ai_nodeconfigurators.yaml
+++ b/config/crd/bases/slurm.nebius.ai_nodeconfigurators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: nodeconfigurators.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai

--- a/config/crd/bases/slurm.nebius.ai_nodesets.yaml
+++ b/config/crd/bases/slurm.nebius.ai_nodesets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: nodesets.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: slurmclusters.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: activechecks.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai
@@ -7783,7 +7783,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: jailedconfigs.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai
@@ -7987,7 +7987,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: nodeconfigurators.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai
@@ -12734,7 +12734,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: nodesets.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai
@@ -18087,7 +18087,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: slurmclusters.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: activechecks.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai
@@ -7783,7 +7783,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: jailedconfigs.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai
@@ -7987,7 +7987,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: nodeconfigurators.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai
@@ -12734,7 +12734,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: nodesets.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai
@@ -18087,7 +18087,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: slurmclusters.slurm.nebius.ai
 spec:
   group: slurm.nebius.ai


### PR DESCRIPTION
## Problem
K8s packages diverge in versions between `go.mod` and `controller-gen`'s `go.mod`.

## Solution
`controller-tools`@`0.19.0` [introduces](https://github.com/kubernetes-sigs/controller-tools/releases/tag/v0.19.0) K8s package version bump to `v0.34`.

## Testing
No testing needed. Only annotations on generated resources are changed.

## Release Notes
Bumped version of `controller-tools` to `0.19.0`.