### PR TITLE
SCHED-734: Fix k8sJobSpec volumes placement in ActiveChecks template

### DIFF
--- a/helm/soperator-activechecks/templates/_helpers.tpl
+++ b/helm/soperator-activechecks/templates/_helpers.tpl
@@ -195,8 +195,8 @@ jobContainer:
 {{ toYaml $volumeMounts | indent 4 }}
 {{- end }}
 {{- if $volumes }}
-volumes:
-{{ toYaml $volumes | indent 2 }}
+  volumes:
+{{ toYaml $volumes | indent 4 }}
 {{- end }}
 {{- if and $spec.mungeContainer $spec.mungeContainer.enabled }}
 mungeContainer:

--- a/helm/soperator-activechecks/tests/k8sjob_spec_test.yaml
+++ b/helm/soperator-activechecks/tests/k8sjob_spec_test.yaml
@@ -1,0 +1,45 @@
+suite: test k8sJobSpec structure
+templates:
+  - templates/active-checks.yaml
+tests:
+  - it: should render k8sJobSpec with correct structure
+    documentSelector:
+      path: metadata.name
+      value: test-k8sjob
+    set:
+      slurmClusterRefName: test-cluster
+      images:
+        k8sJob: "test-image:latest"
+        munge: "munge-image:latest"
+      jobContainer:
+        volumeMounts:
+          - mountPath: /mnt/jail
+            name: jail
+        volumes:
+          - name: jail
+            persistentVolumeClaim:
+              claimName: jail-pvc
+      checks:
+        test-k8sjob:
+          enabled: true
+          checkType: k8sJob
+          k8sJobSpec:
+            jobContainer:
+              command: ["echo", "test"]
+            mungeContainer:
+              enabled: true
+    asserts:
+      - isKind:
+          of: ActiveCheck
+      - exists:
+          path: spec.k8sJobSpec.jobContainer.image
+      - exists:
+          path: spec.k8sJobSpec.jobContainer.command
+      - exists:
+          path: spec.k8sJobSpec.jobContainer.volumeMounts
+      - exists:
+          path: spec.k8sJobSpec.jobContainer.volumes
+      - exists:
+          path: spec.k8sJobSpec.mungeContainer
+      - exists:
+          path: spec.k8sJobSpec.mungeContainer.image


### PR DESCRIPTION
## Problem

The volumes were incorrectly placed at the k8sJobSpec level instead of under jobContainer, causing CronJob validation errors like: "volumeMounts[0].name: Not found: jail"

## Solution

This fix corrects the YAML indentation to match the Go API structure where volumes belong under K8sJobSpec.JobContainer.Volumes.

## Testing

Added a helm unit test to prevent regression.

## Release Notes

None