### PR TITLE
SCHED-561: Add slack notifications about nightly builds.

### DIFF
--- a/.github/branch-config.json
+++ b/.github/branch-config.json
@@ -1,0 +1,3 @@
+{
+  "release_branch": "soperator-release-1.23"
+}

--- a/.github/workflows/e2e_test_scheduler.yml
+++ b/.github/workflows/e2e_test_scheduler.yml
@@ -15,10 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Determine branch and terraform ref
         id: select_params
+        shell: bash
         run: |
-          RELEASE_BRANCH="soperator-release-1.23"
+          RELEASE_BRANCH=$(jq -r .release_branch .github/branch-config.json)
           HOUR=$(date -u +%-H)  # %-H removes leading zeros to avoid octal interpretation
           if [ $((HOUR % 2)) -eq 0 ]; then
             echo "ref=main" >> $GITHUB_OUTPUT

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,0 +1,36 @@
+name: Nightly Multi-Arch Build
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Midnight UTC daily
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  trigger-builds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Trigger nightly build on main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "Triggering nightly multi-arch build on main"
+          gh workflow run one_job.yml --ref main -f multi_arch=true
+          echo "Build triggered on main"
+
+      - name: Trigger nightly build on release branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          RELEASE_BRANCH=$(jq -r .release_branch .github/branch-config.json)
+          echo "Triggering nightly multi-arch build on ${RELEASE_BRANCH}"
+          gh workflow run one_job.yml --ref "${RELEASE_BRANCH}" -f multi_arch=true
+          echo "Build triggered on ${RELEASE_BRANCH}"

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -14,6 +14,19 @@ on:
         required: false
         default: "false"
 
+  workflow_dispatch:
+    inputs:
+      unstable:
+        description: "Build unstable version"
+        type: string
+        required: false
+        default: "true"
+      multi_arch:
+        description: "Build for both amd64 and arm64 platforms"
+        type: string
+        required: false
+        default: "false"
+
   push:
     branches:
       - main

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -441,3 +441,37 @@ jobs:
             exit 1
           fi
           echo "All CI jobs passed!"
+
+  notify-failure:
+    name: Notify Slack on failure
+    needs: [ci-success]
+    if: |
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      (needs.ci-success.result == 'failure' || needs.ci-success.result == 'cancelled')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          STATUS="${{ needs.ci-success.result }}"
+          if [[ "$STATUS" == "failure" ]]; then
+            EMOJI=":x:"
+            COLOR="danger"
+          else
+            EMOJI=":warning:"
+            COLOR="warning"
+          fi
+
+          curl -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{
+              \"attachments\": [{
+                \"color\": \"${COLOR}\",
+                \"title\": \"${EMOJI} Nightly Build ${STATUS}\",
+                \"text\": \"Branch: ${{ github.ref_name }}\nWorkflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>\",
+                \"footer\": \"soperator nightly build\"
+              }]
+            }"


### PR DESCRIPTION
## Problem

ARM64 builds are not run in CI builds anymore, we have nighly builds, but no notifications about their failures.

## Solution

Add slack notifcations from the builds itself iff they run via `workflow_dispatch`.
Also cherry-pick workflow changes commit to enable nightly builds for the release branch. 

## Testing

None

## Release Notes

None
