### PR TITLE
SCHED-570 Use storage-driver vfs by default

### DIFF
--- a/images/worker/docker/daemon.json
+++ b/images/worker/docker/daemon.json
@@ -1,4 +1,5 @@
 {
+  "storage-driver": "vfs",
   "hosts": [
     "unix:///var/run/docker.sock"
   ],


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Without additional local disks docker does not work because it try to use overlayfs inside overlayfs

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Use storage-driver vfs by default

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
