### PR TITLE
Use unstable NFS version in E2E TF

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -160,14 +160,14 @@ func overrideTestValues(tfVars map[string]interface{}, cfg testConfig) map[strin
 
 	// nfs_in_k8s = {
 	//    enabled         = true
-	//    version         = "1.2.0"
+	//    version         = "1.2.0-f67979d7"
 	//    size_gibibytes  = 3720
 	//    disk_type       = "NETWORK_SSD_IO_M3"
 	//    filesystem_type = "ext4"
 	// }
 	tfVars["nfs_in_k8s"] = map[string]interface{}{
 		"enabled":         true,
-		"version":         "1.2.0",
+		"version":         "1.2.0-f67979d7",
 		"size_gibibytes":  3720,
 		"disk_type":       "NETWORK_SSD_IO_M3",
 		"filesystem_type": "ext4",


### PR DESCRIPTION
## Problem
E2E Terraform fails because it uses the unstable container registry, but the stable nfs_in_k8s release is not available there. We should use corresponding unstable versions for E2E.

## Solution
Change the version to an unstable one.

## Testing
Make sure E2Es are green.

## Release Notes
Nothing
