### PR TITLE
Ignore NOT_RESPONDING nodes in sconfigcontroller

### DIFF
--- a/internal/controller/sconfigcontroller/jailedconfig_controller.go
+++ b/internal/controller/sconfigcontroller/jailedconfig_controller.go
@@ -695,11 +695,15 @@ func (r *JailedConfigReconciler) getNodesStartTime(ctx context.Context) (map[str
 			return nil, fmt.Errorf("duplicated worker name in Slurm API: %s", name)
 		}
 
+		var skip bool
 		for _, state := range *node.State {
-			if state == v0041.V0041NodeStateDOWN {
-				// Ignore DOWN nodes, since their start time won't change during reconfigure.
-				continue
+			if state == v0041.V0041NodeStateNOTRESPONDING {
+				// Ignore NOT_RESPONDING nodes, since their start time doesn't change after reconfigure.
+				skip = true
 			}
+		}
+		if skip {
+			continue
 		}
 
 		if *node.SlurmdStartTime.Infinite {


### PR DESCRIPTION
## Problem
Currently, sconfigcontroller ignores DOWN nodes when waiting for reconfiguration. But it should ignore NOT_RESPONDING nodes, as these are ones that don't update SlurmdStartTime after reconfiguration.
Also, there is a bug with exiting nested `for` loops.

## Solution
Ignore NOT_RESPONDING nodes instead of DOWN ones. Exit `for` loops via a flag.

## Testing
To test:
1. Create a test cluster
2. Delete K8s node under one of worker pods
3. Update Slurm config and check if SlurmdStartTime doesn't change every minute and hc_program passive checks run

## Release Notes
Nothing
