### PR TITLE
SCHED-180: Refactor ActiveCheck CRD additional printer columns

### DIFF
--- a/api/v1alpha1/activecheck_types.go
+++ b/api/v1alpha1/activecheck_types.go
@@ -225,12 +225,15 @@ type JobAndReason struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.checkType`,description="The type of the active check"
-// +kubebuilder:printcolumn:name="K8s Job Status",type=string,JSONPath=`.status.k8sJobsStatus.lastJobStatus`,description="Last K8s job status"
-// +kubebuilder:printcolumn:name="Slurm Run Status",type=string,JSONPath=`.status.slurmJobsStatus.lastRunStatus`,description="Last Slurm run status"
-// +kubebuilder:printcolumn:name="Last Run Name",type=string,JSONPath=`.status.slurmJobsStatus.lastRunName`,description="Last run name"
-// +kubebuilder:printcolumn:name="Last Run ID",type=string,JSONPath=`.status.slurmJobsStatus.lastRunId`,description="Last run ID"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.checkType`,description="Active check type"
+// +kubebuilder:printcolumn:name="Run After Creation",type=boolean,JSONPath=`.spec.runAfterCreation`,description="Whether to run this check after creation"
+// +kubebuilder:printcolumn:name="Suspend Periodic",type=boolean,JSONPath=`.spec.suspend`,description="Whether to suspend periodic runs of this check"
+// +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=`.spec.schedule`,description="Schedule"
+// +kubebuilder:printcolumn:name="K8s Status",type=string,JSONPath=`.status.k8sJobsStatus.lastJobStatus`,description="Status of the last K8s job"
+// +kubebuilder:printcolumn:name="Slurm Status",type=string,JSONPath=`.status.slurmJobsStatus.lastRunStatus`,description="Status of the last Slurm job"
+// +kubebuilder:printcolumn:name="Slurm Submit Time",type=string,JSONPath=`.status.slurmJobStatus.lastJobSubmitTime`,description="Submission time of the last Slurm job"
+// +kubebuilder:printcolumn:name="Slurm ID",type=string,JSONPath=`.status.slurmJobsStatus.lastRunId`,description="ID of the last Slurm job"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="When the job was created"
 
 // ActiveCheck is the Schema for the activechecks API.
 type ActiveCheck struct {

--- a/config/crd/bases/slurm.nebius.ai_activechecks.yaml
+++ b/config/crd/bases/slurm.nebius.ai_activechecks.yaml
@@ -15,27 +15,40 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The type of the active check
+    - description: Active check type
       jsonPath: .spec.checkType
       name: Type
       type: string
-    - description: Last K8s job status
+    - description: Whether to run this check after creation
+      jsonPath: .spec.runAfterCreation
+      name: Run After Creation
+      type: boolean
+    - description: Whether to suspend periodic runs of this check
+      jsonPath: .spec.suspend
+      name: Suspend Periodic
+      type: boolean
+    - description: Schedule
+      jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - description: Status of the last K8s job
       jsonPath: .status.k8sJobsStatus.lastJobStatus
-      name: K8s Job Status
+      name: K8s Status
       type: string
-    - description: Last Slurm run status
+    - description: Status of the last Slurm job
       jsonPath: .status.slurmJobsStatus.lastRunStatus
-      name: Slurm Run Status
+      name: Slurm Status
       type: string
-    - description: Last run name
-      jsonPath: .status.slurmJobsStatus.lastRunName
-      name: Last Run Name
+    - description: Submission time of the last Slurm job
+      jsonPath: .status.slurmJobStatus.lastJobSubmitTime
+      name: Slurm Submit Time
       type: string
-    - description: Last run ID
+    - description: ID of the last Slurm job
       jsonPath: .status.slurmJobsStatus.lastRunId
-      name: Last Run ID
+      name: Slurm ID
       type: string
-    - jsonPath: .metadata.creationTimestamp
+    - description: When the job was created
+      jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
     name: v1alpha1

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -14,27 +14,40 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The type of the active check
+    - description: Active check type
       jsonPath: .spec.checkType
       name: Type
       type: string
-    - description: Last K8s job status
+    - description: Whether to run this check after creation
+      jsonPath: .spec.runAfterCreation
+      name: Run After Creation
+      type: boolean
+    - description: Whether to suspend periodic runs of this check
+      jsonPath: .spec.suspend
+      name: Suspend Periodic
+      type: boolean
+    - description: Schedule
+      jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - description: Status of the last K8s job
       jsonPath: .status.k8sJobsStatus.lastJobStatus
-      name: K8s Job Status
+      name: K8s Status
       type: string
-    - description: Last Slurm run status
+    - description: Status of the last Slurm job
       jsonPath: .status.slurmJobsStatus.lastRunStatus
-      name: Slurm Run Status
+      name: Slurm Status
       type: string
-    - description: Last run name
-      jsonPath: .status.slurmJobsStatus.lastRunName
-      name: Last Run Name
+    - description: Submission time of the last Slurm job
+      jsonPath: .status.slurmJobStatus.lastJobSubmitTime
+      name: Slurm Submit Time
       type: string
-    - description: Last run ID
+    - description: ID of the last Slurm job
       jsonPath: .status.slurmJobsStatus.lastRunId
-      name: Last Run ID
+      name: Slurm ID
       type: string
-    - jsonPath: .metadata.creationTimestamp
+    - description: When the job was created
+      jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
     name: v1alpha1

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -14,27 +14,40 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The type of the active check
+    - description: Active check type
       jsonPath: .spec.checkType
       name: Type
       type: string
-    - description: Last K8s job status
+    - description: Whether to run this check after creation
+      jsonPath: .spec.runAfterCreation
+      name: Run After Creation
+      type: boolean
+    - description: Whether to suspend periodic runs of this check
+      jsonPath: .spec.suspend
+      name: Suspend Periodic
+      type: boolean
+    - description: Schedule
+      jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - description: Status of the last K8s job
       jsonPath: .status.k8sJobsStatus.lastJobStatus
-      name: K8s Job Status
+      name: K8s Status
       type: string
-    - description: Last Slurm run status
+    - description: Status of the last Slurm job
       jsonPath: .status.slurmJobsStatus.lastRunStatus
-      name: Slurm Run Status
+      name: Slurm Status
       type: string
-    - description: Last run name
-      jsonPath: .status.slurmJobsStatus.lastRunName
-      name: Last Run Name
+    - description: Submission time of the last Slurm job
+      jsonPath: .status.slurmJobStatus.lastJobSubmitTime
+      name: Slurm Submit Time
       type: string
-    - description: Last run ID
+    - description: ID of the last Slurm job
       jsonPath: .status.slurmJobsStatus.lastRunId
-      name: Last Run ID
+      name: Slurm ID
       type: string
-    - jsonPath: .metadata.creationTimestamp
+    - description: When the job was created
+      jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
     name: v1alpha1


### PR DESCRIPTION
## Problem
`kubectl get` of ActiveCheck CR instances doesn't show some important fields (such as last job submission time).

## Solution
Changed the list of fields shown in the overview and renamed column names to make them shorter.

## Testing
1. Deploy a new cluster
2. Look at the `kubectl get activechecks -n soperator` output and ensure it shows new columns (i.e. "Schedule") and values are correct

## Release Notes
Show more columns in `kubectl get` of ActiveCheck CR instances in K8s.
