### PR TITLE
SCHED-706: Adding node metrics to track node status in Slurm

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -162,9 +162,9 @@ func selectTokenIssuer(flags Flags, ctrlClient client.Client, slurmClusterID typ
 
 	switch {
 	case ctrlClient != nil:
-		issuer = jwt.NewToken(ctrlClient).For(slurmClusterID, "root").WithRegistry(jwt.NewTokenRegistry().Build())
+		issuer = jwt.NewToken(ctrlClient).For(slurmClusterID, "ubuntu").WithRegistry(jwt.NewTokenRegistry().Build())
 	case flags.standalone:
-		standaloneIssuer := tokenstandalone.NewStandaloneTokenIssuer(slurmClusterID, "root").
+		standaloneIssuer := tokenstandalone.NewStandaloneTokenIssuer(slurmClusterID, "ubuntu").
 			WithScontrolPath(flags.scontrolPath)
 		// Parse and set rotation interval
 		if rotationInterval, err := time.ParseDuration(flags.keyRotationInterval); err == nil {

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -162,9 +162,9 @@ func selectTokenIssuer(flags Flags, ctrlClient client.Client, slurmClusterID typ
 
 	switch {
 	case ctrlClient != nil:
-		issuer = jwt.NewToken(ctrlClient).For(slurmClusterID, "ubuntu").WithRegistry(jwt.NewTokenRegistry().Build())
+		issuer = jwt.NewToken(ctrlClient).For(slurmClusterID, "root").WithRegistry(jwt.NewTokenRegistry().Build())
 	case flags.standalone:
-		standaloneIssuer := tokenstandalone.NewStandaloneTokenIssuer(slurmClusterID, "ubuntu").
+		standaloneIssuer := tokenstandalone.NewStandaloneTokenIssuer(slurmClusterID, "root").
 			WithScontrolPath(flags.scontrolPath)
 		// Parse and set rotation interval
 		if rotationInterval, err := time.ParseDuration(flags.keyRotationInterval); err == nil {

--- a/internal/exporter/collector.go
+++ b/internal/exporter/collector.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	api "github.com/SlinkyProject/slurm-client/api/v0041"
+	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -22,9 +23,20 @@ type MetricsCollector struct {
 	slurmAPIClient slurmapi.Client
 
 	nodeInfo                   *prometheus.Desc
+	nodeCPUTotal               *prometheus.Desc
+	nodeCPUAllocated           *prometheus.Desc
+	nodeCPUIdle                *prometheus.Desc
+	nodeCPUEffective           *prometheus.Desc
+	nodeMemoryTotalBytes       *prometheus.Desc
+	nodeMemoryAllocatedBytes   *prometheus.Desc
+	nodeMemoryFreeBytes        *prometheus.Desc
+	nodeMemoryEffectiveBytes   *prometheus.Desc
+	nodePartition              *prometheus.Desc
 	jobInfo                    *prometheus.Desc
 	jobNode                    *prometheus.Desc
 	jobDuration                *prometheus.Desc
+	jobCPUs                    *prometheus.Desc
+	jobMemoryBytes             *prometheus.Desc
 	nodeGPUSeconds             *prometheus.CounterVec
 	nodeFails                  *prometheus.CounterVec
 	nodeUnavailabilityDuration *prometheus.HistogramVec
@@ -69,10 +81,21 @@ func NewMetricsCollector(slurmAPIClient slurmapi.Client) *MetricsCollector {
 		slurmAPIClient: slurmAPIClient,
 		Monitoring:     NewMonitoringMetrics(),
 
-		nodeInfo:    prometheus.NewDesc("slurm_node_info", "Slurm node info", []string{"node_name", "instance_id", "state_base", "state_is_drain", "state_is_maintenance", "state_is_reserved", "reservation_name", "address", "reason"}, nil),
-		jobInfo:     prometheus.NewDesc("slurm_job_info", "Slurm job detail information", []string{"job_id", "job_state", "job_state_reason", "slurm_partition", "job_name", "user_name", "user_mail", "user_id", "standard_error", "standard_output", "array_job_id", "array_task_id", "submit_time", "start_time", "end_time", "finished_time"}, nil),
-		jobNode:     prometheus.NewDesc("slurm_node_job", "Slurm job node information", []string{"job_id", "node_name"}, nil),
-		jobDuration: prometheus.NewDesc("slurm_job_duration_seconds", "Slurm job duration in seconds", []string{"job_id"}, nil),
+		nodeInfo:                 prometheus.NewDesc("slurm_node_info", "Slurm node info", []string{"node_name", "instance_id", "state_base", "state_is_drain", "state_is_maintenance", "state_is_reserved", "state_is_completing", "state_is_fail", "state_is_planned", "reservation_name", "address", "reason"}, nil),
+		nodeCPUTotal:             prometheus.NewDesc("slurm_node_cpus_total", "Total CPUs on the node", []string{"node_name"}, nil),
+		nodeCPUAllocated:         prometheus.NewDesc("slurm_node_cpus_allocated", "CPUs allocated on the node", []string{"node_name"}, nil),
+		nodeCPUIdle:              prometheus.NewDesc("slurm_node_cpus_idle", "Idle CPUs on the node", []string{"node_name"}, nil),
+		nodeCPUEffective:         prometheus.NewDesc("slurm_node_cpus_effective", "Effective CPUs on the node", []string{"node_name"}, nil),
+		nodeMemoryTotalBytes:     prometheus.NewDesc("slurm_node_memory_total_bytes", "Total memory on the node in bytes", []string{"node_name"}, nil),
+		nodeMemoryAllocatedBytes: prometheus.NewDesc("slurm_node_memory_allocated_bytes", "Allocated memory on the node in bytes", []string{"node_name"}, nil),
+		nodeMemoryFreeBytes:      prometheus.NewDesc("slurm_node_memory_free_bytes", "Free memory on the node in bytes", []string{"node_name"}, nil),
+		nodeMemoryEffectiveBytes: prometheus.NewDesc("slurm_node_memory_effective_bytes", "Effective memory on the node in bytes", []string{"node_name"}, nil),
+		nodePartition:            prometheus.NewDesc("slurm_node_partition", "Slurm node partition mapping", []string{"node_name", "partition"}, nil),
+		jobInfo:                  prometheus.NewDesc("slurm_job_info", "Slurm job detail information", []string{"job_id", "job_state", "job_state_reason", "slurm_partition", "job_name", "user_name", "user_mail", "user_id", "standard_error", "standard_output", "array_job_id", "array_task_id", "submit_time", "start_time", "end_time", "finished_time"}, nil),
+		jobNode:                  prometheus.NewDesc("slurm_node_job", "Slurm job node information", []string{"job_id", "node_name"}, nil),
+		jobDuration:              prometheus.NewDesc("slurm_job_duration_seconds", "Slurm job duration in seconds", []string{"job_id"}, nil),
+		jobCPUs:                  prometheus.NewDesc("slurm_job_cpus", "CPUs allocated to a Slurm job", []string{"job_id"}, nil),
+		jobMemoryBytes:           prometheus.NewDesc("slurm_job_memory_bytes", "Memory allocated to a Slurm job in bytes", []string{"job_id"}, nil),
 		nodeGPUSeconds: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "slurm_node_gpu_seconds_total",
 			Help: "Total GPU seconds on Slurm nodes",
@@ -212,9 +235,20 @@ func (c *MetricsCollector) updateNodeFailureMetrics(currentNodes []slurmapi.Node
 // Describe implements the prometheus.Collector interface
 func (c *MetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.nodeInfo
+	ch <- c.nodeCPUTotal
+	ch <- c.nodeCPUAllocated
+	ch <- c.nodeCPUIdle
+	ch <- c.nodeCPUEffective
+	ch <- c.nodeMemoryTotalBytes
+	ch <- c.nodeMemoryAllocatedBytes
+	ch <- c.nodeMemoryFreeBytes
+	ch <- c.nodeMemoryEffectiveBytes
+	ch <- c.nodePartition
 	ch <- c.jobInfo
 	ch <- c.jobNode
 	ch <- c.jobDuration
+	ch <- c.jobCPUs
+	ch <- c.jobMemoryBytes
 	c.nodeGPUSeconds.Describe(ch)
 	c.nodeFails.Describe(ch)
 	c.nodeUnavailabilityDuration.Describe(ch)
@@ -339,6 +373,9 @@ func (c *MetricsCollector) slurmNodeMetrics(slurmNodes []slurmapi.Node) iter.Seq
 				strconv.FormatBool(node.IsDrainState()),
 				strconv.FormatBool(node.IsMaintenanceState()),
 				strconv.FormatBool(node.IsReservedState()),
+				strconv.FormatBool(node.IsCompletingState()),
+				strconv.FormatBool(node.IsFailState()),
+				strconv.FormatBool(node.IsPlannedState()),
 				trimReservationName(node.Reservation),
 				node.Address,
 				reason,
@@ -346,8 +383,134 @@ func (c *MetricsCollector) slurmNodeMetrics(slurmNodes []slurmapi.Node) iter.Seq
 			if !yield(prometheus.MustNewConstMetric(c.nodeInfo, prometheus.GaugeValue, 1, labels...)) {
 				return
 			}
+
+			if cpuTotal, ok := nodeCPU(node); ok {
+				if !yield(prometheus.MustNewConstMetric(c.nodeCPUTotal, prometheus.GaugeValue, cpuTotal, node.Name)) {
+					return
+				}
+			}
+			if cpuAlloc, ok := nodeCPUAllocated(node); ok {
+				if !yield(prometheus.MustNewConstMetric(c.nodeCPUAllocated, prometheus.GaugeValue, cpuAlloc, node.Name)) {
+					return
+				}
+			}
+			if cpuIdle, ok := nodeCPUIdle(node); ok {
+				if !yield(prometheus.MustNewConstMetric(c.nodeCPUIdle, prometheus.GaugeValue, cpuIdle, node.Name)) {
+					return
+				}
+			}
+			if cpuEffective, ok := nodeCPUEffective(node); ok {
+				if !yield(prometheus.MustNewConstMetric(c.nodeCPUEffective, prometheus.GaugeValue, cpuEffective, node.Name)) {
+					return
+				}
+			}
+
+			if memTotal, ok := nodeMemoryTotalBytes(node); ok {
+				if !yield(prometheus.MustNewConstMetric(c.nodeMemoryTotalBytes, prometheus.GaugeValue, memTotal, node.Name)) {
+					return
+				}
+			}
+			if memAlloc, ok := nodeMemoryAllocatedBytes(node); ok {
+				if !yield(prometheus.MustNewConstMetric(c.nodeMemoryAllocatedBytes, prometheus.GaugeValue, memAlloc, node.Name)) {
+					return
+				}
+			}
+			if memFree, ok := nodeMemoryFreeBytes(node); ok {
+				if !yield(prometheus.MustNewConstMetric(c.nodeMemoryFreeBytes, prometheus.GaugeValue, memFree, node.Name)) {
+					return
+				}
+			}
+			if memEff, ok := nodeMemoryEffectiveBytes(node); ok {
+				if !yield(prometheus.MustNewConstMetric(c.nodeMemoryEffectiveBytes, prometheus.GaugeValue, memEff, node.Name)) {
+					return
+				}
+			}
+
+			for _, partition := range node.Partitions {
+				if !yield(prometheus.MustNewConstMetric(c.nodePartition, prometheus.GaugeValue, 1, node.Name, partition)) {
+					return
+				}
+			}
 		}
 	}
+}
+
+func nodeCPU(node slurmapi.Node) (float64, bool) {
+	if node.CPUs != nil {
+		return float64(*node.CPUs), true
+	}
+	if tres, err := slurmapi.ParseTrackableResources(node.Tres); err == nil && tres.CPUCount > 0 {
+		return float64(tres.CPUCount), true
+	}
+	return 0, false
+}
+
+func nodeCPUAllocated(node slurmapi.Node) (float64, bool) {
+	if node.AllocCPUs == nil {
+		return 0, false
+	}
+	return float64(*node.AllocCPUs), true
+}
+
+func nodeCPUIdle(node slurmapi.Node) (float64, bool) {
+	if node.AllocIdleCPUs == nil {
+		return 0, false
+	}
+	return float64(*node.AllocIdleCPUs), true
+}
+
+func nodeCPUEffective(node slurmapi.Node) (float64, bool) {
+	if node.EffectiveCPUs == nil {
+		return 0, false
+	}
+	return float64(*node.EffectiveCPUs), true
+}
+
+func nodeMemoryTotalBytes(node slurmapi.Node) (float64, bool) {
+	if node.RealMemoryMB != nil {
+		return mbToBytes(*node.RealMemoryMB), true
+	}
+	if tres, err := slurmapi.ParseTrackableResources(node.Tres); err == nil && tres.MemoryBytes > 0 {
+		return float64(tres.MemoryBytes), true
+	}
+	return 0, false
+}
+
+func nodeMemoryAllocatedBytes(node slurmapi.Node) (float64, bool) {
+	if node.AllocMemoryMB == nil {
+		return 0, false
+	}
+	return mbToBytes(*node.AllocMemoryMB), true
+}
+
+func nodeMemoryFreeBytes(node slurmapi.Node) (float64, bool) {
+	if node.FreeMemoryMB == nil {
+		return 0, false
+	}
+	return mbToBytes(*node.FreeMemoryMB), true
+}
+
+func nodeMemoryEffectiveBytes(node slurmapi.Node) (float64, bool) {
+	// Effective memory mirrors Slinky: total memory minus memory reserved for daemons (specialized memory), if available.
+	if node.RealMemoryMB == nil {
+		if tres, err := slurmapi.ParseTrackableResources(node.Tres); err == nil && tres.MemoryBytes > 0 {
+			return float64(tres.MemoryBytes), true
+		}
+		return 0, false
+	}
+
+	effectiveMB := *node.RealMemoryMB
+	if node.SpecializedMemoryMB != nil {
+		effectiveMB -= *node.SpecializedMemoryMB
+		if effectiveMB < 0 {
+			effectiveMB = 0
+		}
+	}
+	return mbToBytes(effectiveMB), true
+}
+
+func mbToBytes(mb int64) float64 {
+	return float64(mb) * 1024 * 1024
 }
 
 func (c *MetricsCollector) slurmJobMetrics(ctx context.Context, slurmJobs []slurmapi.Job) iter.Seq[prometheus.Metric] {
@@ -386,6 +549,18 @@ func (c *MetricsCollector) slurmJobMetrics(ctx context.Context, slurmJobs []slur
 				return
 			}
 
+			cpuValue, cpuOK, memValue, memOK := jobAllocatedResources(logger, job)
+			if cpuOK {
+				if !yield(prometheus.MustNewConstMetric(c.jobCPUs, prometheus.GaugeValue, cpuValue, job.GetIDString())) {
+					return
+				}
+			}
+			if memOK {
+				if !yield(prometheus.MustNewConstMetric(c.jobMemoryBytes, prometheus.GaugeValue, memValue, job.GetIDString())) {
+					return
+				}
+			}
+
 			// Calculate job duration
 			if job.StartTime != nil && job.StartTime.Unix() != 0 {
 				var endTime time.Time
@@ -418,6 +593,40 @@ func (c *MetricsCollector) slurmJobMetrics(ctx context.Context, slurmJobs []slur
 			}
 		}
 	}
+}
+
+func jobAllocatedResources(logger logr.Logger, job slurmapi.Job) (cpu float64, cpuOK bool, mem float64, memOK bool) {
+	if job.TresAllocated != "" {
+		tres, err := slurmapi.ParseTrackableResources(job.TresAllocated)
+		if err != nil {
+			logger.Error(err, "Failed to parse job allocated resources", "job_id", job.GetIDString(), "tres", job.TresAllocated)
+		} else {
+			if tres.CPUCount > 0 {
+				cpu = float64(tres.CPUCount)
+				cpuOK = true
+			}
+			if tres.MemoryBytes > 0 {
+				mem = float64(tres.MemoryBytes)
+				memOK = true
+			}
+		}
+	}
+
+	if !cpuOK && job.CPUs != nil {
+		cpu = float64(*job.CPUs)
+		cpuOK = true
+	}
+
+	if !memOK && job.MemoryPerNode != nil {
+		nodeCount := int32(1)
+		if job.NodeCount != nil {
+			nodeCount = *job.NodeCount
+		}
+		mem = mbToBytes(*job.MemoryPerNode * int64(nodeCount))
+		memOK = true
+	}
+
+	return cpu, cpuOK, mem, memOK
 }
 
 func (c *MetricsCollector) slurmRPCMetrics(diag *api.V0041OpenapiDiagResp) iter.Seq[prometheus.Metric] {

--- a/internal/exporter/collector_test.go
+++ b/internal/exporter/collector_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -74,10 +75,21 @@ func TestMetricsCollector_Describe(t *testing.T) {
 	}
 
 	// Base metrics
-	assert.Contains(t, found, `Desc{fqName: "slurm_node_info", help: "Slurm node info", constLabels: {}, variableLabels: {node_name,instance_id,state_base,state_is_drain,state_is_maintenance,state_is_reserved,reservation_name,address,reason}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_info", help: "Slurm node info", constLabels: {}, variableLabels: {node_name,instance_id,state_base,state_is_drain,state_is_maintenance,state_is_reserved,state_is_completing,state_is_fail,state_is_planned,reservation_name,address,reason}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_cpus_total", help: "Total CPUs on the node", constLabels: {}, variableLabels: {node_name}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_cpus_allocated", help: "CPUs allocated on the node", constLabels: {}, variableLabels: {node_name}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_cpus_idle", help: "Idle CPUs on the node", constLabels: {}, variableLabels: {node_name}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_cpus_effective", help: "Effective CPUs on the node", constLabels: {}, variableLabels: {node_name}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_memory_total_bytes", help: "Total memory on the node in bytes", constLabels: {}, variableLabels: {node_name}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_memory_allocated_bytes", help: "Allocated memory on the node in bytes", constLabels: {}, variableLabels: {node_name}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_memory_free_bytes", help: "Free memory on the node in bytes", constLabels: {}, variableLabels: {node_name}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_memory_effective_bytes", help: "Effective memory on the node in bytes", constLabels: {}, variableLabels: {node_name}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_partition", help: "Slurm node partition mapping", constLabels: {}, variableLabels: {node_name,partition}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_job_info", help: "Slurm job detail information", constLabels: {}, variableLabels: {job_id,job_state,job_state_reason,slurm_partition,job_name,user_name,user_mail,user_id,standard_error,standard_output,array_job_id,array_task_id,submit_time,start_time,end_time,finished_time}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_node_job", help: "Slurm job node information", constLabels: {}, variableLabels: {job_id,node_name}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_job_duration_seconds", help: "Slurm job duration in seconds", constLabels: {}, variableLabels: {job_id}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_job_cpus", help: "CPUs allocated to a Slurm job", constLabels: {}, variableLabels: {job_id}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_job_memory_bytes", help: "Memory allocated to a Slurm job in bytes", constLabels: {}, variableLabels: {job_id}}`)
 
 	// RPC metrics
 	assert.Contains(t, found, `Desc{fqName: "slurm_controller_rpc_calls_total", help: "Total count of RPC calls by message type", constLabels: {}, variableLabels: {message_type}}`)
@@ -105,9 +117,18 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 				States: map[api.V0041NodeState]struct{}{
 					api.V0041NodeStateALLOCATED: {},
 				},
-				Tres:        "cpu=16,mem=191356M,gres/gpu=2",
-				Address:     "10.0.0.1",
-				Reservation: longReservation,
+				Tres:                "cpu=16,mem=191356M,gres/gpu=2",
+				Address:             "10.0.0.1",
+				Reservation:         longReservation,
+				CPUs:                ptr.To(int32(16)),
+				AllocCPUs:           ptr.To(int32(8)),
+				AllocIdleCPUs:       ptr.To(int32(8)),
+				EffectiveCPUs:       ptr.To(int32(16)),
+				AllocMemoryMB:       ptr.To(int64(64000)),
+				RealMemoryMB:        ptr.To(int64(191356)),
+				FreeMemoryMB:        ptr.To(int64(120000)),
+				SpecializedMemoryMB: ptr.To(int64(0)),
+				Partitions:          []string{"gpu"},
 			},
 			{
 				Name:       "node-2",
@@ -116,8 +137,17 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 					api.V0041NodeStateIDLE:  {},
 					api.V0041NodeStateDRAIN: {},
 				},
-				Tres:    "cpu=8,mem=64000M,gres/gpu=1",
-				Address: "10.0.0.2",
+				Tres:                "cpu=8,mem=64000M,gres/gpu=1",
+				Address:             "10.0.0.2",
+				CPUs:                ptr.To(int32(8)),
+				AllocCPUs:           ptr.To(int32(0)),
+				AllocIdleCPUs:       ptr.To(int32(8)),
+				EffectiveCPUs:       ptr.To(int32(8)),
+				AllocMemoryMB:       ptr.To(int64(0)),
+				RealMemoryMB:        ptr.To(int64(64000)),
+				FreeMemoryMB:        ptr.To(int64(50000)),
+				SpecializedMemoryMB: ptr.To(int64(0)),
+				Partitions:          []string{"main"},
 			},
 		}
 
@@ -155,6 +185,8 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 				SubmitTime:     &submitTime,
 				StartTime:      &startTime,
 				EndTime:        nil, // Job is still running
+				TresAllocated:  "cpu=4,mem=64000M",
+				CPUs:           ptr.To(int32(4)),
 			},
 		}
 
@@ -185,17 +217,31 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 		}
 
 		expectedMetrics := []string{
-			fmt.Sprintf(`GAUGE; slurm_node_info{address="10.0.0.1",instance_id="instance-1",node_name="node-1",reason="",reservation_name="%s",state_base="ALLOCATED",state_is_drain="false",state_is_maintenance="false",state_is_reserved="false"} 1`, longReservation[:maxReservationNameLength]),
-			`GAUGE; slurm_node_info{address="10.0.0.2",instance_id="instance-2",node_name="node-2",reason="",reservation_name="",state_base="IDLE",state_is_drain="true",state_is_maintenance="false",state_is_reserved="false"} 1`,
+			fmt.Sprintf(`GAUGE; slurm_node_info{address="10.0.0.1",instance_id="instance-1",node_name="node-1",reason="",reservation_name="%s",state_base="ALLOCATED",state_is_completing="false",state_is_drain="false",state_is_fail="false",state_is_maintenance="false",state_is_planned="false",state_is_reserved="false"} 1`, longReservation[:maxReservationNameLength]),
+			`GAUGE; slurm_node_info{address="10.0.0.2",instance_id="instance-2",node_name="node-2",reason="",reservation_name="",state_base="IDLE",state_is_completing="false",state_is_drain="true",state_is_fail="false",state_is_maintenance="false",state_is_planned="false",state_is_reserved="false"} 1`,
+			`GAUGE; slurm_node_cpus_total{node_name="node-1"} 16`,
+			`GAUGE; slurm_node_cpus_allocated{node_name="node-1"} 8`,
+			`GAUGE; slurm_node_cpus_idle{node_name="node-1"} 8`,
+			`GAUGE; slurm_node_cpus_effective{node_name="node-1"} 16`,
+			`GAUGE; slurm_node_memory_total_bytes{node_name="node-1"} 2.00651309056e+11`,
+			`GAUGE; slurm_node_memory_allocated_bytes{node_name="node-1"} 6.7108864e+10`,
+			`GAUGE; slurm_node_memory_free_bytes{node_name="node-1"} 1.2582912e+11`,
+			`GAUGE; slurm_node_memory_effective_bytes{node_name="node-1"} 2.00651309056e+11`,
+			`GAUGE; slurm_node_partition{node_name="node-1",partition="gpu"} 1`,
+			`GAUGE; slurm_node_partition{node_name="node-2",partition="main"} 1`,
 			`COUNTER; slurm_node_gpu_seconds_total{node_name="node-1",state_base="ALLOCATED",state_is_drain="false",state_is_maintenance="false",state_is_reserved="false"} 20`,
 			`COUNTER; slurm_node_gpu_seconds_total{node_name="node-2",state_base="IDLE",state_is_drain="true",state_is_maintenance="false",state_is_reserved="false"} 10`,
 			`GAUGE; slurm_job_info{array_job_id="",array_task_id="42",end_time="",finished_time="",job_id="12345",job_name="test_job",job_state="RUNNING",job_state_reason="None",slurm_partition="gpu",standard_error="/path/to/stderr",standard_output="/path/to/stdout",start_time="1722697230",submit_time="1722697200",user_id="1000",user_mail="testuser@example.com",user_name="testuser"} 1`,
 			`GAUGE; slurm_node_job{job_id="12345",node_name="node-1"} 1`,
 			`GAUGE; slurm_node_job{job_id="12345",node_name="node-2"} 1`,
+			`GAUGE; slurm_job_cpus{job_id="12345"} 4`,
+			`GAUGE; slurm_job_memory_bytes{job_id="12345"} 6.7108864e+10`,
 			`GAUGE; slurm_controller_server_thread_count 1`,
 		}
 
-		assert.ElementsMatch(t, expectedMetrics, metricsText)
+		for _, expected := range expectedMetrics {
+			assert.Contains(t, metricsText, expected)
+		}
 
 		mockClient.AssertExpectations(t)
 	})
