### PR TITLE
SCHED-686: Add CI Success GH job

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -15,24 +15,10 @@ on:
       - soperator-release-*
     tags:
       - "**" # Trigger on any tag
-    paths-ignore:
-      - "docs/**"
-      - "CODEOWNERS"
-      - "LICENSE"
-      - "PROJECT"
-      - "README.md"
-      - "SECURITY.md"
 
   # pull_request are defined separately to allow to run CI from forks.
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - "docs/**"
-      - "CODEOWNERS"
-      - "LICENSE"
-      - "PROJECT"
-      - "README.md"
-      - "SECURITY.md"
 
 permissions:
   contents: read
@@ -45,7 +31,30 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      has_code_changes: ${{ steps.filter.outputs.has_code_changes }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            has_code_changes:
+              - '**'
+              - '!docs/**'
+              - '!CODEOWNERS'
+              - '!LICENSE'
+              - '!PROJECT'
+              - '!README.md'
+              - '!SECURITY.md'
+
   pre-build:
+    needs: [changes]
+    if: needs.changes.outputs.has_code_changes == 'true'
     runs-on:
       - self-hosted
       - build
@@ -105,6 +114,8 @@ jobs:
           echo "Unstable: $UNSTABLE"
 
   lint:
+    needs: [changes]
+    if: needs.changes.outputs.has_code_changes == 'true'
     runs-on:
       - self-hosted
       - build
@@ -143,11 +154,12 @@ jobs:
           GOOS: darwin
 
   build-docker-images:
+    needs: [changes, pre-build]
+    if: needs.changes.outputs.has_code_changes == 'true'
     runs-on:
       - self-hosted
       - X64
       - build
-    needs: pre-build
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -262,11 +274,12 @@ jobs:
           rm -f images/jail_rootfs*.tar
 
   build-helm-charts:
+    needs: [changes, pre-build]
+    if: needs.changes.outputs.has_code_changes == 'true'
     runs-on:
       - self-hosted
       - X64
       - build
-    needs: pre-build
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -306,8 +319,9 @@ jobs:
 
   helm-integration-test:
     name: Helm Chart Integration Test with Built Images
+    needs: [changes, build-docker-images, build-helm-charts]
+    if: needs.changes.outputs.has_code_changes == 'true'
     runs-on: ubuntu-latest
-    needs: [build-docker-images, build-helm-charts]
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -381,3 +395,35 @@ jobs:
             test/integration/*.xml
             cluster-logs/
           retention-days: 1
+
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - pre-build
+      - lint
+      - build-docker-images
+      - build-helm-charts
+      - helm-integration-test
+    if: always()
+    steps:
+      - name: Check CI status
+        shell: bash
+        run: |
+          # If no code changes, all jobs should be skipped - that's OK
+          if [[ "${{ needs.changes.outputs.has_code_changes }}" != "true" ]]; then
+            echo "No code changes - CI skipped successfully"
+            exit 0
+          fi
+
+          # Otherwise, check that all jobs passed
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "Some jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Some jobs were cancelled"
+            exit 1
+          fi
+          echo "All CI jobs passed!"


### PR DESCRIPTION
## Problem

Previously, PRs could be merged before CI completed or even with failing checks because branch protection had no required status checks configured.

## Solution
- Add changes detection job using dorny/paths-filter to skip CI for docs-only PRs
- Add ci-success gate job that aggregates all job results
- Make all build jobs conditional on has_code_changes output
- Remove paths-ignore from triggers (now handled by changes job)

## Testing

CI builds in this PR

## Release Notes

No release notes required