### PR TITLE
SCHED-1015: add retries values for all Helm Releases (#2215)

### DIFF
--- a/helm/soperator-fluxcd/templates/backup-config.yaml
+++ b/helm/soperator-fluxcd/templates/backup-config.yaml
@@ -21,15 +21,13 @@ spec:
   dependsOn:
   - name: {{ include "soperator-fluxcd.fullname" . }}-ns
   install:
-    remediation:
-      retries: 3
+    {{- toYaml .Values.backup.config.install | nindent 4 }}
   interval: {{ default .Values.backup.interval .Values.backup.config.interval }}
   timeout: {{ default .Values.backup.timeout .Values.backup.config.timeout }}
   releaseName: {{ .Values.backup.config.releaseName }}
   targetNamespace: {{ .Values.slurmCluster.namespace }}
   upgrade:
-    remediation:
-      retries: 3
+    {{- toYaml .Values.backup.config.upgrade | nindent 4 }}
   values:
   {{- if .Values.backup.config.values }}
   {{- toYaml .Values.backup.config.values | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/backup.yaml
+++ b/helm/soperator-fluxcd/templates/backup.yaml
@@ -27,11 +27,9 @@ spec:
   - name: {{ include "soperator-fluxcd.fullname" . }}-prometheus-operator-crds
   {{- end }}
   install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
+    {{- toYaml .Values.backup.install | nindent 4 }}
   upgrade:
-    crds: CreateReplace
+    {{- toYaml .Values.backup.upgrade | nindent 4 }}
   interval: {{ .Values.backup.interval }}
   timeout: {{ .Values.backup.timeout }}
   releaseName: {{ .Values.backup.releaseName }}

--- a/helm/soperator-fluxcd/templates/cert-manager.yaml
+++ b/helm/soperator-fluxcd/templates/cert-manager.yaml
@@ -24,14 +24,9 @@ spec:
   - name: {{ include "soperator-fluxcd.fullname" . }}-prometheus-operator-crds
   {{- end }}
   install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
+    {{- toYaml .Values.certManager.install | nindent 4 }}
   upgrade:
-    crds: CreateReplace
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.certManager.upgrade | nindent 4 }}
   interval: {{ .Values.certManager.interval }}
   targetNamespace: {{ .Values.certManager.namespace }}
   releaseName: {{ .Values.certManager.releaseName }}

--- a/helm/soperator-fluxcd/templates/csi-driver-nfs.yaml
+++ b/helm/soperator-fluxcd/templates/csi-driver-nfs.yaml
@@ -21,11 +21,9 @@ spec:
   dependsOn:
   - name: {{ include "soperator-fluxcd.fullname" . }}-ns
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.csiDriverNfs.install | nindent 4 }}
   upgrade:
-    crds: Skip
+    {{- toYaml .Values.csiDriverNfs.upgrade | nindent 4 }}
   interval: {{ .Values.csiDriverNfs.interval }}
   timeout: {{ .Values.csiDriverNfs.timeout }}
   releaseName: {{ .Values.csiDriverNfs.releaseName }}

--- a/helm/soperator-fluxcd/templates/dcgm-exporter.yaml
+++ b/helm/soperator-fluxcd/templates/dcgm-exporter.yaml
@@ -19,18 +19,13 @@ spec:
         name: {{ include "soperator-fluxcd.fullname" . }}-soperator
       version: {{ .Values.observability.dcgmExporter.version }}
   install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
+    {{- toYaml .Values.observability.dcgmExporter.install | nindent 4 }}
   interval: {{ .Values.observability.dcgmExporter.interval }}
   timeout: {{ .Values.observability.dcgmExporter.timeout }}
   releaseName: {{ .Values.observability.dcgmExporter.releaseName }}
   targetNamespace: {{ .Values.observability.dcgmExporter.namespace }}
   upgrade:
-    crds: CreateReplace
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.observability.dcgmExporter.upgrade | nindent 4 }}
   values:
     dcgmHpcJobMappingDir: {{ .Values.observability.dcgmExporter.values.hpcJobMapDir }}
     validateToolkit: {{ .Values.observability.dcgmExporter.values.validateToolkit }}

