### PR TITLE
SCHED-490 Add a flag to disable extensive check

### DIFF
--- a/cmd/soperatorchecks/main.go
+++ b/cmd/soperatorchecks/main.go
@@ -112,7 +112,7 @@ func main() {
 		logFormat                   string
 		logLevel                    string
 		enabledNodeReplacement      bool
-		disableExtensiveCheck       bool
+		enableExtensiveCheck        bool
 		deleteNotReadyNodes         bool
 		notReadyTimeout             time.Duration
 		maintenanceConditionType    string
@@ -151,7 +151,7 @@ func main() {
 	flag.IntVar(&maxConcurrencyPodEphemeralStorageCheck, "pod-ephemeral-max-concurrent-reconciles", 10, "Configures number of concurrent reconciles for Pod Ephemeral Storage Check. It should improve performance for clusters with many pods.")
 	flag.DurationVar(&cacheSyncTimeout, "cache-sync-timeout", 2*time.Minute, "The maximum duration allowed for caching sync")
 	flag.BoolVar(&enabledNodeReplacement, "enable-node-replacement", true, "Enable node replacement controller")
-	flag.BoolVar(&disableExtensiveCheck, "disable-extensive-check", false, "If set, skips extensive check and sets unhealthy flag right after any HC failure")
+	flag.BoolVar(&enableExtensiveCheck, "enable-extensive-check", true, "If set, runs extensive check before setting unhealthy flag for HC failures")
 	flag.DurationVar(&notReadyTimeout, "not-ready-timeout", 15*time.Minute, "The timeout after which a NotReady node will be deleted. Nodes can be NotReady for more than 10 minutes when GPU operator is starting.")
 	flag.BoolVar(&deleteNotReadyNodes, "delete-not-ready-nodes", true, "If set, NotReady nodes will be deleted after the not-ready timeout is reached. If false, they will be marked as NotReady but not deleted.")
 	flag.Float64Var(&ephemeralStorageThreshold, "ephemeral-storage-threshold", 85.0, "The threshold percentage for ephemeral storage usage warnings (default 85%)")
@@ -252,7 +252,7 @@ func main() {
 		slurmAPIClients,
 		reconcileTimeout,
 		enabledNodeReplacement,
-		disableExtensiveCheck,
+		enableExtensiveCheck,
 		mgr.GetAPIReader(),
 		corev1.NodeConditionType(maintenanceConditionType),
 	).SetupWithManager(mgr, maxConcurrency, cacheSyncTimeout); err != nil {

--- a/helm/soperatorchecks/templates/deployment.yaml
+++ b/helm/soperatorchecks/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         resources: {{- toYaml .Values.checks.kubeRbacProxy.resources | nindent 10 }}
         securityContext: {{- toYaml .Values.checks.kubeRbacProxy.containerSecurityContext
           | nindent 10 }}
-      - args: {{- toYaml (append (append .Values.checks.manager.args (printf "--enable-node-replacement=%t" .Values.checks.manager.enableNodeReplacement)) (printf "--disable-extensive-check=%t" .Values.checks.manager.disableExtensiveCheck)) | nindent 8 }}
+      - args: {{- toYaml (append (append .Values.checks.manager.args (printf "--enable-node-replacement=%t" .Values.checks.manager.enableNodeReplacement)) (printf "--enable-extensive-check=%t" .Values.checks.manager.enableExtensiveCheck)) | nindent 8 }}
         command:
         - /usr/bin/soperatorchecks
         env:

--- a/helm/soperatorchecks/values.yaml
+++ b/helm/soperatorchecks/values.yaml
@@ -21,7 +21,7 @@ checks:
         memory: 64Mi
   manager:
     enableNodeReplacement: false
-    disableExtensiveCheck: true
+    enableExtensiveCheck: false
     args:
       - --log-format=json
       - --log-level=info

--- a/internal/controller/soperatorchecks/maintenance_condition_test.go
+++ b/internal/controller/soperatorchecks/maintenance_condition_test.go
@@ -85,7 +85,7 @@ func TestMaintenanceConditionTypeConfiguration(t *testing.T) {
 				slurmAPIClients,
 				30*time.Second,
 				true,
-				false,
+				true,
 				client,
 				corev1.NodeConditionType(tt.inputConditionType),
 			)
@@ -105,7 +105,7 @@ func TestDefaultMaintenanceConditionTypeConstant(t *testing.T) {
 
 	slurmAPIController := NewSlurmAPIClientsController(client, scheme, recorder, slurmAPIClients, "")
 	k8sController := NewK8SNodesController(client, scheme, recorder, 15*time.Minute, true, "", "")
-	slurmController := NewSlurmNodesController(client, scheme, recorder, slurmAPIClients, 30*time.Second, true, false, client, "")
+	slurmController := NewSlurmNodesController(client, scheme, recorder, slurmAPIClients, 30*time.Second, true, true, client, "")
 
 	expectedDefault := string(consts.DefaultMaintenanceConditionType)
 

--- a/internal/controller/soperatorchecks/slurm_nodes_controller.go
+++ b/internal/controller/soperatorchecks/slurm_nodes_controller.go
@@ -40,7 +40,7 @@ type SlurmNodesController struct {
 	slurmAPIClients          *slurmapi.ClientSet
 	reconcileTimeout         time.Duration
 	enabledNodeReplacement   bool
-	disableExtensiveCheck    bool
+	enableExtensiveCheck     bool
 	apiReader                client.Reader // Direct API reader for pagination
 	MaintenanceConditionType corev1.NodeConditionType
 }
@@ -52,7 +52,7 @@ func NewSlurmNodesController(
 	slurmAPIClients *slurmapi.ClientSet,
 	reconcileTimeout time.Duration,
 	enabledNodeReplacement bool,
-	disableExtensiveCheck bool,
+	enableExtensiveCheck bool,
 	apiReader client.Reader,
 	maintenanceConditionType corev1.NodeConditionType,
 ) *SlurmNodesController {
@@ -67,7 +67,7 @@ func NewSlurmNodesController(
 		slurmAPIClients:          slurmAPIClients,
 		reconcileTimeout:         reconcileTimeout,
 		enabledNodeReplacement:   enabledNodeReplacement,
-		disableExtensiveCheck:    disableExtensiveCheck,
+		enableExtensiveCheck:     enableExtensiveCheck,
 		apiReader:                apiReader,
 		MaintenanceConditionType: maintenanceConditionType,
 	}
@@ -263,8 +263,8 @@ func (c *SlurmNodesController) processHealthCheckFailed(
 		return nil
 	}
 
-	if c.disableExtensiveCheck {
-		logger.V(1).Info("Skipping extensive check flow, setting unhealthy right away")
+	if !c.enableExtensiveCheck {
+		logger.V(1).Info("Extensive check not enabled, setting unhealthy right away")
 		return c.processSetUnhealthy(ctx, k8sNode, slurmClusterName, slurmNode)
 	}
 


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Now we don't have a reliable way to disable extensive check but still have set-unhealthy after any HC failure

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Adding disable-extensive-check flag for it

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
