### PR TITLE
Add slurm script that does chmod a+rw for enroot image layers

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/chmod_enroot_layers.sh
+++ b/helm/slurm-cluster/slurm_scripts/chmod_enroot_layers.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+echo "[$(date)] Make image layers cached by enroot readable and writable for anyone"
+
+IMAGE_STORAGE_VOLUME="/mnt/jail/mnt/image-storage"
+
+if ! mountpoint "$IMAGE_STORAGE_VOLUME"; then
+    echo "There is no separate volume for container images"
+    exit 0
+fi
+
+ENROOT_LAYERS_DIR="$IMAGE_STORAGE_VOLUME/enroot/cache"
+
+echo "Add read and write permissions for all files inside $ENROOT_LAYERS_DIR"
+mkdir -p "$ENROOT_LAYERS_DIR" || true
+chmod -R a+rw "$ENROOT_LAYERS_DIR" || true
+
+exit 0

--- a/helm/slurm-cluster/slurm_scripts/chmod_enroot_layers.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/chmod_enroot_layers.sh.json
@@ -1,0 +1,17 @@
+{
+  "name": "chmod_enroot_layers",
+  "command": "./chmod_enroot_layers.sh",
+  "platforms": ["any"],
+  "skip_for_cpu_jobs": false,
+  "skip_for_partial_gpu_jobs": false,
+  "skip_for_reservation_prefixes": [],
+  "contexts": ["prolog", "epilog"],
+  "node_states": ["any"],
+  "on_fail": "none",
+  "on_ok": "none",
+  "reason_base": "",
+  "reason_append_details": false,
+  "run_in_jail": false,
+  "log": "slurm_scripts/$worker.$name.$context.out",
+  "need_env": []
+}

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -603,6 +603,10 @@ slurmScripts:
       enabled: true
       customContent: null
       customConfig: null
+    chmod_enroot_layers.sh:
+      enabled: true
+      customContent: null
+      customConfig: null
     cleanup_enroot.sh:
       enabled: true
       customContent: null


### PR DESCRIPTION
## Problem
1. If there is no squashfs file for a given user’s image in /var/cache/enroot-container-images/, then:
  - one worker acquires a lock /var/cache/enroot-container-images/<uid>/docker:/<repo>/<image>.lock
  - downloads image layers locally into /mnt/image-storage/enroot/cache/using the uid/gid of that user
  - after all layers are downloaded, assembles a squashfs image and places it into the shared directory /var/cache/enroot-container-images/<uid>/docker:/<repo>/<image>.squashfs

2. If the squashfs file already exists, workers unpack it locally into /mnt/image-storage/enroot/data/pyxis_<job_id/container_name>

The issue occurs when the same image is used by different users:
- For the second user, the squashfs file does not exist
- However, the image layers have already been downloaded previously by the first user and remain in the local layer cache
- Workers that participated in the previous run and have this cached state fail when attempting to download layers again in a new run
- Workers without the old cache can successfully download the image and build the squashfs, but the job still fails because some workers have already crashed

On the next run, the job usually succeeds because:
- the image is taken from the squashfs
- the layer cache is no longer involved

## Solution
Add a new Slurm script that is executed in Prolog and Epilog that sets permissions 666 to all cached enroot image layers.

## Testing
Tested on a dev cluster.

## Release Notes
Fixed the bug when users couldn't start Enroot containers because the cached image layers were not readable for them.