--- a/helm/soperator-fluxcd/templates/kruise.yaml
+++ b/helm/soperator-fluxcd/templates/kruise.yaml
@@ -24,14 +24,9 @@ spec:
   - name: {{ include "soperator-fluxcd.fullname" . }}-cert-manager
   {{- end }}
   install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
+    {{- toYaml .Values.soperator.kruise.install | nindent 4 }}
   upgrade:
-    crds: CreateReplace
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.soperator.kruise.upgrade | nindent 4 }}
   interval: {{ .Values.soperator.kruise.interval }}
   timeout: {{ .Values.soperator.kruise.timeout }}
   releaseName: {{ .Values.soperator.kruise.releaseName }}

--- a/helm/soperator-fluxcd/templates/mariadb-operator-crds.yaml
+++ b/helm/soperator-fluxcd/templates/mariadb-operator-crds.yaml
@@ -19,11 +19,9 @@ spec:
         name: {{ include "soperator-fluxcd.fullname" . }}-mariadb-operator
       version: {{ .Values.mariadbOperator.version }}
   install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
+    {{- toYaml .Values.mariadbOperator.crds.install | nindent 4 }}
   interval: {{ .Values.mariadbOperator.interval }}
   timeout: {{ .Values.mariadbOperator.timeout }}
   upgrade:
-    crds: CreateReplace
+    {{- toYaml .Values.mariadbOperator.crds.upgrade | nindent 4 }}
 {{- end }}

--- a/helm/soperator-fluxcd/templates/mariadb-operator.yaml
+++ b/helm/soperator-fluxcd/templates/mariadb-operator.yaml
@@ -23,18 +23,13 @@ spec:
   - name: {{ include "soperator-fluxcd.fullname" . }}-mariadb-operator-crds
   - name: {{ include "soperator-fluxcd.fullname" . }}-cert-manager
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.mariadbOperator.install | nindent 4 }}
   interval: {{ .Values.mariadbOperator.interval }}
   timeout: {{ .Values.mariadbOperator.timeout }}
   releaseName: {{ .Values.mariadbOperator.releaseName }}
   targetNamespace: {{ .Values.mariadbOperator.namespace }}
   upgrade:
-    crds: Skip
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.mariadbOperator.upgrade | nindent 4 }}
   values:
   {{- if .Values.mariadbOperator.overrideValues }}
     {{- toYaml .Values.mariadbOperator.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/monitoring-dashboards.yaml
+++ b/helm/soperator-fluxcd/templates/monitoring-dashboards.yaml
@@ -21,13 +21,9 @@ spec:
   dependsOn:
   - name: {{ include "soperator-fluxcd.fullname" . }}-ns
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.soperator.monitoringDashboards.install | nindent 4 }}
   upgrade:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.soperator.monitoringDashboards.upgrade | nindent 4 }}
   interval: {{ .Values.soperator.monitoringDashboards.interval }}
   timeout: {{ .Values.soperator.monitoringDashboards.timeout }}
   releaseName: {{ .Values.soperator.monitoringDashboards.releaseName }}

--- a/helm/soperator-fluxcd/templates/nfs-server.yaml
+++ b/helm/soperator-fluxcd/templates/nfs-server.yaml
@@ -22,11 +22,9 @@ spec:
   - name: {{ include "soperator-fluxcd.fullname" . }}-ns
   - name: {{ include "soperator-fluxcd.fullname" . }}-csi-driver-nfs
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.nfsServer.install | nindent 4 }}
   upgrade:
-    crds: Skip
+    {{- toYaml .Values.nfsServer.upgrade | nindent 4 }}
   interval: {{ .Values.nfsServer.interval }}
   timeout: {{ .Values.nfsServer.timeout }}
   releaseName: {{ .Values.nfsServer.releaseName }}

--- a/helm/soperator-fluxcd/templates/nodeconfigurator.yaml
+++ b/helm/soperator-fluxcd/templates/nodeconfigurator.yaml
@@ -21,18 +21,13 @@ spec:
   dependsOn:
   - name: {{ include "soperator-fluxcd.fullname" . }}-soperator
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.soperator.nodeConfigurator.install | nindent 4 }}
   interval: {{ .Values.soperator.nodeConfigurator.interval }}
   timeout: {{ .Values.soperator.nodeConfigurator.timeout }}
   releaseName: {{ .Values.soperator.nodeConfigurator.releaseName }}
   targetNamespace: {{ .Values.soperator.namespace }}
   upgrade:
