### PR TITLE
SCHED-1039: Add CUDA-to-NCCL tests version mapping into the helm chart.

### DIFF
--- a/helm/soperator-activechecks/templates/_helpers.tpl
+++ b/helm/soperator-activechecks/templates/_helpers.tpl
@@ -82,6 +82,19 @@ Converts from format "reg#repo:tag" to format "reg/repo:tag".
 {{- end -}}
 
 {{/*
+Resolve NCCL tests version from cudaVersion.
+If .Values.ncclTestsVersion is non-empty, use it (flat override).
+Otherwise, look up from .Values.ncclTestsVersions map.
+*/}}
+{{- define "soperator-activechecks.ncclTestsVersion" -}}
+{{- if .Values.ncclTestsVersion -}}
+  {{- .Values.ncclTestsVersion -}}
+{{- else -}}
+  {{- required (printf "ncclTestsVersions must contain an entry for CUDA %s, or set ncclTestsVersion explicitly" .Values.cudaVersion) (index .Values.ncclTestsVersions (printf "%v" .Values.cudaVersion)) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Render script content from a file with optional tpl evaluation.
 */}}
 {{- define "soperator-activechecks.renderScript" -}}
@@ -175,7 +188,7 @@ Render k8sJobSpec for an ActiveCheck.
 {{- with $jobContainerRaw.extraEnv }}{{- $env = concat $env . -}}{{- end }}
 {{- if eq $workingDir "/opt/ansible" -}}
   {{- with $ctx.Values.cudaVersion }}{{ $env = concat $env (list (dict "name" "CUDA_VERSION" "value" (printf "%v" .))) -}}{{- end }}
-  {{- with $ctx.Values.ncclTestsVersion }}{{ $env = concat $env (list (dict "name" "NCCL_TESTS_VERSION" "value" (printf "%v" .))) -}}{{- end }}
+  {{- $env = concat $env (list (dict "name" "NCCL_TESTS_VERSION" "value" (include "soperator-activechecks.ncclTestsVersion" $ctx))) -}}
 {{- end -}}
 {{- $volumeMounts := default (list) $jobContainer.volumeMounts -}}
 {{- with $jobContainerRaw.extraVolumeMounts }}{{- $volumeMounts = concat $volumeMounts . -}}{{- end }}

--- a/helm/soperator-activechecks/tests/k8sjob_spec_test.yaml
+++ b/helm/soperator-activechecks/tests/k8sjob_spec_test.yaml
@@ -99,3 +99,159 @@ tests:
       - equal:
           path: spec.k8sJobSpec.jobContainer.appArmorProfile
           value: unconfined
