### PR TITLE
Allow volume size increase for filestore PVCs and PVs

### DIFF
--- a/helm/slurm-cluster-storage/templates/local-storageclass.yaml
+++ b/helm/slurm-cluster-storage/templates/local-storageclass.yaml
@@ -4,3 +4,4 @@ metadata:
   name: {{ include "slurm-cluster-storage.class.local.name" . }}
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

When we change filestore size via Terraform, it would also update the size in Helm values that control the capacity field in PVs and storage requests in PVCs. That operation will fail because these fields are immutable.

> error: persistentvolumeclaims "xxx" could not be patched: persistentvolumeclaims "xxx" is forbidden: only dynamically provisioned pvc can be resized and the storageclass that provisions the pvc must support resize


## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Setting `allowVolumeExpansion: true` in the storageClass allows size change (increase), so the value of PVC/PV in cluster matches the size in cloud.
This would not result in any change or action on the actual filestore, since the storage class uses `no-provisioner` and has no CSI.  

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
* Set `allowVolumeExpansion: true` in storage class
* Edit a PVC using the storage class and increase the size
* Describe the PVC afterwards and check for event:
   > Warning  ExternalExpanding  5m    volume_expand  waiting for an external controller to expand this PV

No K8S API errors

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Allow filestore size expansion (when the underlying storage has already change in the cloud)