### PR TITLE
SCHED-295: Fix unstable parameter handling

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -11,11 +11,6 @@ jobs:
     with:
       unstable: false
     secrets: inherit
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
 
   tag:
     name: Push new tag
@@ -36,7 +31,9 @@ jobs:
         run: |
           # Get the latest release tag (semantic version) that's reachable from the current commit
           # Match tags like: 1.2.3 (without 'v' prefix)
-          PREV_TAG=$(git tag --merged HEAD^ | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          # Exclude current version to support hotfix re-runs
+          CURRENT_VERSION="$(cat VERSION)"
+          PREV_TAG=$(git tag --merged HEAD^ | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${CURRENT_VERSION}$" | sort -V | tail -1)
           if [ -z "$PREV_TAG" ]; then
             echo "Error: No previous release tag found in current branch history"
             echo "This is unexpected - there should be previous releases in the history"
@@ -51,11 +48,11 @@ jobs:
           VERSION="$(cat VERSION)"
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
 
-      - name: Push new tag
-        uses: pxpm/github-tag-action@07a0f099a1db2ef2c50367665450b9f6ef3b6e9d # 1.0.1
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: ${{ steps.get-version.outputs.version }}
+      - name: Push new tag (force update if exists)
+        run: |
+          VERSION="${{ steps.get-version.outputs.version }}"
+          git tag -f "${VERSION}"
+          git push -f origin "${VERSION}"
 
     outputs:
       previous-tag: ${{ steps.get-previous-tag.outputs.tag }}

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -64,13 +64,8 @@ jobs:
 
       - name: Generate version file
         run: |
-          UNSTABLE="true"
-          if [[ "${{ github.event_name }}" == "workflow_call" ]]; then
-            UNSTABLE="${{ inputs.unstable }}"
-            echo "Called from workflow_call with unstable=${UNSTABLE}"
-          else
-            echo "Building unstable version"
-          fi
+          UNSTABLE="${{ inputs.unstable || 'true' }}"
+          echo "Building with unstable=${UNSTABLE}"
 
           make get-version UNSTABLE=${UNSTABLE} >> version.txt
           echo "${UNSTABLE}" >> version.txt


### PR DESCRIPTION
## Problem
Release trigger builds unstable release, but it should be stable.

## Solution
Fix passing unstable flag.

## Testing
No testing is possible. Will test running new release :-)
