### PR TITLE
SCHED-785: Plug-in SPANK plugins properly in slurm job active checks

### DIFF
--- a/images/slurm_check_job/slurm_check_job.dockerfile
+++ b/images/slurm_check_job/slurm_check_job.dockerfile
@@ -60,6 +60,9 @@ RUN ARCH="$(uname -m)" && \
     ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/spank_pyxis.so" /usr/lib/slurm/spank_pyxis.so && \
     ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/spanknccldebug.so" /usr/lib/slurm/spanknccldebug.so
 
+# Disable NCCL debug plugin by default for slurm jobs
+ENV SNCCLD_ENABLED="false"
+
 # Delete users & home because they will be linked from jail
 RUN rm /etc/passwd* /etc/group* /etc/shadow* /etc/gshadow*
 RUN rm -rf /home


### PR DESCRIPTION
## Problem

In slurm job active check container, `/usr/lib/slurm` misses required plugins which are mentioned in `/etc/slurm/plugstack.conf`:
- `chroot.so` (required)
- `spank_pyxis.so` (required)
- `spanknccldebug.so` (optional)

## Solution

Link the plugin files during the image build.

## Testing

None

## Release Notes

Loading spanknccldebug.so error is no longer appearing in slurm active check jobs:

```
srun: error: plugin_load_from_file: dlopen(spanknccldebug.so): spanknccldebug.so: cannot open shared object file: No such file or directory
```

