### PR TITLE
Fix k8up backup image repo and tag

### DIFF
--- a/helm/soperator-fluxcd/templates/backup.yaml
+++ b/helm/soperator-fluxcd/templates/backup.yaml
@@ -41,10 +41,10 @@ spec:
     {{- toYaml .Values.backup.overrideValues | nindent 4 }}
   {{- else }}
     k8up:
+      backupImage:
+        repository: k8up-io/k8up
+        tag: v2.13.1
       skipWithoutAnnotation: true
-      image:
-        repository: ghcr.io/vshn/k8up
-        tag: v4.8.0
     {{- if .Values.observability.prometheusOperator.enabled }}
       metrics:
         grafanaDashboard:


### PR DESCRIPTION
## Problem
In the backup HelmRelease for k8up, there are hard coded values for `k8up.image` set to the legacy `ghcr.io/vshn/k8up` repository and hardcoded to version `v4.8.0`.

`k8up.image` is not a valid Values file setting. The correct one is [`k8up.backupImage`](https://github.com/k8up-io/k8up/blob/master/charts/k8up/values.yaml#L36) so these values aren't even being used.  

## Solution
Removed the unused values.

## Testing
On a 1.22.3 Soperator cluster I uninstalled `k8up` and then reinstalled using the `HelmRelease` with these values removed and it installed with the same configuration settings.

## Release Notes
None needed as this is removing unused values and thus no changes to Soperator.
