### PR TITLE
Allocate all available memory by default

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -74,7 +74,7 @@ type SlurmClusterSpec struct {
 	// SlurmConfig represents the Slurm configuration in slurm.conf. Not all options are supported.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={defMemPerNode: 1048576, defCpuPerGPU: 4, completeWait: 5, epilog: "", prolog: "", maxJobCount: 20000, minJobAge: 28800, messageTimeout: 60}
+	// +kubebuilder:default={defMemPerNode: 0, defCpuPerGPU: 4, completeWait: 5, epilog: "", prolog: "", maxJobCount: 20000, minJobAge: 28800, messageTimeout: 60}
 	SlurmConfig SlurmConfig `json:"slurmConfig,omitempty"`
 
 	// CustomSlurmConfig represents the raw Slurm configuration from slurm.conf.
@@ -123,7 +123,7 @@ type SlurmConfig struct {
 	// Default real memory size available per allocated node in mebibytes.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=1048576
+	// +kubebuilder:default=0
 	DefMemPerNode *int32 `json:"defMemPerNode,omitempty"`
 	// Default count of CPUs allocated per allocated GPU
 	//

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -3410,7 +3410,7 @@ spec:
                 default:
                   completeWait: 5
                   defCpuPerGPU: 4
-                  defMemPerNode: 1048576
+                  defMemPerNode: 0
                   epilog: ""
                   maxJobCount: 20000
                   messageTimeout: 60
@@ -3431,7 +3431,7 @@ spec:
                     format: int32
                     type: integer
                   defMemPerNode:
-                    default: 1048576
+                    default: 0
                     description: Default real memory size available per allocated
                       node in mebibytes.
                     format: int32

--- a/helm/slurm-cluster/tests/default-values_test.yaml
+++ b/helm/slurm-cluster/tests/default-values_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.slurmConfig.defMemPerNode
-          value: 1048576
+          value: 0
       - equal:
           path: spec.slurmConfig.defCpuPerGPU
           value: 4

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -145,7 +145,7 @@ populateJail:
   #    volumeSourceName: "jail-snapshot"
   overwrite: false
 slurmConfig:
-  defMemPerNode: 1048576
+  defMemPerNode: 0
   defCpuPerGPU: 4
   completeWait: 5
   prolog: /opt/slurm_scripts/prolog.sh

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -29208,7 +29208,7 @@ spec:
                 default:
                   completeWait: 5
                   defCpuPerGPU: 4
-                  defMemPerNode: 1048576
+                  defMemPerNode: 0
                   epilog: ""
                   maxJobCount: 20000
                   messageTimeout: 60
@@ -29229,7 +29229,7 @@ spec:
                     format: int32
                     type: integer
                   defMemPerNode:
-                    default: 1048576
+                    default: 0
                     description: Default real memory size available per allocated
                       node in mebibytes.
                     format: int32

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -29208,7 +29208,7 @@ spec:
                 default:
                   completeWait: 5
                   defCpuPerGPU: 4
-                  defMemPerNode: 1048576
+                  defMemPerNode: 0
                   epilog: ""
                   maxJobCount: 20000
                   messageTimeout: 60
@@ -29229,7 +29229,7 @@ spec:
                     format: int32
                     type: integer
                   defMemPerNode:
-                    default: 1048576
+                    default: 0
                     description: Default real memory size available per allocated
                       node in mebibytes.
                     format: int32


### PR DESCRIPTION
## Problem
Allocating 1TiB of memory by default is a bad default for heterogeneous clusters that include CPU-only nodes.
Also, 1TiB is some arbitrary value; it's better to allocate all available memory.

## Solution
Replace 1TiB with 0, which means "all available memory" in Slurm.

## Testing
Create a new cluster and check the `scontrol show config`.

## Release Notes
Adjusted the default Slurm config so that all node memory is allocated by default.
