### PR TITLE
[SCHED-540] E2E broken: wrong helmrelease name

### DIFF
--- a/helm/soperator-fluxcd-bootstrap/values.yaml
+++ b/helm/soperator-fluxcd-bootstrap/values.yaml
@@ -9,7 +9,7 @@ helmRepository:
     "helm.sh/resource-policy": keep
 helmRelease:
   enabled: true
-  name: soperator-fluxcd
+  name: flux-system-soperator-fluxcd
   namespace: flux-system
   interval: 5m
   timeout: 5m


### PR DESCRIPTION
## Problem

Cluster provisioning is broken because the script waits for wrong helm release.
Because helm releases lost "flux-system-" prefix in this PR: https://github.com/nebius/soperator/pull/1854/files

## Solution

Update helm release name

## Testing

https://github.com/nebius/soperator/actions/runs/19858833160

## Release Notes

Nothing