### PR TITLE
SCHED-737: Include PR number in merge-back branch name to avoid collisions

### DIFF
--- a/.github/workflows/scripts/auto-merge-back.sh
+++ b/.github/workflows/scripts/auto-merge-back.sh
@@ -101,7 +101,7 @@ create_merge_branch() {
 
     # Use original PR branch name if available, otherwise use release branch with SHA
     if [ -n "${PR_HEAD_REF}" ]; then
-        NEW_BRANCH="merge-to-main-from/${PR_HEAD_REF}"
+        NEW_BRANCH="merge-to-main-from/pr-${PR_NUMBER}/${PR_HEAD_REF}"
     else
         NEW_BRANCH="merge-to-main-from/${RELEASE_BRANCH}-${COMMIT_SHORT_SHA}"
     fi
@@ -157,6 +157,12 @@ ${COMMIT_MESSAGE}
 }
 
 main() {
+    # Skip re-runs to avoid duplicate PR creation attempts
+    if [ "${GITHUB_RUN_ATTEMPT:-1}" -gt 1 ]; then
+        echo "Skipping re-run (attempt ${GITHUB_RUN_ATTEMPT}). Merge-back PRs should only be created on first run."
+        exit 0
+    fi
+
     get_commit_info
     get_github_username
     get_pr_info

--- a/images/jail/jail.dockerfile
+++ b/images/jail/jail.dockerfile
@@ -30,8 +30,8 @@ RUN chmod 644 /etc/passwd /etc/group && chown 0:0 /etc/passwd /etc/group && \
 # Install minimal python packages for Ansible
 RUN apt-get update && \
     apt-get install -y \
-        python3.12="3.12.3-1ubuntu0.9" \
-        python3.12-venv="3.12.3-1ubuntu0.9"
+        python3.12="3.12.3-1ubuntu0.10" \
+        python3.12-venv="3.12.3-1ubuntu0.10"
 
 # Install Ansible and base configs
 COPY ansible/ansible.cfg ansible/requirements.txt ansible/run.yml /opt/ansible/

--- a/images/k8s_check_job/k8s_check_job.dockerfile
+++ b/images/k8s_check_job/k8s_check_job.dockerfile
@@ -19,9 +19,9 @@ RUN chmod +x /opt/bin/install_kubectl.sh && \
 # Install python
 RUN apt-get update && \
     apt-get install -y \
-        python3.12="3.12.3-1ubuntu0.9" \
-        python3.12-dev="3.12.3-1ubuntu0.9" \
-        python3.12-venv="3.12.3-1ubuntu0.9" \
+        python3.12="3.12.3-1ubuntu0.10" \
+        python3.12-dev="3.12.3-1ubuntu0.10" \
+        python3.12-venv="3.12.3-1ubuntu0.10" \
         python3-pip="24.0+dfsg-1ubuntu1.3" \
         python3-pip-whl="24.0+dfsg-1ubuntu1.3" && \
     apt-get clean && \


### PR DESCRIPTION
## Problem

When multiple PRs are created from the same feature branch, the merge-back workflow would fail because it tried to create a branch with the same name. Adding the PR number ensures uniqueness.

## Solution

Add a PR_NUMBER to the branch name.

## Testing

None

## Release Notes

None