### PR TITLE
SCHED-243: Make Nebius Mk8s conditions configurable

### DIFF
--- a/helm/soperatorchecks/values.yaml
+++ b/helm/soperatorchecks/values.yaml
@@ -31,6 +31,7 @@ checks:
       - --not-ready-timeout=15m
       - --delete-not-ready-nodes=true
       - --leader-elect
+      - --maintenance-condition-type="NebiusMaintenanceScheduled"
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/internal/consts/conditions.go
+++ b/internal/consts/conditions.go
@@ -9,9 +9,9 @@ const (
 	// SoperatorChecks related conditions to distinguish what happened to the k8s node.
 	SoperatorChecksK8SNodeDegraded    corev1.NodeConditionType = "SoperatorChecksNodeDegraded"
 	SoperatorChecksK8SNodeMaintenance corev1.NodeConditionType = "SoperatorChecksNodeMaintenance"
-	// External condition to react in soperator checks.
-	K8SNodeMaintenanceScheduled corev1.NodeConditionType = "NebiusMaintenanceScheduled"
-	HardwareIssuesSuspected     corev1.NodeConditionType = "HardwareIssuesSuspected"
+	HardwareIssuesSuspected           corev1.NodeConditionType = "HardwareIssuesSuspected"
+
+	DefaultMaintenanceConditionType corev1.NodeConditionType = "NebiusMaintenanceScheduled"
 )
 
 type ReasonConditionType string

--- a/internal/controller/soperatorchecks/k8s_nodes_controller_test.go
+++ b/internal/controller/soperatorchecks/k8s_nodes_controller_test.go
@@ -130,7 +130,7 @@ func TestK8SNodesController_processNotReadyCondition(t *testing.T) {
 				Build()
 
 			recorder := record.NewFakeRecorder(10)
-			controller := NewK8SNodesController(client, scheme, recorder, 15*time.Minute, true)
+			controller := NewK8SNodesController(client, scheme, recorder, 15*time.Minute, true, consts.DefaultMaintenanceConditionType)
 
 			ctx := context.Background()
 			err := controller.processNotReadyCondition(ctx, tt.node)
@@ -222,7 +222,7 @@ func TestK8SNodesController_requeueDurationForNotReady(t *testing.T) {
 	require.NoError(t, corev1.AddToScheme(scheme))
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 	recorder := record.NewFakeRecorder(10)
-	controller := NewK8SNodesController(client, scheme, recorder, 15*time.Minute, true)
+	controller := NewK8SNodesController(client, scheme, recorder, 15*time.Minute, true, consts.DefaultMaintenanceConditionType)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -319,7 +319,7 @@ func TestK8SNodesController_Reconcile_NotReadyFlow(t *testing.T) {
 				Build()
 
 			recorder := record.NewFakeRecorder(10)
-			controller := NewK8SNodesController(client, scheme, recorder, 15*time.Minute, true)
+			controller := NewK8SNodesController(client, scheme, recorder, 15*time.Minute, true, consts.DefaultMaintenanceConditionType)
 
 			ctx := context.Background()
 			req := ctrl.Request{

--- a/internal/controller/soperatorchecks/maintenance_condition_test.go
+++ b/internal/controller/soperatorchecks/maintenance_condition_test.go
@@ -1,0 +1,165 @@
+package soperatorchecks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"nebius.ai/slurm-operator/internal/consts"
+	"nebius.ai/slurm-operator/internal/slurmapi"
+)
+
+func TestMaintenanceConditionTypeConfiguration(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	recorder := record.NewFakeRecorder(10)
+	slurmAPIClients := slurmapi.NewClientSet()
+
+	tests := []struct {
+		name                  string
+		inputConditionType    string
+		expectedConditionType string
+		description           string
+	}{
+		{
+			name:                  "default value when empty string provided",
+			inputConditionType:    "",
+			expectedConditionType: string(consts.DefaultMaintenanceConditionType),
+			description:           "Should use default when empty string is provided",
+		},
+		{
+			name:                  "custom value is preserved",
+			inputConditionType:    "CustomMaintenanceScheduled",
+			expectedConditionType: "CustomMaintenanceScheduled",
+			description:           "Should preserve custom maintenance condition type",
+		},
+		{
+			name:                  "another custom value",
+			inputConditionType:    "MyCustomCondition",
+			expectedConditionType: "MyCustomCondition",
+			description:           "Should work with any custom condition type",
+		},
+		{
+			name:                  "default value constant matches expected",
+			inputConditionType:    string(consts.DefaultMaintenanceConditionType),
+			expectedConditionType: "NebiusMaintenanceScheduled",
+			description:           "Default constant should match expected default value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := NewSlurmAPIClientsController(
+				client,
+				scheme,
+				recorder,
+				slurmAPIClients,
+				corev1.NodeConditionType(tt.inputConditionType),
+			)
+
+			assert.Equal(t, tt.expectedConditionType, string(controller.MaintenanceConditionType),
+				"SlurmAPIClientsController: %s", tt.description)
+
+			k8sController := NewK8SNodesController(
+				client,
+				scheme,
+				recorder,
+				15*time.Minute,
+				true,
+				corev1.NodeConditionType(tt.inputConditionType),
+			)
+
+			assert.Equal(t, tt.expectedConditionType, string(k8sController.MaintenanceConditionType),
+				"K8SNodesController: %s", tt.description)
+
+			slurmController := NewSlurmNodesController(
+				client,
+				scheme,
+				recorder,
+				slurmAPIClients,
+				30*time.Second,
+				true,
+				client,
+				corev1.NodeConditionType(tt.inputConditionType),
+			)
+
+			assert.Equal(t, tt.expectedConditionType, string(slurmController.MaintenanceConditionType),
+				"SlurmNodesController: %s", tt.description)
+		})
+	}
+}
+
+func TestDefaultMaintenanceConditionTypeConstant(t *testing.T) {
+
+	scheme := runtime.NewScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	recorder := record.NewFakeRecorder(10)
+	slurmAPIClients := slurmapi.NewClientSet()
+
+	slurmAPIController := NewSlurmAPIClientsController(client, scheme, recorder, slurmAPIClients, "")
+	k8sController := NewK8SNodesController(client, scheme, recorder, 15*time.Minute, true, "")
+	slurmController := NewSlurmNodesController(client, scheme, recorder, slurmAPIClients, 30*time.Second, true, client, "")
+
+	expectedDefault := string(consts.DefaultMaintenanceConditionType)
+
+	assert.Equal(t, expectedDefault, string(slurmAPIController.MaintenanceConditionType),
+		"SlurmAPIClientsController should use default maintenance condition type")
+	assert.Equal(t, expectedDefault, string(k8sController.MaintenanceConditionType),
+		"K8SNodesController should use default maintenance condition type")
+	assert.Equal(t, expectedDefault, string(slurmController.MaintenanceConditionType),
+		"SlurmNodesController should use default maintenance condition type")
+}
+
+func TestMaintenanceConditionTypeIntegration(t *testing.T) {
+	testCases := []struct {
+		name           string
+		cmdLineArg     string
+		expectedResult string
+	}{
+		{
+			name:           "command line flag with custom value",
+			cmdLineArg:     "ProductionMaintenanceScheduled",
+			expectedResult: "ProductionMaintenanceScheduled",
+		},
+		{
+			name:           "command line flag with default value",
+			cmdLineArg:     string(consts.DefaultMaintenanceConditionType),
+			expectedResult: "NebiusMaintenanceScheduled",
+		},
+		{
+			name:           "empty command line flag uses default",
+			cmdLineArg:     "",
+			expectedResult: string(consts.DefaultMaintenanceConditionType),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			recorder := record.NewFakeRecorder(10)
+			slurmAPIClients := slurmapi.NewClientSet()
+
+			maintenanceConditionType := tc.cmdLineArg
+			if maintenanceConditionType == "" {
+				maintenanceConditionType = string(consts.DefaultMaintenanceConditionType)
+			}
+
+			controller := NewSlurmAPIClientsController(
+				client,
+				scheme,
+				recorder,
+				slurmAPIClients,
+				corev1.NodeConditionType(maintenanceConditionType),
+			)
+
+			assert.Equal(t, tc.expectedResult, string(controller.MaintenanceConditionType),
+				"Integration test failed for case: %s", tc.name)
+		})
+	}
+}

