### PR TITLE
SCHED-540: fix e2e broken: wrong helmrelease name

### DIFF
--- a/helm/soperator-fluxcd-bootstrap/templates/helmrelease.yaml
+++ b/helm/soperator-fluxcd-bootstrap/templates/helmrelease.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     {{- toYaml .Values.helmRelease.annotations | nindent 4 }}
 spec:
+  targetNamespace: {{ .Values.helmRelease.namespace }}
   interval: {{ .Values.helmRelease.interval }}
   {{- if .Values.helmRelease.timeout }}
   timeout: {{ .Values.helmRelease.timeout }}


### PR DESCRIPTION
## Problem

Cluster provisioning is broken because the script waits for wrong helm release.
Because helm releases lost "flux-system-" prefix in this PR: https://github.com/nebius/soperator/pull/1854/files

## Solution

Set targetNamespace, it will be propagated to the helm release names

## Testing

https://github.com/nebius/soperator/actions/runs/19860319111

## Release Notes

Nothing