### PR TITLE
SCHED-315: Enable graceful leader election release on shutdown

### DIFF
--- a/cmd/sconfigcontroller/main.go
+++ b/cmd/sconfigcontroller/main.go
@@ -173,10 +173,11 @@ func main() {
 			SecureServing: secureMetrics,
 			TLSOpts:       tlsOpts,
 		},
-		WebhookServer:          webhookServer,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "vqeyz6ae.nebius.ai",
+		WebhookServer:                 webhookServer,
+		HealthProbeBindAddress:        probeAddr,
+		LeaderElection:                enableLeaderElection,
+		LeaderElectionID:              "vqeyz6ae.nebius.ai",
+		LeaderElectionReleaseOnCancel: true,
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{
 				clusterNamespace: {},


### PR DESCRIPTION
## Problem
When the current leader pod is gracefully terminated (e.g., during updates or restarts), it previously held the leader lock until the lease expired. This caused unnecessary delays in leadership transition.

With this change, the leader immediately releases the lock on shutdown, allowing a new leader to be elected within seconds instead of waiting for the lease expiration (default 15 seconds).

## Solution
Added `LeaderElectionReleaseOnCancel: true` to controller manager options


## Testing
- Verified that the code compiles
- Leader election behavior will be tested in the cluster environment

## Release Notes
Enable `LeaderElectionReleaseOnCancel` option for sconfigcontroller to improve leader election behavior during graceful shutdowns.
