### PR TITLE
SCHED-300: Delete wait-for-checks-job if helm release failed

### DIFF
--- a/helm/soperator-activechecks/templates/wait-for-checks-job.yaml
+++ b/helm/soperator-activechecks/templates/wait-for-checks-job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: wait-for-active-checks
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed,before-hook-creation
 spec:
   template:
     spec:


### PR DESCRIPTION
## Problem
If soperator-activechecks helm release failed, a new attempt fails as well because K8s job "wait-for-checks-job" already exists.

## Solution
Add `hook-failed` and `before-hook-creation` values to this K8s job's `"helm.sh/hook-delete-policy"` annotation.

## Testing
To test:
1. Create a new cluster with a wrong path to the image used by active checks.
2. Wait until soperator-activechecks HR failed
3. Redeploy this HR

## Release Notes
Fixed a bug that caused repeated attempts of cluster creation to fail if the deployment of active checks failed during the first attempt.