### PR TITLE
Fix: set versions annotation for AdvancedStatefulSet

### DIFF
--- a/internal/controller/reconciler/versioning.go
+++ b/internal/controller/reconciler/versioning.go
@@ -6,10 +6,10 @@ import (
 	"maps"
 	"strings"
 
+	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"


### PR DESCRIPTION
## Release Notes
he change ensures that when reconciling Kruise StatefulSets, their pod template annotations are updated with dependency versions in the same way as standard Kubernetes StatefulSets.