-    crds: Skip
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.soperator.nodeConfigurator.upgrade | nindent 4 }}
   values:
   {{- if .Values.soperator.nodeConfigurator.overrideValues }}
     {{- toYaml .Values.soperator.nodeConfigurator.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/nodesets.yaml
+++ b/helm/soperator-fluxcd/templates/nodesets.yaml
@@ -26,18 +26,13 @@ spec:
 {{- end }}
 
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.nodesets.install | nindent 4 }}
   interval: {{ .Values.nodesets.interval }}
   timeout: {{ .Values.nodesets.timeout }}
   releaseName: {{ .Values.nodesets.releaseName }}
   targetNamespace: {{ .Values.nodesets.namespace }}
   upgrade:
-    crds: Skip
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.nodesets.upgrade | nindent 4 }}
   values:
   {{- if .Values.nodesets.overrideValues }}
     {{- toYaml .Values.nodesets.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/notifier.yaml
+++ b/helm/soperator-fluxcd/templates/notifier.yaml
@@ -22,12 +22,9 @@ spec:
     - name: {{ include "soperator-fluxcd.fullname" . }}-ns
     - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
   install:
-    remediation:
-      retries: 3
+    {{- toYaml .Values.notifier.install | nindent 4 }}
   upgrade:
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.notifier.upgrade | nindent 4 }}
   interval: {{ .Values.notifier.interval }}
   timeout: {{ .Values.notifier.timeout }}
   releaseName: {{ .Values.notifier.releaseName }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -23,12 +23,9 @@ spec:
   - name: {{ include "soperator-fluxcd.fullname" . }}-ns
   - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
   install:
-    remediation:
-      retries: 3
+    {{- toYaml .Values.observability.opentelemetry.events.install | nindent 4 }}
   upgrade:
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.observability.opentelemetry.events.upgrade | nindent 4 }}
   interval: {{ .Values.observability.opentelemetry.events.interval }}
   timeout: {{ .Values.observability.opentelemetry.events.timeout }}
   releaseName: opentelemetry-collector-events

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -25,12 +25,9 @@ spec:
   - name: {{ include "soperator-fluxcd.fullname" . }}-ns
   - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
   install:
-    remediation:
-      retries: 3
+    {{- toYaml .Values.observability.opentelemetry.logs.install | nindent 4 }}
   upgrade:
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.observability.opentelemetry.logs.upgrade | nindent 4 }}
   interval: {{ .Values.observability.opentelemetry.logs.interval }}
   timeout: {{ .Values.observability.opentelemetry.logs.timeout }}
   releaseName: opentelemetry-collector-jail-logs

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -23,12 +23,9 @@ spec:
   - name: {{ include "soperator-fluxcd.fullname" . }}-ns
   - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
   install:
-    remediation:
-      retries: 3
+    {{- toYaml .Values.observability.opentelemetry.logs.install | nindent 4 }}
   upgrade:
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.observability.opentelemetry.logs.upgrade | nindent 4 }}
   interval: {{ .Values.observability.opentelemetry.logs.interval }}
   timeout: {{ .Values.observability.opentelemetry.logs.timeout }}
   releaseName: opentelemetry-collector-logs

--- a/helm/soperator-fluxcd/templates/security-profiles-operator.yaml
+++ b/helm/soperator-fluxcd/templates/security-profiles-operator.yaml
@@ -19,14 +19,9 @@ spec:
         name: {{ include "soperator-fluxcd.fullname" . }}-security-profiles-operator
       version: {{ .Values.securityProfilesOperator.version }}
   install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
+    {{- toYaml .Values.securityProfilesOperator.install | nindent 4 }}
   upgrade:
-    crds: CreateReplace
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.securityProfilesOperator.upgrade | nindent 4 }}
   interval: {{ .Values.securityProfilesOperator.interval }}
   timeout: {{ .Values.securityProfilesOperator.timeout }}
   releaseName: {{ .Values.securityProfilesOperator.releaseName }}

