### PR TITLE
Disable periodic JobAcctGather stats collection by default

### DIFF
--- a/helm/slurm-cluster/tests/default-values_test.yaml
+++ b/helm/slurm-cluster/tests/default-values_test.yaml
@@ -205,7 +205,7 @@ tests:
           value: "jobacct_gather/cgroup"
       - equal:
           path: spec.slurmNodes.accounting.slurmConfig.jobAcctGatherFrequency
-          value: 30
+          value: 0
       - equal:
           path: spec.slurmNodes.accounting.slurmdbdConfig.archiveEvents
           value: "yes"

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -186,7 +186,7 @@ slurmNodes:
     slurmConfig:
       accountingStorageTRES: "CPU,Mem,Node,VMem,Gres/gpu"
       jobAcctGatherType: "jobacct_gather/cgroup"
-      jobAcctGatherFrequency: 30
+      jobAcctGatherFrequency: 0
       priorityWeightAge: 0
       priorityWeightFairshare: 0
       priorityWeightQOS: 0

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -351,9 +351,12 @@ func addSlurmConfigProperties(res *renderutils.PropertiesConfig, config interfac
 			continue
 		}
 
-		if field.Kind() == reflect.Int32 || field.Kind() == reflect.Int16 {
+		switch field.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			res.AddProperty(fieldName, field.Int())
 			continue
+		default:
+			// Skip
 		}
 	}
 }


### PR DESCRIPTION
## Problem
The JobAcctGather plugin collects stats for each process running in a job, which can decrease the performance for some workloads.

## Solution
Disable periodic stats collection by default. Only one sample will be collected at the end of the job.
To disable it, `JobAcctGatherFrequency` should be set to `0`.

## Testing
- Create a dev cluster
- Make sure `scontrol show config | grep JobAcctGatherFrequency` shows `0`.

## Release Notes
Disabled Slurm `JobAcctGather` by default to reduce system CPU usage
