### PR TITLE
SCHED-846: Run E2E's more often and on more branches

### DIFF
--- a/.github/branch-config.json
+++ b/.github/branch-config.json
@@ -1,3 +1,0 @@
-{
-  "release_branch": "soperator-release-2.0"
-}

--- a/.github/branch-config.yaml
+++ b/.github/branch-config.yaml
@@ -1,0 +1,5 @@
+# Branch configuration for E2E tests and nightly builds.
+# "main" is always included automatically (not listed here)
+release_branches:
+  - soperator-release-2.0
+  - soperator-release-1.23

--- a/.github/workflows/e2e_test_scheduler.yml
+++ b/.github/workflows/e2e_test_scheduler.yml
@@ -2,8 +2,8 @@ name: E2E Test Scheduler
 
 on:
   schedule:
-    # Every hour - alternates between main and release branches
-    - cron: '0 */3 * * *'
+    # Periodically - uses persistent counter to rotate through main and release branches
+    - cron: '0 */2 * * *'
   workflow_dispatch:  # Allow manual trigger for testing
 
 permissions:
@@ -18,25 +18,35 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Install yq
+        uses: frenck/action-setup-yq@v1
+
       - name: Determine branch and terraform ref
         id: select_params
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          RELEASE_BRANCH=$(jq -r .release_branch .github/branch-config.json)
-          HOUR=$(date -u +%-H)  # %-H removes leading zeros to avoid octal interpretation
-          if [ $((HOUR % 2)) -eq 0 ]; then
-            echo "ref=main" >> $GITHUB_OUTPUT
-            echo "terraform_ref=main" >> $GITHUB_OUTPUT
-            echo "Even hour ($HOUR UTC) - Testing main branch with terraform main"
-          else
-            echo "ref=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
-            echo "terraform_ref=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
-            echo "Odd hour ($HOUR UTC) - Testing $RELEASE_BRANCH branch with terraform $RELEASE_BRANCH"
-          fi
+          readarray -t RELEASE_BRANCHES < <(yq -r '.release_branches[]' .github/branch-config.yaml)
+          BRANCHES=("main" "${RELEASE_BRANCHES[@]}")
+          BRANCH_COUNT=${#BRANCHES[@]}
+
+          COUNTER=$(gh variable get E2E_TRIGGER_COUNTER 2>/dev/null || echo "0")
+          RUN_INDEX=$(( COUNTER % BRANCH_COUNT ))
+          REF="${BRANCHES[$RUN_INDEX]}"
+          TERRAFORM_REF="$REF"
+
+          NEXT_COUNTER=$(( COUNTER + 1 ))
+          gh variable set E2E_TRIGGER_COUNTER --body "$NEXT_COUNTER"
+
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+          echo "terraform_ref=$TERRAFORM_REF" >> $GITHUB_OUTPUT
+          echo "Testing branch $REF (counter=$COUNTER, index $RUN_INDEX of $BRANCH_COUNT branches)"
 
       - name: Trigger E2E test workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
           REF="${{ steps.select_params.outputs.ref }}"
           TERRAFORM_REF="${{ steps.select_params.outputs.terraform_ref }}"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -16,21 +16,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Trigger nightly build on main
+      - name: Trigger nightly builds on all branches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
+          # Always build main
           echo "Triggering nightly multi-arch build on main"
           gh workflow run one_job.yml --ref main -f multi_arch=true
-          echo "Build triggered on main"
 
-      - name: Trigger nightly build on release branch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          RELEASE_BRANCH=$(jq -r .release_branch .github/branch-config.json)
-          echo "Triggering nightly multi-arch build on ${RELEASE_BRANCH}"
-          gh workflow run one_job.yml --ref "${RELEASE_BRANCH}" -f multi_arch=true
-          echo "Build triggered on ${RELEASE_BRANCH}"
+          # Build all release branches from config
+          for branch in $(yq -r '.release_branches[]' .github/branch-config.yaml); do
+            echo "Triggering nightly multi-arch build on ${branch}"
+            gh workflow run one_job.yml --ref "${branch}" -f multi_arch=true
+          done
+          echo "All builds triggered"


### PR DESCRIPTION
- Add soperator-1.23 to the nightly builds and e2e tests, support multiple release branches in rotation
- Run e2e every more frequent (every 2 hours)
- Use repository variable E2E_TRIGGER_COUNTER to deterministically rotate between branches in e2e
- Switch `branch-config.yaml` from JSON to YAML config format
