### PR TITLE
SCHED-303: update health-checker

### DIFF
--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -31,7 +31,7 @@ createUser:
 upgradeCuda:
   cudaVersion: "12.4.1-1"
 upgradeHealthChecker:
-  healthCheckerVersion: "1.0.0-156.250917"
+  healthCheckerVersion: "1.0.0-161.251029"
 ensureDirSnccldLogs:
   enabled: false
   dir: /opt/soperator-outputs/nccl_logs

--- a/images/jail/jail.dockerfile
+++ b/images/jail/jail.dockerfile
@@ -223,7 +223,7 @@ RUN chmod +x /etc/update-motd.d/*
 COPY VERSION /etc/soperator-jail-version
 
 # Moved down to reduce build time
-ARG NC_HEALTH_CHECKER=1.0.0-156.250917
+ARG NC_HEALTH_CHECKER=1.0.0-161.251029
 
 # Install Nebius health-check library
 RUN apt-get update && \


### PR DESCRIPTION
## Problem
Issues in health-checker library for some platforms

## Solution
Update health-checker

## Testing
Run health-checker on a cluster with problem platforms

## Release Notes
Update health-checker to the version 1.0.0-161.251029
