### PR TITLE
SCHED-991: Replace flat worker fields in E2E profile with a nodesets list

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ""
         type: string
+      profile_env_var:
+        description: "Name of the GitHub variable containing the profile YAML (defaults to env setting)"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -33,8 +38,8 @@ jobs:
       TERRAFORM_REPO: "nebius/nebius-solution-library"
       TERRAFORM_REPO_REF: "${{ github.event.inputs.terraform_repo_ref || github.ref_name }}"
       O11Y_ACCESS_TOKEN: ${{ secrets.E2E_O11Y_ACCESS_TOKEN }}
-      PROFILE_ENV_VAR: ${{ vars.PROFILE_ENV_VAR }}
-      E2E_PROFILE: ${{ vars[vars.PROFILE_ENV_VAR] }}
+      PROFILE_ENV_VAR: ${{ inputs.profile_env_var || vars.PROFILE_ENV_VAR }}
+      E2E_PROFILE: ${{ vars[inputs.profile_env_var || vars.PROFILE_ENV_VAR] }}
 
     steps:
       - name: Checkout repository

--- a/internal/e2e/config.go
+++ b/internal/e2e/config.go
@@ -7,16 +7,52 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// NodeSetDef describes a single worker nodeset in the e2e profile.
+type NodeSetDef struct {
+	Name             string `json:"name"`
+	Platform         string `json:"platform"`
+	Preset           string `json:"preset"`
+	Size             int    `json:"size"`
+	InfinibandFabric string `json:"infiniband_fabric"`
+	Preemptible      bool   `json:"preemptible"`
+}
+
 // Profile holds infrastructure-specific settings loaded from the PROFILE env var.
 // JSON tags are required by sigs.k8s.io/yaml.
 type Profile struct {
-	NebiusProjectID  string `json:"nebius_project_id"`
-	NebiusRegion     string `json:"nebius_region"`
-	NebiusTenantID   string `json:"nebius_tenant_id"`
-	InfinibandFabric string `json:"infiniband_fabric"`
-	WorkerPlatform   string `json:"worker_platform"`
-	WorkerPreset     string `json:"worker_preset"`
-	PreemptibleNodes bool   `json:"preemptible_nodes"`
+	NebiusProjectID string       `json:"nebius_project_id"`
+	NebiusRegion    string       `json:"nebius_region"`
+	NebiusTenantID  string       `json:"nebius_tenant_id"`
+	NodeSets        []NodeSetDef `json:"nodesets"`
+}
+
+// Validate checks that the profile is well-formed.
+func (p Profile) Validate() error {
+	if len(p.NodeSets) == 0 {
+		return fmt.Errorf("nodesets must not be empty")
+	}
+
+	seen := make(map[string]struct{}, len(p.NodeSets))
+	for i, ns := range p.NodeSets {
+		if ns.Name == "" {
+			return fmt.Errorf("nodeset[%d]: name is required", i)
+		}
+		if ns.Platform == "" {
+			return fmt.Errorf("nodeset[%d] %q: platform is required", i, ns.Name)
+		}
+		if ns.Preset == "" {
+			return fmt.Errorf("nodeset[%d] %q: preset is required", i, ns.Name)
+		}
+		if ns.Size <= 0 {
+			return fmt.Errorf("nodeset[%d] %q: size must be positive, got %d", i, ns.Name, ns.Size)
+		}
+		if _, ok := seen[ns.Name]; ok {
+			return fmt.Errorf("nodeset[%d]: duplicate name %q", i, ns.Name)
+		}
+		seen[ns.Name] = struct{}{}
+	}
+
+	return nil
 }
 
 // LoadProfile reads the PROFILE env var (already-resolved YAML content) and returns a Profile.