--- a/helm/soperator-fluxcd/templates/slurm-cluster-storage.yaml
+++ b/helm/soperator-fluxcd/templates/slurm-cluster-storage.yaml
@@ -25,12 +25,9 @@ spec:
   - name: {{ include "soperator-fluxcd.fullname" . }}-soperator
   {{- end }}
   install:
-    remediation:
-      retries: 3
+    {{- toYaml .Values.slurmCluster.slurmClusterStorage.install | nindent 4 }}
   upgrade:
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.slurmCluster.slurmClusterStorage.upgrade | nindent 4 }}
   interval: {{ .Values.slurmCluster.slurmClusterStorage.interval }}
   timeout: {{ .Values.slurmCluster.slurmClusterStorage.timeout }}
   releaseName: {{ .Values.slurmCluster.slurmClusterStorage.releaseName }}

--- a/helm/soperator-fluxcd/templates/slurm-cluster.yaml
+++ b/helm/soperator-fluxcd/templates/slurm-cluster.yaml
@@ -31,18 +31,13 @@ spec:
 {{- end }}
 
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.slurmCluster.install | nindent 4 }}
   interval: {{ .Values.slurmCluster.interval }}
   timeout: {{ .Values.slurmCluster.timeout }}
   releaseName: soperator
   targetNamespace: soperator
   upgrade:
-    crds: Skip
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.slurmCluster.upgrade | nindent 4 }}
   values:
   {{- if .Values.slurmCluster.overrideValues }}
     {{- toYaml .Values.slurmCluster.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/soperator-activechecks.yaml
+++ b/helm/soperator-fluxcd/templates/soperator-activechecks.yaml
@@ -22,18 +22,13 @@ spec:
   - name: {{ include "soperator-fluxcd.fullname" . }}-slurm-cluster
   - name: {{ include "soperator-fluxcd.fullname" . }}-soperatorchecks  
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.soperatorActiveChecks.install | nindent 4 }}
   interval: {{ .Values.soperatorActiveChecks.interval }}
   timeout: {{ .Values.soperatorActiveChecks.timeout }}
   releaseName: {{ .Values.soperatorActiveChecks.releaseName }}
   targetNamespace: {{ .Values.soperatorActiveChecks.namespace }}
   upgrade:
-    crds: Skip
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.soperatorActiveChecks.upgrade | nindent 4 }}
   values:
   {{- if .Values.soperatorActiveChecks.overrideValues }}
     {{- toYaml .Values.soperatorActiveChecks.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/soperator-custom-configmaps.yaml
+++ b/helm/soperator-fluxcd/templates/soperator-custom-configmaps.yaml
@@ -21,13 +21,9 @@ spec:
   dependsOn:
   - name: {{ include "soperator-fluxcd.fullname" . }}-ns
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.customConfigmaps.install | nindent 4 }}
   upgrade:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.customConfigmaps.upgrade | nindent 4 }}
   interval: {{ .Values.customConfigmaps.interval }}
   timeout: {{ .Values.customConfigmaps.timeout }}
   releaseName: {{ .Values.customConfigmaps.releaseName }}

--- a/helm/soperator-fluxcd/templates/soperator.yaml
+++ b/helm/soperator-fluxcd/templates/soperator.yaml
@@ -25,14 +25,9 @@ spec:
   - name: {{ include "soperator-fluxcd.fullname" . }}-cert-manager
   {{- end }}
   install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
+    {{- toYaml .Values.soperator.install | nindent 4 }}
   upgrade:
-    crds: CreateReplace
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.soperator.upgrade | nindent 4 }}
   interval: {{ .Values.soperator.interval }}
   timeout: {{ .Values.soperator.timeout }}
   releaseName: {{ .Values.soperator.releaseName }}

--- a/helm/soperator-fluxcd/templates/soperatorchecks.yaml
+++ b/helm/soperator-fluxcd/templates/soperatorchecks.yaml
@@ -21,12 +21,9 @@ spec:
   dependsOn:
   - name: {{ include "soperator-fluxcd.fullname" . }}-soperator
   install:
