### PR TITLE
SCHED-743: Fix soperator-activechecks Helm chart and add it to CI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -711,6 +711,7 @@ helmtest: check-helm
 	@helm unittest $(CHART_PATH)/slurm-cluster-storage
 	@helm unittest $(CHART_PATH)/soperator-notifier
 	@helm unittest $(CHART_PATH)/nodesets
+	@helm unittest $(CHART_PATH)/soperator-activechecks
 
 check-helm:
 	@echo "Checking Helm installation..."

--- a/helm/soperator-activechecks/templates/_helpers.tpl
+++ b/helm/soperator-activechecks/templates/_helpers.tpl
@@ -203,7 +203,7 @@ mungeContainer:
 {{ include "soperator-activechecks.renderMungeContainer" (dict "ctx" $ctx "container" $spec.mungeContainer) | indent 2 }}
 {{- end }}
 {{- end -}}
- 
+
 {{/*
 Validate that a check does not enable both commentSlurmNode and drainSlurmNode
 under `failureReactions` for a single check. Invoke with (dict "name" "<checkKey>" "vals" .Values)
@@ -218,8 +218,8 @@ under `failureReactions` for a single check. Invoke with (dict "name" "<checkKey
     {{- if $check }}
       {{- $fr := index $check "failureReactions" -}}
       {{- if $fr }}
-        {{- $commentVal := default "" (index $fr "commentSlurmNode" "commentPrefix") -}}
-        {{- $drainVal := default "" (index $fr "drainSlurmNode" "drainReasonPrefix") -}}
+        {{- $commentVal := default "" (index (default dict (index $fr "commentSlurmNode")) "commentPrefix") -}}
+        {{- $drainVal := default "" (index (default dict (index $fr "drainSlurmNode")) "drainReasonPrefix") -}}
         {{- if and (ne $commentVal "") (ne $drainVal "") -}}
           {{- fail (printf "checks.%s.failureReactions: cannot set both commentSlurmNode and drainSlurmNode simultaneously" $name) -}}
         {{- end -}}
@@ -227,140 +227,4 @@ under `failureReactions` for a single check. Invoke with (dict "name" "<checkKey
     {{- end -}}
   {{- end -}}
 {{- end -}}
-{{- end -}}
-
-{{/*
-Render script content from a file with optional tpl evaluation.
-*/}}
-{{- define "soperator-activechecks.renderScript" -}}
-{{- $content := .ctx.Files.Get .path -}}
-{{- tpl $content .ctx -}}
-{{- end -}}
-
-{{/*
-Render munge container with defaults that match the existing checks.
-*/}}
-{{- define "soperator-activechecks.renderMungeContainer" -}}
-{{- $ctx := default .ctx .renderCtx -}}
-{{- $raw := default dict .container -}}
-{{- $container := fromYaml (tpl (toYaml $raw) $ctx) -}}
-{{- $image := default $ctx.Values.images.munge $container.image -}}
-{{- $appArmor := default "unconfined" $container.appArmorProfile -}}
-appArmorProfile: {{ $appArmor }}
-image: {{ tpl $image $ctx | quote }}
-{{- end -}}
-
-{{/*
-Render slurmJobSpec for an ActiveCheck.
-*/}}
-{{- define "soperator-activechecks.slurmJobSpec" -}}
-{{- $ctx := .ctx -}}
-{{- $spec := default dict .check.slurmJobSpec -}}
-{{- $jobContainerRaw := default dict $spec.jobContainer -}}
-{{- $baseContainer := dict "appArmorProfile" "unconfined" "image" $ctx.Values.images.slurmJob "env" $ctx.Values.jobContainer.env "volumeMounts" $ctx.Values.jobContainer.volumeMounts "volumes" $ctx.Values.jobContainer.volumes -}}
-{{- $jobContainer := mustMerge $baseContainer (omit $jobContainerRaw "extraEnv" "extraVolumeMounts" "extraVolumes") -}}
-{{- $env := default (list) $jobContainer.env -}}
-{{- with $jobContainerRaw.extraEnv }}{{- $env = concat $env . -}}{{- end }}
-{{- $volumeMounts := default (list) $jobContainer.volumeMounts -}}
-{{- with $jobContainerRaw.extraVolumeMounts }}{{- $volumeMounts = concat $volumeMounts . -}}{{- end }}
-{{- $volumes := default (list) $jobContainer.volumes -}}
-{{- with $jobContainerRaw.extraVolumes }}{{- $volumes = concat $volumes . -}}{{- end }}
-sbatchScript: |
-{{ include "soperator-activechecks.renderScript" (dict "path" $spec.sbatchScriptFile "ctx" $ctx) | indent 2 }}
-{{- if hasKey $spec "eachWorkerJobs" }}
-eachWorkerJobs: {{ $spec.eachWorkerJobs }}
-{{- end }}
-{{- with $spec.maxNumberOfJobs }}
-maxNumberOfJobs: {{ . }}
-{{- end }}
-jobContainer:
-  appArmorProfile: {{ $jobContainer.appArmorProfile }}
-  image: {{ tpl $jobContainer.image $ctx | quote }}
-{{- with $jobContainer.command }}
-  command:
-{{ toYaml . | indent 4 }}
-{{- end }}
-{{- with $jobContainer.args }}
-  args:
-{{ toYaml . | indent 4 }}
-{{- end }}
-{{- if $env }}
-  env:
-{{ toYaml $env | indent 4 }}
-{{- end }}
-{{- if $volumeMounts }}
-  volumeMounts:
-{{ toYaml $volumeMounts | indent 4 }}
-{{- end }}
-{{- if $volumes }}
-  volumes:
-{{ toYaml $volumes | indent 4 }}
-{{- end }}
-mungeContainer:
-{{ include "soperator-activechecks.renderMungeContainer" (dict "ctx" $ctx "container" $spec.mungeContainer) | indent 2 }}
-{{- end -}}
-
-{{/*
-Render k8sJobSpec for an ActiveCheck.
-*/}}
-{{- define "soperator-activechecks.k8sJobSpec" -}}
-{{- $ctx := .ctx -}}
-{{- $spec := default dict .check.k8sJobSpec -}}
-{{- $jobContainerRaw := default dict $spec.jobContainer -}}
-{{- $useCommonVolumeMounts := default true $spec.useCommonVolumeMounts -}}
-{{- $useCommonVolumes := default true $spec.useCommonVolumes -}}
-{{- $includeCommonEnv := default false $spec.includeCommonEnv -}}
-{{- $baseContainer := dict "image" $ctx.Values.images.k8sJob -}}
-{{- if $useCommonVolumeMounts }}{{- $_ := set $baseContainer "volumeMounts" $ctx.Values.jobContainer.volumeMounts -}}{{- end }}
-{{- if $includeCommonEnv }}{{- $_ := set $baseContainer "env" $ctx.Values.jobContainer.env -}}{{- end }}
-{{- $jobContainer := mustMerge $baseContainer (omit $jobContainerRaw "extraEnv" "extraVolumeMounts" "extraVolumes") -}}
-{{- $env := default (list) $jobContainer.env -}}
-{{- with $jobContainerRaw.extraEnv }}{{- $env = concat $env . -}}{{- end }}
-{{- $volumeMounts := default (list) $jobContainer.volumeMounts -}}
-{{- with $jobContainerRaw.extraVolumeMounts }}{{- $volumeMounts = concat $volumeMounts . -}}{{- end }}
-{{- $volumes := list -}}
-{{- if $useCommonVolumes }}{{- $volumes = $ctx.Values.jobContainer.volumes -}}{{- end }}
-{{- if $spec.volumes }}{{- $volumes = $spec.volumes -}}{{- end }}
-{{- with $spec.extraVolumes }}{{- $volumes = concat $volumes . -}}{{- end }}
-{{- $command := $jobContainer.command -}}
-{{- if and (not $command) $spec.scriptFile }}
-{{- $command = list "bash" "-c" (include "soperator-activechecks.renderScript" (dict "path" $spec.scriptFile "ctx" $ctx)) -}}
-{{- end }}
-{{- if and (not $command) $spec.pythonScriptFile }}
-{{- $command = list "bash" "-c" (printf "python3 - <<'PY'\n%s\nPY" (include "soperator-activechecks.renderScript" (dict "path" $spec.pythonScriptFile "ctx" $ctx))) -}}
-{{- end }}
-{{- $args := $jobContainer.args -}}
-{{- $image := tpl (default $ctx.Values.images.k8sJob $jobContainer.image) $ctx }}
-{{- if $spec.appArmorProfile }}
-appArmorProfile: {{ $spec.appArmorProfile }}
-{{- end }}
-jobContainer:
-  image: {{ $image | quote }}
-{{- with $jobContainer.appArmorProfile }}
-  appArmorProfile: {{ . }}
-{{- end }}
-{{- if $command }}
-  command:
-{{ toYaml $command | indent 4 }}
-{{- end }}
-{{- if $args }}
-  args:
-{{ toYaml $args | indent 4 }}
-{{- end }}
-{{- if $env }}
-  env:
-{{ toYaml $env | indent 4 }}
-{{- end }}
-{{- if $volumeMounts }}
-  volumeMounts:
-{{ toYaml $volumeMounts | indent 4 }}
-{{- end }}
-{{- if $volumes }}
-  volumes:
-{{ toYaml $volumes | indent 4 }}
-{{- end }}
-{{- if and $spec.mungeContainer $spec.mungeContainer.enabled }}
-mungeContainer:
-{{ include "soperator-activechecks.renderMungeContainer" (dict "ctx" $ctx "container" $spec.mungeContainer) | indent 2 }}
-{{- end }}
 {{- end -}}