--- a/internal/controller/soperatorchecks/slurm_api_clients_controller.go
+++ b/internal/controller/soperatorchecks/slurm_api_clients_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"nebius.ai/slurm-operator/internal/consts"
@@ -30,7 +31,8 @@ var (
 type SlurmAPIClientsController struct {
 	*reconciler.Reconciler
 
-	slurmAPIClients *slurmapi.ClientSet
+	slurmAPIClients          *slurmapi.ClientSet
+	MaintenanceConditionType corev1.NodeConditionType
 }
 
 func NewSlurmAPIClientsController(
@@ -38,12 +40,18 @@ func NewSlurmAPIClientsController(
 	scheme *runtime.Scheme,
 	recorder record.EventRecorder,
 	slurmAPIClients *slurmapi.ClientSet,
+	maintenanceConditionType corev1.NodeConditionType,
 ) *SlurmAPIClientsController {
 	r := reconciler.NewReconciler(client, scheme, recorder)
 
+	if maintenanceConditionType == "" {
+		maintenanceConditionType = consts.DefaultMaintenanceConditionType
+	}
+
 	return &SlurmAPIClientsController{
-		Reconciler:      r,
-		slurmAPIClients: slurmAPIClients,
+		Reconciler:               r,
+		slurmAPIClients:          slurmAPIClients,
+		MaintenanceConditionType: maintenanceConditionType,
 	}
 }
 


### PR DESCRIPTION
## Problem
The maintenance condition type for Kubernetes nodes was hardcoded as `"NebiusMaintenanceScheduled"` in the soperatorchecks controllers, making it impossible to customize for different environments or deployments.

## Solution
- Made maintenance condition type configurable via `--maintenance-condition-type` command line flag
- Added Helm chart parameter `soperatorchecks.maintenanceConditionType` with proper template support
- Moved constant to `internal/consts/conditions.go` for better organization
- Updated all three controllers (`SlurmAPIClientsController`, `K8SNodesController`, `SlurmNodesController`) to accept configurable maintenance condition type
- Added comprehensive tests to verify configuration works correctly with default and custom values

## Testing
- Added `TestMaintenanceConditionTypeConfiguration` to verify all controllers accept custom and default values
- Added `TestDefaultMaintenanceConditionTypeConstant` to ensure consistent defaults across controllers  
- Added `TestMaintenanceConditionTypeIntegration` to simulate real command-line usage scenarios
- Verified Helm template renders correctly with custom values: `helm template helm/soperatorchecks`
- All existing tests pass, confirming no regressions

## Release Notes
Feature: Added configurable maintenance condition type via `--maintenance-condition-type` flag and Helm parameter `soperatorchecks.maintenanceConditionType`. Default value remains `"NebiusMaintenanceScheduled"` for backward compatibility.