### PR TITLE
Set `driftDetection.mode: warn` by default for helm releases

### DIFF
--- a/helm/soperator-fluxcd/templates/_helpers.tpl
+++ b/helm/soperator-fluxcd/templates/_helpers.tpl
@@ -51,14 +51,3 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
-
-{{/*
-Get driftDetection configuration for Helm Releases
-Usage: {{ include "soperator-fluxcd.driftDetection" .Values.release.driftDetection }}
-*/}}
-{{- define "soperator-fluxcd.driftDetection" -}}
-{{- with . -}}
-driftDetection:
-  mode: {{ .mode }}
-{{- end }}
-{{- end }}

--- a/helm/soperator-fluxcd/templates/backup.yaml
+++ b/helm/soperator-fluxcd/templates/backup.yaml
@@ -32,7 +32,10 @@ spec:
   timeout: {{ .Values.backup.timeout }}
   releaseName: {{ .Values.backup.releaseName }}
   targetNamespace: {{ .Values.backup.namespace }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.backup.driftDetection | nindent 2 }}
+  {{- if .Values.backup.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.backup.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.backup.overrideValues }}
     {{- toYaml .Values.backup.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/backup_schedule.yaml
+++ b/helm/soperator-fluxcd/templates/backup_schedule.yaml
@@ -27,7 +27,10 @@ spec:
   targetNamespace: {{ .Values.slurmCluster.namespace }}
   upgrade:
     crds: Skip
-  {{- include "soperator-fluxcd.driftDetection" .Values.backup.driftDetection | nindent 2 }}
+  {{- if .Values.backup.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.backup.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
     resources:
     - apiVersion: k8up.io/v1

--- a/helm/soperator-fluxcd/templates/cert-manager.yaml
+++ b/helm/soperator-fluxcd/templates/cert-manager.yaml
@@ -32,7 +32,10 @@ spec:
   targetNamespace: {{ .Values.certManager.namespace }}
   releaseName: {{ .Values.certManager.releaseName }}
   timeout: {{ .Values.certManager.timeout }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.certManager.driftDetection | nindent 2 }}
+  {{- if .Values.certManager.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.certManager.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.certManager.overrideValues }}
     {{- toYaml .Values.certManager.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/csi-driver-nfs.yaml
+++ b/helm/soperator-fluxcd/templates/csi-driver-nfs.yaml
@@ -26,7 +26,10 @@ spec:
   timeout: {{ .Values.csiDriverNfs.timeout }}
   releaseName: {{ .Values.csiDriverNfs.releaseName }}
   targetNamespace: {{ .Values.csiDriverNfs.namespace }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.csiDriverNfs.driftDetection | nindent 2 }}
+  {{- if .Values.csiDriverNfs.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.csiDriverNfs.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.csiDriverNfs.overrideValues }}
     {{- toYaml .Values.csiDriverNfs.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/dcgm-exporter.yaml
+++ b/helm/soperator-fluxcd/templates/dcgm-exporter.yaml
@@ -27,7 +27,10 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- include "soperator-fluxcd.driftDetection" .Values.observability.dcgmExporter.driftDetection | nindent 2 }}
+  {{- if .Values.observability.dcgmExporter.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.observability.dcgmExporter.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
     dcgmHpcJobMappingDir: {{ .Values.observability.dcgmExporter.values.hpcJobMapDir }}
     validateToolkit: {{ .Values.observability.dcgmExporter.values.validateToolkit }}

--- a/helm/soperator-fluxcd/templates/helmrelease-trigger-operator.yaml
+++ b/helm/soperator-fluxcd/templates/helmrelease-trigger-operator.yaml
@@ -29,7 +29,10 @@ spec:
   timeout: {{ .Values.helmReleaseTriggerOperator.timeout }}
   releaseName: {{ .Values.helmReleaseTriggerOperator.releaseName }}
   targetNamespace: {{ .Values.helmReleaseTriggerOperator.namespace }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.helmReleaseTriggerOperator.driftDetection | nindent 2 }}
+  {{- if .Values.helmReleaseTriggerOperator.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.helmReleaseTriggerOperator.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.helmReleaseTriggerOperator.overrideValues }}
     {{- toYaml .Values.helmReleaseTriggerOperator.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/kruise.yaml
+++ b/helm/soperator-fluxcd/templates/kruise.yaml
@@ -32,7 +32,10 @@ spec:
   timeout: {{ .Values.soperator.kruise.timeout }}
   releaseName: {{ .Values.soperator.kruise.releaseName }}
   targetNamespace: {{ .Values.slurmCluster.namespace }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.soperator.kruise.driftDetection | nindent 2 }}
+  {{- if .Values.soperator.kruise.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.soperator.kruise.driftDetection | nindent 4 -}}
+  {{- end }}
   {{- if .Values.soperator.kruise.overrideValues }}
   values:
     {{- toYaml .Values.soperator.kruise.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/mariadb-operator-crds.yaml
+++ b/helm/soperator-fluxcd/templates/mariadb-operator-crds.yaml
@@ -14,7 +14,10 @@ spec:
         kind: HelmRepository
         name: {{ include "soperator-fluxcd.fullname" . }}-mariadb-operator
       version: {{ .Values.mariadbOperator.version }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.mariadbOperator.driftDetection | nindent 2 }}
+  {{- if .Values.mariadbOperator.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.mariadbOperator.driftDetection | nindent 4 -}}
+  {{- end }}
   install:
     crds: CreateReplace
     remediation:

--- a/helm/soperator-fluxcd/templates/mariadb-operator.yaml
+++ b/helm/soperator-fluxcd/templates/mariadb-operator.yaml
@@ -31,7 +31,10 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- include "soperator-fluxcd.driftDetection" .Values.mariadbOperator.driftDetection | nindent 2 }}
+  {{- if .Values.mariadbOperator.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.mariadbOperator.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.mariadbOperator.overrideValues }}
     {{- toYaml .Values.mariadbOperator.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/namespaces.yaml
+++ b/helm/soperator-fluxcd/templates/namespaces.yaml
@@ -17,7 +17,10 @@ spec:
     remediation:
       retries: 3
   interval: {{ .Values.ns.interval }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.ns.driftDetection | nindent 2 }}
+  {{- if .Values.ns.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.ns.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
     resources:
     - apiVersion: v1

--- a/helm/soperator-fluxcd/templates/nfs-server.yaml
+++ b/helm/soperator-fluxcd/templates/nfs-server.yaml
@@ -27,7 +27,10 @@ spec:
   timeout: {{ .Values.nfsServer.timeout }}
   releaseName: {{ .Values.nfsServer.releaseName }}
   targetNamespace: {{ .Values.nfsServer.namespace }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.nfsServer.driftDetection | nindent 2 }}
+  {{- if .Values.nfsServer.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.nfsServer.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.nfsServer.overrideValues }}
     {{- toYaml .Values.nfsServer.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/nodeconfigurator.yaml
+++ b/helm/soperator-fluxcd/templates/nodeconfigurator.yaml
@@ -29,7 +29,10 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- include "soperator-fluxcd.driftDetection" .Values.soperator.nodeConfigurator.driftDetection | nindent 2 }}
+  {{- if .Values.soperator.nodeConfigurator.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.soperator.nodeConfigurator.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.soperator.nodeConfigurator.overrideValues }}
     {{- toYaml .Values.soperator.nodeConfigurator.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/notifier.yaml
+++ b/helm/soperator-fluxcd/templates/notifier.yaml
@@ -28,7 +28,10 @@ spec:
   timeout: {{ .Values.notifier.timeout }}
   releaseName: {{ .Values.notifier.releaseName }}
   targetNamespace: {{ .Values.notifier.namespace }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.notifier.driftDetection | nindent 2 }}
+  {{- if .Values.notifier.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.notifier.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
     {{- if .Values.notifier.overrideValues }}
     {{- toYaml .Values.notifier.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -28,7 +28,10 @@ spec:
   timeout: {{ .Values.observability.opentelemetry.events.timeout }}
   releaseName: opentelemetry-collector-events
   targetNamespace: logs-system
-  {{- include "soperator-fluxcd.driftDetection" .Values.observability.opentelemetry.events.driftDetection | nindent 2 }}
+  {{- if .Values.observability.opentelemetry.events.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.observability.opentelemetry.events.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- if .Values.observability.opentelemetry.events.overrideValues }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -30,7 +30,10 @@ spec:
   timeout: {{ .Values.observability.opentelemetry.logs.timeout }}
   releaseName: opentelemetry-collector-jail-logs
   targetNamespace: logs-system
-  {{- include "soperator-fluxcd.driftDetection" .Values.observability.opentelemetry.logs.driftDetection | nindent 2 }}
+  {{- if .Values.observability.opentelemetry.logs.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.observability.opentelemetry.logs.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -28,7 +28,10 @@ spec:
   timeout: {{ .Values.observability.opentelemetry.logs.timeout }}
   releaseName: opentelemetry-collector-logs
   targetNamespace: logs-system
-  {{- include "soperator-fluxcd.driftDetection" .Values.observability.opentelemetry.logs.driftDetection | nindent 2 }}
+  {{- if .Values.observability.opentelemetry.logs.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.observability.opentelemetry.logs.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}

--- a/helm/soperator-fluxcd/templates/prometheus-operator-crds.yaml
+++ b/helm/soperator-fluxcd/templates/prometheus-operator-crds.yaml
@@ -14,6 +14,9 @@ spec:
         kind: HelmRepository
         name: {{ include "soperator-fluxcd.fullname" . }}-prometheus-operator-crds
       version: {{ .Values.observability.prometheusOperator.version }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.observability.prometheusOperator.driftDetection | nindent 2 }}
+  {{- if .Values.observability.prometheusOperator.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.observability.prometheusOperator.driftDetection | nindent 4 -}}
+  {{- end }}
   interval: 60m
 {{- end }}

--- a/helm/soperator-fluxcd/templates/security-profiles-operator.yaml
+++ b/helm/soperator-fluxcd/templates/security-profiles-operator.yaml
@@ -27,7 +27,10 @@ spec:
   timeout: {{ .Values.securityProfilesOperator.timeout }}
   releaseName: {{ .Values.securityProfilesOperator.releaseName }}
   targetNamespace: {{ .Values.securityProfilesOperator.namespace }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.securityProfilesOperator.driftDetection | nindent 2 }}
+  {{- if .Values.securityProfilesOperator.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.securityProfilesOperator.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.securityProfilesOperator.overrideValues }}
     {{- toYaml .Values.securityProfilesOperator.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/slurm-cluster-storage.yaml
+++ b/helm/soperator-fluxcd/templates/slurm-cluster-storage.yaml
@@ -30,7 +30,10 @@ spec:
   timeout: {{ .Values.slurmCluster.slurmClusterStorage.timeout }}
   releaseName: {{ .Values.slurmCluster.slurmClusterStorage.releaseName }}
   targetNamespace: {{ .Values.slurmCluster.namespace }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.slurmCluster.slurmClusterStorage.driftDetection | nindent 2 }}
+  {{- if .Values.slurmCluster.slurmClusterStorage.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.slurmCluster.slurmClusterStorage.driftDetection | nindent 4 -}}
+  {{- end }}
   {{- if .Values.slurmCluster.slurmClusterStorage.overrideValues }}
   values:
     {{- toYaml .Values.slurmCluster.slurmClusterStorage.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/slurm-cluster.yaml
+++ b/helm/soperator-fluxcd/templates/slurm-cluster.yaml
@@ -39,7 +39,10 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- include "soperator-fluxcd.driftDetection" .Values.slurmCluster.driftDetection | nindent 2 }}
+  {{- if .Values.slurmCluster.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.slurmCluster.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.slurmCluster.overrideValues }}
     {{- toYaml .Values.slurmCluster.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/soperator-activechecks.yaml
+++ b/helm/soperator-fluxcd/templates/soperator-activechecks.yaml
@@ -30,7 +30,10 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- include "soperator-fluxcd.driftDetection" .Values.soperatorActiveChecks.driftDetection | nindent 2 }}
+  {{- if .Values.soperatorActiveChecks.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.soperatorActiveChecks.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.soperatorActiveChecks.overrideValues }}
     {{- toYaml .Values.soperatorActiveChecks.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/soperator.yaml
+++ b/helm/soperator-fluxcd/templates/soperator.yaml
@@ -33,7 +33,10 @@ spec:
   timeout: {{ .Values.soperator.timeout }}
   releaseName: {{ .Values.soperator.releaseName }}
   targetNamespace: {{ .Values.soperator.namespace }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.soperator.driftDetection | nindent 2 }}
+  {{- if .Values.soperator.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.soperator.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.soperator.overrideValues }}
     {{- toYaml .Values.soperator.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/soperatorchecks.yaml
+++ b/helm/soperator-fluxcd/templates/soperatorchecks.yaml
@@ -27,7 +27,10 @@ spec:
   timeout: {{ .Values.soperator.soperatorChecks.timeout }}
   releaseName: {{ .Values.soperator.soperatorChecks.releaseName }}
   targetNamespace: {{ .Values.soperator.namespace }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.soperator.soperatorChecks.driftDetection | nindent 2 }}
+  {{- if .Values.soperator.soperatorChecks.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.soperator.soperatorChecks.driftDetection | nindent 4 -}}
+  {{- end }}
   {{- if .Values.soperator.soperatorChecks.values }}
   values:
     {{- toYaml .Values.soperator.soperatorChecks.values | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/tailscale.yaml
+++ b/helm/soperator-fluxcd/templates/tailscale.yaml
@@ -22,7 +22,10 @@ spec:
   timeout: {{ .Values.tailscale.timeout }}
   upgrade:
     crds: Skip
-  {{- include "soperator-fluxcd.driftDetection" .Values.tailscale.driftDetection | nindent 2 }}
+  {{- if .Values.tailscale.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.tailscale.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/soperator-fluxcd/templates/victoria-metrics-operator-crds.yaml
+++ b/helm/soperator-fluxcd/templates/victoria-metrics-operator-crds.yaml
@@ -14,7 +14,10 @@ spec:
         kind: HelmRepository
         name: {{ include "soperator-fluxcd.fullname" . }}-victoriametrics
       version: {{ .Values.observability.vmStack.crds.version }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.observability.vmStack.crds.driftDetection | nindent 2 }}
+  {{- if .Values.observability.vmStack.crds.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.observability.vmStack.crds.driftDetection | nindent 4 -}}
+  {{- end }}
   install:
     crds: CreateReplace
     remediation:

--- a/helm/soperator-fluxcd/templates/vm-logs.yaml
+++ b/helm/soperator-fluxcd/templates/vm-logs.yaml
@@ -27,7 +27,10 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- include "soperator-fluxcd.driftDetection" .Values.observability.vmLogs.driftDetection | nindent 2 }}
+  {{- if .Values.observability.vmLogs.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.observability.vmLogs.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.observability.vmStack.overrideValues }}
     {{- toYaml .Values.observability.vmStack.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -35,7 +35,10 @@ spec:
   {{- if .Values.observability.vmStack.namespace }}
   targetNamespace: {{ .Values.observability.vmStack.namespace }}
   {{- end }}
-  {{- include "soperator-fluxcd.driftDetection" .Values.observability.vmStack.driftDetection | nindent 2 }}
+  {{- if .Values.observability.vmStack.driftDetection }}
+  driftDetection:
+    {{- toYaml .Values.observability.vmStack.driftDetection | nindent 4 -}}
+  {{- end }}
   values:
   {{- if .Values.observability.vmStack.overrideValues }}
     {{- toYaml .Values.observability.vmStack.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -59,6 +59,8 @@ certManager:
   overrideValues: null
 backup:
   enabled: true
+  driftDetection:
+    mode: warn
   interval: 5m
   timeout: 5m
   version: 4.8.*


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

We need to check whether K8S resources have drifted from helm releases (chart + value).

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
We can make use of [FluxCD drift detection](https://fluxcd.io/flux/components/helm/helmreleases/#drift-detection) by setting it to warn, so it emit K8S events on detected drifts.
## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Setting `driftDetection.mode: warn` by default for helm releases in FluxCD.