### PR TITLE
Fix node auto-replacement after maintenance events

### DIFF
--- a/helm/soperatorchecks/values.yaml
+++ b/helm/soperatorchecks/values.yaml
@@ -31,7 +31,7 @@ checks:
       - --not-ready-timeout=15m
       - --delete-not-ready-nodes=true
       - --leader-elect
-      - --maintenance-condition-type="NebiusMaintenanceScheduled"
+      - --maintenance-condition-type=NebiusMaintenanceScheduled
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:


### PR DESCRIPTION
## Problem
Soperator doesn't react to maintenance event conditions and doesn't replace nodes because the condition is passed to the controller with redundant quotes.

## Solution
Remove quotes from the controller arguments.

## Testing
Tested on a dev cluster.

## Release Notes
Nothing
