### PR TITLE
Better default params for NFS storageclass

### DIFF
--- a/helm/nfs-server/values.yaml
+++ b/helm/nfs-server/values.yaml
@@ -47,7 +47,6 @@ storageClass:
     - timeo=150
     - retrans=2
     - actimeo=30
-    - local_lock=all
     - proto=tcp
     - noresvport
     - noatime


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Default settings are not tuned for best performance.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Adding more sane defaults, specially `nconnect=16` to improve performance where multiple users interact with the NFS mount.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
I created a new cluster:
- Verified that there were 16 established TCP connections
- Ran some `fio` tests before and after with results to confirm improvement across iops, bw, and latency

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Improved NFS default mount options