### PR TITLE
SCHED-789: nvtop 3.2.0.2-1+noble is no longer available

### DIFF
--- a/ansible/roles/nvtop/tasks/main.yml
+++ b/ansible/roles/nvtop/tasks/main.yml
@@ -44,7 +44,7 @@
 - name: Ensure nvtop package is installed
   ansible.builtin.apt:
     name:
-      - nvtop=3.2.0.2-1+noble
+      - nvtop=3.3.1-1+noble
     state: present
     update_cache: true
   tags:


### PR DESCRIPTION
## Problem

Builds are failing with `[ERROR]: Task failed: Module failed: no available installation candidate for nvtop=3.2.0.2-1+noble`

## Solution

Bump the version

