### PR TITLE
SCHED-295: Fix GitHub Actions expression handling.

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build stable release
     uses: ./.github/workflows/one_job.yml
     with:
-      unstable: false
+      unstable: 'false'
     secrets: inherit
 
   tag:

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -5,9 +5,9 @@ on:
     inputs:
       unstable:
         description: 'Build unstable version'
-        type: boolean
+        type: string
         required: false
-        default: true
+        default: 'true'
 
   push:
     branches:


### PR DESCRIPTION
## Problem
Create Release GH Action still builds unstable builds 

## Solution
Boolean vars require complex expressions, so use a string instead.
