### PR TITLE
NOTIC: Use sudo only in active checks that don't use containers

### DIFF
--- a/helm/soperator-activechecks/scripts/all-reduce-perf-nccl-with-ib.sh
+++ b/helm/soperator-activechecks/scripts/all-reduce-perf-nccl-with-ib.sh
@@ -24,7 +24,8 @@ echo "Platform found: $platform"
 echo "Running all_reduce_perf_nccl check on $(hostname)..."
 HC_OUTPUT=$(srun --cpu-bind=cores sudo bash -l -c "health-checker run -e soperator -p $platform -n all_reduce_with_ib -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout --log-level info")
 
-echo "Health checker output: $HC_OUTPUT"
+echo "Health checker output:"
+echo "$HC_OUTPUT"
 HC_STATUS=$(echo "$HC_OUTPUT" | awk '/^\s*{/,/^\s*}/' | jq -r '.status')
 
 echo "Health checker status: $HC_STATUS"

--- a/helm/soperator-activechecks/scripts/all-reduce-perf-nccl-without-ib.sh
+++ b/helm/soperator-activechecks/scripts/all-reduce-perf-nccl-without-ib.sh
@@ -24,7 +24,8 @@ echo "Platform found: $platform"
 echo "Running all_reduce_perf_nccl check on $(hostname)..."
 
 HC_OUTPUT=$(srun --cpu-bind=cores sudo bash -l -c "health-checker run -e soperator -p $platform -n all_reduce_without_ib -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout --log-level info")
-echo "Health checker output: $HC_OUTPUT"
+echo "Health checker output:"
+echo "$HC_OUTPUT"
 HC_STATUS=$(echo "$HC_OUTPUT" | awk '/^\s*{/,/^\s*}/' | jq -r '.status')
 
 echo "Health checker status: $HC_STATUS"

--- a/helm/soperator-activechecks/scripts/cuda-samples.sh
+++ b/helm/soperator-activechecks/scripts/cuda-samples.sh
@@ -25,9 +25,10 @@ echo "Running cuda samples check on $(hostname)..."
 HC_OUTPUT_DIR="/opt/soperator-outputs/health_checker_cmd_stdout"
 HC_OUTPUT=$(srun --container-image={{ include "activecheck.image.pyxis" . }} \
   --container-mounts=$(which health-checker):/usr/local/bin/health-checker,$HC_OUTPUT_DIR:$HC_OUTPUT_DIR \
-  sudo bash -l -c "health-checker run -e soperator -p $platform -n deviceQuery,vectorAdd,simpleMultiGPU,p2pBandwidthLatencyTest -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout")
+  bash -l -c "health-checker run -e soperator -p $platform -n deviceQuery,vectorAdd,simpleMultiGPU,p2pBandwidthLatencyTest -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout")
 
-echo "Health checker output: $HC_OUTPUT"
+echo "Health checker output:"
+echo "$HC_OUTPUT"
 HC_STATUS=$(echo "$HC_OUTPUT" | awk '/^\s*{/,/^\s*}/' | jq -r '.status')
 
 echo "Health checker status: $HC_STATUS"

--- a/helm/soperator-activechecks/scripts/dcgmi-diag-r2.sh
+++ b/helm/soperator-activechecks/scripts/dcgmi-diag-r2.sh
@@ -24,7 +24,8 @@ echo "Platform found: $platform"
 echo "Running dcgmi_diag_r2 check on $(hostname)..."
 HC_OUTPUT=$(srun --cpu-bind=cores sudo bash -l -c "health-checker run -e soperator -p $platform -n dcgmi_diag_r2 -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout")
 
-echo "Health checker output: $HC_OUTPUT"
+echo "Health checker output:"
+echo "$HC_OUTPUT"
 HC_STATUS=$(echo "$HC_OUTPUT" | awk '/^\s*{/,/^\s*}/' | jq -r '.status')
 
 echo "Health checker status: $HC_STATUS"

--- a/helm/soperator-activechecks/scripts/dcgmi-diag-r3.sh
+++ b/helm/soperator-activechecks/scripts/dcgmi-diag-r3.sh
@@ -24,7 +24,8 @@ echo "Platform found: $platform"
 echo "Running dcgmi_diag_r3 check on $(hostname)..."
 HC_OUTPUT=$(srun --cpu-bind=cores sudo bash -l -c "health-checker run -e soperator-acceptance -p $platform -n dcgmi_diag_r3 -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout")
 
-echo "Health checker output: $HC_OUTPUT"
+echo "Health checker output:"
+echo "$HC_OUTPUT"
 HC_STATUS=$(echo "$HC_OUTPUT" | awk '/^\s*{/,/^\s*}/' | jq -r '.status')
 
 echo "Health checker status: $HC_STATUS"

