### PR TITLE
NOTIC: Don't use sudo in soperator-outputs-logs-cleaner

### DIFF
--- a/helm/soperator-activechecks/scripts/soperator-outputs-logs-cleaner.sh
+++ b/helm/soperator-activechecks/scripts/soperator-outputs-logs-cleaner.sh
@@ -2,4 +2,4 @@ set -euxo pipefail
 
 echo "Cleaning old Soperator outputs"
 
-sudo find /mnt/jail/opt/soperator-outputs -type f -mmin +30 -delete
+find /mnt/jail/opt/soperator-outputs -type f -mmin +30 -delete


### PR DESCRIPTION
## Problem
The k8sJob active check that removes old soperator output files fails because the container doesn't have `sudo`.

## Solution
Don't use sudo. It's not needed, because k8sJob active checks run as root user

## Testing
Create a new cluster, see if the `soperator-outputs-logs-cleaner` completes successfully.

## Release Notes
Nothing.
