### PR TITLE
Run hc_program passive checks more often

### DIFF
--- a/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
+++ b/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
@@ -23,7 +23,7 @@ spec:
   {{- end }}
   {{- if eq .Values.clusterType "gpu" }}
   healthCheckConfig:
-    healthCheckInterval: 300
+    healthCheckInterval: 120
     healthCheckProgram: /opt/slurm_scripts/hc_program.sh
     healthCheckNodeState:
     - state: ANY


### PR DESCRIPTION
## Problem
Periodic passive checks that should undrain `[user_problem]` nodes run too rarely.

## Solution
Run passive checks in "hc_program" context more often: every 2 minutes instead of 5 minutes.

## Testing
1. Create a new cluster
2. Check `scontrol show config | grep HealthCheckInterval`

## Release Notes
Slurm `HealthCheckProgram` is launched every 2 minutes instead of 5 minutes.
