### PR TITLE
Fix bug in maintenanceIgnoreNodeLabels 

### DIFF
--- a/internal/controller/clustercontroller/controller.go
+++ b/internal/controller/clustercontroller/controller.go
@@ -108,6 +108,35 @@ func (r SlurmClusterReconciler) ReconcileControllers(
 					return nil
 				},
 			},
+			utils.MultiStepExecutionStep{
+				Name: "Slurm Controller DaemonSet",
+				Func: func(stepCtx context.Context) error {
+					stepLogger := log.FromContext(stepCtx)
+					stepLogger.V(1).Info("Reconciling DaemonSet")
+
+					desired := controller.RenderPlaceholderDaemonSet(
+						clusterValues.Namespace,
+						clusterValues.Name,
+						clusterValues.NodeFilters,
+						&clusterValues.NodeController,
+					)
+					stepLogger = stepLogger.WithValues(logfield.ResourceKV(&desired)...)
+					stepLogger.V(1).Info("Rendered DaemonSet")
+
+					deps, err := r.getControllersDaemonSetDependencies(stepCtx, clusterValues)
+					if err != nil {
+						return fmt.Errorf("retrieving dependencies for controller DaemonSet: %w", err)
+					}
+					stepLogger.V(1).Info("Retrieved dependencies for DaemonSet")
+
+					if err = r.DaemonSet.Reconcile(stepCtx, cluster, &desired, deps...); err != nil {
+						return fmt.Errorf("reconciling controller DaemonSet: %w", err)
+					}
+					stepLogger.V(1).Info("Reconciled DaemonSet")
+
+					return nil
+				},
+			},
 		)
 	}
 
