### PR TITLE
SCHED-549: Make topology config controller work with NodeSets

### DIFF
--- a/internal/controller/topologyconfcontroller/workertopology_controller.go
+++ b/internal/controller/topologyconfcontroller/workertopology_controller.go
@@ -22,13 +22,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
+
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"nebius.ai/slurm-operator/api/v1alpha1"
 	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/controllerconfig"
-	"nebius.ai/slurm-operator/internal/render/common"
-
-	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
 )
 
 var (
@@ -298,7 +297,7 @@ func (r *WorkerTopologyReconciler) GetStatefulSetsWithFallback(
 ) (*kruisev1b1.StatefulSetList, error) {
 	listASTS := &kruisev1b1.StatefulSetList{}
 
-	if err := r.getAdvancedSTS(ctx, clusterName, listASTS); err != nil {
+	if err := r.getAdvancedSTS(ctx, listASTS); err != nil {
 		return nil, fmt.Errorf("get advanced stateful sets: %w", err)
 	}
 
@@ -324,8 +323,11 @@ func (r *WorkerTopologyReconciler) GetStatefulSetsWithFallback(
 }
 
 func (r *WorkerTopologyReconciler) getAdvancedSTS(
-	ctx context.Context, clusterName string, asts *kruisev1b1.StatefulSetList) error {
-	labels := common.RenderLabels(consts.ComponentTypeWorker, clusterName)
+	ctx context.Context, asts *kruisev1b1.StatefulSetList,
+) error {
+	labels := map[string]string{
+		consts.LabelWorkerKey: consts.LabelWorkerValue,
+	}
 	return r.Client.List(ctx, asts, client.MatchingLabels(labels))
 }
 

--- a/internal/controller/topologyconfcontroller/workertopology_controller_test.go
+++ b/internal/controller/topologyconfcontroller/workertopology_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -216,7 +217,10 @@ func TestWorkerTopologyReconciler_GetStatefulSetsWithFallback(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "worker-group-1",
 						Namespace: namespace,
-						Labels:    common.RenderLabels(consts.ComponentTypeWorker, clusterName),
+						Labels: labels.Merge(
+							common.RenderLabels(consts.ComponentTypeWorker, clusterName),
+							labels.Set{consts.LabelWorkerKey: consts.LabelWorkerValue},
+						),
 					},
 					Spec: kruisev1b1.StatefulSetSpec{
 						Replicas: ptr.To(int32(3)),
@@ -265,7 +269,10 @@ func TestWorkerTopologyReconciler_GetStatefulSetsWithFallback(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "worker-group-1",
 						Namespace: namespace,
-						Labels:    common.RenderLabels(consts.ComponentTypeWorker, clusterName),
+						Labels: labels.Merge(
+							common.RenderLabels(consts.ComponentTypeWorker, clusterName),
+							labels.Set{consts.LabelWorkerKey: consts.LabelWorkerValue},
+						),
 					},
 					Spec: kruisev1b1.StatefulSetSpec{
 						Replicas: ptr.To(int32(2)),
@@ -275,7 +282,10 @@ func TestWorkerTopologyReconciler_GetStatefulSetsWithFallback(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "worker-group-2",
 						Namespace: namespace,
-						Labels:    common.RenderLabels(consts.ComponentTypeWorker, clusterName),
+						Labels: labels.Merge(
+							common.RenderLabels(consts.ComponentTypeWorker, clusterName),
+							labels.Set{consts.LabelWorkerKey: consts.LabelWorkerValue},
+						),
 					},
 					Spec: kruisev1b1.StatefulSetSpec{
 						Replicas: ptr.To(int32(3)),


### PR DESCRIPTION
## Problem
Topology config controller:
- Indexes `.Status.Phase` field along with filtration by pod labels
- Uses the whole list of labels for initial topology generation
These labels only work with old workers.

## Solution
Labels could be extended with common label for workers (old and new), but it's better to reduce the list only to this label.
Field indexer could also be left only for its direct responsibility - indexing pod fields, not filtering them.

## Testing
Topology got generated for cluster with multiple nodesets on a test cluster.