### PR TITLE
fix long termination of worker pods

### DIFF
--- a/images/login/sshd_entrypoint.sh
+++ b/images/login/sshd_entrypoint.sh
@@ -33,4 +33,4 @@ echo "Waiting until munge started"
 while [ ! -S "/run/munge/munge.socket.2" ]; do sleep 2; done
 
 echo "Start sshd daemon"
-/usr/sbin/sshd -D -e -f /mnt/ssh-configs/sshd_config
+exec /usr/sbin/sshd -D -e -f /mnt/ssh-configs/sshd_config

--- a/images/munge/munge_entrypoint.sh
+++ b/images/munge/munge_entrypoint.sh
@@ -9,4 +9,4 @@ echo "Set permissions for shared /run/munge"
 chmod 755 /run/munge # It changes permissions of this shared directory in other containers as well
 
 echo "Start munge daemon"
-munged -F --num-threads="$MUNGE_NUM_THREADS" --key-file="$MUNGE_KEY_FILE" --pid-file="$MUNGE_PID_FILE" -S "$MUNGE_SOCKET_FILE"
+exec munged -F --num-threads="$MUNGE_NUM_THREADS" --key-file="$MUNGE_KEY_FILE" --pid-file="$MUNGE_PID_FILE" -S "$MUNGE_SOCKET_FILE"

--- a/images/worker/supervisord_entrypoint.sh
+++ b/images/worker/supervisord_entrypoint.sh
@@ -97,4 +97,4 @@ fi
 
 # Hack with logs: multilog will write log in stdout and in log file, and rotate log file
 echo "Start supervisord daemon"
-/usr/bin/supervisord
+exec /usr/bin/supervisord


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Worker and login pods do not respect `kill -TERM`.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Add `exec` in entrypoints to the main processes.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Fix: long termination of login and worker pods
