### PR TITLE
Use default nfs-in-k8s for e2e

### DIFF
--- a/test/e2e/e2e_values_test.go
+++ b/test/e2e/e2e_values_test.go
@@ -63,23 +63,6 @@ func overrideTestValues(t *testing.T, tfVars map[string]interface{}, cfg testCon
 	// company_name = "e2e-test"
 	tfVars["company_name"] = "e2e-test"
 
-	// nfs_in_k8s = {
-	//    enabled         = true
-	//    version         = "1.2.0-f67979d7"
-	//    size_gibibytes  = 3720
-	//    disk_type       = "NETWORK_SSD_IO_M3"
-	//    filesystem_type = "ext4"
-	//    threads         = 32
-	// }
-	tfVars["nfs_in_k8s"] = map[string]interface{}{
-		"enabled":         true,
-		"version":         "1.2.0-f67979d7",
-		"size_gibibytes":  3720,
-		"disk_type":       "NETWORK_SSD_IO_M3",
-		"filesystem_type": "ext4",
-		"threads":         32,
-	}
-
 	// filestore_jail = {
 	//   spec = {
 	//     size_gibibytes       = 2048


### PR DESCRIPTION
Use default nfs-in-k8s for e2e, since it's fixed when using together with unstable soperator version

## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
There was a problem when using unstable soperator with nfs_in_k8s, now it's fixed so we have to revert custom variables

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
