### PR TITLE
SCHED-696: customize log headers

### DIFF
--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -76,6 +76,10 @@ spec:
           timeout: 5s
           headers:
             iam-container: {{ .Values.observability.logsProjectId }}
+            {{- $extraHeaders := .Values.observability.opentelemetry.extraHeaders }}
+            {{- if and $extraHeaders (gt (len $extraHeaders) 0) }}
+            {{- toYaml $extraHeaders | nindent 12 }}
+            {{- end }}
           auth:
             authenticator: bearertokenauth
         {{- end }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -231,6 +231,10 @@ spec:
           timeout: 5s
           headers:
             iam-container: {{ .Values.observability.logsProjectId }}
+            {{- $extraHeaders := .Values.observability.opentelemetry.extraHeaders }}
+            {{- if and $extraHeaders (gt (len $extraHeaders) 0) }}
+            {{- toYaml $extraHeaders | nindent 12 }}
+            {{- end }}
           auth:
             authenticator: bearertokenauth
         {{- end }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -69,6 +69,10 @@ spec:
           timeout: 5s
           headers:
             iam-container: {{ .Values.observability.logsProjectId }}
+            {{- $extraHeaders := .Values.observability.opentelemetry.extraHeaders }}
+            {{- if and $extraHeaders (gt (len $extraHeaders) 0) }}
+            {{- toYaml $extraHeaders | nindent 12 }}
+            {{- end }}
           auth:
             authenticator: bearertokenauth
         {{- end }}

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -109,6 +109,7 @@ observability:
   opentelemetry:
     enabled: true
     namespace: logs-system
+    extraHeaders: {}
     logs:
       version: 0.117.*
       interval: 15m


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Right now there's no way to add additional headers while pushing logs.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Add chart value with custom headers.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Feature: add value in soperator-fluxcd umbrella chart with additional opentelemetry headers during logs/events push.
