### PR TITLE
SCHED-303, SCHED-304: Fix health checks: ib_link on Supermicro B200, nvidia_smi output format

### DIFF
--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -31,7 +31,7 @@ createUser:
 upgradeCuda:
   cudaVersion: "12.4.1-1"
 upgradeHealthChecker:
-  healthCheckerVersion: "1.0.0-161.251029"
+  healthCheckerVersion: "1.0.0-162.251030"
 ensureDirSnccldLogs:
   enabled: false
   dir: /opt/soperator-outputs/nccl_logs

--- a/images/jail/jail.dockerfile
+++ b/images/jail/jail.dockerfile
@@ -223,7 +223,7 @@ RUN chmod +x /etc/update-motd.d/*
 COPY VERSION /etc/soperator-jail-version
 
 # Moved down to reduce build time
-ARG NC_HEALTH_CHECKER=1.0.0-161.251029
+ARG NC_HEALTH_CHECKER=1.0.0-162.251030
 
 # Install Nebius health-check library
 RUN apt-get update && \


### PR DESCRIPTION
## Problem
1. ib_link check in health-checker fails on Supermicro B200 even though everything is OK
2. nvidia_smi check writes JSON output that is different from other checks and gpu_health_check.py misses its failures

## Solution
Bump health-checker version

## Testing
1. Create a new Supermicro B200 cluster
3. See no nodes are drained

## Release Notes
1. Fixed ib_link passive health check on B200 Supermicro.
2. Fixed failure detection of the nvidia_smi passive health check.
