### PR TITLE
SCHED-485: First slurmJob active checks may fail in soperator

### DIFF
--- a/helm/soperator-activechecks/scripts/wait-for-soperatorchecks-srun-ready.sh
+++ b/helm/soperator-activechecks/scripts/wait-for-soperatorchecks-srun-ready.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+MAX_ATTEMPTS=60
+
+echo "Waiting for Slurm controller to be ready for soperatorchecks user..."
+
+for i in $(seq 1 "$MAX_ATTEMPTS"); do
+  echo "Attempt $i/$MAX_ATTEMPTS: Testing srun availability..."
+  if srun --job-name=test-controller-is-ready -n1 -t1 hostname; then
+    echo "SUCCESS: Slurm controller is ready for soperatorchecks user"
+    exit 0
+  fi
+  echo "Attempt $i/$MAX_ATTEMPTS failed, waiting 1 second..."
+  sleep 1
+done
+
+echo "ERROR: Failed to verify Slurm readiness after $MAX_ATTEMPTS attempts"
+exit 1

--- a/helm/soperator-activechecks/templates/all-reduce-perf-nccl-in-docker.yaml
+++ b/helm/soperator-activechecks/templates/all-reduce-perf-nccl-in-docker.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   checkType: "slurmJob"
   name: "all-reduce-perf-nccl-in-docker"
-  dependsOn: [ "create-user-soperatorchecks", "wait-for-topology", "prepull-container-image" ]
+  dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology", "prepull-container-image" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   suspend: {{ .Values.checks.allReducePerfNCCLInDocker.suspend }}
   runAfterCreation: {{ .Values.checks.allReducePerfNCCLInDocker.runAfterCreation }}

--- a/helm/soperator-activechecks/templates/all-reduce-perf-nccl-with-ib.yaml
+++ b/helm/soperator-activechecks/templates/all-reduce-perf-nccl-with-ib.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   checkType: "slurmJob"
   name: "all-reduce-perf-nccl-with-ib"
-  dependsOn: [ "create-user-soperatorchecks", "wait-for-topology" ]
+  dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   schedule: "45 0-18/6 * * *" # 4 times a day at 00:45, 6:45, 12:45 and 18:45 UTC
   suspend: {{ .Values.checks.allReducePerfNCCLWithIB.suspend }}

--- a/helm/soperator-activechecks/templates/all-reduce-perf-nccl-without-ib.yaml
+++ b/helm/soperator-activechecks/templates/all-reduce-perf-nccl-without-ib.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   checkType: "slurmJob"
   name: "all-reduce-perf-nccl-without-ib"
-  dependsOn: [ "create-user-soperatorchecks", "wait-for-topology" ]
+  dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   schedule: "25 5-23/6 * * *" # 4 times a day at 05:25, 11:25, 17:25 and 23:25 UTC
   suspend: {{ .Values.checks.allReducePerfNCCLWithoutIB.suspend }}

--- a/helm/soperator-activechecks/templates/cuda-samples.yaml
+++ b/helm/soperator-activechecks/templates/cuda-samples.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   checkType: "slurmJob"
   name: "cuda-samples"
-  dependsOn: [ "create-user-soperatorchecks", "wait-for-topology", "prepull-container-image" ]
+  dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology", "prepull-container-image" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   schedule: "30 0-18/6 * * *" # 4 times a day at 00:30, 06:30, 12:30 and 18:30 UTC
   suspend: {{ .Values.checks.cudaSamples.suspend }}

--- a/helm/soperator-activechecks/templates/dcgmi-diag-r2.yaml
+++ b/helm/soperator-activechecks/templates/dcgmi-diag-r2.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   checkType: "slurmJob"
   name: "dcgmi-diag-r2"
-  dependsOn: [ "create-user-soperatorchecks", "wait-for-topology" ]
+  dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   schedule: "5 12 * * *" # Once a day at 12:05 UTC
   suspend: {{ .Values.checks.dcgmiDiagR2.suspend }}

--- a/helm/soperator-activechecks/templates/dcgmi-diag-r3.yaml
+++ b/helm/soperator-activechecks/templates/dcgmi-diag-r3.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   checkType: "slurmJob"
   name: "dcgmi-diag-r3"
-  dependsOn: [ "create-user-soperatorchecks", "wait-for-topology" ]
+  dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   suspend: {{ .Values.checks.dcgmiDiagR3.suspend }}
   runAfterCreation: {{ .Values.checks.dcgmiDiagR3.runAfterCreation }}

--- a/helm/soperator-activechecks/templates/extensive-check.yaml
+++ b/helm/soperator-activechecks/templates/extensive-check.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   name: "extensive-check"
   checkType: "slurmJob"
