### PR TITLE
NOTIC: Don't use sudo in all-reduce-perf-nccl-in-docker

### DIFF
--- a/helm/soperator-activechecks/scripts/all-reduce-perf-nccl-in-docker.sh
+++ b/helm/soperator-activechecks/scripts/all-reduce-perf-nccl-in-docker.sh
@@ -16,5 +16,5 @@ srun --gpus=8 docker run --rm \
   -v /tmp/soperatorchecks/a:/a \
   --mount type=bind,source=/tmp/soperatorchecks/b,target=/b \
   {{ include "activecheck.image.docker" . }} \
-  sudo bash -l -c "NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1 NCCL_ALGO=Ring all_reduce_perf -b 512M -e 8G -f 2 -g 8"
+  bash -l -c "NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1 NCCL_ALGO=Ring all_reduce_perf -b 512M -e 8G -f 2 -g 8"
 


### PR DESCRIPTION
## Problem
`all-reduce-perf-nccl-in-docker` active check doesn't work because the docker image it uses doesn't have `sudo`.

## Solution
Get rid of `sudo` -- it's not needed in this check.

## Testing
Create a cluster and make sure this active check works.

## Release Notes
Nothing