-    remediation:
-      retries: 3
+    {{- toYaml .Values.soperator.soperatorChecks.install | nindent 4 }}
   upgrade:
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.soperator.soperatorChecks.upgrade | nindent 4 }}
   interval: {{ .Values.soperator.soperatorChecks.interval }}
   timeout: {{ .Values.soperator.soperatorChecks.timeout }}
   releaseName: {{ .Values.soperator.soperatorChecks.releaseName }}

--- a/helm/soperator-fluxcd/templates/storageclasses.yaml
+++ b/helm/soperator-fluxcd/templates/storageclasses.yaml
@@ -21,14 +21,9 @@ spec:
   dependsOn:
   - name: {{ include "soperator-fluxcd.fullname" . }}-ns
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.storageClasses.install | nindent 4 }}
   upgrade:
-    crds: Skip
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.storageClasses.upgrade | nindent 4 }}
   interval: {{ .Values.storageClasses.interval }}
   timeout: {{ .Values.storageClasses.timeout }}
   releaseName: {{ .Values.storageClasses.releaseName }}

--- a/helm/soperator-fluxcd/templates/tailscale.yaml
+++ b/helm/soperator-fluxcd/templates/tailscale.yaml
@@ -19,13 +19,11 @@ spec:
         name: {{ include "soperator-fluxcd.fullname" . }}-bedag
       version: {{ .Values.tailscale.version }}
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.tailscale.install | nindent 4 }}
   interval: {{ .Values.tailscale.interval }}
   timeout: {{ .Values.tailscale.timeout }}
   upgrade:
-    crds: Skip
+    {{- toYaml .Values.tailscale.upgrade | nindent 4 }}
   values:
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/soperator-fluxcd/templates/victoria-metrics-operator-crds.yaml
+++ b/helm/soperator-fluxcd/templates/victoria-metrics-operator-crds.yaml
@@ -19,13 +19,8 @@ spec:
         name: {{ include "soperator-fluxcd.fullname" . }}-victoriametrics
       version: {{ .Values.observability.vmStack.crds.version }}
   install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
+    {{- toYaml .Values.observability.vmStack.crds.install | nindent 4 }}
   interval: {{ .Values.observability.vmStack.crds.interval }}
   upgrade:
-    crds: CreateReplace
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.observability.vmStack.crds.upgrade | nindent 4 }}
 {{- end }}

--- a/helm/soperator-fluxcd/templates/vm-logs.yaml
+++ b/helm/soperator-fluxcd/templates/vm-logs.yaml
@@ -19,18 +19,13 @@ spec:
         name: {{ include "soperator-fluxcd.fullname" . }}-victoriametrics
       version: 0.9.*
   install:
-    crds: CreateReplace
-    remediation:
-      retries: 3
+    {{- toYaml .Values.observability.vmLogs.install | nindent 4 }}
   interval: {{ .Values.observability.vmLogs.interval }}
   timeout: {{ .Values.observability.vmLogs.timeout }}
   releaseName: {{ .Values.observability.vmLogs.releaseName }}
   targetNamespace: {{ .Values.observability.vmLogs.namespace }}
   upgrade:
