### PR TITLE
SCHED-561: Add nightly builds

### DIFF
--- a/.github/branch-config.json
+++ b/.github/branch-config.json
@@ -1,0 +1,3 @@
+{
+  "release_branch": "soperator-release-1.23"
+}

--- a/.github/workflows/e2e_test_scheduler.yml
+++ b/.github/workflows/e2e_test_scheduler.yml
@@ -15,10 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Determine branch and terraform ref
         id: select_params
+        shell: bash
         run: |
-          RELEASE_BRANCH="soperator-release-1.23"
+          RELEASE_BRANCH=$(jq -r .release_branch .github/branch-config.json)
           HOUR=$(date -u +%-H)  # %-H removes leading zeros to avoid octal interpretation
           if [ $((HOUR % 2)) -eq 0 ]; then
             echo "ref=main" >> $GITHUB_OUTPUT
@@ -29,9 +33,6 @@ jobs:
             echo "terraform_ref=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
             echo "Odd hour ($HOUR UTC) - Testing $RELEASE_BRANCH branch with terraform $RELEASE_BRANCH"
           fi
-
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Trigger E2E test workflow
         env:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,0 +1,36 @@
+name: Nightly Multi-Arch Build
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Midnight UTC daily
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  trigger-builds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Trigger nightly build on main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "Triggering nightly multi-arch build on main"
+          gh workflow run one_job.yml --ref main -f multi_arch=true
+          echo "Build triggered on main"
+
+      - name: Trigger nightly build on release branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          RELEASE_BRANCH=$(jq -r .release_branch .github/branch-config.json)
+          echo "Triggering nightly multi-arch build on ${RELEASE_BRANCH}"
+          gh workflow run one_job.yml --ref "${RELEASE_BRANCH}" -f multi_arch=true
+          echo "Build triggered on ${RELEASE_BRANCH}"

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -14,6 +14,19 @@ on:
         required: false
         default: "false"
 
+  workflow_dispatch:
+    inputs:
+      unstable:
+        description: "Build unstable version"
+        type: string
+        required: false
+        default: "true"
+      multi_arch:
+        description: "Build for both amd64 and arm64 platforms"
+        type: string
+        required: false
+        default: "false"
+
   push:
     branches:
       - main


### PR DESCRIPTION
## Problem

We stopped building ARM64 images in CI, so there is no longer visibility for ARM64 build problems.

## Solution

Add cross-platform nightly builds.

## Testing

None

## Release Notes

None