### PR TITLE
Fix ActiveCheck additional printer columns

### DIFF
--- a/api/v1alpha1/activecheck_types.go
+++ b/api/v1alpha1/activecheck_types.go
@@ -217,12 +217,12 @@ type JobAndReason struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.checkType`,description="Active check type"
-// +kubebuilder:printcolumn:name="Run After Creation",type=boolean,JSONPath=`.spec.runAfterCreation`,description="Whether to run this check after creation"
-// +kubebuilder:printcolumn:name="Suspend Periodic",type=boolean,JSONPath=`.spec.suspend`,description="Whether to suspend periodic runs of this check"
+// +kubebuilder:printcolumn:name="Init",type=boolean,JSONPath=`.spec.runAfterCreation`,description="Whether to run this check after creation"
+// +kubebuilder:printcolumn:name="Suspend",type=boolean,JSONPath=`.spec.suspend`,description="Whether to suspend periodic runs of this check"
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=`.spec.schedule`,description="Schedule"
 // +kubebuilder:printcolumn:name="K8s Status",type=string,JSONPath=`.status.k8sJobsStatus.lastJobStatus`,description="Status of the last K8s job"
 // +kubebuilder:printcolumn:name="Slurm Status",type=string,JSONPath=`.status.slurmJobsStatus.lastRunStatus`,description="Status of the last Slurm job"
-// +kubebuilder:printcolumn:name="Slurm Submit Time",type=string,JSONPath=`.status.slurmJobStatus.lastJobSubmitTime`,description="Submission time of the last Slurm job"
+// +kubebuilder:printcolumn:name="Slurm Submit Time",type=string,JSONPath=`.status.slurmJobStatus.lastRunSubmitTime`,description="Submission time of the last Slurm job"
 // +kubebuilder:printcolumn:name="Slurm ID",type=string,JSONPath=`.status.slurmJobsStatus.lastRunId`,description="ID of the last Slurm job"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="When the job was created"
 

--- a/config/crd/bases/slurm.nebius.ai_activechecks.yaml
+++ b/config/crd/bases/slurm.nebius.ai_activechecks.yaml
@@ -21,11 +21,11 @@ spec:
       type: string
     - description: Whether to run this check after creation
       jsonPath: .spec.runAfterCreation
-      name: Run After Creation
+      name: Init
       type: boolean
     - description: Whether to suspend periodic runs of this check
       jsonPath: .spec.suspend
-      name: Suspend Periodic
+      name: Suspend
       type: boolean
     - description: Schedule
       jsonPath: .spec.schedule
@@ -40,7 +40,7 @@ spec:
       name: Slurm Status
       type: string
     - description: Submission time of the last Slurm job
-      jsonPath: .status.slurmJobStatus.lastJobSubmitTime
+      jsonPath: .status.slurmJobStatus.lastRunSubmitTime
       name: Slurm Submit Time
       type: string
     - description: ID of the last Slurm job

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -20,11 +20,11 @@ spec:
       type: string
     - description: Whether to run this check after creation
       jsonPath: .spec.runAfterCreation
-      name: Run After Creation
+      name: Init
       type: boolean
     - description: Whether to suspend periodic runs of this check
       jsonPath: .spec.suspend
-      name: Suspend Periodic
+      name: Suspend
       type: boolean
     - description: Schedule
       jsonPath: .spec.schedule
@@ -39,7 +39,7 @@ spec:
       name: Slurm Status
       type: string
     - description: Submission time of the last Slurm job
-      jsonPath: .status.slurmJobStatus.lastJobSubmitTime
+      jsonPath: .status.slurmJobStatus.lastRunSubmitTime
       name: Slurm Submit Time
       type: string
     - description: ID of the last Slurm job

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -20,11 +20,11 @@ spec:
       type: string
     - description: Whether to run this check after creation
       jsonPath: .spec.runAfterCreation
-      name: Run After Creation
+      name: Init
       type: boolean
     - description: Whether to suspend periodic runs of this check
       jsonPath: .spec.suspend
-      name: Suspend Periodic
+      name: Suspend
       type: boolean
     - description: Schedule
       jsonPath: .spec.schedule
@@ -39,7 +39,7 @@ spec:
       name: Slurm Status
       type: string
     - description: Submission time of the last Slurm job
-      jsonPath: .status.slurmJobStatus.lastJobSubmitTime
+      jsonPath: .status.slurmJobStatus.lastRunSubmitTime
       name: Slurm Submit Time
       type: string
     - description: ID of the last Slurm job


### PR DESCRIPTION
## Problem
Additional printer columns for ActiveCheck CRs now:
- Have too long headers
- Slurm Submit Time value is empty

## Solution
Make some headers shorter.
Fix CR path for the Slurm Submit Time column

## Testing
1. Create a cluster
2. Look at ActiveCheck CRs table in Lens or using kubectl

## Release Notes
Nothing
