### PR TITLE
turn off dcgmi diag active checks

### DIFF
--- a/helm/soperator-activechecks/scripts/extensive-check.sh
+++ b/helm/soperator-activechecks/scripts/extensive-check.sh
@@ -190,7 +190,7 @@ health_checker_runs=(
   all_reduce_with_ib
   all_reduce_without_ib
   cuda_samples
-  dcgmi_diag_r2
+# dcgmi_diag_r2
   gpu_fryer
 #  ib_gpu_perf
   mem_perf

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -107,8 +107,8 @@ checks:
       - "wait-for-soperatorchecks-srun-ready"
       - "wait-for-topology"
     schedule: "5 12 * * *"
-    suspend: false
-    runAfterCreation: true
+    suspend: true
+    runAfterCreation: false
     slurmJobSpec:
       sbatchScriptFile: "scripts/dcgmi-diag-r2.sh"
       eachWorkerJobs: true
@@ -123,7 +123,7 @@ checks:
       - "wait-for-soperatorchecks-srun-ready"
       - "wait-for-topology"
     suspend: true
-    runAfterCreation: true
+    runAfterCreation: false
     slurmJobSpec:
       sbatchScriptFile: "scripts/dcgmi-diag-r3.sh"
       eachWorkerJobs: true


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
On BX00 platforms dcgmi daig r2 (and more) takes too long to finish

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Disable dcgmi diag r2 and r3 by default

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Fix: disable dcgmi diag r2 and r3 by default
