### PR TITLE
SCHED-756: Fix `Failed to pull image "k8up-io/k8up:v2.13.1`

### DIFF
--- a/helm/soperator-fluxcd/templates/backup.yaml
+++ b/helm/soperator-fluxcd/templates/backup.yaml
@@ -42,7 +42,7 @@ spec:
   {{- else }}
     k8up:
       backupImage:
-        repository: k8up-io/k8up
+        repository: ghcr.io/k8up-io/k8up
         tag: v2.13.1
       skipWithoutAnnotation: true
     {{- if .Values.observability.prometheusOperator.enabled }}


### PR DESCRIPTION
## Problem

There is a wrong repository for k8up which leads to pull image errors:

```
Failed to pull image "k8up-io/k8up:v2.13.1": failed to pull and unpack image "docker.io/k8up-io/k8up:v2.13.1": failed to resolve reference "docker.io/k8up-io/k8up:v2.13.1": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```

Introduced here: https://github.com/nebius/soperator/pull/1966

## Solution

Fix the repo