--- a/helm/soperator-activechecks/templates/ib-gpu-perf.yaml
+++ b/helm/soperator-activechecks/templates/ib-gpu-perf.yaml
@@ -1,4 +1,5 @@
-{{- include "soperator-activechecks.checkReactionsConflict" (dict "name" "ibGpuPerf" "vals" .Values) -}}
+{{- $check := index .Values.checks "ib-gpu-perf" -}}
+{{- include "soperator-activechecks.checkReactionsConflict" (dict "name" "ib-gpu-perf" "vals" .Values) -}}
 apiVersion: slurm.nebius.ai/v1alpha1
 kind: ActiveCheck
 metadata:
@@ -9,8 +10,8 @@ spec:
   dependsOn: [ "wait-for-soperatorchecks-srun-ready", "wait-for-topology", "prepull-container-image" ]
   slurmClusterRefName: {{ .Values.slurmClusterRefName | quote }}
   schedule: "55 1-21/4 * * *" # 6 times a day at 01:55, 05:55, 09:55, 13:55, 17:55 and 21:55 UTC
-  suspend: {{ .Values.checks.ibGpuPerf.suspend }}
-  runAfterCreation: {{ .Values.checks.ibGpuPerf.runAfterCreation }}
+  suspend: {{ $check.suspend }}
+  runAfterCreation: {{ $check.runAfterCreation }}
   slurmJobSpec:
     sbatchScript: |
 {{ tpl (.Files.Get "scripts/ib-gpu-perf.sh") . | indent 6 }}
