### PR TITLE
SCHED-658: remove reaction on the comment int ensure healthy

### DIFF
--- a/helm/soperator-activechecks/scripts/ensure-healthy-nodes.sh
+++ b/helm/soperator-activechecks/scripts/ensure-healthy-nodes.sh
@@ -9,10 +9,9 @@ bad_nodes=$(echo "$json" | jq -r '
   .nodes[]
   | select(
       (.reason // "") != "" 
-      or (.comment // "") != "" 
       or ((.state? // "") | tostring | test("DOWN|DRAIN|FAIL"))
     )
-  | {name, reason: (.reason // ""), comment: (.comment // ""), state: .state}
+  | {name, reason: (.reason // ""), state: .state}
 ')
 
 if [[ -n "$bad_nodes" ]]; then


### PR DESCRIPTION
## Problem
Currently, we switch flapping (or just new) active checks to comment-only mode.

However, some tools expects them to pass when they run after creation, and get stuck if they fail.


## Solution
Remove the handling of node comments in active checks.

## Testing
Manually 

## Release Notes
Stop considering node comments in the ensure-healthy-nodes active check.