### PR TITLE
Remove empty lib bind-mount targets in populate_jail

### DIFF
--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -23,7 +23,7 @@ if [ -z "$jaildir" ] || [ -z "$upperdir" ]; then
 fi
 
 ALT_ARCH="$(uname -m)"
-echo "🔧 Using ALT_ARCH = ${ALT_ARCH}"
+echo "Using ALT_ARCH = ${ALT_ARCH}"
 
 SLURM_LIB_PATH="usr/lib/${ALT_ARCH}-linux-gnu/slurm"
 

--- a/images/populate_jail/populate_jail_entrypoint.sh
+++ b/images/populate_jail/populate_jail_entrypoint.sh
@@ -23,6 +23,22 @@ populate_jail_rootfs() {
     ssh-keygen -t ecdsa -f /mnt/jail/root/.ssh/id_ecdsa -N "" && cat /mnt/jail/root/.ssh/id_ecdsa.pub >> /mnt/jail/root/.ssh/authorized_keys
 }
 
+remove_empty_lib_mount_targets() {
+    echo "Removing the flag file that shows that GPU library bind-mount targets exist"
+    rm "/mnt/jail/etc/gpu_libs_installed.flag"
+
+    echo "Removing empty library files that were used as bind-mount targets on the previous cluster"
+    ARCH_LIST="x86_64 aarch64"
+    for arch in $ARCH_LIST; do
+        find "/mnt/jail/lib/${arch}-linux-gnu" \
+            -maxdepth 1 -type f ! -type l -empty -print |
+        while IFS= read -r file; do
+            echo "Removing $file"
+            rm -- "$file"
+        done
+    done
+}
+
 if [ "${OVERWRITE:-}" = "1" ]; then
     echo "Content overwriting is turned on, repopulating jail directory"
     populate_jail_rootfs
@@ -32,7 +48,8 @@ else
         echo "Jail directory is empty, populating"
         populate_jail_rootfs
     elif [ -d /mnt/jail/dev ] || [ -d /mnt/jail/etc ] || [ -d /mnt/jail/usr ]; then
-        echo "Jail directory is already populated with something that resembles a rootfs, exiting"
+        echo "Jail directory is already populated with something that resembles a rootfs, removing empty libs"
+        remove_empty_lib_mount_targets
         exit 0
     else
         echo "Jail directory is filled with something that does not resemble a rootfs, failing"


### PR DESCRIPTION
## Problem
Entrypoint scripts on GPU worker pods create empty files to mount GPU driver libraries to them.
After upgrading to the new driver version, they create new empty files corresponding to the new version.
The problem is that nobody removes old, unused empty files. It usually doesn't lead to any issues, because they aren't added to the linker cache (`ldconfig` ignores them). But if any software accesses these paths directly, there could be some problems.

## Solution
In the `populate-jail` job, delete all empty lib files in jail.
This job runs after cluster upgrades, but if the jail is already populated, it just exists.
Now it will remove empty lib files before exiting.

## Testing
Tested on a dev cluster.

## Release Notes
Fixed the bug when empty Slurm and GPU driver library files remained in the shared filesystem after cluster upgrade.
