### PR TITLE
Bind libslurm.so.* from container to jail

### DIFF
--- a/images/common/scripts/bind_slurm_common.sh
+++ b/images/common/scripts/bind_slurm_common.sh
@@ -22,9 +22,10 @@ if [ -z "$jaildir" ]; then
 fi
 
 ALT_ARCH="$(uname -m)"
-ALT_LIBDIR="usr/lib/${ALT_ARCH}-linux-gnu"
+JAIL_LIBDIR="usr/lib/${ALT_ARCH}-linux-gnu"
 SLURM_LIB_PATH="usr/lib/${ALT_ARCH}-linux-gnu/slurm"
-LIBSLURM_REAL=$(find "${ALT_LIBDIR}" -maxdepth 1 -type f -name 'libslurm.so.*' -printf '%f\n' | sort -V | tail -n1)
+CONTAINER_LIBDIR="/usr/lib/${ALT_ARCH}-linux-gnu"
+LIBSLURM_REAL=$(find "${CONTAINER_LIBDIR}" -maxdepth 1 -type f -name 'libslurm.so.*' -printf '%f\n' | sort -V | tail -n1)
 
 echo "🔧 Using ALT_ARCH = ${ALT_ARCH}"
 
@@ -36,11 +37,11 @@ pushd "${jaildir}"
     mkdir -p "${SLURM_LIB_PATH}"
     mount --bind "/${SLURM_LIB_PATH}" "${SLURM_LIB_PATH}"
 
-    touch "${ALT_LIBDIR}/${LIBSLURM_REAL}"
-    mount --bind "/usr/lib/${ALT_ARCH}-linux-gnu/${LIBSLURM_REAL}" "${ALT_LIBDIR}/${LIBSLURM_REAL}"
+    touch "${JAIL_LIBDIR}/${LIBSLURM_REAL}"
+    mount --bind "${CONTAINER_LIBDIR}/${LIBSLURM_REAL}" "${JAIL_LIBDIR}/${LIBSLURM_REAL}"
 
     MAJOR=$(printf '%s\n' "$LIBSLURM_REAL" | sed -E 's/.*\.so\.([0-9]+).*/\1/')
-    pushd "${ALT_LIBDIR}"
+    pushd "${JAIL_LIBDIR}"
         ln -sf "${LIBSLURM_REAL}" "libslurm.so.${MAJOR}"
         ln -sf "${LIBSLURM_REAL}" "libslurm.so"
     popd


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Currently we try to bind a libslurm.so.* file found in jail from container to jail, but it should be found inside container instead

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Find this file in the container, not in the jail

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
