### PR TITLE
SCHED-173: Fix the jobs limit increase

### DIFF
--- a/helm/slurm-cluster/tests/README.md
+++ b/helm/slurm-cluster/tests/README.md
@@ -39,8 +39,8 @@ These tests verify the following kubebuilder default values:
 - `epilog: ""`
 - `prolog: ""`
 - `taskPluginParam: ""`
-- `maxJobCount: 10000`
-- `minJobAge: 86400`
+- `maxJobCount: 20000`
+- `minJobAge: 28800`
 - `messageTimeout: 60`
 - `topologyPlugin: "topology/tree"`
 - `topologyParam: "SwitchAsNodeRank"`

--- a/helm/slurm-cluster/tests/default-values_test.yaml
+++ b/helm/slurm-cluster/tests/default-values_test.yaml
@@ -45,10 +45,10 @@ tests:
           value: ""
       - equal:
           path: spec.slurmConfig.maxJobCount
-          value: 10000
+          value: 20000
       - equal:
           path: spec.slurmConfig.minJobAge
-          value: 86400
+          value: 28800
       - equal:
           path: spec.slurmConfig.messageTimeout
           value: 60

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -123,8 +123,8 @@ slurmConfig:
   prolog: /opt/slurm_scripts/prolog.sh
   epilog: /opt/slurm_scripts/epilog.sh
   taskPluginParam: ""
-  maxJobCount: 10000
-  minJobAge: 86400
+  maxJobCount: 20000
+  minJobAge: 28800
   messageTimeout: 60
   topologyPlugin: "topology/tree"
   topologyParam: "SwitchAsNodeRank"


### PR DESCRIPTION
## Problem
We tried to increase the default limit on how many jobs can run on clusters, but that change didn't work correctly because I forgot to set new values in some places.

## Solution
Update `maxJobCount` and `minJobAge` settings in `slurm-cluster` default Helm values.

## Testing
1. Create a new cluster
2. Ensure `MaxJobCount` is `20000` and `MinJobAge` is `28800` in `scontrol show config`

## Release Notes
Increased the default limit on the maximum number of jobs: 10k/1d -> 20k/8h
