### PR TITLE
SCHED-955: Do not set partitions in e2e

### DIFF
--- a/internal/e2e/init.go
+++ b/internal/e2e/init.go
@@ -40,10 +40,7 @@ func setupTerraform(cfg Config) (tf *tfexec.Terraform, varFilePath string, clean
 		return nil, "", nil, fmt.Errorf("read terraform variables: %w", err)
 	}
 
-	tfVars, err = overrideTestValues(tfVars, cfg)
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("override test values: %w", err)
-	}
+	tfVars = overrideTestValues(tfVars, cfg)
 
 	varsJSON, err := json.MarshalIndent(tfVars, "", "  ")
 	if err != nil {

--- a/internal/e2e/values.go
+++ b/internal/e2e/values.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strconv"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -56,7 +54,7 @@ func readTFVars(filename string) (map[string]interface{}, error) {
 	return varsMap, nil
 }
 
-func overrideTestValues(tfVars map[string]interface{}, cfg Config) (map[string]interface{}, error) {
+func overrideTestValues(tfVars map[string]interface{}, cfg Config) map[string]interface{} {
 	tfVars["active_checks_scope"] = "testing"
 	tfVars["slurm_operator_version"] = cfg.SoperatorVersion
 	tfVars["slurm_operator_stable"] = !cfg.SoperatorUnstable
@@ -81,8 +79,6 @@ func overrideTestValues(tfVars map[string]interface{}, cfg Config) (map[string]i
 		},
 	}
 
-	tfVars["slurm_nodesets_enabled"] = true
-
 	tfVars["slurm_nodeset_workers"] = []interface{}{
 		map[string]interface{}{
 			"name": "worker",
@@ -105,82 +101,11 @@ func overrideTestValues(tfVars map[string]interface{}, cfg Config) (map[string]i
 		},
 	}
 
-	defCpuPerGpu, err := renderDefCpuPerGpu(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("render DefCpuPerGpu: %w", err)
-	}
-
-	tfVars["slurm_nodesets_partitions"] = []any{
-		map[string]any{
-			"name":   "workers",
-			"is_all": false,
-			"config": strings.TrimSpace(fmt.Sprintf(
-				"Default=YES PriorityTier=10 MaxTime=INFINITE State=UP OverSubscribe=YES %s",
-				defCpuPerGpu,
-			)),
-			"nodeset_refs": []string{
-				"worker",
-			},
-		},
-	}
-
 	tfVars["slurm_login_ssh_root_public_keys"] = cfg.SSHKeys
 	tfVars["etcd_cluster_size"] = 1
 	tfVars["cleanup_bucket_on_destroy"] = true
 
-	return tfVars, nil
-}
-
-func renderDefCpuPerGpu(cfg Config) (string, error) {
-	if !strings.HasPrefix(cfg.WorkerPlatform, "gpu") {
-		return "", nil
-	}
-
-	presetComponents := strings.Split(cfg.WorkerPreset, "-")
-	if len(presetComponents) < 3 {
-		return "", fmt.Errorf("gpu worker preset must contain at least gpu, cpu, and memory specifiers, got %q", cfg.WorkerPreset)
-	}
-
-	var gpusString, cpusString string
-	for _, component := range presetComponents {
-		if strings.HasSuffix(component, "gpu") {
-			gpusString = strings.TrimSuffix(component, "gpu")
-			continue
-		}
-		if strings.HasSuffix(component, "vcpu") {
-			cpusString = strings.TrimSuffix(component, "vcpu")
-			continue
-		}
-	}
-	if gpusString == "" {
-		return "", fmt.Errorf("worker preset %q must have gpu specifier", cfg.WorkerPreset)
-	}
-	if cpusString == "" {
-		return "", fmt.Errorf("worker preset %q must have vcpu specifier", cfg.WorkerPreset)
-	}
-
-	gpus, err := strconv.Atoi(gpusString)
-	if err != nil {
-		return "", fmt.Errorf("parse gpu count from preset specifier %q: %w", gpusString, err)
-	}
-	if gpus <= 0 {
-		return "", fmt.Errorf("gpu count must be greater than zero, got %d", gpus)
-	}
-
-	cpus, err := strconv.Atoi(cpusString)
-	if err != nil {
-		return "", fmt.Errorf("parse cpu count from preset specifier %q: %w", cpusString, err)
-	}
-	if cpus <= 0 {
-		return "", fmt.Errorf("cpu count must be greater than zero, got %d", cpus)
-	}
-
-	cpuPerGpu := cpus / gpus
-	if cpuPerGpu <= 0 {
-		return "", fmt.Errorf("cpu per gpu must be greater than zero, got %d", cpuPerGpu)
-	}
-
-	return fmt.Sprintf("DefCpuPerGPU=%d", cpuPerGpu), nil
+	return tfVars
 }
 
 func preemptibleValue(enabled bool) interface{} {


### PR DESCRIPTION
## Problem

After partition logic was fixed (https://github.com/nebius/nebius-solutions-library/pull/798), e2e fail because they set incorrect partitions.

## Solution

Remove setting of partitions in e2e's, default terraform partitions will be used.
