### PR TITLE
Add affinity and nodeSelector support to soperator manager

### DIFF
--- a/helm/soperator/templates/deployment.yaml
+++ b/helm/soperator/templates/deployment.yaml
@@ -107,3 +107,9 @@ spec:
       {{- if .Values.controllerManager.tolerations }}
       tolerations: {{- toYaml .Values.controllerManager.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.controllerManager.affinity }}
+      affinity: {{- toYaml .Values.controllerManager.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.controllerManager.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
+      {{- end }}

--- a/helm/soperator/tests/deployment_test.yaml
+++ b/helm/soperator/tests/deployment_test.yaml
@@ -1,4 +1,4 @@
-suite: test deployment tolerations
+suite: test deployment scheduling fields (tolerations, affinity, nodeSelector)
 release:
   name: test-soperator
   namespace: soperator-system
@@ -6,6 +6,9 @@ templates:
   - templates/deployment.yaml
 
 tests:
+  #
+  # --- TOLERATIONS ---
+  #
   - it: should not render tolerations when not set
     asserts:
       - isKind:
@@ -143,3 +146,143 @@ tests:
       - equal:
           path: spec.template.spec.tolerations[2].effect
           value: "NoExecute"
+
+  #
+  # --- AFFINITY ---
+  #
+  - it: should not render affinity when not set
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: should not render affinity when empty map
+    set:
+      controllerManager:
+        affinity: {}
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: should render nodeAffinity correctly when set
+    set:
+      controllerManager:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: "kubernetes.io/os"
+                      operator: "In"
+                      values: ["linux"]
+    asserts:
+      - isKind:
+          of: Deployment
+      - exists:
+          path: spec.template.spec.affinity
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0]
+          value:
+            key: "kubernetes.io/os"
+            operator: "In"
+            values:
+              - "linux"
+
+  - it: should render podAntiAffinity preferred rules correctly
+    set:
+      controllerManager:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: "kubernetes.io/hostname"
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: "soperator"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
+          value: "kubernetes.io/hostname"
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: "soperator"
+
+  - it: should render affinity at the same level as other pod spec fields
+    set:
+      controllerManager:
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: "example.com/test"
+                      operator: "Exists"
+    asserts:
+      - exists:
+          path: spec.template.spec.affinity
+      - exists:
+          path: spec.template.spec.securityContext
+      - exists:
+          path: spec.template.spec.serviceAccountName
+      - exists:
+          path: spec.template.spec.terminationGracePeriodSeconds
+
+  #
+  # --- NODESELECTOR ---
+  #
+  - it: should not render nodeSelector when not set
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.nodeSelector
+
+  - it: should not render nodeSelector when empty map
+    set:
+      controllerManager:
+        nodeSelector: {}
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.nodeSelector
+
+  - it: should render nodeSelector correctly when set
+    set:
+      controllerManager:
+        nodeSelector:
+          kubernetes.io/os: linux
+          node-role.kubernetes.io/control-plane: ""
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kubernetes.io/os: linux
+            node-role.kubernetes.io/control-plane: ""
+
+  - it: should render nodeSelector at the same level as other pod spec fields
+    set:
+      controllerManager:
+        nodeSelector:
+          kubernetes.io/os: linux
+    asserts:
+      - exists:
+          path: spec.template.spec.nodeSelector
+      - exists:
+          path: spec.template.spec.securityContext
+      - exists:
+          path: spec.template.spec.serviceAccountName
+      - exists:
+          path: spec.template.spec.terminationGracePeriodSeconds

--- a/helm/soperator/values.yaml
+++ b/helm/soperator/values.yaml
@@ -54,6 +54,8 @@ controllerManager:
   replicas: 1
   serviceAccount:
     annotations: {}
+  affinity: {}
+  nodeSelector: {}
   tolerations: []
 kubernetesClusterDomain: cluster.local
 webhookService:


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
The controller-manager supports tolerations but does not expose affinity or nodeSelector. In clusters with strict placement requirements, this forces users to rely on workarounds to control pod scheduling.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
I have just added other scheduling mechanisms for soperator manager beside the existing `tolerations`.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
I have added yaml unit tests and executed it.

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Feature: Added affinity and nodeSelector support to soperator
