### PR TITLE
SCHED-941: upgrade verions of munge

### DIFF
--- a/images/munge/munge.dockerfile
+++ b/images/munge/munge.dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile-upstream:1.20.0
 
-# https://github.com/nebius/ml-containers/pull/56
+# https://github.com/nebius/ml-containers/pull/66
 FROM cr.eu-north1.nebius.cloud/ml-containers/neubuntu:noble-20260218112629 AS munge
 
 RUN apt-get update && \


### PR DESCRIPTION
## Problem
CVE-2026-25506
## Solution
upgrade version munge

## Release Notes
upgrade version munge to 0.5.15-4ubuntu0.1
