### PR TITLE
SCHED-247: Rename K8s node condition MaintenanceScheduled->NebiusMaintenanceScheduled

### DIFF
--- a/internal/consts/conditions.go
+++ b/internal/consts/conditions.go
@@ -10,7 +10,7 @@ const (
 	SoperatorChecksK8SNodeDegraded    corev1.NodeConditionType = "SoperatorChecksNodeDegraded"
 	SoperatorChecksK8SNodeMaintenance corev1.NodeConditionType = "SoperatorChecksNodeMaintenance"
 	// External condition to react in soperator checks.
-	K8SNodeMaintenanceScheduled corev1.NodeConditionType = "MaintenanceScheduled"
+	K8SNodeMaintenanceScheduled corev1.NodeConditionType = "NebiusMaintenanceScheduled"
 	HardwareIssuesSuspected     corev1.NodeConditionType = "HardwareIssuesSuspected"
 )
 


### PR DESCRIPTION

## Problem
Nebius Managed Kubernetes renamed the condition "MaintenanceScheduled" to "NebiusMaintenanceScheduled" (the previous one is still supported for now).

## Solution
Rename it in Soperator as well.

## Testing
1. Create a new cluster.
2. Ensure Soperator replaces nodes with "NebiusMaintenanceScheduled" conditions. 

## Release Notes
Nothing
