### PR TITLE
Fix adding tier-2 topoogy switches to node extra

### DIFF
--- a/images/worker/slurmd_entrypoint.sh
+++ b/images/worker/slurmd_entrypoint.sh
@@ -31,7 +31,7 @@ feature_conf() {
     fi
 }
 
-TOPO_LABELS_FILE="/tmp/slurm/topology-node-labels"
+TOPO_LABELS_FILE="/tmp/slurm/topology-node-labels/$INSTANCE_ID"
 if [[ -f $TOPO_LABELS_FILE ]]; then
     switch_tier2=$(jq -r '."tier-2" // empty' "$TOPO_LABELS_FILE" 2>/dev/null || echo "")
     export TOPO_SWITCH_TIER2="${switch_tier2:-unknown}"


### PR DESCRIPTION
## Problem
The feature implemented [here](https://github.com/nebius/soperator/pull/2206) doesn't work correctly because there's a mistake in reading the topology labels file.

## Solution
Read `/tmp/slurm/topology-node-labels/$INSTANCE_ID` file instead of `/tmp/slurm/topology-node-labels`.

## Testing
Tested on a dev cluster.

## Release Notes
Nothing