@@ -28,4 +29,4 @@ spec:
       image: {{ .Values.images.munge | quote }}
   failureReactions:
     commentSlurmNode:
-      commentPrefix: {{ .Values.checks.ibGpuPerf.commentPrefix | quote }}
+      commentPrefix: {{ $check.failureReactions.commentSlurmNode.commentPrefix | quote }}

--- a/helm/soperator-activechecks/tests/reactions_conflict_test.yaml
+++ b/helm/soperator-activechecks/tests/reactions_conflict_test.yaml
@@ -5,9 +5,10 @@ templates:
 
 tests:
   - it: should fail if both commentSlurmNode and drainSlurmNode are set under failureReactions
+    template: templates/ib-gpu-perf.yaml
     set:
       checks:
-        ibGpuPerf:
+        ib-gpu-perf:
           failureReactions:
             commentSlurmNode:
               commentPrefix: "[node_problem]"
@@ -15,12 +16,13 @@ tests:
               drainReasonPrefix: "[node_problem]"
     asserts:
       - failedTemplate:
-          errorMessage: "checks.ibGpuPerf.failureReactions: cannot set both commentSlurmNode and drainSlurmNode simultaneously"
+          errorMessage: "checks.ib-gpu-perf.failureReactions: cannot set both commentSlurmNode and drainSlurmNode simultaneously"
 
   - it: should render when only commentSlurmNode is set
