### PR TITLE
SCHED-251: ignore down nodes

### DIFF
--- a/internal/controller/sconfigcontroller/jailedconfig_controller.go
+++ b/internal/controller/sconfigcontroller/jailedconfig_controller.go
@@ -695,6 +695,13 @@ func (r *JailedConfigReconciler) getNodesStartTime(ctx context.Context) (map[str
 			return nil, fmt.Errorf("duplicated worker name in Slurm API: %s", name)
 		}
 
+		for _, state := range *node.State {
+			if state == v0041.V0041NodeStateDOWN {
+				// Ignore DOWN nodes, since their start time won't change during reconfigure.
+				continue
+			}
+		}
+
 		if *node.SlurmdStartTime.Infinite {
 			return nil, fmt.Errorf("unexpected infinite start time for worker in Slurm API: %s", name)
 		}

--- a/internal/controller/sconfigcontroller/jailedconfig_controller_test.go
+++ b/internal/controller/sconfigcontroller/jailedconfig_controller_test.go
@@ -233,6 +233,7 @@ func prepareSlurmApi(
 				Number:   &slurmdStartTimeBefore,
 				Set:      ptr.To(true),
 			},
+			State: &[]v0041.V0041NodeState{v0041.V0041NodeStateALLOCATED},
 		})
 	}
 
@@ -250,6 +251,7 @@ func prepareSlurmApi(
 				Number:   &slurmdStartTime,
 				Set:      ptr.To(true),
 			},
+			State: &[]v0041.V0041NodeState{v0041.V0041NodeStateALLOCATED},
 		})
 	}
 
@@ -262,6 +264,7 @@ func prepareSlurmApi(
 				Number:   &slurmdStartTimeAfter,
 				Set:      ptr.To(true),
 			},
+			State: &[]v0041.V0041NodeState{v0041.V0041NodeStateALLOCATED},
 		})
 	}
 


### PR DESCRIPTION
## Problem
Sconfigcontroller watches SlurmdStartTime of every node that are stored in the contoller state. Once any node is DOWN, Sconfigcontroller won't spot it and will continuously reconcile JailedConfig, because SlurmdStartTime doesn't change for DOWN nodes.

## Solution
Ignore DOWN nodes during nodes polling in Sconfigcontroller.

## Testing
Dev cluster.

## Release Notes
SConfigController now ignores `DOWN` nodes during nodes polling in reconfigure wait.