### PR TITLE
SCHED-822: Fix ".spec.k8sJobSpec.appArmorProfile: field not declared in schema"

### DIFF
--- a/helm/soperator-activechecks/templates/_helpers.tpl
+++ b/helm/soperator-activechecks/templates/_helpers.tpl
@@ -183,9 +183,6 @@ Render k8sJobSpec for an ActiveCheck.
 {{- end }}
 {{- $args := $jobContainer.args -}}
 {{- $image := tpl (default $ctx.Values.images.k8sJob $jobContainer.image) $ctx }}
-{{- if $spec.appArmorProfile }}
-appArmorProfile: {{ $spec.appArmorProfile }}
-{{- end }}
 jobContainer:
   image: {{ $image | quote }}
 {{- with $jobContainer.appArmorProfile }}

--- a/helm/soperator-activechecks/tests/k8sjob_spec_test.yaml
+++ b/helm/soperator-activechecks/tests/k8sjob_spec_test.yaml
@@ -71,3 +71,31 @@ tests:
       - equal:
           path: spec.k8sJobSpec.jobContainer.image
           value: "slurm-job-image:latest"
+
+  - it: should not render appArmorProfile at k8sJobSpec level (regression test)
+    documentSelector:
+      path: metadata.name
+      value: test-apparmorprofile-placement
+    set:
+      slurmClusterRefName: test-cluster
+      images:
+        k8sJob: "test-image:latest"
+      jobContainer:
+        volumeMounts: []
+        volumes: []
+      checks:
+        test-apparmorprofile-placement:
+          enabled: true
+          checkType: k8sJob
+          k8sJobSpec:
+            jobContainer:
+              appArmorProfile: unconfined
+              command: ["echo", "test"]
+    asserts:
+      - isKind:
+          of: ActiveCheck
+      - notExists:
+          path: spec.k8sJobSpec.appArmorProfile
+      - equal:
+          path: spec.k8sJobSpec.jobContainer.appArmorProfile
+          value: unconfined

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -400,8 +400,9 @@ checks:
     suspend: true
     runAfterCreation: true
     k8sJobSpec:
-      appArmorProfile: unconfined
       scriptFile: "scripts/wait-for-topology.sh"
+      jobContainer:
+        appArmorProfile: unconfined
   wait-for-soperatorchecks-srun-ready:
     enabled: true
     checkType: "k8sJob"


### PR DESCRIPTION
## Problem

```
flux-system-soperator-fluxcd-soperator-activechecks              113m   False   Could not determine release state: unable to determine cluster state: ActiveCheck/soperator/wait-for-topology dry-run failed: failed to create typed patch object (soperator/wait-for-topology; slurm.nebius.ai/v1alpha1, Kind=ActiveCheck): .spec.k8sJobSpec.appArmorProfile: field not declared in schema
```

## Solution
Move appArmorProfile from k8sJobSpec level to jobContainer level to match the CRD schema. The template was incorrectly rendering appArmorProfile at the wrong YAML level, causing intermittent validation failures during Helm release installation.


## Testing

Regression test added

## Release Notes

None