+    template: templates/ib-gpu-perf.yaml
     set:
       checks:
-        ibGpuPerf:
+        ib-gpu-perf:
           failureReactions:
             commentSlurmNode:
               commentPrefix: "[node_problem]"
@@ -28,29 +30,25 @@ tests:
       - notFailedTemplate: {}
 
   - it: should render when only drainSlurmNode is set
+    template: templates/ib-gpu-perf.yaml
     set:
       checks:
-        ibGpuPerf:
+        ib-gpu-perf:
           failureReactions:
             drainSlurmNode:
               drainReasonPrefix: "[node_problem]"
-    asserts:
-      - notFailedTemplate: {}
-
-  - it: should render when both reaction nodes are explicitly null
-    set:
-      checks:
-        ibGpuPerf:
-          failureReactions:
-            commentSlurmNode: null
-            drainSlurmNode: null
+            # ib-gpu-perf.yaml hardcodes commentSlurmNode.commentPrefix in output,
+            # so we can't set commentSlurmNode: null - use empty string instead.
+            commentSlurmNode:
+              commentPrefix: ""
     asserts:
       - notFailedTemplate: {}
 
   - it: gpu-fryer should fail if both commentSlurmNode and drainSlurmNode are set under failureReactions
+    template: templates/active-checks.yaml
     set:
       checks:
-        "gpu-fryer":
+        gpu-fryer:
           failureReactions:
             commentSlurmNode:
               commentPrefix: "[node_problem]"
@@ -61,29 +59,34 @@ tests:
           errorMessage: "checks.gpu-fryer.failureReactions: cannot set both commentSlurmNode and drainSlurmNode simultaneously"
 
   - it: gpu-fryer should render when only commentSlurmNode is set
+    template: templates/active-checks.yaml
     set:
       checks:
-        "gpu-fryer":
+        gpu-fryer:
           failureReactions:
             commentSlurmNode:
               commentPrefix: "[node_problem]"
+            drainSlurmNode: null
     asserts:
       - notFailedTemplate: {}
 
   - it: gpu-fryer should render when only drainSlurmNode is set
+    template: templates/active-checks.yaml
     set:
       checks:
-        "gpu-fryer":
+        gpu-fryer:
           failureReactions:
+            commentSlurmNode: null
             drainSlurmNode:
               drainReasonPrefix: "[node_problem]"
     asserts:
       - notFailedTemplate: {}
 
   - it: gpu-fryer should render when both reaction nodes are explicitly null
+    template: templates/active-checks.yaml
     set:
       checks:
-        "gpu-fryer":
+        gpu-fryer:
           failureReactions:
             commentSlurmNode: null
             drainSlurmNode: null


### PR DESCRIPTION
## Problem

There was a bad merge in PR #2022 which introduced duplicate helm template definitions. The tests didn't help because active check helm charts were not checked in CI.

## Solution

- Remove duplicate template definitions from _helpers.tpl that were introduced by a 
- Fix nil pointer bug in checkReactionsConflict template.
- Update broken tests to use proper values and the generic active-checks.yaml template.
- Add the chart to helmtest target to prevent future regressions.

## Testing

Fixed helm unittests, added them to CI.

## Release Notes

None