### PR TITLE
SCHED-310: Explicitly set $HOME in slurmJob ActiveChecks

### DIFF
--- a/images/slurm_check_job/slurm_check_job_entrypoint.sh
+++ b/images/slurm_check_job/slurm_check_job_entrypoint.sh
@@ -27,6 +27,9 @@ mount --bind /opt/bin/sbatch.sh opt/bin/sbatch.sh
 echo "Create directory for slurm job outputs"
 (umask 000; mkdir -p "/mnt/jail/opt/soperator-outputs/slurm_jobs")
 
+echo "Set HOME to soperatorchecks' home directory"
+export HOME=~soperatorchecks
+
 if [[ "${EACH_WORKER_JOB_ARRAY:-}" == "true" ]]; then
     echo "Submitting job using slurm_submit_array_job.sh..."
     SUBMIT_OUTPUT=$(/opt/bin/slurm/slurm_submit_array_job.sh)


### PR DESCRIPTION
## Problem
Currently, `$HOME` of Slurm jobs launched by active checks depends on the cluster environment.
It's better to fix it to the home directory of `soperatorchecks` user.

## Solution
Explicitly set `$HOME` environment variable in the script that launches active checks' Slurm jobs.

## Testing
To test:
1. Check for "Set HOME to soperatorchecks' home directory" line in any active check logs with "slurmJob" type.

Not tested on a dev cluster, green E2E should be enough.

## Release Notes
Nothing
