### PR TITLE
Revert "Set `driftDetection.mode: warn` by default for helm releases …

### DIFF
--- a/fluxcd/base/soperator-fluxcd/resources.yaml
+++ b/fluxcd/base/soperator-fluxcd/resources.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   interval: 60m
   driftDetection:
-    mode: warn
+    mode: enabled
   chart:
     spec:
       chart: helm-soperator-fluxcd

--- a/helm/soperator-fluxcd/templates/backup.yaml
+++ b/helm/soperator-fluxcd/templates/backup.yaml
@@ -32,10 +32,6 @@ spec:
   timeout: {{ .Values.backup.timeout }}
   releaseName: {{ .Values.backup.releaseName }}
   targetNamespace: {{ .Values.backup.namespace }}
-  {{- if .Values.backup.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.backup.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.backup.overrideValues }}
     {{- toYaml .Values.backup.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/backup_schedule.yaml
+++ b/helm/soperator-fluxcd/templates/backup_schedule.yaml
@@ -27,10 +27,6 @@ spec:
   targetNamespace: {{ .Values.slurmCluster.namespace }}
   upgrade:
     crds: Skip
-  {{- if .Values.backup.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.backup.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
     resources:
     - apiVersion: k8up.io/v1

--- a/helm/soperator-fluxcd/templates/cert-manager.yaml
+++ b/helm/soperator-fluxcd/templates/cert-manager.yaml
@@ -32,10 +32,6 @@ spec:
   targetNamespace: {{ .Values.certManager.namespace }}
   releaseName: {{ .Values.certManager.releaseName }}
   timeout: {{ .Values.certManager.timeout }}
-  {{- if .Values.certManager.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.certManager.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.certManager.overrideValues }}
     {{- toYaml .Values.certManager.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/csi-driver-nfs.yaml
+++ b/helm/soperator-fluxcd/templates/csi-driver-nfs.yaml
@@ -26,10 +26,6 @@ spec:
   timeout: {{ .Values.csiDriverNfs.timeout }}
   releaseName: {{ .Values.csiDriverNfs.releaseName }}
   targetNamespace: {{ .Values.csiDriverNfs.namespace }}
-  {{- if .Values.csiDriverNfs.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.csiDriverNfs.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.csiDriverNfs.overrideValues }}
     {{- toYaml .Values.csiDriverNfs.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/dcgm-exporter.yaml
+++ b/helm/soperator-fluxcd/templates/dcgm-exporter.yaml
@@ -27,10 +27,6 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- if .Values.observability.dcgmExporter.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.observability.dcgmExporter.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
     dcgmHpcJobMappingDir: {{ .Values.observability.dcgmExporter.values.hpcJobMapDir }}
     validateToolkit: {{ .Values.observability.dcgmExporter.values.validateToolkit }}

--- a/helm/soperator-fluxcd/templates/helmrelease-trigger-operator.yaml
+++ b/helm/soperator-fluxcd/templates/helmrelease-trigger-operator.yaml
@@ -29,10 +29,6 @@ spec:
   timeout: {{ .Values.helmReleaseTriggerOperator.timeout }}
   releaseName: {{ .Values.helmReleaseTriggerOperator.releaseName }}
   targetNamespace: {{ .Values.helmReleaseTriggerOperator.namespace }}
-  {{- if .Values.helmReleaseTriggerOperator.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.helmReleaseTriggerOperator.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.helmReleaseTriggerOperator.overrideValues }}
     {{- toYaml .Values.helmReleaseTriggerOperator.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/kruise.yaml
+++ b/helm/soperator-fluxcd/templates/kruise.yaml
@@ -32,10 +32,6 @@ spec:
   timeout: {{ .Values.soperator.kruise.timeout }}
   releaseName: {{ .Values.soperator.kruise.releaseName }}
   targetNamespace: {{ .Values.slurmCluster.namespace }}
-  {{- if .Values.soperator.kruise.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.soperator.kruise.driftDetection | nindent 4 -}}
-  {{- end }}
   {{- if .Values.soperator.kruise.overrideValues }}
   values:
     {{- toYaml .Values.soperator.kruise.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/mariadb-operator-crds.yaml
+++ b/helm/soperator-fluxcd/templates/mariadb-operator-crds.yaml
@@ -14,10 +14,8 @@ spec:
         kind: HelmRepository
         name: {{ include "soperator-fluxcd.fullname" . }}-mariadb-operator
       version: {{ .Values.mariadbOperator.version }}
-  {{- if .Values.mariadbOperator.driftDetection }}
   driftDetection:
-    {{- toYaml .Values.mariadbOperator.driftDetection | nindent 4 -}}
-  {{- end }}
+    mode: enabled
   install:
     crds: CreateReplace
     remediation:

--- a/helm/soperator-fluxcd/templates/mariadb-operator.yaml
+++ b/helm/soperator-fluxcd/templates/mariadb-operator.yaml
@@ -31,10 +31,6 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- if .Values.mariadbOperator.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.mariadbOperator.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.mariadbOperator.overrideValues }}
     {{- toYaml .Values.mariadbOperator.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/namespaces.yaml
+++ b/helm/soperator-fluxcd/templates/namespaces.yaml
@@ -17,10 +17,6 @@ spec:
     remediation:
       retries: 3
   interval: {{ .Values.ns.interval }}
-  {{- if .Values.ns.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.ns.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
     resources:
     - apiVersion: v1

--- a/helm/soperator-fluxcd/templates/nfs-server.yaml
+++ b/helm/soperator-fluxcd/templates/nfs-server.yaml
@@ -27,10 +27,6 @@ spec:
   timeout: {{ .Values.nfsServer.timeout }}
   releaseName: {{ .Values.nfsServer.releaseName }}
   targetNamespace: {{ .Values.nfsServer.namespace }}
-  {{- if .Values.nfsServer.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.nfsServer.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.nfsServer.overrideValues }}
     {{- toYaml .Values.nfsServer.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/nodeconfigurator.yaml
+++ b/helm/soperator-fluxcd/templates/nodeconfigurator.yaml
@@ -29,10 +29,6 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- if .Values.soperator.nodeConfigurator.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.soperator.nodeConfigurator.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.soperator.nodeConfigurator.overrideValues }}
     {{- toYaml .Values.soperator.nodeConfigurator.overrideValues | nindent 4 }}
@@ -42,7 +38,7 @@ spec:
     rebooter:
       enabled: true
       {{- if and .Values.soperator.nodeConfigurator.values.rebooter .Values.soperator.nodeConfigurator.values.rebooter.resources }}
-      resources:
+      resources: 
       {{- toYaml .Values.soperator.nodeConfigurator.values.rebooter.resources | nindent 8 }}
       {{- end }}
       generateRBAC: true

--- a/helm/soperator-fluxcd/templates/notifier.yaml
+++ b/helm/soperator-fluxcd/templates/notifier.yaml
@@ -28,10 +28,6 @@ spec:
   timeout: {{ .Values.notifier.timeout }}
   releaseName: {{ .Values.notifier.releaseName }}
   targetNamespace: {{ .Values.notifier.namespace }}
-  {{- if .Values.notifier.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.notifier.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
     {{- if .Values.notifier.overrideValues }}
     {{- toYaml .Values.notifier.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -28,10 +28,6 @@ spec:
   timeout: {{ .Values.observability.opentelemetry.events.timeout }}
   releaseName: opentelemetry-collector-events
   targetNamespace: logs-system
-  {{- if .Values.observability.opentelemetry.events.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.observability.opentelemetry.events.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- if .Values.observability.opentelemetry.events.overrideValues }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -30,10 +30,6 @@ spec:
   timeout: {{ .Values.observability.opentelemetry.logs.timeout }}
   releaseName: opentelemetry-collector-jail-logs
   targetNamespace: logs-system
-  {{- if .Values.observability.opentelemetry.logs.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.observability.opentelemetry.logs.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -28,10 +28,6 @@ spec:
   timeout: {{ .Values.observability.opentelemetry.logs.timeout }}
   releaseName: opentelemetry-collector-logs
   targetNamespace: logs-system
-  {{- if .Values.observability.opentelemetry.logs.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.observability.opentelemetry.logs.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}

--- a/helm/soperator-fluxcd/templates/prometheus-operator-crds.yaml
+++ b/helm/soperator-fluxcd/templates/prometheus-operator-crds.yaml
@@ -14,9 +14,5 @@ spec:
         kind: HelmRepository
         name: {{ include "soperator-fluxcd.fullname" . }}-prometheus-operator-crds
       version: {{ .Values.observability.prometheusOperator.version }}
-  {{- if .Values.observability.prometheusOperator.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.observability.prometheusOperator.driftDetection | nindent 4 -}}
-  {{- end }}
   interval: 60m
 {{- end }}

--- a/helm/soperator-fluxcd/templates/security-profiles-operator.yaml
+++ b/helm/soperator-fluxcd/templates/security-profiles-operator.yaml
@@ -27,10 +27,6 @@ spec:
   timeout: {{ .Values.securityProfilesOperator.timeout }}
   releaseName: {{ .Values.securityProfilesOperator.releaseName }}
   targetNamespace: {{ .Values.securityProfilesOperator.namespace }}
-  {{- if .Values.securityProfilesOperator.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.securityProfilesOperator.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.securityProfilesOperator.overrideValues }}
     {{- toYaml .Values.securityProfilesOperator.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/slurm-cluster-storage.yaml
+++ b/helm/soperator-fluxcd/templates/slurm-cluster-storage.yaml
@@ -30,10 +30,6 @@ spec:
   timeout: {{ .Values.slurmCluster.slurmClusterStorage.timeout }}
   releaseName: {{ .Values.slurmCluster.slurmClusterStorage.releaseName }}
   targetNamespace: {{ .Values.slurmCluster.namespace }}
-  {{- if .Values.slurmCluster.slurmClusterStorage.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.slurmCluster.slurmClusterStorage.driftDetection | nindent 4 -}}
-  {{- end }}
   {{- if .Values.slurmCluster.slurmClusterStorage.overrideValues }}
   values:
     {{- toYaml .Values.slurmCluster.slurmClusterStorage.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/slurm-cluster.yaml
+++ b/helm/soperator-fluxcd/templates/slurm-cluster.yaml
@@ -39,10 +39,6 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- if .Values.slurmCluster.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.slurmCluster.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.slurmCluster.overrideValues }}
     {{- toYaml .Values.slurmCluster.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/soperator-activechecks.yaml
+++ b/helm/soperator-fluxcd/templates/soperator-activechecks.yaml
@@ -16,7 +16,7 @@ spec:
       version: {{ .Values.soperatorActiveChecks.version }}
   dependsOn:
   - name: {{ include "soperator-fluxcd.fullname" . }}-slurm-cluster
-  - name: {{ include "soperator-fluxcd.fullname" . }}-soperatorchecks
+  - name: {{ include "soperator-fluxcd.fullname" . }}-soperatorchecks  
   install:
     crds: Skip
     remediation:
@@ -30,10 +30,6 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- if .Values.soperatorActiveChecks.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.soperatorActiveChecks.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.soperatorActiveChecks.overrideValues }}
     {{- toYaml .Values.soperatorActiveChecks.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/soperator.yaml
+++ b/helm/soperator-fluxcd/templates/soperator.yaml
@@ -33,10 +33,6 @@ spec:
   timeout: {{ .Values.soperator.timeout }}
   releaseName: {{ .Values.soperator.releaseName }}
   targetNamespace: {{ .Values.soperator.namespace }}
-  {{- if .Values.soperator.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.soperator.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.soperator.overrideValues }}
     {{- toYaml .Values.soperator.overrideValues | nindent 4 }}
@@ -54,10 +50,10 @@ spec:
         {{- if and .Values.soperator.values .Values.soperator.values.manager .Values.soperator.values.manager.resources }}
         resources: {{- toYaml .Values.soperator.values.manager.resources | nindent 10 }}
         {{- end }}
-        {{- if or
-          .Values.observability.enabled
-          .Values.observability.prometheusOperator.enabled
-          .Values.mariadbOperator.enabled
+        {{- if or 
+          .Values.observability.enabled 
+          .Values.observability.prometheusOperator.enabled 
+          .Values.mariadbOperator.enabled 
         }}
         env:
           {{- if .Values.securityProfilesOperator.enabled }}
@@ -66,10 +62,10 @@ spec:
           {{- if .Values.mariadbOperator.enabled }}
           isMariadbCrdInstalled: true
           {{- end }}
-          {{- if and
-            .Values.observability.enabled
-            .Values.observability.prometheusOperator.enabled
-          }}
+          {{- if and  
+            .Values.observability.enabled 
+            .Values.observability.prometheusOperator.enabled 
+          }} 
           isPrometheusCrdInstalled: true
           {{- end }}
       kruise:

--- a/helm/soperator-fluxcd/templates/soperatorchecks.yaml
+++ b/helm/soperator-fluxcd/templates/soperatorchecks.yaml
@@ -27,10 +27,6 @@ spec:
   timeout: {{ .Values.soperator.soperatorChecks.timeout }}
   releaseName: {{ .Values.soperator.soperatorChecks.releaseName }}
   targetNamespace: {{ .Values.soperator.namespace }}
-  {{- if .Values.soperator.soperatorChecks.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.soperator.soperatorChecks.driftDetection | nindent 4 -}}
-  {{- end }}
   {{- if .Values.soperator.soperatorChecks.values }}
   values:
     {{- toYaml .Values.soperator.soperatorChecks.values | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/tailscale.yaml
+++ b/helm/soperator-fluxcd/templates/tailscale.yaml
@@ -22,10 +22,6 @@ spec:
   timeout: {{ .Values.tailscale.timeout }}
   upgrade:
     crds: Skip
-  {{- if .Values.tailscale.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.tailscale.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/soperator-fluxcd/templates/victoria-metrics-operator-crds.yaml
+++ b/helm/soperator-fluxcd/templates/victoria-metrics-operator-crds.yaml
@@ -14,10 +14,8 @@ spec:
         kind: HelmRepository
         name: {{ include "soperator-fluxcd.fullname" . }}-victoriametrics
       version: {{ .Values.observability.vmStack.crds.version }}
-  {{- if .Values.observability.vmStack.crds.driftDetection }}
   driftDetection:
-    {{- toYaml .Values.observability.vmStack.crds.driftDetection | nindent 4 -}}
-  {{- end }}
+    mode: enabled
   install:
     crds: CreateReplace
     remediation:

--- a/helm/soperator-fluxcd/templates/vm-logs.yaml
+++ b/helm/soperator-fluxcd/templates/vm-logs.yaml
@@ -27,10 +27,6 @@ spec:
     remediation:
       retries: 3
       remediateLastFailure: true
-  {{- if .Values.observability.vmLogs.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.observability.vmLogs.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.observability.vmStack.overrideValues }}
     {{- toYaml .Values.observability.vmStack.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -35,10 +35,6 @@ spec:
   {{- if .Values.observability.vmStack.namespace }}
   targetNamespace: {{ .Values.observability.vmStack.namespace }}
   {{- end }}
-  {{- if .Values.observability.vmStack.driftDetection }}
-  driftDetection:
-    {{- toYaml .Values.observability.vmStack.driftDetection | nindent 4 -}}
-  {{- end }}
   values:
   {{- if .Values.observability.vmStack.overrideValues }}
     {{- toYaml .Values.observability.vmStack.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -41,15 +41,11 @@ helmRepository:
     type: oci
 ns:
   enabled: true
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 5m
   version: 2.0.0
 certManager:
   enabled: true
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 5m
   version: v1.17.*
@@ -59,8 +55,6 @@ certManager:
   overrideValues: null
 backup:
   enabled: true
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 5m
   version: 4.8.*
@@ -84,8 +78,6 @@ backup:
       spec: {}
 mariadbOperator:
   enabled: true
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 5m
   version: 0.38.*
@@ -102,8 +94,6 @@ observability:
   region: eu-north1
   opentelemetry:
     enabled: true
-    driftDetection:
-      mode: warn
     namespace: logs-system
     logs:
       version: 0.117.*
@@ -127,16 +117,12 @@ observability:
       overrideValues: null
   prometheusOperator:
     enabled: true
-    driftDetection:
-      mode: warn
     interval: 5m
     timeout: 5m
     version: 19.1.*
     namespace: monitoring-system
   vmStack:
     enabled: true
-    driftDetection:
-      mode: warn
     crds:
       interval: 5m
       timeout: 5m
@@ -197,8 +183,6 @@ observability:
     overrideValues: null
   vmLogs:
     enabled: true
-    driftDetection:
-      mode: warn
     interval: 5m
     timeout: 5m
     version: 0.9.*
@@ -213,8 +197,6 @@ observability:
     overrideValues: null
   dcgmExporter:
     enabled: true
-    driftDetection:
-      mode: warn
     interval: 5m
     timeout: 5m
     version: 1.22.1
@@ -226,8 +208,6 @@ observability:
       resources: {}
 securityProfilesOperator:
   enabled: true
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 5m
   version: 0.8.4-soperator
@@ -251,8 +231,6 @@ securityProfilesOperator:
   overrideValues: null
 slurmCluster:
   enabled: true
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 5m
   version: 1.22.1
@@ -262,8 +240,6 @@ slurmCluster:
   overrideValues: null
   slurmClusterStorage:
     enabled: true
-    driftDetection:
-      mode: warn
     releaseName: slurm-cluster-storage
     interval: 5m
     timeout: 5m
@@ -282,8 +258,6 @@ nodesets:
   overrideValues: null
 soperatorActiveChecks:
   enabled: true
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 120m
   version: 1.22.1
@@ -292,8 +266,6 @@ soperatorActiveChecks:
   overrideValues: null
 soperator:
   enabled: true
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 5m
   version: 1.22.1
@@ -324,8 +296,6 @@ soperator:
       featureGates: "ImagePullJobGate=true,RecreatePodWhenChangeVCTInCloneSetGate=true,StatefulSetAutoResizePVCGate=true,StatefulSetAutoDeletePVC=true,PreDownloadImageForInPlaceUpdate=true"
   soperatorChecks:
     enabled: true
-    driftDetection:
-      mode: warn
     interval: 5m
     timeout: 5m
     releaseName: soperator-checks
@@ -333,8 +303,6 @@ soperator:
     overrideValues: null
   nodeConfigurator:
     enabled: true
-    driftDetection:
-      mode: warn
     interval: 5m
     timeout: 5m
     releaseName: soperator-node-configurator
@@ -344,8 +312,6 @@ soperator:
     overrideValues: null
 helmReleaseTriggerOperator:
   enabled: true
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 5m
   version: 0.0.1
@@ -363,8 +329,6 @@ helmReleaseTriggerOperator:
   overrideValues: null
 notifier:
   enabled: false
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 5m
   version: 1.22.1
@@ -376,8 +340,6 @@ notifier:
   overrideValues: null
 csiDriverNfs:
   interval: 5m
-  driftDetection:
-    mode: warn
   timeout: 5m
   version: 4.11.0
   namespace: nfs-system
@@ -386,8 +348,6 @@ csiDriverNfs:
   values: null
 nfsServer:
   enabled: true
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 5m
   version: 1.21.12
@@ -397,8 +357,6 @@ nfsServer:
   values: null
 tailscale:
   enabled: false
-  driftDetection:
-    mode: warn
   interval: 5m
   timeout: 5m
   version: 2.0.0


### PR DESCRIPTION
Revert PR "Set driftDetection.mode: warn by default for helm releases" (#1669) since it cause issues when dry-run fails and prevent dependent charts to release.

This reverts commit ac2582367685bf0f84d6e5fce01fcb8549e4fbe4.

