### PR TITLE
SCHED-885: change init containers order

### DIFF
--- a/internal/render/controller/statefulset.go
+++ b/internal/render/controller/statefulset.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"slices"
 
 	appspub "github.com/openkruise/kruise-api/apps/pub"
 	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
@@ -52,13 +53,11 @@ func RenderStatefulSet(
 		replicas = ptr.To(consts.ZeroReplicas)
 	}
 
-	initContainers := []corev1.Container{
-		common.RenderContainerMunge(&controller.ContainerMunge),
-	}
+	initContainers := slices.Clone(controller.CustomInitContainers)
+	initContainers = append(initContainers, common.RenderContainerMunge(&controller.ContainerMunge))
 	if accountingEnabled {
 		initContainers = append(initContainers, renderContainerAccountingWaiter(&controller.ContainerSlurmctld))
 	}
-	initContainers = append(initContainers, controller.CustomInitContainers...)
 
 	return kruisev1b1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
We need to run several init containers before default rendered ones.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Change init containers order, so customInitContainers would run before default rendered.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Breaking: customInitContainers run before default rendered.