-  dependsOn: [ "create-user-soperatorchecks", "wait-for-topology", "prepull-container-image" ]
+  dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology", "prepull-container-image" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   # extensive-check is suspended and its schedule is not used.
   # It is being scheduled using `cronjob/run-extensive-check-on-reservations`

--- a/helm/soperator-activechecks/templates/gpu-fryer.yaml
+++ b/helm/soperator-activechecks/templates/gpu-fryer.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   checkType: "slurmJob"
   name: "gpu-fryer"
-  dependsOn: [ "create-user-soperatorchecks", "wait-for-topology", "prepull-container-image" ]
+  dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology", "prepull-container-image" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   schedule: "15 9-21/12 * * *" # 2 times a day at 9:15 and 21:15 UTC
   suspend: {{ .Values.checks.gpuFryer.suspend }}

--- a/helm/soperator-activechecks/templates/ib-gpu-perf.yaml
+++ b/helm/soperator-activechecks/templates/ib-gpu-perf.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   checkType: "slurmJob"
   name: "ib-gpu-perf"
-  dependsOn: [ "create-user-soperatorchecks", "wait-for-topology", "prepull-container-image" ]
+  dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology", "prepull-container-image" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   schedule: "55 1-21/4 * * *" # 6 times a day at 01:55, 05:55, 09:55, 13:55, 17:55 and 21:55 UTC
   suspend: {{ .Values.checks.ibGpuPerf.suspend }}

--- a/helm/soperator-activechecks/templates/mem-perf.yaml
+++ b/helm/soperator-activechecks/templates/mem-perf.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   checkType: "slurmJob"
   name: "mem-perf"
-  dependsOn: [ "create-user-soperatorchecks", "wait-for-topology", "prepull-container-image" ]
+  dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology", "prepull-container-image" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   schedule: "20 10-22/12 * * *" # 2 times a day at 10:20 and 22:20 UTC
   suspend: {{ .Values.checks.memPerf.suspend }}

--- a/helm/soperator-activechecks/templates/prepull-container-image.yaml
+++ b/helm/soperator-activechecks/templates/prepull-container-image.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   checkType: "slurmJob"
   name: "prepull-container-image"
-  dependsOn: [ "create-user-soperatorchecks", "wait-for-topology" ]
+  dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   suspend: {{ .Values.checks.prepullContainerImage.suspend }}
   runAfterCreation: {{ .Values.checks.prepullContainerImage.runAfterCreation }}

--- a/helm/soperator-activechecks/templates/wait-for-soperatorchecks-srun-ready.yaml
+++ b/helm/soperator-activechecks/templates/wait-for-soperatorchecks-srun-ready.yaml
@@ -1,19 +1,18 @@
 apiVersion: slurm.nebius.ai/v1alpha1
 kind: ActiveCheck
 metadata:
-  name: "enroot-cleanup"
+  name: "wait-for-soperatorchecks-srun-ready"
 spec:
   checkType: "slurmJob"
-  name: "enroot-cleanup"
-  dependsOn: [ "wait-for-soperatorchecks-srun-ready" ]
+  name: "wait-for-soperatorchecks-srun-ready"
+  dependsOn: [ "create-user-soperatorchecks" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
-  schedule: "10 8-20/12 * * *" # 2 times a day at 8:10 and 20:10 UTC
-  suspend: {{ .Values.checks.enrootCleanup.suspend }}
-  runAfterCreation: {{ .Values.checks.enrootCleanup.runAfterCreation }}
+  schedule: "0 0 1 1 *" # Never run on schedule, only runAfterCreation
+  suspend: true
+  runAfterCreation: true
   slurmJobSpec:
     sbatchScript: |
-{{ .Files.Get "scripts/enroot-cleanup.sh" | indent 6 }}
-    eachWorkerJobs: true
+{{ .Files.Get "scripts/wait-for-soperatorchecks-srun-ready.sh" | indent 6 }}
     jobContainer:
       image: {{ .Values.images.slurmJob | quote }}
       env:


### PR DESCRIPTION
## Problem

First active checks with slurmJob type may fail. Error message: srun: error: Unable to create step for job 1: Error generating job credential.

## Solution

Introduce a new `wait-for-soperatorchecks-srun-ready` active check that verifies the Slurm controller is ready to accept jobs from the soperatorchecks user before allowing other slurmJob checks to run.

The new check retries srun command up to 60 times with 1-second intervals, preventing credential creation errors when the controller doesn't know about the soperatorchecks user yet or when slurmctl/munge is not fully ready.

## Testing

- [x] Run e2es twice, no errors

## Release Notes
Nothing