### PR TITLE
Increase Slurm controller conmgr_threads and max_connections

### DIFF
--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -318,9 +318,9 @@ func generateSlurmConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
 	res.AddProperty("TCPTimeout", 15)
 	res.AddProperty("WaitTime", 0)
 	if cluster.HasEphemeralNodes() {
-		res.AddProperty("SlurmctldParameters", "conmgr_max_connections=512,conmgr_threads=16,cloud_dns,idle_on_node_suspend")
+		res.AddProperty("SlurmctldParameters", "conmgr_max_connections=1024,conmgr_threads=32,cloud_dns,idle_on_node_suspend")
 	} else {
-		res.AddProperty("SlurmctldParameters", "conmgr_max_connections=512,conmgr_threads=16")
+		res.AddProperty("SlurmctldParameters", "conmgr_max_connections=1024,conmgr_threads=32")
 	}
 
 	res.AddProperty("RebootProgram", "/opt/bin/slurm/reboot.sh")


### PR DESCRIPTION
## Problem
There are warnings in Slurm controller logs when it runs on a 4vCPU VM:
```
warning: CONMGR_THREADS=16 is configured outside of the suggested range of [2, 8] for 4 CPUs. Performance will be negatively impacted, potentially causing difficult to debug hangs. Please keep within the suggested range or use the automatically detected thread count of 8 threads.
```
Also, sometimes the controller struggles with the load on relatively big clusters with hundreds of nodes.

## Solution
Use 16vCPU VMs by default and `SlurmctldParameters=conmgr_max_connections=1024,conmgr_threads=32` by default.

## Testing
-

## Release Notes
Increased the default value for max number of connections to the Slurm controller (512 -> 1024) and the number of connection management threads (16 -> 32).
