### PR TITLE
SCHED-248 Set-unhealthy on extensive check failure

### DIFF
--- a/helm/soperator-activechecks/scripts/extensive-check.sh
+++ b/helm/soperator-activechecks/scripts/extensive-check.sh
@@ -119,6 +119,7 @@ funcs_to_test=(
 for test in "${funcs_to_test[@]}"
 do
   echo "Running $test on $(hostname)..."
+  LAST_RUN_ID=""
   $test
   TEST_EXIT_CODE=$?
 
@@ -126,8 +127,9 @@ do
     if [[ -z "$LAST_RUN_ID" ]]; then
       LAST_RUN_ID="undefined"
     fi
-    COMMENT="{health_checker_run_id: ${LAST_RUN_ID}}"
     NODE_NAME=$(hostname)
+    COMPUTE_INSTANCE_ID=$(scontrol show node "$NODE_NAME" -o 2>/dev/null | sed -n 's/.*InstanceId=\([^ ]*\).*/\1/p')
+    COMMENT="{health_checker_run_id: ${LAST_RUN_ID}, compute_instance_id: ${COMPUTE_INSTANCE_ID}}"
     echo "Setting node comment: $COMMENT"
     sudo scontrol update NodeName=$NODE_NAME Comment="$COMMENT"
 

--- a/internal/consts/conditions.go
+++ b/internal/consts/conditions.go
@@ -30,6 +30,8 @@ const (
 	ReasonSlurmNodeDegraded ReasonConditionType = "SlurmNodeDegraded"
 
 	ReasonNodeNotReady ReasonConditionType = "NodeNotReady"
+
+	ReasonGPUHealthCheckFailed ReasonConditionType = "GPUHealthCheckFailed (Soperator)"
 )
 
 const (

--- a/internal/slurmapi/node.go
+++ b/internal/slurmapi/node.go
@@ -17,6 +17,7 @@ type Node struct {
 	Tres        string    // Trackable Resources (e.g., CPUs, GPUs) assigned to the node.
 	Address     string    // IP Address of the node in the Kubernetes cluster.
 	BootTime    time.Time // The boot time of the node.
+	Comment     string
 }
 
 type NodeReason struct {
@@ -71,6 +72,7 @@ func NodeFromAPI(node api.V0041Node) (Node, error) {
 		Partitions:  *node.Partitions,
 		Tres:        *node.Tres,
 		Address:     *node.Address,
+		Comment:     *node.Comment,
 	}
 
 	if node.BootTime != nil && node.BootTime.Number != nil {


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
When extensive check fails we need to mark k8s node with HardwareIssueSuspected condition for replacment

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Setting this condition

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
Tested on dev cluster

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