@@ -150,7 +179,7 @@ func (r SlurmClusterReconciler) ValidateControllers(
 			status.SetCondition(metav1.Condition{
 				Type:   slurmv1.ConditionClusterControllersAvailable,
 				Status: metav1.ConditionFalse, Reason: "NotAvailable",
-				Message: "Slurm controller is not available yet",
+				Message: "Slurm controllers are not available yet",
 			})
 		}); err != nil {
 			return ctrl.Result{}, err
@@ -161,7 +190,7 @@ func (r SlurmClusterReconciler) ValidateControllers(
 			status.SetCondition(metav1.Condition{
 				Type:   slurmv1.ConditionClusterControllersAvailable,
 				Status: metav1.ConditionTrue, Reason: "Available",
-				Message: "Slurm controller is available",
+				Message: "Slurm controllers are available",
 			})
 		}); err != nil {
 			return ctrl.Result{}, err
@@ -172,6 +201,44 @@ func (r SlurmClusterReconciler) ValidateControllers(
 }
 
 func (r SlurmClusterReconciler) getControllersStatefulSetDependencies(
+	ctx context.Context,
+	clusterValues *values.SlurmCluster,
+) ([]metav1.Object, error) {
+	var res []metav1.Object
+
+	mungeKeySecret := &corev1.Secret{}
+	if err := r.Get(
+		ctx,
+		types.NamespacedName{
+			Namespace: clusterValues.Namespace,
+			Name:      naming.BuildSecretMungeKeyName(clusterValues.Name),
+		},
+		mungeKeySecret,
+	); err != nil {
+		return []metav1.Object{}, err
+	}
+	res = append(res, mungeKeySecret)
+
+	if clusterValues.NodeAccounting.Enabled {
+		slurmdbdSecret := &corev1.Secret{}
+		if err := r.Get(
+			ctx,
+			types.NamespacedName{
+				Namespace: clusterValues.Namespace,
+				Name:      naming.BuildSecretSlurmdbdConfigsName(clusterValues.Name),
+			},
+			slurmdbdSecret,
+		); err != nil {
+			return []metav1.Object{}, err
+		}
+		res = append(res, slurmdbdSecret)
+	}
+
+	return res, nil
+}
+
+// getControllersDaemonSetDependencies returns the dependencies required for the controller DaemonSet.
+func (r SlurmClusterReconciler) getControllersDaemonSetDependencies(
 	ctx context.Context,
 	clusterValues *values.SlurmCluster,
 ) ([]metav1.Object, error) {

--- a/internal/render/controller/daemonset.go
+++ b/internal/render/controller/daemonset.go
@@ -1,0 +1,99 @@
+package controller
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	slurmv1 "nebius.ai/slurm-operator/api/v1"
+	"nebius.ai/slurm-operator/internal/consts"
+	"nebius.ai/slurm-operator/internal/render/common"
+	"nebius.ai/slurm-operator/internal/utils"
+	"nebius.ai/slurm-operator/internal/values"
+)
+
+// RenderDaemonSet renders new [appsv1.DaemonSet] containing additional Slurm controller pods
+func RenderPlaceholderDaemonSet(
+	namespace,
+	clusterName string,
+	nodeFilters []slurmv1.K8sNodeFilter,
+	controller *values.SlurmController,
+) appsv1.DaemonSet {
+	labels := common.RenderLabels(consts.ComponentTypeController, clusterName)
+	matchLabels := common.RenderMatchLabels(consts.ComponentTypeController, clusterName)
+
+	labels[consts.LabelControllerType] = consts.LabelControllerTypePlaceholder
+	matchLabels[consts.LabelControllerType] = consts.LabelControllerTypePlaceholder
+
+	nodeFilter := utils.MustGetBy(
+		nodeFilters,
+		controller.K8sNodeFilterName,
+		func(f slurmv1.K8sNodeFilter) string { return f.Name },
+	)
+
+	return appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controller.DaemonSet.Name + "-placeholder",
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: matchLabels,
+			},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					HostUsers:    controller.HostUsers,
+					Affinity:     nodeFilter.Affinity,
+					NodeSelector: nodeFilter.NodeSelector,
+					Tolerations:  nodeFilter.Tolerations,
+					InitContainers: []corev1.Container{
+						common.RenderPlaceholderContainerMunge(&controller.ContainerMunge),
+					},
+					Containers: append(
+						[]corev1.Container{
+							renderContainerSlurmctldSleep(&controller.ContainerSlurmctld),
+						},
+						renderCustomContainersSleep(controller.CustomInitContainers)...,
+					),
+					RestartPolicy:                 corev1.RestartPolicyAlways,
+					TerminationGracePeriodSeconds: ptr.To(common.DefaultPodTerminationGracePeriodSeconds),
+					SecurityContext:               &corev1.PodSecurityContext{},
+					SchedulerName:                 corev1.DefaultSchedulerName,
+					DNSPolicy:                     corev1.DNSClusterFirst,
+					PriorityClassName:             controller.PriorityClass,
+				},
+			},
+		},
+	}
+}
+
+// renderCustomContainersSleep converts custom init containers to sleep containers
+func renderCustomContainersSleep(customInitContainers []corev1.Container) []corev1.Container {
+	if len(customInitContainers) == 0 {
+		return nil
+	}
+
+	result := make([]corev1.Container, len(customInitContainers))
+	for i, container := range customInitContainers {
+		sleepContainer := container.DeepCopy()
+		sleepContainer.Command = []string{"sleep"}
+		sleepContainer.Args = []string{"infinity"}
+		sleepContainer.Resources = corev1.ResourceRequirements{}
+		sleepContainer.VolumeMounts = nil
+		sleepContainer.Env = nil
+		result[i] = *sleepContainer
+	}
+	return result
+}

