### PR TITLE
SCHED-507: (e2e) Install yq in github action

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -64,10 +64,10 @@ jobs:
           go-version-file: 'go.mod'
           cache: false
 
-      - name: Install yq
-        uses: frenck/action-setup-yq@v1
-        with:
-          version: v4.44.2
+      - name: Install E2E tools
+        run: |
+          make install-e2e-tools
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Install AWS CLI v2
         run: |

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -64,6 +64,11 @@ jobs:
           go-version-file: 'go.mod'
           cache: false
 
+      - name: Install yq
+        uses: frenck/action-setup-yq@v1
+        with:
+          version: v4.44.2
+
       - name: Install AWS CLI v2
         run: |
           if command -v aws >/dev/null 2>&1; then
@@ -75,6 +80,43 @@ jobs:
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip -q awscliv2.zip
           sudo ./aws/install --update
+
+      - name: Check tools versions
+        shell: bash
+        run: |
+          echo "yq:"
+          which yq
+          yq --version
+          echo ""
+
+          echo "jq:"
+          which jq
+          jq --version
+          echo ""
+
+          echo "nebius:"
+          which nebius
+          nebius version
+          echo ""
+
+          echo "terraform:"
+          which terraform
+          terraform --version
+          echo ""
+
+          echo "kubectl:"
+          which kubectl
+          kubectl version --client
+          echo ""
+
+          echo "aws:"
+          which aws
+          aws --version
+          echo ""
+
+          echo "go:"
+          which go
+          go version
 
       - name: Find latest build run on current branch
         id: find_build

--- a/Makefile
+++ b/Makefile
@@ -608,6 +608,9 @@ yq: $(YQ) ## Download yq locally if necessary.
 $(YQ): $(LOCALBIN)
 	test -s $(LOCALBIN)/yq || GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@v$(YQ_VERSION)
 
+.PHONY: install-e2e-tools
+install-e2e-tools: yq ## Install tools required for E2E tests
+
 .PHONY: install-kind
 install-kind: $(KIND) ## Download kind locally if necessary.
 $(KIND): $(LOCALBIN)


### PR DESCRIPTION
## Problem
`yq` is broken on the build runner, e2e tests fail

```
$ yq
/user.slice/user-1003.slice/session-3276.scope is not a snap cgroup
```


## Solution
Install `yq` with a dedicated github action.

## Testing
Run e2e

