### PR TITLE
SCHED-993: Add workflow to trigger revert-latest-pr via PR comment

### DIFF
--- a/.github/workflows/revert_last_pr.yml
+++ b/.github/workflows/revert_last_pr.yml
@@ -1,0 +1,29 @@
+name: "Revert last PR in merge-to-main"
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  revert:
+    name: Revert last PR
+    if: |
+      github.event.issue.pull_request
+      && startsWith(github.event.issue.title, 'Merge to ')
+      && github.event.comment.body == '/revert-last-pr'
+    runs-on: self-hosted
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Revert last PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/workflows/scripts/revert-latest-pr.sh "${{ github.event.issue.number }}"

--- a/.github/workflows/scripts/auto-merge-back.sh
+++ b/.github/workflows/scripts/auto-merge-back.sh
@@ -133,7 +133,11 @@ create_pull_request() {
 
 # Original PR Description
 
-${PR_BODY}"
+${PR_BODY}
+
+---
+
+> You cannot skip this merge, but if you really don't want these changes (conflicts or doesn't make sense), just comment \`/revert-last-pr\`, and wait for the revert to come, then merge this PR (even if 0 changes)."
     else
         # Fallback for commits without PRs
         pr_body="This is merge back of commit ${COMMIT_SHORT_SHA} by @${USERNAME}
@@ -141,7 +145,11 @@ ${PR_BODY}"
 Commit message:
 \`\`\`
 ${COMMIT_MESSAGE}
-\`\`\`"
+\`\`\`
+
+---
+
+> You cannot skip this merge, but if you really don't want these changes (conflicts or doesn't make sense), just comment \`/revert-last-pr\`, and wait for the revert to come, then merge this PR (even if 0 changes)."
     fi
 
     # Create the PR

--- a/.github/workflows/scripts/revert-latest-pr.sh
+++ b/.github/workflows/scripts/revert-latest-pr.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+MERGE_PR="$1"
+WORKTREE_DIR=""
+
+cleanup() {
+  if [ -n "$WORKTREE_DIR" ] && [ -d "$WORKTREE_DIR" ]; then
+    echo "Cleaning up worktree..."
+    git worktree remove --force "$WORKTREE_DIR"
+  fi
+}
+trap cleanup EXIT
+
+ORIG_PR=$(gh pr view "$MERGE_PR" --json body -q '.body' \
+  | sed -n 's/.*Pull Request #\([0-9]*\).*/\1/p')
+if [ -z "$ORIG_PR" ]; then
+  echo "Error: could not find original PR number in PR #$MERGE_PR body"
+  exit 1
+fi
+echo "Original PR: #$ORIG_PR"
+
+MERGE_SHA=$(gh pr view "$ORIG_PR" --json mergeCommit -q '.mergeCommit.oid')
+if [ -z "$MERGE_SHA" ]; then
+  echo "Error: PR #$ORIG_PR has no merge commit (not merged yet?)"
+  exit 1
+fi
+echo "Merge commit: ${MERGE_SHA:0:7}"
+
+BRANCH=$(gh pr view "$MERGE_PR" --json headRefName -q '.headRefName')
+echo "Branch: $BRANCH"
+
+git fetch origin "$BRANCH"
+WORKTREE_DIR=$(mktemp -d)
+git worktree add "$WORKTREE_DIR" "origin/$BRANCH"
+
+pushd "$WORKTREE_DIR" > /dev/null
+git checkout -B "$BRANCH" "origin/$BRANCH"
+# Merge commits need -m 1 to specify which parent to revert to
+PARENT_COUNT=$(git cat-file -p "$MERGE_SHA" | grep -c '^parent ')
+if [ "$PARENT_COUNT" -gt 1 ]; then
+  echo "Merge commit detected, reverting with -m 1"
+  git revert --no-edit -m 1 "$MERGE_SHA"
+else
+  git revert --no-edit "$MERGE_SHA"
+fi
+popd > /dev/null
+
+git -C "$WORKTREE_DIR" push origin "$BRANCH"
+
+gh pr comment "$MERGE_PR" \
+  --body "Reverted changes from PR #$ORIG_PR (commit ${MERGE_SHA:0:7})"
+echo "Done. Reverted PR #$ORIG_PR on merge-to-main PR #$MERGE_PR"


### PR DESCRIPTION
## Problem

Sometimes merge-back doesn't make sense, e.g. when soperator version is changed in the release branch. In this case conflict resolution can be painful.

## Solution

Add revert_last_pr.yml workflow triggered by `/revert-last-pr` comment on merge-to-main PRs. Also add a hint about this command to the auto-merge-back PR body.
Then the release branch will be merged to `main`, although changes in the release branch will be reverted in `main`.