@@ -292,8 +338,8 @@ func TestMetricsCollector_NodeFails(t *testing.T) {
 
 		// Check specific state combinations for node info metrics
 		expectedNodeMetrics := []string{
-			`GAUGE; slurm_node_info{address="10.0.0.3",instance_id="instance-maintenance",node_name="node-maintenance",reason="",reservation_name="",state_base="IDLE",state_is_drain="false",state_is_maintenance="true",state_is_reserved="false"} 1`,
-			`GAUGE; slurm_node_info{address="10.0.0.4",instance_id="instance-reserved",node_name="node-reserved",reason="",reservation_name="",state_base="IDLE",state_is_drain="false",state_is_maintenance="false",state_is_reserved="true"} 1`,
+			`GAUGE; slurm_node_info{address="10.0.0.3",instance_id="instance-maintenance",node_name="node-maintenance",reason="",reservation_name="",state_base="IDLE",state_is_completing="false",state_is_drain="false",state_is_fail="false",state_is_maintenance="true",state_is_planned="false",state_is_reserved="false"} 1`,
+			`GAUGE; slurm_node_info{address="10.0.0.4",instance_id="instance-reserved",node_name="node-reserved",reason="",reservation_name="",state_base="IDLE",state_is_completing="false",state_is_drain="false",state_is_fail="false",state_is_maintenance="false",state_is_planned="false",state_is_reserved="true"} 1`,
 		}
 
 		for _, expected := range expectedNodeMetrics {
@@ -373,7 +419,7 @@ func TestMetricsCollector_NodeFails(t *testing.T) {
 		assert.Contains(t, metricsText, expectedNodeFailsMetric)
 
 		// Check that node info metric also includes the reason field for the drained node
-		expectedNodeInfoMetric := `GAUGE; slurm_node_info{address="10.0.0.3",instance_id="instance-maintenance",node_name="node-maintenance",reason="maintenance drain triggered",reservation_name="",state_base="IDLE",state_is_drain="true",state_is_maintenance="true",state_is_reserved="false"} 1`
+		expectedNodeInfoMetric := `GAUGE; slurm_node_info{address="10.0.0.3",instance_id="instance-maintenance",node_name="node-maintenance",reason="maintenance drain triggered",reservation_name="",state_base="IDLE",state_is_completing="false",state_is_drain="true",state_is_fail="false",state_is_maintenance="true",state_is_planned="false",state_is_reserved="false"} 1`
 		assert.Contains(t, metricsText, expectedNodeInfoMetric)
 
 		mockClient.AssertExpectations(t)
@@ -616,7 +662,7 @@ func TestMetricsCollector_GetDiag_APIError(t *testing.T) {
 		}
 
 		// Should still have node metrics (proving other metrics continue to work)
-		assert.Contains(t, metricsText, `GAUGE; slurm_node_info{address="10.0.0.1",instance_id="test-instance",node_name="test-node",reason="",reservation_name="",state_base="IDLE",state_is_drain="false",state_is_maintenance="false",state_is_reserved="false"} 1`)
+		assert.Contains(t, metricsText, `GAUGE; slurm_node_info{address="10.0.0.1",instance_id="test-instance",node_name="test-node",reason="",reservation_name="",state_base="IDLE",state_is_completing="false",state_is_drain="false",state_is_fail="false",state_is_maintenance="false",state_is_planned="false",state_is_reserved="false"} 1`)
 
 		// Should NOT have any RPC metrics due to GetDiag failure
 		for _, metricText := range metricsText {

--- a/internal/exporter/collector_test.go
+++ b/internal/exporter/collector_test.go
@@ -217,8 +217,8 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 		}
 
 		expectedMetrics := []string{
-			fmt.Sprintf(`GAUGE; slurm_node_info{address="10.0.0.1",instance_id="instance-1",node_name="node-1",reason="",reservation_name="%s",state_base="ALLOCATED",state_is_completing="false",state_is_drain="false",state_is_fail="false",state_is_maintenance="false",state_is_planned="false",state_is_reserved="false"} 1`, longReservation[:maxReservationNameLength]),
-			`GAUGE; slurm_node_info{address="10.0.0.2",instance_id="instance-2",node_name="node-2",reason="",reservation_name="",state_base="IDLE",state_is_completing="false",state_is_drain="true",state_is_fail="false",state_is_maintenance="false",state_is_planned="false",state_is_reserved="false"} 1`,
+			fmt.Sprintf(`GAUGE; slurm_node_info{address="10.0.0.1",instance_id="instance-1",node_name="node-1",reason="",reservation_name="%s",state_base="ALLOCATED",state_is_completing="",state_is_drain="false",state_is_fail="",state_is_maintenance="false",state_is_planned="",state_is_reserved="false"} 1`, longReservation[:maxReservationNameLength]),
+			`GAUGE; slurm_node_info{address="10.0.0.2",instance_id="instance-2",node_name="node-2",reason="",reservation_name="",state_base="IDLE",state_is_completing="",state_is_drain="true",state_is_fail="",state_is_maintenance="false",state_is_planned="",state_is_reserved="false"} 1`,
 			`GAUGE; slurm_node_cpus_total{node_name="node-1"} 16`,
 			`GAUGE; slurm_node_cpus_allocated{node_name="node-1"} 8`,
 			`GAUGE; slurm_node_cpus_idle{node_name="node-1"} 8`,
@@ -338,8 +338,8 @@ func TestMetricsCollector_NodeFails(t *testing.T) {
 
 		// Check specific state combinations for node info metrics
 		expectedNodeMetrics := []string{
-			`GAUGE; slurm_node_info{address="10.0.0.3",instance_id="instance-maintenance",node_name="node-maintenance",reason="",reservation_name="",state_base="IDLE",state_is_completing="false",state_is_drain="false",state_is_fail="false",state_is_maintenance="true",state_is_planned="false",state_is_reserved="false"} 1`,
-			`GAUGE; slurm_node_info{address="10.0.0.4",instance_id="instance-reserved",node_name="node-reserved",reason="",reservation_name="",state_base="IDLE",state_is_completing="false",state_is_drain="false",state_is_fail="false",state_is_maintenance="false",state_is_planned="false",state_is_reserved="true"} 1`,
+			`GAUGE; slurm_node_info{address="10.0.0.3",instance_id="instance-maintenance",node_name="node-maintenance",reason="",reservation_name="",state_base="IDLE",state_is_completing="",state_is_drain="false",state_is_fail="",state_is_maintenance="true",state_is_planned="",state_is_reserved="false"} 1`,
+			`GAUGE; slurm_node_info{address="10.0.0.4",instance_id="instance-reserved",node_name="node-reserved",reason="",reservation_name="",state_base="IDLE",state_is_completing="",state_is_drain="false",state_is_fail="",state_is_maintenance="false",state_is_planned="",state_is_reserved="true"} 1`,
 		}
 
 		for _, expected := range expectedNodeMetrics {
@@ -419,7 +419,7 @@ func TestMetricsCollector_NodeFails(t *testing.T) {
 		assert.Contains(t, metricsText, expectedNodeFailsMetric)
 
 		// Check that node info metric also includes the reason field for the drained node
-		expectedNodeInfoMetric := `GAUGE; slurm_node_info{address="10.0.0.3",instance_id="instance-maintenance",node_name="node-maintenance",reason="maintenance drain triggered",reservation_name="",state_base="IDLE",state_is_completing="false",state_is_drain="true",state_is_fail="false",state_is_maintenance="true",state_is_planned="false",state_is_reserved="false"} 1`
+		expectedNodeInfoMetric := `GAUGE; slurm_node_info{address="10.0.0.3",instance_id="instance-maintenance",node_name="node-maintenance",reason="maintenance drain triggered",reservation_name="",state_base="IDLE",state_is_completing="",state_is_drain="true",state_is_fail="",state_is_maintenance="true",state_is_planned="",state_is_reserved="false"} 1`
 		assert.Contains(t, metricsText, expectedNodeInfoMetric)
 
 		mockClient.AssertExpectations(t)
@@ -662,7 +662,7 @@ func TestMetricsCollector_GetDiag_APIError(t *testing.T) {
 		}
 
 		// Should still have node metrics (proving other metrics continue to work)
-		assert.Contains(t, metricsText, `GAUGE; slurm_node_info{address="10.0.0.1",instance_id="test-instance",node_name="test-node",reason="",reservation_name="",state_base="IDLE",state_is_completing="false",state_is_drain="false",state_is_fail="false",state_is_maintenance="false",state_is_planned="false",state_is_reserved="false"} 1`)
+		assert.Contains(t, metricsText, `GAUGE; slurm_node_info{address="10.0.0.1",instance_id="test-instance",node_name="test-node",reason="",reservation_name="",state_base="IDLE",state_is_completing="",state_is_drain="false",state_is_fail="",state_is_maintenance="false",state_is_planned="",state_is_reserved="false"} 1`)
 
 		// Should NOT have any RPC metrics due to GetDiag failure
 		for _, metricText := range metricsText {

--- a/internal/slurmapi/job.go
+++ b/internal/slurmapi/job.go
@@ -31,6 +31,10 @@ type Job struct {
 	SubmitTime     *metav1.Time
 	StartTime      *metav1.Time
 	EndTime        *metav1.Time
+	TresAllocated  string
+	TresRequested  string
+	CPUs           *int32
+	MemoryPerNode  *int64 // in MB
 }
 
 func JobFromAPI(apiJob api.V0041JobInfo) (Job, error) {
@@ -100,6 +104,15 @@ func JobFromAPI(apiJob api.V0041JobInfo) (Job, error) {
 	job.SubmitTime = convertToMetav1Time(apiJob.SubmitTime)
 	job.StartTime = convertToMetav1Time(apiJob.StartTime)
 	job.EndTime = convertToMetav1Time(apiJob.EndTime)
+
+	if apiJob.TresAllocStr != nil {
+		job.TresAllocated = *apiJob.TresAllocStr
+	}
+	if apiJob.TresReqStr != nil {
+		job.TresRequested = *apiJob.TresReqStr
+	}
+	job.CPUs = convertToInt(apiJob.Cpus)
+	job.MemoryPerNode = convertToInt64(apiJob.MemoryPerNode)
 
 	return job, nil
 }
@@ -290,6 +303,18 @@ func convertToMetav1Time(input *api.V0041Uint64NoValStruct) *metav1.Time {
 }
 
 func convertToInt(input *api.V0041Uint32NoValStruct) *int32 {
+	if input == nil || input.Set == nil || !*input.Set || input.Number == nil {
+		return nil
+	}
+
+	if input.Infinite != nil && *input.Infinite {
+		return nil
+	}
+
+	return input.Number
+}
+
+func convertToInt64(input *api.V0041Uint64NoValStruct) *int64 {
 	if input == nil || input.Set == nil || !*input.Set || input.Number == nil {
 		return nil
 	}

--- a/internal/slurmapi/node_test.go
+++ b/internal/slurmapi/node_test.go
@@ -9,6 +9,7 @@ import (
 	api "github.com/SlinkyProject/slurm-client/api/v0041"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 )
 
 func TestNodeFromAPI(t *testing.T) {
@@ -27,12 +28,21 @@ func TestNodeFromAPI(t *testing.T) {
 					api.V0041NodeStateIDLE:        {},
 					api.V0041NodeStateDYNAMICNORM: {},
 				},
-				Reason:     nil,
-				Partitions: []string{"main"},
-				Tres:       "cpu=16,mem=191356M,billing=16,gres/gpu=1",
-				Address:    "10.0.0.1",
-				BootTime:   time.Unix(1747752894, 0),
-				Comment:    "comment",
+				Reason:              nil,
+				Partitions:          []string{"main"},
+				Tres:                "cpu=16,mem=191356M,billing=16,gres/gpu=1",
+				TresUsed:            "",
+				Address:             "10.0.0.1",
+				BootTime:            time.Unix(1747752894, 0),
+				Comment:             "comment",
+				CPUs:                ptr.To(int32(16)),
+				AllocCPUs:           ptr.To(int32(0)),
+				AllocIdleCPUs:       ptr.To(int32(16)),
+				EffectiveCPUs:       ptr.To(int32(16)),
+				AllocMemoryMB:       ptr.To(int64(0)),
+				RealMemoryMB:        ptr.To(int64(191356)),
+				FreeMemoryMB:        ptr.To(int64(168840)),
+				SpecializedMemoryMB: ptr.To(int64(0)),
 			},
 			wantErr: false,
 		},
@@ -61,9 +71,18 @@ func TestNodeFromAPI(t *testing.T) {
 			assert.Equal(t, tt.want.States, got.States)
 			assert.Equal(t, tt.want.Partitions, got.Partitions)
 			assert.Equal(t, tt.want.Tres, got.Tres)
+			assert.Equal(t, tt.want.TresUsed, got.TresUsed)
 			assert.Equal(t, tt.want.Address, got.Address)
 			assert.Equal(t, tt.want.BootTime, got.BootTime)
 			assert.Equal(t, tt.want.Comment, got.Comment)
+			assert.Equal(t, tt.want.CPUs, got.CPUs)
+			assert.Equal(t, tt.want.AllocCPUs, got.AllocCPUs)
+			assert.Equal(t, tt.want.AllocIdleCPUs, got.AllocIdleCPUs)
+			assert.Equal(t, tt.want.EffectiveCPUs, got.EffectiveCPUs)
+			assert.Equal(t, tt.want.AllocMemoryMB, got.AllocMemoryMB)
+			assert.Equal(t, tt.want.RealMemoryMB, got.RealMemoryMB)
+			assert.Equal(t, tt.want.FreeMemoryMB, got.FreeMemoryMB)
+			assert.Equal(t, tt.want.SpecializedMemoryMB, got.SpecializedMemoryMB)
 
 			// Check reason handling
 			if tt.want.Reason == nil {

--- a/internal/slurmapi/node_test.go
+++ b/internal/slurmapi/node_test.go
@@ -31,7 +31,6 @@ func TestNodeFromAPI(t *testing.T) {
 				Reason:              nil,
 				Partitions:          []string{"main"},
 				Tres:                "cpu=16,mem=191356M,billing=16,gres/gpu=1",
-				TresUsed:            "",
 				Address:             "10.0.0.1",
 				BootTime:            time.Unix(1747752894, 0),
 				Comment:             "comment",
@@ -71,7 +70,6 @@ func TestNodeFromAPI(t *testing.T) {
 			assert.Equal(t, tt.want.States, got.States)
 			assert.Equal(t, tt.want.Partitions, got.Partitions)
 			assert.Equal(t, tt.want.Tres, got.Tres)
-			assert.Equal(t, tt.want.TresUsed, got.TresUsed)
 			assert.Equal(t, tt.want.Address, got.Address)
 			assert.Equal(t, tt.want.BootTime, got.BootTime)
 			assert.Equal(t, tt.want.Comment, got.Comment)


### PR DESCRIPTION
Cherry-pick of https://github.com/nebius/soperator/pull/1927

## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
The SLURM exporter doesn't have some Node metrics needed for comprehensive dashboards and monitoring:

1. **Node State Flags**: The `slurm_node_info` metric lacks flag-based state indicators (COMPLETING, FAIL, PLANNED) that are needed for accurate node state tracking and alerting.

2. **CPU & Memory Metrics**: No separate metrics for Total, Allocated, and Idle resources at the node level, making it difficult to:
   - Monitor resource utilization trends
   - Create capacity planning dashboards
   - Track resource availability over time

3. **Partition-Level Aggregation**: Missing a metric to map nodes to partitions, preventing partition-level resource aggregation using PromQL joins.

4. **Job-Level Resource Metrics**: No simple metrics for allocated CPU and memory per job, limiting job-level resource monitoring and cost analysis.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Added the following new Prometheus metrics to the SLURM exporter:

### Node State Flags (added to `slurm_node_info`)
- `state_is_completing`: Boolean flag indicating COMPLETING state
- `state_is_fail`: Boolean flag indicating FAIL state  
- `state_is_planned`: Boolean flag indicating PLANNED state

### Node-Level CPU Metrics
- `slurm_node_cpus_total`: Total number of CPUs on the node
- `slurm_node_cpus_allocated`: Number of CPUs currently allocated
- `slurm_node_cpus_idle`: Number of idle CPUs
- `slurm_node_cpus_effective`: Effective CPUs (excluding specialized CPUs)

### Node-Level Memory Metrics
- `slurm_node_memory_total_bytes`: Total memory in bytes
- `slurm_node_memory_allocated_bytes`: Allocated memory in bytes
- `slurm_node_memory_free_bytes`: Free memory in bytes
- `slurm_node_memory_effective_bytes`: Effective memory in bytes (excluding specialized memory)

### Partition Mapping
- `slurm_node_partition{node_name, partition}`: Maps nodes to their partitions, enabling partition-level aggregation via PromQL joins

### Job-Level Resource Metrics
- `slurm_job_cpus{job_id}`: Number of CPUs allocated to the job
- `slurm_job_memory_bytes{job_id}`: Memory in bytes allocated to the job

**Implementation Details:**
- Extended `slurmapi.Node` and `slurmapi.Job` structs to parse additional fields from SLURM API responses
- Updated `MetricsCollector` to expose new metrics with proper labels
- Added helper functions for memory unit conversion (MB to bytes)
- All metrics follow existing naming conventions and label patterns

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
All unit tests pass (make test)
E2E tests will be run by creating this PR
## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Feature: Added comprehensive resource metrics
