### PR TITLE
Fix: Check if driver installed in /run/nvidia/driver

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/alloc_gpus_busy.drain.sh
+++ b/helm/slurm-cluster/slurm_scripts/alloc_gpus_busy.drain.sh
@@ -10,8 +10,15 @@ if [[ -z "${SLURM_JOB_GPUS:-}" ]]; then
     exit 0
 fi
 
+# Check if chroot to driver dir required
+chroot_cmd=""
+driver_dir="/run/nvidia/driver"
+if [[ "$(ls -A $driver_dir)" ]]; then
+    chroot_cmd="chroot $driver_dir"
+fi
+
 # For each allocated GPU, check for running compute apps
-pids=$(chroot /run/nvidia/driver /bin/bash -c "
+pids=$($chroot_cmd /bin/bash -c "
   IFS=',' read -ra ALLOC_GPUS <<< \"\${SLURM_JOB_GPUS}\"
   for gpu in \"\${ALLOC_GPUS[@]}\"; do
       pid=\$(nvidia-smi \

--- a/helm/slurm-cluster/slurm_scripts/alloc_gpus_busy.undrain.sh
+++ b/helm/slurm-cluster/slurm_scripts/alloc_gpus_busy.undrain.sh
@@ -4,7 +4,14 @@ set -euxo pipefail
 
 echo "[$(date)] Check if no process are running on GPUs"
 
-out=$(chroot /run/nvidia/driver nvidia-smi \
+# Check if chroot to driver dir required
+chroot_cmd=""
+driver_dir="/run/nvidia/driver"
+if [[ "$(ls -A $driver_dir)" ]]; then
+    chroot_cmd="chroot $driver_dir"
+fi
+
+out=$($chroot_cmd nvidia-smi \
     --query-compute-apps="gpu_serial,process_name,pid" \
     --format="csv,noheader" 2>/dev/null || echo "")
 if [[ -n "${out}" ]]; then


### PR DESCRIPTION
## Problem
In case when gpu-operator installed with driver.enabled=false
it is supposed that nvidia-smi is installed in image and /run/nvidia/driver dir is empty.

## Solution
Check driver installation mode and use chroot only of required.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
