### PR TITLE
SCHED-565 Change node replacement drain prefix to [compute_maintenance]

### DIFF
--- a/internal/consts/slurm.go
+++ b/internal/consts/slurm.go
@@ -17,10 +17,10 @@ var (
 	SlurmUserReasonHC              string = "[user_problem]"
 	SlurmNodeReasonHC              string = "[node_problem]"
 	SlurmHardwareReasonHC          string = "[hardware_problem]"
-	SlurmNodeComputeMaintenance    string = SlurmNodeReasonHC + " compute_maintenance"
+	SlurmNodeComputeMaintenance    string = "[compute_maintenance]"
 	SlurmNodeReasonKillTaskFailed  string = "Kill task failed"
-	SlurmNodeReasonNodeReplacement string = SlurmNodeComputeMaintenance + ": node replacement process"
-	SlurmNodeReasonNodeReboot      string = SlurmNodeComputeMaintenance + ": node reboot process"
+	SlurmNodeReasonNodeReplacement string = SlurmNodeComputeMaintenance + " node replacement process"
+	SlurmNodeReasonNodeReboot      string = SlurmNodeComputeMaintenance + " node reboot process"
 )
 
 // order of reasons is important, because we use it to determine if node is in maintenance


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Currently HC drains and compute maintenance drains may interfere with each other since they have the same drain prefix

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Change compute maintenance prefix

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
