### PR TITLE
SCHED-448: Fix extensive check job name

### DIFF
--- a/helm/soperator-activechecks/scripts/run-extensive-check-on-reservations.sh
+++ b/helm/soperator-activechecks/scripts/run-extensive-check-on-reservations.sh
@@ -53,7 +53,9 @@ echo "Submitting k8s jobs for active check $TARGET_ACTIVE_CHECK_NAME for reserve
 
 submitted_jobs=0
 for reservationName in $(scontrol show reservation --json | jq -r --arg RESERVATION_PREFIX "$RESERVATION_PREFIX" '.reservations | .[] | select(.name | startswith($RESERVATION_PREFIX)) | .name' ); do
-  jobName="$TARGET_ACTIVE_CHECK_NAME-$reservationName"
+  # Sanitize reservation name for Kubernetes Job name (replace : with - for RFC 1123 compliance)
+  sanitizedReservationName="${reservationName//:/-}"
+  jobName="$TARGET_ACTIVE_CHECK_NAME-$sanitizedReservationName"
 
   action=$(whatToDo)
   if [[ "$action" == "create" ]]; then


### PR DESCRIPTION
## Problem
Generated job name was invalid: `The Job "extensive-check-suspicious-node:worker-0" is invalid`

## Solution
Sanitize reservation name to prevent colons in a job name

## Testing
No testing

## Release Notes
No release notes
