### PR TITLE
SCHED-696: add attribute for service provider application

### DIFF
--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -143,6 +143,9 @@ spec:
               "^\\{")
             - set(severity_text, "INFO")
             - set(attributes["cluster"], "${env:CLUSTER_NAME}")
+            {{- if .Values.observability.clusterId }}
+            - set(attributes["sp_resource_id"], "${env:CLUSTER_ID}")
+            {{- end }}
       receivers:
         k8sobjects:
           auth_type: serviceAccount
@@ -179,6 +182,10 @@ spec:
           fieldPath: spec.nodeName
     - name: CLUSTER_NAME
       value: {{ .Values.observability.clusterName | quote }}
+    {{- if .Values.observability.clusterId }}
+    - name: CLUSTER_ID
+      value: {{ .Values.observability.clusterId | quote }}
+    {{- end }}
     - name: GOMAXPROCS
       value: "1"
     image:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -213,6 +213,9 @@ spec:
             error_mode: ignore
             statements:
             - set(attributes["cluster"], {{ .Values.observability.clusterName | quote }})
+            {{- if .Values.observability.clusterId }}
+            - set(attributes["sp_resource_id"], "${env:CLUSTER_ID}")
+            {{- end }}
       exporters:
         otlphttp/victorialogs:
           compression: gzip
@@ -278,6 +281,10 @@ spec:
     extraEnvs:
     - name: GOMAXPROCS
       value: "1"
+    {{- if .Values.observability.clusterId }}
+    - name: CLUSTER_ID
+      value: {{ .Values.observability.clusterId | quote }}
+    {{- end }}
     extraVolumeMounts:
     {{- if $hasPublicEndpoint }}
     - mountPath: /o11ytoken

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -136,6 +136,9 @@ spec:
             statements:
             - set(attributes["cluster"], "${env:CLUSTER_NAME}")
             - set(attributes["k8s.node.name"], "${env:K8S_NODE_NAME}")
+            {{- if .Values.observability.clusterId }}
+            - set(attributes["sp_resource_id"], "${env:CLUSTER_ID}")
+            {{- end }}
       receivers:
         {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
         filelog/nodelogs:
@@ -346,6 +349,10 @@ spec:
           fieldPath: spec.nodeName
     - name: CLUSTER_NAME
       value: {{ .Values.observability.clusterName | quote }}
+    {{- if .Values.observability.clusterId }}
+    - name: CLUSTER_ID
+      value: {{ .Values.observability.clusterId | quote }}
+    {{- end }}
     - name: GOMAXPROCS
       value: "1"
     extraVolumeMounts:

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -101,6 +101,7 @@ mariadbOperator:
 observability:
   enabled: true
   clusterName: soperator
+  clusterId: ""
   publicEndpointEnabled: true
   publicEndpointTokenKind: secret
   logsProjectId: default-project-id


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Right now logs granularity is not enough to distinguish different clusters. We need a separate attribute to be able to filter logs per cluster, since current cluster_name could be the same in different clusters.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Add attribute `sp_resource_id` to distinguish cluster related logs.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Feature: add `sp_resource_id` logs attribute and `clusterId` helm chart value for cluster log constraints.
