### PR TITLE
SCHED-549: Have consistent label for worker pods across STSs and topology configurator

### DIFF
--- a/internal/consts/label.go
+++ b/internal/consts/label.go
@@ -23,7 +23,9 @@ const (
 	LabelNodeConfiguratorKey   = K8sGroupNameSoperator + "/node-configurator"
 	LabelNodeConfiguratorValue = "true"
 
-	LabelNodeSetKey = K8sGroupNameSoperator + "/nodeset"
+	LabelNodeSetKey  = K8sGroupNameSoperator + "/nodeset"
+	LabelWorkerKey   = K8sGroupNameSoperator + "/worker"
+	LabelWorkerValue = "true"
 
 	LabelSConfigControllerSourceKey   = "sconfigcontroller." + K8sGroupNameSoperator
 	LabelSConfigControllerSourceValue = "true"

--- a/internal/controller/topologyconfcontroller/workertopology_controller.go
+++ b/internal/controller/topologyconfcontroller/workertopology_controller.go
@@ -104,7 +104,7 @@ func (r *WorkerTopologyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		"ConfigMapNamespace", nodeTopologyLabelsConfigMap.Namespace,
 	)
 
-	labelSelector := client.MatchingLabels{consts.LabelComponentKey: consts.ComponentTypeWorker.String()}
+	labelSelector := client.MatchingLabels{consts.LabelWorkerKey: consts.LabelWorkerValue}
 	fieldSelector := client.MatchingFields{consts.FieldStatusPhase: string(corev1.PodRunning)}
 	podList, err := r.getPodList(ctx, labelSelector, fieldSelector, req.Namespace)
 	if err != nil {

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -33,6 +33,7 @@ func RenderStatefulSet(
 	workerFeatures []slurmv1.WorkerFeature,
 ) (kruisev1b1.StatefulSet, error) {
 	labels := common.RenderLabels(consts.ComponentTypeWorker, clusterName)
+	labels[consts.LabelWorkerKey] = consts.LabelWorkerValue
 	matchLabels := common.RenderMatchLabels(consts.ComponentTypeWorker, clusterName)
 
 	nodeFilter := utils.MustGetBy(
@@ -162,6 +163,7 @@ func RenderNodeSetStatefulSet(
 ) (kruisev1b1.StatefulSet, error) {
 	labels := common.RenderLabels(consts.ComponentTypeNodeSet, nodeSet.ParentalCluster.Name)
 	labels[consts.LabelNodeSetKey] = nodeSet.Name
+	labels[consts.LabelWorkerKey] = consts.LabelWorkerValue
 	matchLabels := common.RenderMatchLabels(consts.ComponentTypeNodeSet, nodeSet.ParentalCluster.Name)
 	matchLabels[consts.LabelNodeSetKey] = nodeSet.Name
 


### PR DESCRIPTION
## Problem
Previous implementation of topology configurator relied on worker pods to have a component label equal to `worker`. NodeSet workers have component label equal to `nodeset`.

## Solution
Introduce dedicated label `slurm.nebius.ai/worker=true` to be used for both STSs (old and NodeSet's) and topology configurator.