### PR TITLE
SCHED-775: Fix image for wait-for-soperatorchecks-srun-ready

### DIFF
--- a/helm/soperator-activechecks/templates/_helpers.tpl
+++ b/helm/soperator-activechecks/templates/_helpers.tpl
@@ -97,7 +97,7 @@ Render slurmJobSpec for an ActiveCheck.
 {{- $spec := default dict .check.slurmJobSpec -}}
 {{- $jobContainerRaw := default dict $spec.jobContainer -}}
 {{- $baseContainer := dict "appArmorProfile" "unconfined" "image" $ctx.Values.images.slurmJob "env" $ctx.Values.jobContainer.env "volumeMounts" $ctx.Values.jobContainer.volumeMounts "volumes" $ctx.Values.jobContainer.volumes -}}
-{{- $jobContainer := mustMerge $baseContainer (omit $jobContainerRaw "extraEnv" "extraVolumeMounts" "extraVolumes") -}}
+{{- $jobContainer := mustMerge (omit $jobContainerRaw "extraEnv" "extraVolumeMounts" "extraVolumes") $baseContainer -}}
 {{- $env := default (list) $jobContainer.env -}}
 {{- with $jobContainerRaw.extraEnv }}{{- $env = concat $env . -}}{{- end }}
 {{- $volumeMounts := default (list) $jobContainer.volumeMounts -}}
@@ -152,7 +152,7 @@ Render k8sJobSpec for an ActiveCheck.
 {{- $baseContainer := dict "image" $ctx.Values.images.k8sJob -}}
 {{- if $useCommonVolumeMounts }}{{- $_ := set $baseContainer "volumeMounts" $ctx.Values.jobContainer.volumeMounts -}}{{- end }}
 {{- if $includeCommonEnv }}{{- $_ := set $baseContainer "env" $ctx.Values.jobContainer.env -}}{{- end }}
-{{- $jobContainer := mustMerge $baseContainer (omit $jobContainerRaw "extraEnv" "extraVolumeMounts" "extraVolumes") -}}
+{{- $jobContainer := mustMerge (omit $jobContainerRaw "extraEnv" "extraVolumeMounts" "extraVolumes") $baseContainer -}}
 {{- $env := default (list) $jobContainer.env -}}
 {{- with $jobContainerRaw.extraEnv }}{{- $env = concat $env . -}}{{- end }}
 {{- $volumeMounts := default (list) $jobContainer.volumeMounts -}}

--- a/helm/soperator-activechecks/tests/k8sjob_spec_test.yaml
+++ b/helm/soperator-activechecks/tests/k8sjob_spec_test.yaml
@@ -43,3 +43,31 @@ tests:
           path: spec.k8sJobSpec.mungeContainer
       - exists:
           path: spec.k8sJobSpec.mungeContainer.image
+
+  - it: should allow overriding k8sJob container image
+    documentSelector:
+      path: metadata.name
+      value: test-k8sjob-image-override
+    set:
+      slurmClusterRefName: test-cluster
+      images:
+        k8sJob: "default-k8s-image:latest"
+        slurmJob: "slurm-job-image:latest"
+        munge: "munge-image:latest"
+      jobContainer:
+        volumeMounts: []
+        volumes: []
+      checks:
+        test-k8sjob-image-override:
+          enabled: true
+          checkType: k8sJob
+          k8sJobSpec:
+            jobContainer:
+              image: "{{ .Values.images.slurmJob }}"
+              command: ["echo", "test"]
+    asserts:
+      - isKind:
+          of: ActiveCheck
+      - equal:
+          path: spec.k8sJobSpec.jobContainer.image
+          value: "slurm-job-image:latest"


### PR DESCRIPTION
## Problem

`wait-for-soperatorchecks-srun-ready` job fails blocking all further slurm jobs:

```
runuser: failed to execute srun: No such file or directory
```

Root cause: it usess wrong image `k8s_check_job` instead of `slurm_check_job`.

## Solution

The `mustMerge` function gives precedence to the first argument, but the code was passing default dict first (which contains k8s_check_job image for k8s jobs.

The Fix: swap mustMerge arguments so user-specified parameters take precedence.

## Testing

Add a test that image can be overriden for the job.

## Release Notes

None