### PR TITLE
SCHED-563 Bump health-checker to 1.0.0-171.251205

### DIFF
--- a/ansible/roles/nc-health-checker/defaults/main.yml
+++ b/ansible/roles/nc-health-checker/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 
-nc_health_checker_version: 1.0.0-169.251125
+nc_health_checker_version: 1.0.0-171.251205

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -106,7 +106,7 @@ checks:
   upgradeHealthChecker:
     suspend: true
     runAfterCreation: false
-    healthCheckerVersion: "1.0.0-169.251125"
+    healthCheckerVersion: "1.0.0-171.251205"
   waitForTopology:
     suspend: true
     runAfterCreation: true


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
ib-gpu-perf has wrong limits in the current health-checker version and it's fixed in 1.0.0-171.251205

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Bump health-checker to 1.0.0-171.251205

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
