### PR TITLE
Make scontrol reboot work by fixing RebootProgram script permissions

### DIFF
--- a/images/worker/slurmd.dockerfile
+++ b/images/worker/slurmd.dockerfile
@@ -148,7 +148,8 @@ COPY images/common/scripts/bind_slurm_common.sh /opt/bin/slurm/
 COPY images/common/scripts/reboot.sh /opt/bin/slurm/
 
 RUN chmod +x /opt/bin/slurm/complement_jail.sh && \
-    chmod +x /opt/bin/slurm/bind_slurm_common.sh
+    chmod +x /opt/bin/slurm/bind_slurm_common.sh && \
+    chmod +x /opt/bin/slurm/reboot.sh
 
 # Create single folder with slurm plugins for all architectures
 RUN mkdir -p /usr/lib/slurm && \


### PR DESCRIPTION
## Problem
`scontrol reboot` doesn't work because `slurmd` cannot execute the RebootProgram script, as the file doesn't have execute permission bits.

## Solution
Add `chmod +x /opt/bin/slurm/reboot.sh` in the `slurmd.dockerfile`

## Testing
Try `scontrol reboot`.
Tested on a dev cluster.

## Release Notes
Fix `scontrol reboot` command.
