### PR TITLE
fix syslog parsing on ubuntu24:04

### DIFF
--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -150,10 +150,33 @@ spec:
               field: attributes["log.file.name"]
             - id: get-format
               type: router
+              # From ubuntu24:04 syslog format was changed.
               routes:
+                - expr: attributes["logtype"] matches "syslog|kern" && body matches "^[0-9]{4}-[0-9]{2}-[0-9]{2}T"
+                  output: parse-iso8601
                 - expr: attributes["logtype"] matches "syslog|kern"
                   output: parse-syslog
               default: not-syslog
+            - id: parse-iso8601
+              type: regex_parser
+              parse_from: body
+              # 2025-11-15T23:10:32.025480+00:00 host app: msg
+              regex: '^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})) (?P<host>\S+) (?P<app>[^:]+): (?P<msg>.*)$'
+            - id: ts-iso8601
+              type: time_parser
+              parse_from: attributes.ts
+              layout_type: gotime
+              layout: '2006-01-02T15:04:05.999999Z07:00'
+            - id: move-msg
+              type: move
+              from: attributes.msg
+              to: body
+            - type: move
+              from: attributes.host
+              to: resource["host.name"]
+            - type: move
+              from: attributes.app
+              to: attributes["syslog.appname"]
             - id: parse-syslog
               type: syslog_parser
               protocol: rfc3164


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
syslog are not parsing after ubuntu upgrade, their format has been changed

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
add new rules for o11y collector to parse syslog

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
dev cluster with these changes for o11y collector

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Fix syslog parsing in opentelemtry logs collector on ubuntu24:04.
