### PR TITLE
Disable dependency `kruise` by default

### DIFF
--- a/helm/soperator/values.yaml
+++ b/helm/soperator/values.yaml
@@ -69,7 +69,7 @@ serviceMonitor:
 certManager:
   enabled: true
 kruise:
-  installOperator: true
+  installOperator: false
   manager:
     replicas: 1
   featureGates: "ImagePullJobGate=true,RecreatePodWhenChangeVCTInCloneSetGate=true,StatefulSetAutoResizePVCGate=true,StatefulSetAutoDeletePVC=true,PreDownloadImageForInPlaceUpdate=true"


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Right now, kruise is being deployed by two different helm chart:
- soperator-fluxcd
- soperator (as a helm chart dependency)

This results with constant drift of one of the HelmReleases

## Solution
Solution is to disable kruise installed by soperator helm chart by default.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
Resources related to `kruise` are deployed by HelmRelease `flux-system-soperator-fluxcd-kruise` and there are no other HelmRelease managing the same resources.

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