-    crds: CreateReplace
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.observability.vmLogs.upgrade | nindent 4 }}
   values:
   {{- if .Values.observability.vmStack.overrideValues }}
     {{- toYaml .Values.observability.vmStack.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -25,14 +25,9 @@ spec:
   {{- end }}
   - name: {{ include "soperator-fluxcd.fullname" . }}-victoria-metrics-operator-crds
   install:
-    crds: Skip
-    remediation:
-      retries: 3
+    {{- toYaml .Values.observability.vmStack.install | nindent 4 }}
   upgrade:
-    crds: Skip
-    remediation:
-      retries: 3
-      remediateLastFailure: true
+    {{- toYaml .Values.observability.vmStack.upgrade | nindent 4 }}
   interval: {{ .Values.observability.vmStack.interval }}
   timeout: {{ .Values.observability.vmStack.timeout }}
   releaseName: {{ .Values.observability.vmStack.releaseName }}

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -52,6 +52,15 @@ certManager:
   releaseName: cert-manager
   values: null
   overrideValues: null
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   driftDetection:
     mode: warn
 backup:
@@ -70,6 +79,15 @@ backup:
       repository: alpine/k8s
       tag: 1.34.0
   overrideValues: null
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   config:
     driftDetection:
       mode: warn
@@ -78,6 +96,13 @@ backup:
     timeout: 5m
     version: 1.23.0
     releaseName: soperator-backups
+    install:
+      remediation:
+        retries: 3
+    upgrade:
+      remediation:
+        retries: 3
+        remediateLastFailure: true
     values:
       secret:
         name: jail-backup
@@ -93,7 +118,25 @@ mariadbOperator:
   releaseName: mariadb-operator
   values: null
   overrideValues: null
+  install:
+    crds: Skip
+    remediation:
+      retries: 3
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   crds:
+    install:
+      crds: CreateReplace
+      remediation:
+        retries: 3
+    upgrade:
+      crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
     driftDetection:
       mode: warn
   driftDetection:
@@ -120,6 +163,13 @@ observability:
       version: 0.117.*
       interval: 15m
       timeout: 15m
+      install:
+        remediation:
+          retries: 3
+      upgrade:
+        remediation:
+          retries: 3
+          remediateLastFailure: true
       values:
         jailLogs:
           enabled: true
@@ -151,6 +201,13 @@ observability:
       version: 0.117.*
       interval: 5m
       timeout: 5m
+      install:
+        remediation:
+          retries: 3
+      upgrade:
+        remediation:
+          retries: 3
+          remediateLastFailure: true
       values:
         resources:
           requests:
@@ -175,6 +232,15 @@ observability:
       interval: 5m
       timeout: 5m
       version: 0.0.3
+      install:
+        crds: CreateReplace
+        remediation:
+          retries: 3
+      upgrade:
+        crds: CreateReplace
+        remediation:
+          retries: 3
+          remediateLastFailure: true
       driftDetection:
         mode: warn
     interval: 5m
@@ -182,6 +248,15 @@ observability:
     version: 0.39.*
     namespace: monitoring-system
     releaseName: metrics
+    install:
+      crds: Skip
+      remediation:
+        retries: 3
+    upgrade:
+      crds: Skip
+      remediation:
+        retries: 3
+        remediateLastFailure: true
     values:
       dashboardNamespaces:
         - soperator
@@ -250,6 +325,15 @@ observability:
     version: 0.9.*
     namespace: logs-system
     releaseName: vm-logs
+    install:
+      crds: CreateReplace
+      remediation:
+        retries: 3
+    upgrade:
+      crds: CreateReplace
+      remediation:
+        retries: 3
+        remediateLastFailure: true
     values:
       persistentVolume:
         enabled: true
@@ -271,6 +355,15 @@ observability:
     version: 3.0.1
     namespace: soperator
     releaseName: soperator-dcgm-exporter
+    install:
+      crds: CreateReplace
+      remediation:
+        retries: 3
+    upgrade:
+      crds: CreateReplace
+      remediation:
+        retries: 3
+        remediateLastFailure: true
     values:
       hpcJobMapDir: /var/run/nebius/slurm
       validateToolkit: true
@@ -289,6 +382,15 @@ securityProfilesOperator:
   version: 0.8.4-soperator
   releaseName: security-profiles-operator
   namespace: security-profiles-operator-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     daemon:
       resources:
@@ -316,6 +418,15 @@ slurmCluster:
   releaseName: soperator
   values: null
   overrideValues: null
+  install:
+    crds: Skip
+    remediation:
+      retries: 3
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   slurmClusterStorage:
     enabled: true
     releaseName: slurm-cluster-storage
@@ -323,6 +434,13 @@ slurmCluster:
     timeout: 5m
     values: null
     overrideValues: null
+    install:
+      remediation:
+        retries: 3
+    upgrade:
+      remediation:
+        retries: 3
+        remediateLastFailure: true
     driftDetection:
       mode: warn
   driftDetection:
@@ -338,6 +456,15 @@ nodesets:
   releaseName: soperator-nodesets
   values: null
   overrideValues: null
+  install:
+    crds: Skip
+    remediation:
+      retries: 3
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 3
+      remediateLastFailure: true
 soperatorActiveChecks:
   enabled: true
   interval: 5m
@@ -346,6 +473,15 @@ soperatorActiveChecks:
   releaseName: soperator-activechecks
   namespace: soperator
   overrideValues: null
+  install:
+    crds: Skip
+    remediation:
+      retries: 3
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   driftDetection:
     mode: warn
 soperator:
@@ -355,6 +491,16 @@ soperator:
   version: 3.0.1
   namespace: "soperator-system"
   releaseName: soperator-controller
+  featureGates: ""
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     serviceMonitor:
       enabled: true
@@ -372,6 +518,15 @@ soperator:
     timeout: 5m
     version: 1.8.0
     releaseName: soperator-kruise
+    install:
+      crds: CreateReplace
+      remediation:
+        retries: 3
+    upgrade:
+      crds: CreateReplace
+      remediation:
+        retries: 3
+        remediateLastFailure: true
     overrideValues:
       crds:
         managed: true
@@ -397,6 +552,13 @@ soperator:
     interval: 5m
     timeout: 5m
     releaseName: soperator-checks
+    install:
+      remediation:
+        retries: 3
+    upgrade:
+      remediation:
+        retries: 3
+        remediateLastFailure: true
     values: null
     overrideValues: null
     driftDetection:
@@ -406,6 +568,15 @@ soperator:
     interval: 5m
     timeout: 5m
     releaseName: soperator-node-configurator
+    install:
+      crds: Skip
+      remediation:
+        retries: 3
+    upgrade:
+      crds: Skip
+      remediation:
+        retries: 3
+        remediateLastFailure: true
     values:
       rebooter:
         resources:
@@ -423,6 +594,14 @@ soperator:
     timeout: 5m
     releaseName: soperator-monitoring-dashboards
     namespace: monitoring-system
+    install:
+      crds: Skip
+      remediation:
+        retries: 3
+    upgrade:
+      crds: Skip
+      remediation:
+        retries: 3
     overrideValues: null
     driftDetection:
       mode: warn
@@ -435,6 +614,13 @@ notifier:
   version: 3.0.1
   namespace: monitoring-system
   releaseName: soperator-notifier
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     slack:
       webhookUrl: null
@@ -449,6 +635,15 @@ csiDriverNfs:
   releaseName: csi-driver-nfs
   overrideValues: null
   values: null
+  install:
+    crds: Skip
+    remediation:
+      retries: 3
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   driftDetection:
     mode: warn
 nfsServer:
@@ -460,6 +655,15 @@ nfsServer:
   releaseName: nfs-server
   overrideValues: null
   values: null
+  install:
+    crds: Skip
+    remediation:
+      retries: 3
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   driftDetection:
     mode: warn
 storageClasses:
@@ -470,6 +674,15 @@ storageClasses:
   namespace: storage-system
   releaseName: soperator-storageclasses
   values: null
+  install:
+    crds: Skip
+    remediation:
+      retries: 3
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   driftDetection:
     mode: warn
 customConfigmaps:
@@ -481,6 +694,15 @@ customConfigmaps:
   releaseName: soperator-custom-configmaps
   overrideValues: null
   values: null
+  install:
+    crds: Skip
+    remediation:
+      retries: 3
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   driftDetection:
     mode: warn
 tailscale:
@@ -488,5 +710,14 @@ tailscale:
   interval: 5m
   timeout: 5m
   version: 2.0.0
+  install:
+    crds: Skip
+    remediation:
+      retries: 3
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   driftDetection:
     mode: warn


### PR DESCRIPTION
## Problem
install and upgrade sections in all FluxCD HelmRelease templates were hardcoded, making it impossible to tune CRD handling strategy or remediation retries without modifying templates directly.

## Solution
Extracted install and upgrade blocks into values.yaml for all HelmRelease resources in soperator-fluxcd. Templates now render these sections via toYaml.

## Testing
helm template ./helm/soperator-fluxcd  # renders without errors
helm unittest ./helm/soperator-fluxcd   # all tests pass


## Release Notes
Feature: install and upgrade settings (CRD strategy, remediation retries) for all FluxCD HelmReleases are now configurable via values.yaml. No breaking changes.