### PR TITLE
Build Slurm 25.05.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CHART_DCGM_EXPORTER_PATH      = $(CHART_PATH)/soperator-dcgm-exporter
 CHART_SOPERATOR_NOTIFIER_PATH = $(CHART_PATH)/soperator-notifier
 CHART_NFS_SERVER_PATH         = $(CHART_PATH)/nfs-server
 
-SLURM_VERSION		  		= 25.05.3
+SLURM_VERSION		  		= 25.05.4
 UBUNTU_VERSION		  		?= noble
 VERSION               		= $(shell cat VERSION)
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This helps cluster administrators and users monitor resource utilization, enforc
 - **Single-partition clusters**. Slurm's ability to split clusters into several partitions isn't supported now.
 - **Software versions**. The list of software versions we currently support is quite short.
     - Linux: Ubuntu [24.04](https://releases.ubuntu.com/noble/).
-    - Slurm: versions `25.05.3`.
+    - Slurm: versions `25.05.4`.
     - CUDA: version [12.9](https://docs.nvidia.com/cuda/archive/12.9.0/cuda-toolkit-release-notes/contents.html).
     - Kubernetes: >= [1.31](https://kubernetes.io/blog/2024/08/13/kubernetes-v1-31-release/).
     - Versions of some preinstalled software packages can't be changed.

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -507,14 +507,14 @@ telemetry: {}
 #   otelCollectorPort: 8429
 
 images:
-  slurmctld: "cr.eu-north1.nebius.cloud/soperator/controller_slurmctld:1.22.1-noble-slurm25.05.3"
-  slurmrestd: "cr.eu-north1.nebius.cloud/soperator/slurmrestd:1.22.1-noble-slurm25.05.3"
-  slurmd: "cr.eu-north1.nebius.cloud/soperator/worker_slurmd:1.22.1-noble-slurm25.05.3"
-  sshd: "cr.eu-north1.nebius.cloud/soperator/login_sshd:1.22.1-noble-slurm25.05.3"
-  munge: "cr.eu-north1.nebius.cloud/soperator/munge:1.22.1-noble-slurm25.05.3"
-  populateJail: "cr.eu-north1.nebius.cloud/soperator/populate_jail:1.22.1-noble-slurm25.05.3"
-  slurmdbd: "cr.eu-north1.nebius.cloud/soperator/controller_slurmdbd:1.22.1-noble-slurm25.05.3"
-  soperatorExporter: "cr.eu-north1.nebius.cloud/soperator/soperator-exporter:1.22.1-noble-slurm25.05.3"
+  slurmctld: "cr.eu-north1.nebius.cloud/soperator/controller_slurmctld:1.22.1-noble-slurm25.05.4"
+  slurmrestd: "cr.eu-north1.nebius.cloud/soperator/slurmrestd:1.22.1-noble-slurm25.05.4"
+  slurmd: "cr.eu-north1.nebius.cloud/soperator/worker_slurmd:1.22.1-noble-slurm25.05.4"
+  sshd: "cr.eu-north1.nebius.cloud/soperator/login_sshd:1.22.1-noble-slurm25.05.4"
+  munge: "cr.eu-north1.nebius.cloud/soperator/munge:1.22.1-noble-slurm25.05.4"
+  populateJail: "cr.eu-north1.nebius.cloud/soperator/populate_jail:1.22.1-noble-slurm25.05.4"
+  slurmdbd: "cr.eu-north1.nebius.cloud/soperator/controller_slurmdbd:1.22.1-noble-slurm25.05.4"
+  soperatorExporter: "cr.eu-north1.nebius.cloud/soperator/soperator-exporter:1.22.1-noble-slurm25.05.4"
   sConfigController: cr.eu-north1.nebius.cloud/soperator/sconfigcontroller:1.22.1
   mariaDB: docker-registry1.mariadb.com/library/mariadb:11.4.3
 # Configuration for slurm scripts.

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -19,9 +19,9 @@ jobContainer:
       persistentVolumeClaim:
         claimName: "jail-pvc"
 images:
-  slurmJob: "cr.eu-north1.nebius.cloud/soperator/slurm_check_job:1.22.1-noble-slurm25.05.3"
-  k8sJob: "cr.eu-north1.nebius.cloud/soperator/k8s_check_job:1.22.1-noble-slurm25.05.3"
-  munge: "cr.eu-north1.nebius.cloud/soperator/munge:1.22.1-noble-slurm25.05.3"
+  slurmJob: "cr.eu-north1.nebius.cloud/soperator/slurm_check_job:1.22.1-noble-slurm25.05.4"
+  k8sJob: "cr.eu-north1.nebius.cloud/soperator/k8s_check_job:1.22.1-noble-slurm25.05.4"
+  munge: "cr.eu-north1.nebius.cloud/soperator/munge:1.22.1-noble-slurm25.05.4"
 # Pyxis syntax with '#' separator for registry
 activeCheckImage: "cr.eu-north1.nebius.cloud#soperator/active_checks:12.9.0-ubuntu24.04-nccl_tests2.16.4-4ae0b6d"
 reservationPrefix: soperatorchecks.suspicious

--- a/images/common/spank-nccl-debug/Makefile
+++ b/images/common/spank-nccl-debug/Makefile
@@ -11,7 +11,7 @@ endif
 TARGET_COMPILATION_MODE ?= release
 
 # https://github.com/SchedMD/slurm/tags
-SLURM_VERSION ?= 25.05.3.1
+SLURM_VERSION ?= 25.05.4.1
 # Replace underscores and dashes with dots
 SLURM_VERSION_BRANCH = $(subst _,-,$(subst .,-,$(SLURM_VERSION)))
 

--- a/images/common/spank-nccl-debug/docker/base.dockerfile
+++ b/images/common/spank-nccl-debug/docker/base.dockerfile
@@ -1,7 +1,7 @@
 # Or arm64v8
 ARG ARCH="amd64"
 
-ARG SLURM_VERSION="25-05-3-1"
+ARG SLURM_VERSION="25-05-4-1"
 
 FROM ${ARCH}/fedora:42 AS slurm-base
 LABEL org.opencontainers.image.authors="Dmitrii Starov <dstaroff@nebius.com>"


### PR DESCRIPTION
## Release Notes
Building new Slurm version 25.05.4
[Changelog for Slurm](https://github.com/SchedMD/slurm/blob/slurm-25.05/CHANGELOG/slurm-25.05.md)