+
+  - it: should resolve NCCL tests version from map for CUDA 12.9.0
+    documentSelector:
+      path: metadata.name
+      value: test-nccl-map-lookup
+    set:
+      slurmClusterRefName: test-cluster
+      cudaVersion: "12.9.0"
+      ncclTestsVersion: ""
+      ncclTestsVersions:
+        "12.9.0": "2.16.4"
+        "13.0.2": "2.17.6"
+      images:
+        k8sJob: "test-image:latest"
+        sansible: "sansible-image:latest"
+      jobContainer:
+        volumeMounts:
+          - mountPath: /mnt/jail
+            name: jail
+        volumes:
+          - name: jail
+            persistentVolumeClaim:
+              claimName: jail-pvc
+      checks:
+        test-nccl-map-lookup:
+          enabled: true
+          checkType: k8sJob
+          k8sJobSpec:
+            jobContainer:
+              workingDir: /opt/ansible
+              image: "{{ .Values.images.sansible }}"
+              command: ["echo", "test"]
+    asserts:
+      - isKind:
+          of: ActiveCheck
+      - contains:
+          path: spec.k8sJobSpec.jobContainer.env
+          content:
+            name: NCCL_TESTS_VERSION
+            value: "2.16.4"
+
+  - it: should resolve NCCL tests version from map for CUDA 13.0.2
+    documentSelector:
+      path: metadata.name
+      value: test-nccl-map-lookup-alt
+    set:
+      slurmClusterRefName: test-cluster
+      cudaVersion: "13.0.2"
+      ncclTestsVersion: ""
+      ncclTestsVersions:
+        "12.9.0": "2.16.4"
+        "13.0.2": "2.17.6"
+      images:
+        k8sJob: "test-image:latest"
+        sansible: "sansible-image:latest"
+        activeCheckImageRepository: "cr.eu-north1.nebius.cloud#ml-containers/training_diag"
+        activeCheckImageTags:
+          "13.0.2": "13.0.2-ubuntu24.04-20260206170007"
+      jobContainer:
+        volumeMounts:
+          - mountPath: /mnt/jail
+            name: jail
+        volumes:
+          - name: jail
+            persistentVolumeClaim:
+              claimName: jail-pvc
+      checks:
+        test-nccl-map-lookup-alt:
+          enabled: true
+          checkType: k8sJob
+          k8sJobSpec:
+            jobContainer:
+              workingDir: /opt/ansible
+              image: "{{ .Values.images.sansible }}"
+              command: ["echo", "test"]
+    asserts:
+      - isKind:
+          of: ActiveCheck
+      - contains:
+          path: spec.k8sJobSpec.jobContainer.env
+          content:
+            name: NCCL_TESTS_VERSION
+            value: "2.17.6"
+
+  - it: should use flat override when ncclTestsVersion is set
+    documentSelector:
+      path: metadata.name
+      value: test-nccl-flat-override
+    set:
+      slurmClusterRefName: test-cluster
+      cudaVersion: "12.9.0"
+      ncclTestsVersion: "2.99.0"
+      ncclTestsVersions:
+        "12.9.0": "2.16.4"
+      images:
+        k8sJob: "test-image:latest"
+        sansible: "sansible-image:latest"
+      jobContainer:
+        volumeMounts:
+          - mountPath: /mnt/jail
+            name: jail
+        volumes:
+          - name: jail
+            persistentVolumeClaim:
+              claimName: jail-pvc
+      checks:
+        test-nccl-flat-override:
+          enabled: true
+          checkType: k8sJob
+          k8sJobSpec:
+            jobContainer:
+              workingDir: /opt/ansible
+              image: "{{ .Values.images.sansible }}"
+              command: ["echo", "test"]
+    asserts:
+      - isKind:
+          of: ActiveCheck
+      - contains:
+          path: spec.k8sJobSpec.jobContainer.env
+          content:
+            name: NCCL_TESTS_VERSION
+            value: "2.99.0"
+
+  - it: should fail when CUDA version is not in ncclTestsVersions map
+    set:
+      slurmClusterRefName: test-cluster
+      cudaVersion: "99.0.0"
+      ncclTestsVersion: ""
+      ncclTestsVersions:
+        "12.9.0": "2.16.4"
+      images:
+        k8sJob: "test-image:latest"
+        sansible: "sansible-image:latest"
+        activeCheckImageRepository: "cr.eu-north1.nebius.cloud#ml-containers/training_diag"
+        activeCheckImageTags:
+          "99.0.0": "99.0.0-ubuntu24.04-20260206170007"
+      jobContainer:
+        volumeMounts:
+          - mountPath: /mnt/jail
+            name: jail
+        volumes:
+          - name: jail
+            persistentVolumeClaim:
+              claimName: jail-pvc
+      checks:
+        test-nccl-unknown-cuda:
+          enabled: true
+          checkType: k8sJob
+          k8sJobSpec:
+            jobContainer:
+              workingDir: /opt/ansible
+              image: "{{ .Values.images.sansible }}"
+              command: ["echo", "test"]
+    asserts:
+      - failedTemplate:
+          errorMessage: "ncclTestsVersions must contain an entry for CUDA 99.0.0, or set ncclTestsVersion explicitly"

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -1,7 +1,14 @@
 slurmClusterRefName: "soperator"
 # CUDA version used for active check image selection and for managing jail state
 cudaVersion: 12.9.0
-ncclTestsVersion: 2.16.4
+# Flat override: if non-empty, takes precedence over ncclTestsVersions map.
+ncclTestsVersion: ""
+# Per-CUDA default NCCL tests versions.
+# Source of truth: https://github.com/nebius/ml-containers/blob/main/ansible/roles/nccl-tests/defaults/main.yml
+# Update this map together with activeCheckImageTags when adding new CUDA versions.
+ncclTestsVersions:
+  "12.9.0": "2.16.4"
+  "13.0.2": "2.17.6"
 jobContainer:
   env:
     - name: "K8S_POD_NAME"


### PR DESCRIPTION

## Problem

Current `nccl_tests` version is not compatible with cuda13.0.2 driver preset.

## Solution

Introduce a mapping fro CUDA version to NCCL tests version.

## Testing

Successfully provisioned the cluster with the following terraform customization:

```
platform_cuda_versions = {
  "gpu-h200-sxm": "13.0.2"
}
platform_driver_presets = {
  "gpu-h200-sxm": "cuda13.0"
}
```

## Release Notes

Fix NCCL tests version for cuda13.0.2 driver preset (a mapping was added)