@@ -29,6 +65,10 @@ func LoadProfile() (Profile, error) {
 	var p Profile
 	if err := yaml.Unmarshal([]byte(raw), &p); err != nil {
 		return Profile{}, fmt.Errorf("unmarshal profile YAML: %w", err)
+	}
+
+	if err := p.Validate(); err != nil {
+		return Profile{}, fmt.Errorf("validate profile: %w", err)
 	}
 
 	return p, nil

--- a/internal/e2e/config_test.go
+++ b/internal/e2e/config_test.go
@@ -1,0 +1,81 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func validProfile() Profile {
+	return Profile{
+		NebiusProjectID: "project-123",
+		NebiusRegion:    "eu-north1",
+		NebiusTenantID:  "tenant-456",
+		NodeSets: []NodeSetDef{
+			{
+				Name:             "worker-gpu",
+				Platform:         "gpu-h100-sxm",
+				Preset:           "8gpu-128vcpu-1600gb",
+				Size:             2,
+				InfinibandFabric: "cuda",
+			},
+		},
+	}
+}
+
+func TestValidate_Valid(t *testing.T) {
+	assert.NoError(t, validProfile().Validate())
+}
+
+func TestValidate_MultipleNodeSets(t *testing.T) {
+	p := validProfile()
+	p.NodeSets = append(p.NodeSets, NodeSetDef{
+		Name:     "worker-cpu",
+		Platform: "cpu",
+		Preset:   "16vcpu-64gb",
+		Size:     3,
+	})
+	assert.NoError(t, p.Validate())
+}
+
+func TestValidate_EmptyNodeSets(t *testing.T) {
+	p := validProfile()
+	p.NodeSets = nil
+	assert.ErrorContains(t, p.Validate(), "nodesets must not be empty")
+}
+
+func TestValidate_DuplicateNames(t *testing.T) {
+	p := validProfile()
+	p.NodeSets = append(p.NodeSets, p.NodeSets[0])
+	assert.ErrorContains(t, p.Validate(), "duplicate name")
+}
+
+func TestValidate_MissingName(t *testing.T) {
+	p := validProfile()
+	p.NodeSets[0].Name = ""
+	assert.ErrorContains(t, p.Validate(), "name is required")
+}
+
+func TestValidate_MissingPlatform(t *testing.T) {
+	p := validProfile()
+	p.NodeSets[0].Platform = ""
+	assert.ErrorContains(t, p.Validate(), "platform is required")
+}
+
+func TestValidate_MissingPreset(t *testing.T) {
+	p := validProfile()
+	p.NodeSets[0].Preset = ""
+	assert.ErrorContains(t, p.Validate(), "preset is required")
+}
+
+func TestValidate_ZeroSize(t *testing.T) {
+	p := validProfile()
+	p.NodeSets[0].Size = 0
+	assert.ErrorContains(t, p.Validate(), "size must be positive")
+}
+
+func TestValidate_NegativeSize(t *testing.T) {
+	p := validProfile()
+	p.NodeSets[0].Size = -1
+	assert.ErrorContains(t, p.Validate(), "size must be positive")
+}

--- a/internal/e2e/values.go
+++ b/internal/e2e/values.go
@@ -79,33 +79,43 @@ func overrideTestValues(tfVars map[string]interface{}, cfg Config) map[string]in
 		},
 	}
 
-	tfVars["slurm_nodeset_workers"] = []interface{}{
-		map[string]interface{}{
-			"name": "worker",
-			"size": 2,
+	var nodesetWorkers []interface{}
+	for _, ns := range cfg.Profile.NodeSets {
+		entry := map[string]interface{}{
+			"name": ns.Name,
+			"size": ns.Size,
 			"resource": map[string]interface{}{
-				"platform": cfg.Profile.WorkerPlatform,
-				"preset":   cfg.Profile.WorkerPreset,
+				"platform": ns.Platform,
+				"preset":   ns.Preset,
 			},
 			"boot_disk": map[string]interface{}{
 				"type":                 "NETWORK_SSD",
 				"size_gibibytes":       2048,
 				"block_size_kibibytes": 4,
 			},
-			"gpu_cluster": map[string]interface{}{
-				"infiniband_fabric": cfg.Profile.InfinibandFabric,
-			},
-			"preemptible":      preemptibleValue(cfg.Profile.PreemptibleNodes),
+			"gpu_cluster":      gpuClusterValue(ns.InfinibandFabric),
+			"preemptible":      preemptibleValue(ns.Preemptible),
 			"features":         nil,
 			"create_partition": nil,
-		},
+		}
+		nodesetWorkers = append(nodesetWorkers, entry)
 	}
+	tfVars["slurm_nodeset_workers"] = nodesetWorkers
 
 	tfVars["slurm_login_ssh_root_public_keys"] = []string{cfg.SSHPublicKey}
 	tfVars["etcd_cluster_size"] = 1
 	tfVars["cleanup_bucket_on_destroy"] = true
 
 	return tfVars
+}
+
+func gpuClusterValue(infinibandFabric string) interface{} {
+	if infinibandFabric == "" {
+		return nil
+	}
+	return map[string]interface{}{
+		"infiniband_fabric": infinibandFabric,
+	}
 }
 
 func preemptibleValue(enabled bool) interface{} {


### PR DESCRIPTION
## Problem

There is no way to run E2E on clusters with several nodesets.

## Solution
Support multiple worker nodesets in the E2E profile by replacing WorkerPlatform, WorkerPreset, InfinibandFabric, and PreemptibleNodes with a structured NodeSets list. Each nodeset entry carries its own name, platform, preset, size, infiniband fabric, and preemptible flag.

## Testing
E2E run: https://github.com/nebius/soperator/actions/runs/22313704457