--- a/internal/render/controller/daemonset_test.go
+++ b/internal/render/controller/daemonset_test.go
@@ -1,0 +1,360 @@
+package controller
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	slurmv1 "nebius.ai/slurm-operator/api/v1"
+	"nebius.ai/slurm-operator/internal/consts"
+	"nebius.ai/slurm-operator/internal/values"
+)
+
+func TestRenderDaemonSet(t *testing.T) {
+	tests := []struct {
+		name         string
+		namespace    string
+		clusterName  string
+		controller   *values.SlurmController
+		expectLabels map[string]string
+		expectName   string
+	}{
+		{
+			name:        "basic controller daemonset",
+			namespace:   "test-namespace",
+			clusterName: "test-cluster",
+			controller: &values.SlurmController{
+				K8sNodeFilterName: "test-filter",
+				DaemonSet: values.DaemonSet{
+					Name: "test-controller-daemonset",
+				},
+				ContainerSlurmctld: values.Container{
+					NodeContainer: slurmv1.NodeContainer{
+						Image:           "test-image:latest",
+						ImagePullPolicy: corev1.PullAlways,
+						Port:            6817,
+						AppArmorProfile: "unconfined",
+					},
+					Name: "slurmctld",
+				},
+				ContainerMunge: values.Container{
+					NodeContainer: slurmv1.NodeContainer{
+						Image:           "munge-image:latest",
+						ImagePullPolicy: corev1.PullAlways,
+						AppArmorProfile: "unconfined",
+					},
+				},
+				PriorityClass: "test-priority",
+			},
+			expectLabels: map[string]string{
+				"app.kubernetes.io/component":     "controller",
+				"app.kubernetes.io/instance":      "test-cluster",
+				"slurm.nebius.ai/controller-type": "placeholder",
+			},
+			expectName: "test-controller-daemonset-placeholder",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeFilters := []slurmv1.K8sNodeFilter{
+				{
+					Name: "test-filter",
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "node-type",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"controller"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			result := RenderPlaceholderDaemonSet(
+				tt.namespace,
+				tt.clusterName,
+				nodeFilters,
+				tt.controller,
+			)
+
+			// Check basic metadata
+			if result.Name != tt.expectName {
+				t.Errorf("DaemonSet name = %v, want %v", result.Name, tt.expectName)
+			}
+
+			if result.Namespace != tt.namespace {
+				t.Errorf("DaemonSet namespace = %v, want %v", result.Namespace, tt.namespace)
+			}
+
+			// Check labels
+			for key, expectedValue := range tt.expectLabels {
+				if actualValue, exists := result.Labels[key]; !exists {
+					t.Errorf("Expected label %s not found", key)
+				} else if actualValue != expectedValue {
+					t.Errorf("Label %s = %v, want %v", key, actualValue, expectedValue)
+				}
+			}
+
+			// Check selector includes controller-type
+			if result.Spec.Selector == nil {
+				t.Error("DaemonSet selector is nil")
+			} else {
+				if controllerType, exists := result.Spec.Selector.MatchLabels[consts.LabelControllerType]; !exists {
+					t.Error("DaemonSet selector missing controller-type label")
+				} else if controllerType != consts.LabelControllerTypePlaceholder {
+					t.Errorf("DaemonSet selector controller-type = %v, want %v", controllerType, consts.LabelControllerTypePlaceholder)
+				}
+			}
+
+			// Check pod template labels
+			podLabels := result.Spec.Template.Labels
+			if controllerType, exists := podLabels[consts.LabelControllerType]; !exists {
+				t.Error("Pod template missing controller-type label")
+			} else if controllerType != consts.LabelControllerTypePlaceholder {
+				t.Errorf("Pod template controller-type = %v, want %v", controllerType, consts.LabelControllerTypePlaceholder)
+			}
+
+			// Check priority class
+			if result.Spec.Template.Spec.PriorityClassName != tt.controller.PriorityClass {
+				t.Errorf("PriorityClass = %v, want %v", result.Spec.Template.Spec.PriorityClassName, tt.controller.PriorityClass)
+			}
+
+			// Check update strategy
+			if result.Spec.UpdateStrategy.Type != appsv1.RollingUpdateDaemonSetStrategyType {
+				t.Errorf("UpdateStrategy type = %v, want %v", result.Spec.UpdateStrategy.Type, appsv1.RollingUpdateDaemonSetStrategyType)
+			}
+
+			if result.Spec.UpdateStrategy.RollingUpdate == nil {
+				t.Error("RollingUpdate strategy is nil")
+			} else {
+				expectedMaxUnavailable := intstr.FromInt32(1)
+				if result.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntVal != expectedMaxUnavailable.IntVal {
+					t.Errorf("MaxUnavailable = %v, want %v", result.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntVal, expectedMaxUnavailable.IntVal)
+				}
+			}
+
+			// Check containers - should use sleep versions
+			containers := result.Spec.Template.Spec.Containers
+			if len(containers) != 1 {
+				t.Errorf("Expected 1 container, got %d", len(containers))
+			} else {
+				container := containers[0]
+				if container.Name != consts.ContainerNameSlurmctld {
+					t.Errorf("Container name = %v, want %v", container.Name, consts.ContainerNameSlurmctld)
+				}
+				if container.Image != tt.controller.ContainerSlurmctld.NodeContainer.Image {
+					t.Errorf("Container image = %v, want %v", container.Image, tt.controller.ContainerSlurmctld.NodeContainer.Image)
+				}
+				// Check that it's using sleep command
+				if len(container.Command) != 1 || container.Command[0] != "sleep" {
+					t.Errorf("Container command = %v, want [sleep]", container.Command)
+				}
+				if len(container.Args) != 1 || container.Args[0] != "infinity" {
+					t.Errorf("Container args = %v, want [infinity]", container.Args)
+				}
+				// Check that resources are not set (empty)
+				if len(container.Resources.Limits) != 0 || len(container.Resources.Requests) != 0 {
+					t.Errorf("Container resources should be empty, got limits: %v, requests: %v", container.Resources.Limits, container.Resources.Requests)
+				}
+			}
+
+			// Check init containers - should also use sleep versions
+			initContainers := result.Spec.Template.Spec.InitContainers
+			if len(initContainers) != 1 {
+				t.Errorf("Expected 1 init container, got %d", len(initContainers))
+			} else {
+				initContainer := initContainers[0]
+				if initContainer.Name != consts.ContainerNameMunge {
+					t.Errorf("Init container name = %v, want %v", initContainer.Name, consts.ContainerNameMunge)
+				}
+				if initContainer.Image != tt.controller.ContainerMunge.NodeContainer.Image {
+					t.Errorf("Init container image = %v, want %v", initContainer.Image, tt.controller.ContainerMunge.NodeContainer.Image)
+				}
+				// Check that it's using sleep command
+				if len(initContainer.Command) != 1 || initContainer.Command[0] != "sleep" {
+					t.Errorf("Init container command = %v, want [sleep]", initContainer.Command)
+				}
+				if len(initContainer.Args) != 1 || initContainer.Args[0] != "infinity" {
+					t.Errorf("Init container args = %v, want [infinity]", initContainer.Args)
+				}
+			}
+
+			// Check that volumes are not set (empty) - DaemonSet doesn't need volumes
+			if len(result.Spec.Template.Spec.Volumes) != 0 {
+				t.Errorf("DaemonSet should have no volumes, got %d volumes", len(result.Spec.Template.Spec.Volumes))
+			}
+		})
+	}
+}
+
+func TestRenderDaemonSetNodeAffinity(t *testing.T) {
+	controller := &values.SlurmController{
+		K8sNodeFilterName: "test-filter",
+		DaemonSet: values.DaemonSet{
+			Name: "test-controller-daemonset",
+		},
+		ContainerSlurmctld: values.Container{
+			NodeContainer: slurmv1.NodeContainer{
+				Image:           "test-image:latest",
+				ImagePullPolicy: corev1.PullAlways,
+				AppArmorProfile: "unconfined",
+			},
+			Name: "slurmctld",
+		},
+		ContainerMunge: values.Container{
+			NodeContainer: slurmv1.NodeContainer{
+				Image:           "munge-image:latest",
+				ImagePullPolicy: corev1.PullAlways,
+				AppArmorProfile: "unconfined",
+			},
+		},
+	}
+
+	nodeFilters := []slurmv1.K8sNodeFilter{
+		{
+			Name: "test-filter",
+			NodeSelector: map[string]string{
+				"node-role": "controller",
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "controller",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+
+	result := RenderPlaceholderDaemonSet(
+		"test-namespace",
+		"test-cluster",
+		nodeFilters,
+		controller,
+	)
+
+	// Check node selector
+	expectedNodeSelector := map[string]string{
+		"node-role": "controller",
+	}
+	if len(result.Spec.Template.Spec.NodeSelector) != len(expectedNodeSelector) {
+		t.Errorf("NodeSelector length = %d, want %d", len(result.Spec.Template.Spec.NodeSelector), len(expectedNodeSelector))
+	}
+	for key, expectedValue := range expectedNodeSelector {
+		if actualValue, exists := result.Spec.Template.Spec.NodeSelector[key]; !exists {
+			t.Errorf("NodeSelector key %s not found", key)
+		} else if actualValue != expectedValue {
+			t.Errorf("NodeSelector[%s] = %v, want %v", key, actualValue, expectedValue)
+		}
+	}
+
+	// Check tolerations
+	if len(result.Spec.Template.Spec.Tolerations) != 1 {
+		t.Errorf("Expected 1 toleration, got %d", len(result.Spec.Template.Spec.Tolerations))
+	} else {
+		toleration := result.Spec.Template.Spec.Tolerations[0]
+		if toleration.Key != "node-role" {
+			t.Errorf("Toleration key = %v, want node-role", toleration.Key)
+		}
+		if toleration.Value != "controller" {
+			t.Errorf("Toleration value = %v, want controller", toleration.Value)
+		}
+		if toleration.Effect != corev1.TaintEffectNoSchedule {
+			t.Errorf("Toleration effect = %v, want %v", toleration.Effect, corev1.TaintEffectNoSchedule)
+		}
+	}
+}
+
+func TestRenderDaemonSetHostUsers(t *testing.T) {
+	tests := []struct {
+		name              string
+		hostUsers         *bool
+		expectedHostUsers *bool
+	}{
+		{
+			name:              "hostUsers not set (nil)",
+			hostUsers:         nil,
+			expectedHostUsers: nil,
+		},
+		{
+			name:              "hostUsers set to false",
+			hostUsers:         ptr.To(false),
+			expectedHostUsers: ptr.To(false),
+		},
+		{
+			name:              "hostUsers set to true",
+			hostUsers:         ptr.To(true),
+			expectedHostUsers: ptr.To(true),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := &values.SlurmController{
+				K8sNodeFilterName: "test-filter",
+				HostUsers:         tt.hostUsers,
+				DaemonSet: values.DaemonSet{
+					Name: "test-controller-daemonset",
+				},
+				ContainerSlurmctld: values.Container{
+					NodeContainer: slurmv1.NodeContainer{
+						Image:           "test-image:latest",
+						ImagePullPolicy: corev1.PullAlways,
+						Port:            6817,
+						AppArmorProfile: "unconfined",
+					},
+					Name: "slurmctld",
+				},
+				ContainerMunge: values.Container{
+					NodeContainer: slurmv1.NodeContainer{
+						Image:           "munge-image:latest",
+						ImagePullPolicy: corev1.PullAlways,
+						AppArmorProfile: "unconfined",
+					},
+				},
+			}
+
+			nodeFilters := []slurmv1.K8sNodeFilter{
+				{
+					Name: "test-filter",
+				},
+			}
+
+			result := RenderPlaceholderDaemonSet(
+				"test-namespace",
+				"test-cluster",
+				nodeFilters,
+				controller,
+			)
+
+			// Check HostUsers field in PodSpec
+			actualHostUsers := result.Spec.Template.Spec.HostUsers
+
+			if tt.expectedHostUsers == nil {
+				if actualHostUsers != nil {
+					t.Errorf("Expected HostUsers to be nil, got %v", *actualHostUsers)
+				}
+			} else {
+				if actualHostUsers == nil {
+					t.Errorf("Expected HostUsers to be %v, got nil", *tt.expectedHostUsers)
+				} else if *actualHostUsers != *tt.expectedHostUsers {
+					t.Errorf("Expected HostUsers to be %v, got %v", *tt.expectedHostUsers, *actualHostUsers)
+				}
+			}
+		})
+	}
+}

--- a/internal/values/slurm_controller.go
+++ b/internal/values/slurm_controller.go
@@ -19,6 +19,7 @@ type SlurmController struct {
 
 	Service     Service
 	StatefulSet StatefulSet
+	DaemonSet   DaemonSet
 
 	VolumeSpool        slurmv1.NodeVolume
 	VolumeJail         slurmv1.NodeVolume
@@ -35,6 +36,10 @@ func buildSlurmControllerFrom(clusterName string, maintenance *consts.Maintenanc
 		nil,
 	)
 
+	daemonSet := buildDaemonSetFrom(
+		naming.BuildDaemonSetName(consts.ComponentTypeController),
+	)
+
 	res := SlurmController{
 		K8sNodeFilterName:    controller.K8sNodeFilterName,
 		CustomInitContainers: controller.CustomInitContainers,
@@ -49,6 +54,7 @@ func buildSlurmControllerFrom(clusterName string, maintenance *consts.Maintenanc
 		),
 		Service:            buildServiceFrom(naming.BuildServiceName(consts.ComponentTypeController, clusterName)),
 		StatefulSet:        statefulSet,
+		DaemonSet:          daemonSet,
 		VolumeSpool:        *controller.Volumes.Spool.DeepCopy(),
 		VolumeJail:         *controller.Volumes.Jail.DeepCopy(),
 		CustomVolumeMounts: controller.Volumes.CustomMounts,


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
There was a bug in the new feature that parses env vsr for a list of `key=value` items to ignore nodes for maintenance, it did not support repeated keys.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Now `maintenanceIgnoreNodeLabels` supports repeated keys with different values by making a `map[string][]string` to store them.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
See unit tests.

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Fix bug in maintenanceIgnoreNodeLabels to support same key with different values