### PR TITLE
Add cleanup_scratch_data optional passive check

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/checks.json
+++ b/helm/slurm-cluster/slurm_scripts/checks.json
@@ -187,6 +187,23 @@
     "need_env": []
   },
   {
+    "name": "cleanup_scratch_data",
+    "command": "./cleanup_scratch_data.sh",
+    "platforms": ["any"],
+    "skip_for_cpu_jobs": false,
+    "skip_for_partial_gpu_jobs": false,
+    "skip_for_reservation_prefixes": [],
+    "contexts": ["none"],
+    "node_states": ["any"],
+    "on_fail": "none",
+    "on_ok": "none",
+    "reason_base": "",
+    "reason_append_details": false,
+    "run_in_jail": false,
+    "log": "slurm_scripts/$worker.$name.$context.out",
+    "need_env": []
+  },
+  {
     "name": "map_job_dcgm",
     "command": "./map_job_dcgm.sh",
     "platforms": ["8xGPU", "1xGPU"],

--- a/helm/slurm-cluster/slurm_scripts/cleanup_scratch_data.sh
+++ b/helm/slurm-cluster/slurm_scripts/cleanup_scratch_data.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+echo "[$(date)] Cleanup scratch data"
+
+SCRATCH_DIR="scratch"
+HOST_FS_PATH="/mnt/jail/$SCRATCH_DIR"
+
+rm -rf -- "${HOST_FS_PATH:?}"/..?* "${HOST_FS_PATH:?}"/.[!.]* "${HOST_FS_PATH:?}"/* || true
+
+exit 0

--- a/helm/slurm-cluster/templates/slurm-scripts-cm.yaml
+++ b/helm/slurm-cluster/templates/slurm-scripts-cm.yaml
@@ -52,6 +52,9 @@ data:
   cleanup_enroot.sh: |-
 {{ tpl (.Files.Get "slurm_scripts/cleanup_enroot.sh") . | indent 4 }}
 
+  cleanup_scratch_data.sh: |-
+{{ tpl (.Files.Get "slurm_scripts/cleanup_scratch_data.sh") . | indent 4 }}
+
   drop_page_cache.sh: |-
 {{ tpl (.Files.Get "slurm_scripts/drop_page_cache.sh") . | indent 4 }}
 


### PR DESCRIPTION
## Problem
It might be needed to clean up specific directories in Prolog / Epilog.

## Solution
Implement the `cleanup_scratch_data.sh` passive check that does the thing.
It's disabled by default (has `"contexts": ["none"]` in `checks.json`)

## Testing
Tested on a dev cluster

## Release Notes
There are new Prolog/Epilog scripts cleaning up specific directory for scratch data.
