### PR TITLE
Preinstall sudo in active check images

### DIFF
--- a/helm/soperator-activechecks/scripts/all-reduce-perf-nccl-in-docker.sh
+++ b/helm/soperator-activechecks/scripts/all-reduce-perf-nccl-in-docker.sh
@@ -5,16 +5,15 @@
 #SBATCH --exclusive
 #SBATCH --mem=0
 
-
 echo "Running all_reduce_perf_nccl_in_docker check on $(hostname)..."
 
-mkdir -p /tmp/soperatorchecks/a
-mkdir -p /tmp/soperatorchecks/b
+mkdir -p /tmp/soperatorchecks/docker_check/a
+mkdir -p /tmp/soperatorchecks/docker_check/b
 
-srun --gpus=8 docker run --rm \
+srun docker run --rm \
   --gpus=all --device=/dev/infiniband \
-  -v /tmp/soperatorchecks/a:/a \
-  --mount type=bind,source=/tmp/soperatorchecks/b,target=/b \
+  -v /tmp/soperatorchecks/docker_check/a:/a \
+  --mount type=bind,source=/tmp/soperatorchecks/docker_check/b,target=/b \
   {{ include "activecheck.image.docker" . }} \
   bash -l -c "NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1 NCCL_ALGO=Ring all_reduce_perf -b 512M -e 8G -f 2 -g 8"
 

--- a/helm/soperator-activechecks/templates/all-reduce-perf-nccl-in-docker.yaml
+++ b/helm/soperator-activechecks/templates/all-reduce-perf-nccl-in-docker.yaml
@@ -13,6 +13,7 @@ spec:
     sbatchScript: |
 {{ tpl (.Files.Get "scripts/all-reduce-perf-nccl-in-docker.sh") . | indent 6 }}
     eachWorkerJobs: true
+    maxNumberOfJobs: 200
     jobContainer:
       image: {{ .Values.images.slurmJob | quote }}
       env:

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -25,7 +25,7 @@ images:
   k8sJob: "cr.eu-north1.nebius.cloud/soperator/k8s_check_job:1.23.0-noble-slurm25.05.4"
   munge: "cr.eu-north1.nebius.cloud/soperator/munge:1.23.0-noble-slurm25.05.4"
 # Pyxis syntax with '#' separator for registry
-activeCheckImage: "cr.eu-north1.nebius.cloud#soperator/active_checks:12.9.0-ubuntu24.04-nccl_tests2.16.4-00ce55c"
+activeCheckImage: "cr.eu-north1.nebius.cloud#soperator/active_checks:12.9.0-ubuntu24.04-nccl_tests2.16.4-3935b93"
 checks:
   allReducePerfNCCLInDocker:
     suspend: true


### PR DESCRIPTION
## Problem
`sudo` is not available inside active check images (in both K8s job images and Docker/Enroot container images).

## Solution
Preinstall sudo in K8s job images and bump Docker/Enroot container image to the version that has sudo.

## Testing
Create a new cluster and ensure all active checks complete successfully.

## Release Notes
Nothing.
