### PR TITLE
Don't use `:` in extensive check reservation names

### DIFF
--- a/internal/controller/soperatorchecks/activecheck_jobs_controller.go
+++ b/internal/controller/soperatorchecks/activecheck_jobs_controller.go
@@ -498,7 +498,7 @@ func processAddReservation(ctx context.Context, reservationPrefix string, slurmJ
 }
 
 func getExtensiveCheckReservationName(prefix, node string) string {
-	return fmt.Sprintf("%s:%s", prefix, node)
+	return fmt.Sprintf("%s-%s", prefix, node)
 }
 
 func processRemoveReservation(ctx context.Context, reservationPrefix string, slurmJob slurmapi.Job, slurmAPIClient slurmapi.Client) error {


### PR DESCRIPTION
## Problem
Soperator activecheck controller creates K8s jobs whose names include reservations created for extensive checks in Slurm.
These reservation names include the `:` character, which is not allowed in K8s resource names.

## Solution
Replace `:` with `-`

## Testing
Create a cluster and make sure K8s jobs for extensive checks are created.

## Release Notes
Nothing
