### PR TITLE
Add flock to custom pyxis caching importer

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/pyxis_caching_importer.sh
+++ b/helm/slurm-cluster/slurm_scripts/pyxis_caching_importer.sh
@@ -7,6 +7,7 @@ readonly cmd="$1"
 
 readonly cache_dir="${ENROOT_CONTAINER_IMAGES_CACHE_DIR:-/var/cache/enroot-container-images}"
 readonly squashfs_temp_path="${cache_dir}/${SLURM_JOB_ID}.${SLURM_STEP_ID}.sqsh"
+readonly lock_path="${squashfs_temp_path}.lock"
 
 # Since it's not an ephemeral squashfs file, we can use compression.
 export ENROOT_SQUASH_OPTIONS="-comp zstd -Xcompression-level 3 -b 1M"
@@ -28,6 +29,10 @@ case "${cmd}" in
             exit 1
         fi
         readonly squashfs_path="${cache_dir}/${digest}.sqsh"
+
+        # Serialize access to shared temp/output paths for this SLURM job step.
+        exec 9>"${lock_path}"
+        flock -x 9
 
         if [ ! -e "${squashfs_path}" ]; then
             # TODO: use `digest` approach once 406 Not Acceptable is tolerated in enroot
@@ -58,6 +63,10 @@ case "${cmd}" in
             echo "usage: $0 release" >&2
             exit 1
         fi
+
+        # Serialize cleanup with "get" so temp path isn't removed mid-import.
+        exec 9>"${lock_path}"
+        flock -x 9
 
         # Remove temporary file if still present (e.g. "get" was interrupted)
         rm -f "${squashfs_temp_path}"


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
When big job (16 tasks across 2 nodes), many tasks try to prepare the same container cache file at the same time.
Custom Pyxis importer script uses a non-safe temp-file flow, so tasks step on each other.
Result: corrupted/missing .sqsh file and the whole job fails before training starts.
Small one-task tests often pass because there is no race.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Add flock

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
