### PR TITLE
NOTIC: upgrade cert-manager

### DIFF
--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -47,7 +47,7 @@ certManager:
   enabled: true
   interval: 5m
   timeout: 5m
-  version: v1.17.*
+  version: v1.19.*
   namespace: cert-manager-system
   releaseName: cert-manager
   values: null


### PR DESCRIPTION
## Problem
https://cert-manager.io/docs/releases/#currently-supported-releases 1.17 EOL

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
Upgrade the cert-manager version to 1.19.
