### PR TITLE
SCHED-609: Fix Enroot containers

### DIFF
--- a/helm/soperator-activechecks/scripts/mem-perf.sh
+++ b/helm/soperator-activechecks/scripts/mem-perf.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #SBATCH --deadline="now+8hours"
 #SBATCH --time=15:00
+#SBATCH --gpus-per-node=8
 #SBATCH --exclusive
 #SBATCH --mem=0
 

--- a/helm/soperator-activechecks/scripts/prepull-container-image.sh
+++ b/helm/soperator-activechecks/scripts/prepull-container-image.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #SBATCH --deadline="now+8hours"
 #SBATCH --time=30:00
+#SBATCH --gpus-per-node=8
 #SBATCH --exclusive
 #SBATCH --mem=0
 


### PR DESCRIPTION
## Problem
In soperator-release-1.23 NVIDIA driver's libraries are not propagated from container FS to jail FS because we pass no capabilities to `nvidia-container-cli` in `complement_jail.sh`.

## Solution
Parse `NVIDIA_DRIVER_CAPABILITIES` env var and append CLI args for each capability.

## Testing
Tested on a dev cluster.

## Release Notes
Nothing
