### PR TITLE
increase default reconfiguration period

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -351,7 +351,7 @@ type SConfigController struct {
 	// ReconfigureWaitTimeout defines the maximum time to wait for all nodes to restart during reconfiguration.
 	// Must be greater than ReconfigurePollInterval. Defaults to 1m
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="1m"
+	// +kubebuilder:default="5m"
 	ReconfigureWaitTimeout *string `json:"reconfigureWaitTimeout,omitempty"`
 
 	// HostUsers controls if the pod containers can use the host user namespace

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -3391,7 +3391,7 @@ spec:
                       Defaults to 20s
                     type: string
                   reconfigureWaitTimeout:
-                    default: 1m
+                    default: 5m
                     description: |-
                       ReconfigureWaitTimeout defines the maximum time to wait for all nodes to restart during reconfiguration.
                       Must be greater than ReconfigurePollInterval. Defaults to 1m

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -539,7 +539,7 @@ sConfigController:
   runAsUid: 1001
   runAsGid: 1001
   reconfigurePollInterval: "20s"
-  reconfigureWaitTimeout: "1m"
+  reconfigureWaitTimeout: "5m"
   serviceMonitor:
     enabled: true
     jobLabel: "sconfigcontroller"

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -29375,7 +29375,7 @@ spec:
                       Defaults to 20s
                     type: string
                   reconfigureWaitTimeout:
-                    default: 1m
+                    default: 5m
                     description: |-
                       ReconfigureWaitTimeout defines the maximum time to wait for all nodes to restart during reconfiguration.
                       Must be greater than ReconfigurePollInterval. Defaults to 1m

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -29375,7 +29375,7 @@ spec:
                       Defaults to 20s
                     type: string
                   reconfigureWaitTimeout:
-                    default: 1m
+                    default: 5m
                     description: |-
                       ReconfigureWaitTimeout defines the maximum time to wait for all nodes to restart during reconfiguration.
                       Must be greater than ReconfigurePollInterval. Defaults to 1m

--- a/internal/controller/sconfigcontroller/jailedconfig_controller.go
+++ b/internal/controller/sconfigcontroller/jailedconfig_controller.go
@@ -53,7 +53,7 @@ import (
 const (
 	configMapField = ".spec.configMap.name"
 
-	defaultReconfigureWaitTimeout  = 1 * time.Minute
+	defaultReconfigureWaitTimeout  = 5 * time.Minute
 	defaultReconfigurePollInterval = 20 * time.Second
 )
 


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
On a big cluster scale reconfigure could take more than 1 minute to complete, so sconfigcontroller would fail every reconcilation and reconfigure cluster continuously.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Increase default timeout for reconfigure to 5 min. It should be enough because it's 5 times more then default MessageTimeout option.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Fix: increase default `reconfigureWaitTimeout` to 5 min.
