### PR TITLE
SCHED-561: Don't build ARM images in each CI

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -10,6 +10,7 @@ jobs:
     uses: ./.github/workflows/one_job.yml
     with:
       unstable: 'false'
+      multi_arch: 'true'
     secrets: inherit
 
   tag:

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -8,6 +8,11 @@ on:
         type: string
         required: false
         default: "true"
+      multi_arch:
+        description: "Build for both amd64 and arm64 platforms"
+        type: string
+        required: false
+        default: "false"
 
   push:
     branches:
@@ -197,8 +202,17 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Build and push Docker images
+        shell: bash
         run: |
           UNSTABLE=${{ steps.read-version.outputs.unstable }}
+          MULTI_ARCH="${{ inputs.multi_arch || 'false' }}"
+          if [[ "$MULTI_ARCH" == "true" ]]; then
+            export PLATFORMS="linux/amd64,linux/arm64"
+          else
+            export PLATFORMS="linux/amd64"
+          fi
+          echo "Building for platforms: ${PLATFORMS}"
+
           IMAGE_VERSION="$(make get-image-version UNSTABLE=${UNSTABLE})"
           VERSION=$(make get-version UNSTABLE=${UNSTABLE})
           OPERATOR_IMAGE_TAG=$(make get-operator-tag-version UNSTABLE=${UNSTABLE})

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,11 @@ ifeq ($(UNSTABLE), true)
     IMAGE_REPO			  		= $(NEBIUS_REPO)-unstable
 endif
 
+# Docker build platforms (default: amd64 only, override with PLATFORMS=linux/amd64,linux/arm64 for multi-arch)
+PLATFORMS ?= linux/amd64
+HAS_AMD64 = $(findstring linux/amd64,$(PLATFORMS))
+HAS_ARM64 = $(findstring linux/arm64,$(PLATFORMS))
+
 .PHONY: all
 all: build
 
@@ -357,10 +362,9 @@ run: manifests generate fmt vet ## Run a controller from your host with native t
 	 -log-level=debug -leader-elect=true -operator-namespace=soperator-system --enable-topology-controller=true
 
 .PHONY: docker-build-go-base
-docker-build-go-base: ## Build go-base multiarch manifest locally
-# Build multiarch
+docker-build-go-base: ## Build go-base manifest locally (use PLATFORMS=linux/amd64,linux/arm64 for multi-arch)
 	docker buildx build \
-		--platform linux/amd64,linux/arm64 \
+		--platform $(PLATFORMS) \
 		--target go-base \
 		-t go-base \
 		-f images/common/go-base.dockerfile \
@@ -369,7 +373,7 @@ docker-build-go-base: ## Build go-base multiarch manifest locally
 		.
 
 .PHONY: docker-build-and-push
-docker-build-and-push: ## Build and push docker multi arch manifest
+docker-build-and-push: ## Build and push docker manifest (use PLATFORMS=linux/amd64,linux/arm64 for multi-arch)
 ifndef IMAGE_NAME
 	$(error IMAGE_NAME is not set)
 endif
@@ -379,9 +383,8 @@ endif
 ifndef UNSTABLE
 	$(error UNSTABLE is not set)
 endif
-# Build multiarch
 	docker buildx build \
-		--platform linux/amd64,linux/arm64 \
+		--platform $(PLATFORMS) \
 		--target ${IMAGE_NAME} \
 		-t "$(NEBIUS_REPO)-unstable/${IMAGE_NAME}:${IMAGE_VERSION}" \
 		-f images/${DOCKERFILE} \
@@ -397,12 +400,12 @@ ifeq ($(UNSTABLE), false)
 endif
 
 .PHONY: docker-build-jail
-docker-build-jail: ## Build jail
+docker-build-jail: ## Build jail (use PLATFORMS=linux/amd64,linux/arm64 for multi-arch)
 ifndef IMAGE_VERSION
 	$(error IMAGE_VERSION is not set, docker image cannot be built)
 endif
-# Output type tar doesn't support platform splitting, so we keep single arch build here.
-	# Build amd
+# Output type tar doesn't support multi-platform, so we build each arch separately.
+ifneq ($(HAS_AMD64),)
 	docker buildx build \
 		--platform linux/amd64 \
 		--target jail \
@@ -413,8 +416,8 @@ endif
 		--progress=plain \
 		$(DOCKER_BUILD_ARGS) \
 		.
-
-	# Build arm
+endif
+ifneq ($(HAS_ARM64),)
 	docker buildx build \
 		--platform linux/arm64 \
 		--target jail \
@@ -425,6 +428,7 @@ endif
 		--progress=plain \
 		$(DOCKER_BUILD_ARGS) \
 		.
+endif
 
 .PHONY: docker-manifest
 docker-manifest: ## Create and push docker manifest for multiple image architecture


### PR DESCRIPTION
## Problem

ARM builds via QEMU emulation are extremely slow

## Solution

Build images only for x86 in CI.
Build cross-platform images in stable builds.


