### PR TITLE
Run extensive checks on reservations more often

### DIFF
--- a/helm/soperator-activechecks/templates/run-extensive-check-on-reservations.yaml
+++ b/helm/soperator-activechecks/templates/run-extensive-check-on-reservations.yaml
@@ -12,7 +12,7 @@ spec:
   name: "run-extensive-check-on-reservations"
   # This schedule defines how often the extensive-check is executed.
   # If extensive-check is already running on a node, we don't stop it.
-  schedule: '*/10 * * * *' # every 10 minutes
+  schedule: '*/5 * * * *' # every 5 minutes
   suspend: false
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
## Problem
Now, extensive checks start every 10 minutes, which is too rare.

## Solution
Start them every 5 minutes.

## Testing
Make sure the `run-extensive-checks-on-reservations` CronJob runs every 5 minutes.

## Release Notes
Nothing