--- a/helm/soperator-activechecks/scripts/extensive-check.sh
+++ b/helm/soperator-activechecks/scripts/extensive-check.sh
@@ -54,11 +54,11 @@ parse_hc_output() {
 
   HC_OUTPUT=$(<"$output_file")
 
-  echo "Health-checker output:"
+  echo "Health checker output:"
   echo "$HC_OUTPUT"
   JSON_BLOCK=$(echo "$HC_OUTPUT" | awk '/^\s*{/,/^\s*}/')
   HC_STATUS=$(echo "$JSON_BLOCK" | jq -r '.status // empty')
-  echo "Health-checker finished with status '$HC_STATUS'"
+  echo "Health checker finished with status '$HC_STATUS'"
 
   if [[ "$HC_STATUS" == "FAIL" ]]; then
     HC_RUN_ID=$(echo "$JSON_BLOCK" | jq -r '.meta.run_id // empty')
@@ -68,7 +68,7 @@ parse_hc_output() {
   elif [[ "$HC_STATUS" == "PASS" ]]; then
     return 0
   else
-    echo "Health-checker finished with unknown status."
+    echo "Health checker finished with unknown status."
     return 0
   fi
 }
@@ -122,7 +122,7 @@ cuda_samples() {
 
   srun -J "$NAME" \
     "${SRUN_CONTAINER_ARGS[@]}" \
-    sudo bash -l -c \
+    bash -l -c \
       "health-checker run ${HC_RUN_COMMON_ARGS[*]} \
       -n deviceQuery,vectorAdd,simpleMultiGPU,p2pBandwidthLatencyTest"
 
@@ -149,7 +149,7 @@ gpu_fryer() {
 
   srun -J "$NAME" \
     "${SRUN_CONTAINER_ARGS[@]}" \
-    sudo bash -l -c \
+    bash -l -c \
       "HC_GPU_FRYER_DURATION=300 \
       health-checker run ${HC_RUN_COMMON_ARGS[*]} \
       -n gpu_fryer"
@@ -164,7 +164,7 @@ ib_gpu_perf() {
 
   srun -J "$NAME" \
     "${SRUN_CONTAINER_ARGS[@]}" \
-    sudo bash -l -c \
+    bash -l -c \
       "health-checker run ${HC_RUN_COMMON_ARGS[*]} \
       -n ^ib_write_bw_gpu.*$,^ib_send_lat_gpu.*$,^ib_read_lat_gpu.*$"
 
@@ -178,7 +178,7 @@ mem_perf() {
 
   srun -J "$NAME" \
     "${SRUN_CONTAINER_ARGS[@]}" \
-    sudo bash -l -c \
+    bash -l -c \
       "health-checker run ${HC_RUN_COMMON_ARGS[*]} \
       -n mem_bw,mem_lat"
 

--- a/helm/soperator-activechecks/scripts/extensive-check.sh
+++ b/helm/soperator-activechecks/scripts/extensive-check.sh
@@ -26,7 +26,7 @@ echo "Listing available health checks for platform $platform"
 health-checker list -e soperator -p $platform
 
 HC_RUN_ID=""
-OUT_TMPL="/opt/soperator-outputs/slurm_jobs/%N.extensive-check:@TEST@.%j.out"
+OUT_TMPL="/opt/soperator-outputs/slurm_jobs/$SLURMD_NODENAME.extensive-check:@TEST@.$SLURM_JOB_ID.out"
 HC_CMD_OUT_DIR="/opt/soperator-outputs/health_checker_cmd_stdout"
 mkdir -p "$HC_CMD_OUT_DIR"
 

--- a/helm/soperator-activechecks/scripts/gpu-fryer.sh
+++ b/helm/soperator-activechecks/scripts/gpu-fryer.sh
@@ -25,9 +25,10 @@ echo "Running gpu_fryer check on $(hostname)..."
 HC_OUTPUT_DIR="/opt/soperator-outputs/health_checker_cmd_stdout"
 HC_OUTPUT=$(srun --container-image={{ include "activecheck.image.pyxis" . }} \
   --container-mounts=$(which health-checker):/usr/local/bin/health-checker,$HC_OUTPUT_DIR:$HC_OUTPUT_DIR \
-  sudo bash -l -c "health-checker run -e soperator -p $platform -n gpu_fryer -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout")
+  bash -l -c "health-checker run -e soperator -p $platform -n gpu_fryer -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout")
 
-echo "Health checker output: $HC_OUTPUT"
+echo "Health checker output:"
+echo "$HC_OUTPUT"
 HC_STATUS=$(echo "$HC_OUTPUT" | awk '/^\s*{/,/^\s*}/' | jq -r '.status')
 
 echo "Health checker status: $HC_STATUS"

--- a/helm/soperator-activechecks/scripts/ib-gpu-perf.sh
+++ b/helm/soperator-activechecks/scripts/ib-gpu-perf.sh
@@ -25,9 +25,10 @@ echo "Running ib_gpu_perf check on $(hostname)..."
 HC_OUTPUT_DIR="/opt/soperator-outputs/health_checker_cmd_stdout"
 HC_OUTPUT=$(srun --container-image={{ include "activecheck.image.pyxis" . }} \
   --container-mounts=$(which health-checker):/usr/local/bin/health-checker,$HC_OUTPUT_DIR:$HC_OUTPUT_DIR --cpu-bind=cores \
-  sudo bash -l -c "health-checker run -e soperator -p $platform -n '^ib_write_bw_gpu.*$,^ib_send_lat_gpu.*$,^ib_read_lat_gpu.*$' -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout")
+  bash -l -c "health-checker run -e soperator -p $platform -n '^ib_write_bw_gpu.*$,^ib_send_lat_gpu.*$,^ib_read_lat_gpu.*$' -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout")
 
-echo "Health checker output: $HC_OUTPUT"
+echo "Health checker output:"
+echo "$HC_OUTPUT"
 HC_STATUS=$(echo "$HC_OUTPUT" | awk '/^\s*{/,/^\s*}/' | jq -r '.status')
 
 echo "Health checker status: $HC_STATUS"

--- a/helm/soperator-activechecks/scripts/mem-perf.sh
+++ b/helm/soperator-activechecks/scripts/mem-perf.sh
@@ -24,9 +24,10 @@ echo "Running mem_perf check on $(hostname)..."
 HC_OUTPUT_DIR="/opt/soperator-outputs/health_checker_cmd_stdout"
 HC_OUTPUT=$(srun --container-image={{ include "activecheck.image.pyxis" . }} \
   --container-mounts=$(which health-checker):/usr/local/bin/health-checker,$HC_OUTPUT_DIR:$HC_OUTPUT_DIR --cpu-bind=cores \
-  sudo bash -l -c "health-checker run -e soperator -p $platform -n mem_bw,mem_lat -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout")
+  bash -l -c "health-checker run -e soperator -p $platform -n mem_bw,mem_lat -f json-partial --tests-stdout-path /opt/soperator-outputs/health_checker_cmd_stdout")
 
-echo "Health checker output: $HC_OUTPUT"
+echo "Health checker output:"
+echo "$HC_OUTPUT"
 HC_STATUS=$(echo "$HC_OUTPUT" | awk '/^\s*{/,/^\s*}/' | jq -r '.status')
 
 echo "Health checker status: $HC_STATUS"

--- a/helm/soperator-activechecks/scripts/soperator-outputs-logs-cleaner.sh
+++ b/helm/soperator-activechecks/scripts/soperator-outputs-logs-cleaner.sh
@@ -2,4 +2,4 @@ set -euxo pipefail
 
 echo "Cleaning old Soperator outputs"
 
-find /mnt/jail/opt/soperator-outputs -type f -mmin +30 -delete
+find /mnt/jail/opt/soperator-outputs -type f -mmin +60 -print -delete

--- a/helm/soperator-activechecks/templates/extensive-check.yaml
+++ b/helm/soperator-activechecks/templates/extensive-check.yaml
@@ -22,6 +22,8 @@ spec:
       image: {{ .Values.images.slurmJob | quote }}
       env:
 {{ toYaml .Values.jobContainer.env | indent 8 }}
+        - name: "SLURM_EXTRA_COMMENT_JSON"
+          value: {{ .Values.checks.extensiveCheck.extraCommentJson | quote }}
       volumeMounts:
 {{ toYaml .Values.jobContainer.volumeMounts | indent 8 }}
       volumes:

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -11,8 +11,6 @@ jobContainer:
           fieldPath: "metadata.namespace"
     - name: "SNCCLD_ENABLED"
       value: "false"
-      # - name: "SLURM_EXTRA_COMMENT_JSON"
-      #   value: '{"key1": "value1", "key2": "value2"}'
   volumeMounts:
     - mountPath: "/mnt/jail"
       name: "jail"
@@ -75,6 +73,7 @@ checks:
     runAfterCreation: false
     drainReasonPrefix: "[hardware_problem]"
     reservationPrefix: "suspicious-node"
+    extraCommentJson: ""
   gpuFryer:
     suspend: false
     runAfterCreation: true


### PR DESCRIPTION
## Problem
- Active checks that use containers still don't work with `sudo`, because the executable's effective UID isn't 0 (Enroot changes it).
- Parsing health-checker outputs inside extensive checks still doesn't work because it tries to read filenames by their Slurm filename patterns.
- K8s node condition set after extensive checks has incorrect o11y workspace / project ID.
- Sometimes, soperator outputs are deleted before they are sent by the o11y agent.

## Solution
- Use sudo only in active checks that don't use containers.
- Don't use Slurm templating when building output file paths.
- Accept raw `extraCommentJson` field via Helm values + another fix in Terraform.
- Delete files with mtime older than 1h instead of 30m.

## Testing
Tested.

## Release Notes
Nothing.