### PR TITLE
Fix package installation that depend on libnvidia-compute-590

### DIFF
--- a/images/common/scripts/install_driver_mocks.sh
+++ b/images/common/scripts/install_driver_mocks.sh
@@ -24,6 +24,9 @@ driver_packages=(
   libnvidia-compute-570
   libnvidia-compute-575
   libnvidia-compute-580
+  libnvidia-compute-585
+  libnvidia-compute-590
+  libnvidia-compute-595
 )
 
 # Install deb package mocking tool


### PR DESCRIPTION
## Problem
Installation of packages that depend on the latest libnvidia-compute-590 breaks jail, because the latest version of the mock package we install is 580.

## Solution
Install version 585-595.

## Testing
Create a new cluster and try to install `libnvidia-decode`

## Release Notes
Fixed the bug that occurred when installing `libnvidia-decode` corrupted the jail FS.