### PR TITLE
SCHED-785: Plug-in SPANK plugins properly in slurm job active checks

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -269,6 +269,28 @@ jobs:
           kubectl exec -n soperator controller-0 -- sacct --format=JobID,JobName,Partition,Account,AllocCPUS,State,ExitCode -S now-6hours || true
           kubectl exec -n soperator controller-0 -- sacct --parsable2 --allusers --starttime=now-6hours | column -t -s'|'
 
+      - name: Dump Slurm configuration files
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "=== /etc/slurm directory listing ==="
+          kubectl exec -n soperator controller-0 -- ls -la /etc/slurm/ || true
+
+          echo ""
+          kubectl exec -n soperator controller-0 -- bash -c '
+            for f in /etc/slurm/*.conf; do
+              echo ""
+              echo "=== $f ==="
+              cat "$f"
+              echo ""
+            done
+          ' || true
+
+          echo ""
+          echo "=== Running scontrol show config ==="
+          kubectl exec -n soperator controller-0 -- scontrol show config || true
+
       - name: Collect Full Kubernetes Cluster Info
         if: always()
         shell: bash

--- a/images/slurm_check_job/slurm_check_job.dockerfile
+++ b/images/slurm_check_job/slurm_check_job.dockerfile
@@ -34,6 +34,13 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Install NCCL debug plugin
+COPY images/common/spank-nccl-debug/src /usr/src/soperator/spank/nccld-debug
+COPY images/common/scripts/install_nccld_debug_plugin.sh /opt/bin/
+RUN chmod +x /opt/bin/install_nccld_debug_plugin.sh && \
+    /opt/bin/install_nccld_debug_plugin.sh && \
+    rm /opt/bin/install_nccld_debug_plugin.sh
+
 # Install kubectl
 RUN ARCH="$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')" && \
     KUBECTL_VERSION="$(curl -Ls https://dl.k8s.io/release/stable.txt)" && \

--- a/images/slurm_check_job/slurm_check_job_entrypoint.sh
+++ b/images/slurm_check_job/slurm_check_job_entrypoint.sh
@@ -33,8 +33,14 @@ touch /usr/lib/slurm/chroot.so
 mount --bind "/usr/lib/${ARCH}-linux-gnu/slurm/chroot.so" "/usr/lib/slurm/chroot.so"
 touch /usr/lib/slurm/spank_pyxis.so
 mount --bind "/usr/lib/${ARCH}-linux-gnu/slurm/spank_pyxis.so" "/usr/lib/slurm/spank_pyxis.so"
+
+# Bind-mount spanknccldebug to stop slurm errors like below:
+# srun: error: plugin_load_from_file: dlopen(spanknccldebug.so): spanknccldebug.so: cannot open shared object file: No such file or directory
+# srun: error: spank: spanknccldebug.so: Dlopen of plugin file failed
 touch /usr/lib/slurm/spanknccldebug.so
 mount --bind "/usr/lib/${ARCH}-linux-gnu/slurm/spanknccldebug.so" "/usr/lib/slurm/spanknccldebug.so"
+# And disable spanknccldebug because slurm jobs don't need this plugin.
+export SNCCLD_ENABLED="false"
 
 echo "Bind-mount /opt/bin/sbatch.sh script"
 mount --bind /opt/bin/sbatch.sh opt/bin/sbatch.sh

--- a/images/slurm_check_job/slurm_check_job_entrypoint.sh
+++ b/images/slurm_check_job/slurm_check_job_entrypoint.sh
@@ -26,6 +26,16 @@ mount --bind /etc/hosts /mnt/jail/etc/hosts
 echo "Symlink slurm configs from jail(sconfigcontroller)"
 rm -rf /etc/slurm && ln -s /mnt/jail/etc/slurm /etc/slurm
 
+echo "Bind-mount SPANK plugins to /usr/lib/slurm/"
+ARCH="$(uname -m)"
+mkdir -p /usr/lib/slurm
+touch /usr/lib/slurm/chroot.so
+mount --bind "/usr/lib/${ARCH}-linux-gnu/slurm/chroot.so" "/usr/lib/slurm/chroot.so"
+touch /usr/lib/slurm/spank_pyxis.so
+mount --bind "/usr/lib/${ARCH}-linux-gnu/slurm/spank_pyxis.so" "/usr/lib/slurm/spank_pyxis.so"
+touch /usr/lib/slurm/spanknccldebug.so
+mount --bind "/usr/lib/${ARCH}-linux-gnu/slurm/spanknccldebug.so" "/usr/lib/slurm/spanknccldebug.so"
+
 echo "Bind-mount /opt/bin/sbatch.sh script"
 mount --bind /opt/bin/sbatch.sh opt/bin/sbatch.sh
 


### PR DESCRIPTION
## Problem

In slurm job active check container, `/usr/lib/slurm` misses required plugins which are mentioned in `/etc/slurm/plugstack.conf`:
- `chroot.so` (required)
- `spank_pyxis.so` (required)
- `spanknccldebug.so` (optional)

## Solution

On workers and login nodes these files are bind-mounted in 

## Testing

None

## Release Notes

Loading spanknccldebug.so error is no longer appearing in slurm active check jobs:

```
srun: error: plugin_load_from_file: dlopen(spanknccldebug.so): spanknccldebug.so: cannot open shared object file: No such file or directory
```

