### PR TITLE
SCHED-1007: Ignore CPU-only nodes in IB topology

### DIFF
--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -25,7 +25,7 @@ import (
 func RenderContainerWorkerInit(
 	clusterName string,
 	container *values.Container,
-	topologyEnabled, isNodeSet bool,
+	topologyEnabled, gpuEnabled bool,
 	waitTimeoutSeconds int32,
 ) corev1.Container {
 	command := []string{
@@ -85,19 +85,19 @@ func RenderContainerWorkerInit(
 			Name:  "CONTROLLER_POLL_INTERVAL",
 			Value: "5",
 		},
-	}
-
-	if isNodeSet {
-		env = append(env, corev1.EnvVar{
+		{
 			Name:  "K8S_SERVICE_NAME",
 			Value: naming.BuildServiceName(consts.ComponentTypeNodeSet, clusterName),
-		})
-	} else {
-		// For "legacy" workers without NodeSet, we use the default worker service for backward compatibility.
-		env = append(env, corev1.EnvVar{
-			Name:  "K8S_SERVICE_NAME",
-			Value: naming.BuildServiceName(consts.ComponentTypeWorker, clusterName),
-		})
+		},
+	}
+
+	if gpuEnabled {
+		env = append(env,
+			corev1.EnvVar{
+				Name:  "NODESET_GPU_ENABLED",
+				Value: "true",
+			},
+		)
 	}
 
 	if topologyEnabled {

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -47,12 +47,13 @@ func RenderNodeSetStatefulSet(
 		topologyTimeOut = consts.DefaultEphemeralTopologyWaitTimeout
 	}
 
-	isNodeSet := true
-
 	initContainers := slices.Clone(nodeSet.CustomInitContainers)
 	initContainers = append(initContainers,
 		common.RenderContainerMunge(&nodeSet.ContainerMunge),
-		RenderContainerWorkerInit(clusterName, &nodeSet.ContainerSlurmd, topologyPluginEnabled, isNodeSet, topologyTimeOut),
+		RenderContainerWorkerInit(
+			clusterName, &nodeSet.ContainerSlurmd, topologyPluginEnabled,
+			nodeSet.GPU.Enabled, topologyTimeOut,
+		),
 	)
 
 	if topologyPluginEnabled {


### PR DESCRIPTION
## Problem
CPU-only (non-GPU) worker nodes do not have IB fabric topology labels (topology.nebius.com/tier-*) on their Kubernetes nodes. When wait-topology ran for these nodes, it would wait the full timeout (up to 3 minutes) looking for topology data in the ConfigMap that would never appear, then fail with an error and block the node from starting.

## Solution
Added a fast path in wait_for_topology: if NODESET_GPU_ENABLED is not "true", the node skips the ConfigMap lookup entirely and immediately calls scontrol update with topology=default:root:unknown - the generic switch that topology.conf already defines for all workers.

Added is_gpu_enabled() helper that reads NODESET_GPU_ENABLED (set by RenderContainerWorkerInit when the NodeSet has GPU enabled).

## Testing

- Manually
- All unit test passed

## Release Notes
Fix: CPU-only worker nodes no longer time out waiting for IB topology data on startup - they are immediately assigned to the generic switch and become available without delay.
