### PR TITLE
SCHED-1049: rallback topology controller and fixed bug with dynamic topology

### DIFF
--- a/images/worker/worker_init.py
+++ b/images/worker/worker_init.py
@@ -20,6 +20,7 @@ Environment Variables (wait-topology):
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -177,6 +178,59 @@ def get_topology_poll_interval() -> int:
     """Get the poll interval in seconds."""
     interval = os.environ.get("TOPOLOGY_POLL_INTERVAL", "5")
     return int(interval)
+
+
+def topology_conf_contains_hostname(topology_conf_path: str, hostname: str) -> bool:
+    """Check whether topology.conf contains the given hostname in a nodes list."""
+    if not os.path.isfile(topology_conf_path):
+        return False
+
+    try:
+        with open(topology_conf_path, "r") as f:
+            content = f.read()
+    except (IOError, OSError) as e:
+        logger.warning("Failed to read topology config %s: %s", topology_conf_path, e)
+        return False
+
+    # Match hostname as a full token separated by key/value, comma or whitespace boundaries.
+    pattern = rf"(^|[=,\s]){re.escape(hostname)}($|[,\s])"
+    return re.search(pattern, content, flags=re.MULTILINE) is not None
+
+
+def wait_for_hostname_in_topology_conf(
+    hostname: str, wait_timeout: int, poll_interval: int, topology_conf_path: str = "/etc/slurm/topology.conf"
+) -> None:
+    """Wait until topology.conf contains hostname, otherwise exit on timeout."""
+    logger.info(
+        "Waiting for hostname %s to appear in %s (timeout=%ds, poll=%ds)",
+        hostname,
+        topology_conf_path,
+        wait_timeout,
+        poll_interval,
+    )
+    start_time = time.time()
+    while True:
+        elapsed = time.time() - start_time
+        if elapsed >= wait_timeout:
+            logger.error(
+                "Hostname %s not found in %s after %ds",
+                hostname,
+                topology_conf_path,
+                wait_timeout,
+            )
+            sys.exit(1)
+
+        if topology_conf_contains_hostname(topology_conf_path, hostname):
+            logger.info("Hostname %s found in %s", hostname, topology_conf_path)
+            return
+
+        logger.info(
+            "Hostname %s is not in %s yet, retrying... (%ds elapsed)",
+            hostname,
+            topology_conf_path,
+            int(elapsed),
+        )
+        time.sleep(poll_interval)
 
 
 def read_topology_for_node(topology_path: str, node_name: str) -> str:
@@ -346,6 +400,9 @@ def wait_for_topology() -> None:
         logger.error("HOSTNAME environment variable is not set")
         sys.exit(1)
 
+    wait_timeout = get_topology_wait_timeout()
+    poll_interval = get_topology_poll_interval()
+
     if not is_gpu_enabled():
         logger.info(
             "NODESET_GPU_ENABLED is not set to 'true', "
@@ -356,8 +413,6 @@ def wait_for_topology() -> None:
 
     node_name = get_node_name()
     topology_path = get_topology_path()
-    wait_timeout = get_topology_wait_timeout()
-    poll_interval = get_topology_poll_interval()
 
     logger.info("Waiting for topology data for node: %s", node_name)
     logger.info("Topology ConfigMap path: %s", topology_path)
@@ -413,6 +468,7 @@ def wait_for_topology() -> None:
         logger.error("Failed to format topology from raw data: %s", raw_topology)
         sys.exit(1)
 
+    wait_for_hostname_in_topology_conf(hostname, wait_timeout, poll_interval)
     apply_node_topology(hostname, topology)
 
 

--- a/images/worker/worker_init_test.py
+++ b/images/worker/worker_init_test.py
@@ -585,27 +585,32 @@ class TestIsGpuEnabled(unittest.TestCase):
 class TestWaitForTopologyNonGpu(unittest.TestCase):
     """Tests for wait_for_topology non-GPU fast path."""
 
+    @mock.patch("worker_init.wait_for_hostname_in_topology_conf")
     @mock.patch("worker_init.apply_node_topology")
     @mock.patch("worker_init.is_gpu_enabled", return_value=False)
     @mock.patch.dict(os.environ, {"HOSTNAME": "worker-0"})
-    def test_non_gpu_applies_unknown_topology(self, mock_gpu, mock_apply):
+    def test_non_gpu_applies_unknown_topology(self, mock_gpu, mock_apply, mock_wait_hostname):
         """Non-GPU node immediately applies topology=default:root:unknown."""
         worker_init.wait_for_topology()
 
+        mock_wait_hostname.assert_called_once_with("worker-0", 180, 5)
         mock_apply.assert_called_once_with("worker-0", "topology=default:root:unknown")
 
+    @mock.patch("worker_init.wait_for_hostname_in_topology_conf")
     @mock.patch("worker_init.apply_node_topology")
     @mock.patch("worker_init.is_gpu_enabled", return_value=False)
     @mock.patch.dict(os.environ, {"HOSTNAME": "worker-0"})
-    def test_non_gpu_does_not_read_configmap(self, mock_gpu, mock_apply):
+    def test_non_gpu_does_not_read_configmap(self, mock_gpu, mock_apply, mock_wait_hostname):
         """Non-GPU node does not wait for ConfigMap at all."""
         with mock.patch("worker_init.read_topology_for_node") as mock_read:
             worker_init.wait_for_topology()
             mock_read.assert_not_called()
+        mock_wait_hostname.assert_called_once_with("worker-0", 180, 5)
 
+    @mock.patch("worker_init.wait_for_hostname_in_topology_conf")
     @mock.patch("worker_init.apply_node_topology")
     @mock.patch("worker_init.is_gpu_enabled", return_value=False)
-    def test_non_gpu_exits_if_hostname_not_set(self, mock_gpu, mock_apply):
+    def test_non_gpu_exits_if_hostname_not_set(self, mock_gpu, mock_apply, mock_wait_hostname):
         """Non-GPU node exits if HOSTNAME is not set."""
         env = os.environ.copy()
         env.pop("HOSTNAME", None)
@@ -613,7 +618,29 @@ class TestWaitForTopologyNonGpu(unittest.TestCase):
             with self.assertRaises(SystemExit) as ctx:
                 worker_init.wait_for_topology()
             self.assertEqual(ctx.exception.code, 1)
+        mock_wait_hostname.assert_not_called()
         mock_apply.assert_not_called()
+
+
+def test_topology_conf_contains_hostname_exact_token():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        topology_conf = os.path.join(temp_dir, "topology.conf")
+        with open(topology_conf, "w") as f:
+            f.write(
+                "SwitchName=root Switches=unknown\n"
+                "SwitchName=unknown Nodes=worker-0,worker-1\n"
+            )
+
+        assert worker_init.topology_conf_contains_hostname(topology_conf, "worker-0")
+
+
+def test_topology_conf_does_not_match_partial_hostname():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        topology_conf = os.path.join(temp_dir, "topology.conf")
+        with open(topology_conf, "w") as f:
+            f.write("SwitchName=unknown Nodes=worker-10\n")
+
+        assert not worker_init.topology_conf_contains_hostname(topology_conf, "worker-1")
 
 
 class TestTopologyIntegration(unittest.TestCase):

--- a/internal/controller/topologyconfcontroller/topology_blocks.go
+++ b/internal/controller/topologyconfcontroller/topology_blocks.go
@@ -1,0 +1,83 @@
+package topologyconfcontroller
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// TopologyBlocks represents a block topology.
+// https://slurm.schedmd.com/topology.html#block
+type TopologyBlocks struct {
+	blocks map[string][]string
+}
+
+func newTopologyBlocks() TopologyBlocks {
+	return TopologyBlocks{
+		blocks: make(map[string][]string),
+	}
+}
+
+func (b TopologyBlocks) AddNode(block, worker string) {
+	b.blocks[block] = append(b.blocks[block], worker)
+}
+
+// RenderConfigLines formats each populated block as a Slurm topology.conf line:
+//
+//	BlockName=<tier-0 label> Nodes=<comma-separated worker list>
+//
+// https://slurm.schedmd.com/topology.conf.html#SECTION_EXAMPLE
+func (b TopologyBlocks) RenderConfigLines() []string {
+	if len(b.blocks) == 0 {
+		return nil
+	}
+
+	lines := make([]string, 0, len(b.blocks))
+
+	for blockName, workers := range b.blocks {
+		if len(workers) == 0 {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("BlockName=%s Nodes=%s", blockName, strings.Join(workers, ",")))
+	}
+
+	return lines
+}
+
+// BuildTopologyBlocks groups worker pods by their "tier-0" node label into topology
+// blocks. Nodes without the label (or pods left without a labeled node) are assigned
+// to the synthetic "unknown" block so every pod is represented in the output.
+func BuildTopologyBlocks(
+	ctx context.Context, labelsByNode map[string]NodeTopologyLabels, podsByNode map[string][]string,
+) TopologyBlocks {
+	logger := log.FromContext(ctx).WithName(WorkerTopologyReconcilerName)
+	blocks := newTopologyBlocks()
+	podsByNode = maps.Clone(podsByNode)
+	for node, labels := range labelsByNode {
+		blockName, ok := labels["tier-0"]
+		if !ok {
+			logger.Error(nil, "missing tier-0 label for the block topology", "node", node)
+			continue
+		}
+
+		workers := podsByNode[node]
+		delete(podsByNode, node)
+
+		for _, worker := range workers {
+			blocks.AddNode(blockName, worker)
+		}
+	}
+
+	// Add rest of the pods for unknown blocks.
+	const unknownBlockName = "unknown"
+	for _, pods := range podsByNode {
+		for _, worker := range pods {
+			blocks.AddNode(unknownBlockName, worker)
+		}
+	}
+
+	return blocks
+}

--- a/internal/controller/topologyconfcontroller/topology_blocks_test.go
+++ b/internal/controller/topologyconfcontroller/topology_blocks_test.go
@@ -1,0 +1,85 @@
+package topologyconfcontroller_test
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	tc "nebius.ai/slurm-operator/internal/controller/topologyconfcontroller"
+)
+
+func TestBuildTopologyBlocks_GroupsWorkersByTierZero(t *testing.T) {
+	labelsByNode := map[string]tc.NodeTopologyLabels{
+		"node1": {"tier-0": "block-a"},
+		"node2": {"tier-0": "block-a"},
+		"node3": {"tier-0": "block-b"},
+	}
+	podsByNode := map[string][]string{
+		"node1": {"pod1", "pod2"},
+		"node2": {"pod3"},
+		"node3": {"pod4"},
+	}
+
+	blocks := tc.BuildTopologyBlocks(context.Background(), labelsByNode, podsByNode)
+	lines := blocks.RenderConfigLines()
+
+	require.True(t, len(lines) != 0, "expected non-empty block lines")
+	result := parseBlockLines(t, lines)
+	require.Equal(t, map[string][]string{
+		"block-a": {"pod1", "pod2", "pod3"},
+		"block-b": {"pod4"},
+	}, result)
+
+	require.Equal(t, map[string][]string{
+		"node1": {"pod1", "pod2"},
+		"node2": {"pod3"},
+		"node3": {"pod4"},
+	}, podsByNode, "BuildTopologyBlocks must not mutate the input podsByNode map")
+}
+
+func TestBuildTopologyBlocks_AssignsUnknownBlock(t *testing.T) {
+	labelsByNode := map[string]tc.NodeTopologyLabels{
+		"node1": {"tier-0": "block-a"},
+		"node2": {}, // missing tier-0 label
+	}
+	podsByNode := map[string][]string{
+		"node1": {"pod1"},
+		"node2": {"pod2"},
+		"node3": {"pod3"}, // node without labels entry
+	}
+
+	blocks := tc.BuildTopologyBlocks(context.Background(), labelsByNode, podsByNode)
+	result := parseBlockLines(t, blocks.RenderConfigLines())
+
+	require.Equal(t, map[string][]string{
+		"block-a": {"pod1"},
+		"unknown": {"pod2", "pod3"},
+	}, result)
+}
+
+func TestBuildTopologyBlocks_RenderEmpty(t *testing.T) {
+	blocks := tc.BuildTopologyBlocks(context.Background(), map[string]tc.NodeTopologyLabels{}, map[string][]string{})
+	require.Nil(t, blocks.RenderConfigLines())
+}
+
+func parseBlockLines(t *testing.T, lines []string) map[string][]string {
+	t.Helper()
+
+	result := make(map[string][]string, len(lines))
+	for _, line := range lines {
+		parts := strings.Split(line, " ")
+		require.Len(t, parts, 2, "unexpected block line format")
+
+		require.True(t, strings.HasPrefix(parts[0], "BlockName="), "unexpected block name")
+		require.True(t, strings.HasPrefix(parts[1], "Nodes="), "unexpected node list")
+
+		blockName := strings.TrimPrefix(parts[0], "BlockName=")
+		nodes := strings.Split(strings.TrimPrefix(parts[1], "Nodes="), ",")
+		slices.Sort(nodes)
+		result[blockName] = nodes
+	}
+	return result
+}

--- a/internal/controller/topologyconfcontroller/topology_graph.go
+++ b/internal/controller/topologyconfcontroller/topology_graph.go
@@ -1,0 +1,188 @@
+package topologyconfcontroller
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// TopologyGraph represents a network topology as a single tree with two types of vertices:
+//
+// 1. SWITCHES: Infrastructure nodes (spine, leaf, core switches) that represent network hierarchy.
+//   - Always have children (either other switches or worker nodes)
+//   - Are rendered as "SwitchName=X Switches=..." or "SwitchName=X Nodes=..." lines
+//   - Form the hierarchical backbone of the network topology
+//
+// 2. WORKERS: Compute nodes that execute Slurm jobs.
+//   - Have no children (leaf nodes in the tree)
+//   - Are NOT rendered as separate configuration lines
+//   - Only appear in "Nodes=" lists of their parent switches
+//
+// The graph maintains a single tree structure (using artificial "root" if needed) to ensure
+// strong connectivity - this is required for Slurm to schedule jobs across all nodes.
+type TopologyGraph struct {
+	// children[vertex] is set of children of a vertex.
+	children map[string]map[string]struct{}
+}
+
+func newTopologyGraph() TopologyGraph {
+	return TopologyGraph{
+		children: make(map[string]map[string]struct{}),
+	}
+}
+
+func (g TopologyGraph) AddEdge(parent, child string) {
+	if _, ok := g.children[parent]; !ok {
+		g.children[parent] = make(map[string]struct{})
+	}
+	g.children[parent][child] = struct{}{}
+}
+
+// ensureSingleRoot ensures the topology forms a single tree by adding all parentless switches
+// as children of a single "root" switch. This is required for Slurm's strong connectivity
+// requirement - all nodes must be reachable from each other for job scheduling to work.
+func (g TopologyGraph) ensureSingleRoot() {
+	// Find all nodes that have parents
+	hasParent := make(map[string]bool)
+	for _, children := range g.children {
+		for child := range children {
+			hasParent[child] = true
+		}
+	}
+
+	// Collect all parentless switches (except "root" itself)
+	var rootChildren []string
+	for switch_ := range g.children {
+		if !hasParent[switch_] && switch_ != "root" {
+			rootChildren = append(rootChildren, switch_)
+		}
+	}
+
+	// Always connect top-level switches to a synthetic "root" switch.
+	// This guarantees a stable single-root tree in topology.conf.
+	if len(rootChildren) > 0 {
+		// Sort children for consistent output
+		slices.Sort(rootChildren)
+		for _, child := range rootChildren {
+			g.AddEdge("root", child)
+		}
+	}
+}
+
+// RenderConfigLines renders only SWITCH vertices as Slurm topology configuration lines.
+// WORKER vertices (leaves) are not rendered as separate lines - they only appear in
+// "Nodes=" lists of their parent switches.
+//
+// The format is:
+//
+//	SwitchName=<switch_name> Switches=<child1,child2,...>  (if children are switches)
+//	SwitchName=<switch_name> Nodes=<child1,child2,...>     (if children are workers)
+//
+// This distinction is critical: switches with grandchildren use "Switches=",
+// while switches with only worker children use "Nodes=".
+func (g TopologyGraph) RenderConfigLines() []string {
+	var lines []string
+	for parent, childrenSet := range g.children {
+		if len(childrenSet) == 0 {
+			continue // Skip leaves (worker nodes).
+		}
+		hasGrandChildren := false
+		children := make([]string, 0, len(childrenSet))
+		for child := range childrenSet {
+			if len(g.children[child]) > 0 {
+				hasGrandChildren = true
+			}
+			children = append(children, child)
+		}
+		slices.Sort(children)
+		if hasGrandChildren {
+			lines = append(lines, fmt.Sprintf("SwitchName=%s Switches=%s", parent, strings.Join(children, ",")))
+		} else {
+			lines = append(lines, fmt.Sprintf("SwitchName=%s Nodes=%s", parent, strings.Join(children, ",")))
+		}
+	}
+	slices.Sort(lines)
+	return lines
+}
+
+// BuildTopologyGraph constructs a single tree topology from node labels and pod assignments.
+// Only nodes with actual pod assignments create topology edges - nodes with labels but no
+// pods are ignored to prevent "invalid child" errors in Slurm.
+//
+// The tree construction ensures strong connectivity required for Slurm job scheduling.
+func BuildTopologyGraph(
+	ctx context.Context, labelsByNode map[string]NodeTopologyLabels, podsByNode map[string][]string,
+) TopologyGraph {
+	logger := log.FromContext(ctx).WithName(WorkerTopologyReconcilerName)
+	graph := newTopologyGraph()
+	podsByNode = maps.Clone(podsByNode)
+	for node, labels := range labelsByNode {
+		pathToRoot, err := labelsToPath(labels)
+		if err != nil {
+			logger.Error(err, "Invalid node topology labels", "node", node, "labels", labels)
+			continue
+		}
+
+		workers := podsByNode[node]
+		delete(podsByNode, node)
+
+		// Only create topology edges if this node has workers
+		if len(workers) > 0 {
+			for _, worker := range workers {
+				graph.AddEdge(pathToRoot[0], worker)
+			}
+			for i := range len(pathToRoot) - 1 {
+				graph.AddEdge(pathToRoot[i+1], pathToRoot[i])
+			}
+		}
+	}
+
+	// Add rest of the pods for unknown nodes.
+	const unknownSwitchName = "unknown"
+	for _, pods := range podsByNode {
+		for _, worker := range pods {
+			graph.AddEdge(unknownSwitchName, worker)
+		}
+	}
+
+	// Ensure all top-level switches are under a single root
+	graph.ensureSingleRoot()
+
+	return graph
+}
+
+// labelsToPath converts labels to a path to the root of the topology tree.
+// E.g.:
+//
+//	labels = map[string]string{"tier-1": "switch1", "tier-2": "switch2", "tier-3": "switch3"}
+//	returns ["switch1", "switch2", "switch3"] (from lowest to highest tier)
+//
+// The labels must be in the format "tier-N" where N is a positive integer starting from 1.
+// If any label is missing (or empty), it returns an error.
+// In case of "tier-0" label provided - we ignore it and check only remaining "tier-N" labels.
+// ("tier-0" used for defining block, not IB topology)
+func labelsToPath(labels map[string]string) ([]string, error) {
+	if len(labels) == 0 {
+		return nil, fmt.Errorf("no labels found for node")
+	}
+	pathToRoot := make([]string, 0, len(labels))
+
+	numOfTiers := len(labels)
+	if _, hasTierZero := labels["tier-0"]; hasTierZero {
+		numOfTiers--
+	}
+	for i := range numOfTiers {
+		key := "tier-" + strconv.Itoa(i+1)
+		curTierLabel := labels[key]
+		if curTierLabel == "" {
+			return nil, fmt.Errorf("missing label %q", key)
+		}
+		pathToRoot = append(pathToRoot, curTierLabel)
+	}
+	return pathToRoot, nil
+}

--- a/internal/controller/topologyconfcontroller/topology_graph_test.go
+++ b/internal/controller/topologyconfcontroller/topology_graph_test.go
@@ -1,0 +1,352 @@
+package topologyconfcontroller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	tc "nebius.ai/slurm-operator/internal/controller/topologyconfcontroller"
+)
+
+func TestRenderTopologyConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		labelsByNode map[string]tc.NodeTopologyLabels
+		podsByNode   map[string][]string
+		expected     []string
+	}{
+		{
+			name: "With root node - combined tier1 and higher tiers",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "switch1", "tier-2": "spine1"},
+				"node2": {"tier-1": "switch2", "tier-2": "spine2"},
+				"node3": {"tier-1": "switch1", "tier-2": "spine3"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"pod1", "pod2"},
+				"node2": {"pod3"},
+				"node3": {"pod4"},
+				"":      {"pod5", "pod6"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=spine1,spine2,spine3,unknown",
+				"SwitchName=spine1 Switches=switch1",
+				"SwitchName=spine2 Switches=switch2",
+				"SwitchName=spine3 Switches=switch1",
+				"SwitchName=switch1 Nodes=pod1,pod2,pod4",
+				"SwitchName=switch2 Nodes=pod3",
+				"SwitchName=unknown Nodes=pod5,pod6",
+			},
+		},
+		{
+			name: "With root node and tier-0 label - combined tier1 and higher tiers",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-0": "block0", "tier-1": "switch1", "tier-2": "spine1"},
+				"node2": {"tier-0": "block0", "tier-1": "switch2", "tier-2": "spine2"},
+				"node3": {"tier-0": "block0", "tier-1": "switch1", "tier-2": "spine3"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"pod1", "pod2"},
+				"node2": {"pod3"},
+				"node3": {"pod4"},
+				"":      {"pod5", "pod6"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=spine1,spine2,spine3,unknown",
+				"SwitchName=spine1 Switches=switch1",
+				"SwitchName=spine2 Switches=switch2",
+				"SwitchName=spine3 Switches=switch1",
+				"SwitchName=switch1 Nodes=pod1,pod2,pod4",
+				"SwitchName=switch2 Nodes=pod3",
+				"SwitchName=unknown Nodes=pod5,pod6",
+			},
+		},
+		{
+			name: "Without root node - combined tier1 and higher tiers",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "switch1", "tier-2": "spine1"},
+				"node2": {"tier-1": "switch2", "tier-2": "spine2"},
+				"node3": {"tier-1": "switch1", "tier-2": "spine3"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"pod1", "pod2"},
+				"node2": {"pod3"},
+				"node3": {"pod4"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=spine1,spine2,spine3",
+				"SwitchName=spine1 Switches=switch1",
+				"SwitchName=spine2 Switches=switch2",
+				"SwitchName=spine3 Switches=switch1",
+				"SwitchName=switch1 Nodes=pod1,pod2,pod4",
+				"SwitchName=switch2 Nodes=pod3",
+			},
+		},
+		{
+			name: "Complex 3-tier topology",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "switch0", "tier-2": "leaf1", "tier-3": "spine1"},
+				"node2": {"tier-1": "switch1", "tier-2": "leaf1", "tier-3": "spine1"},
+				"node3": {"tier-1": "switch2", "tier-2": "leaf2", "tier-3": "spine1"},
+				"node4": {"tier-1": "switch3", "tier-2": "leaf3", "tier-3": "spine3"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"node1"},
+				"node2": {"node2"},
+				"node3": {"node3"},
+				"node4": {"node4"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=spine1,spine3",
+				"SwitchName=leaf1 Switches=switch0,switch1",
+				"SwitchName=leaf2 Switches=switch2",
+				"SwitchName=leaf3 Switches=switch3",
+				"SwitchName=spine1 Switches=leaf1,leaf2",
+				"SwitchName=spine3 Switches=leaf3",
+				"SwitchName=switch0 Nodes=node1",
+				"SwitchName=switch1 Nodes=node2",
+				"SwitchName=switch2 Nodes=node3",
+				"SwitchName=switch3 Nodes=node4",
+			},
+		},
+		{
+			name: "Single tier topology",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "switch1"},
+				"node2": {"tier-1": "switch2"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"node1"},
+				"node2": {"node2"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=switch1,switch2",
+				"SwitchName=switch1 Nodes=node1",
+				"SwitchName=switch2 Nodes=node2",
+			},
+		},
+		{
+			name:         "Empty topology",
+			labelsByNode: map[string]tc.NodeTopologyLabels{},
+			podsByNode:   map[string][]string{},
+			expected:     []string{},
+		},
+		{
+			name: "Two tier topology",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "switch1", "tier-2": "spine1"},
+				"node2": {"tier-1": "switch2", "tier-2": "spine1"},
+				"node3": {"tier-1": "switch3", "tier-2": "spine2"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"node1"},
+				"node2": {"node2"},
+				"node3": {"node3"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=spine1,spine2",
+				"SwitchName=spine1 Switches=switch1,switch2",
+				"SwitchName=spine2 Switches=switch3",
+				"SwitchName=switch1 Nodes=node1",
+				"SwitchName=switch2 Nodes=node2",
+				"SwitchName=switch3 Nodes=node3",
+			},
+		},
+		{
+			name: "Four tier topology",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "switch1", "tier-2": "leaf1", "tier-3": "spine1", "tier-4": "core1"},
+				"node2": {"tier-1": "switch2", "tier-2": "leaf1", "tier-3": "spine1", "tier-4": "core1"},
+				"node3": {"tier-1": "switch3", "tier-2": "leaf2", "tier-3": "spine2", "tier-4": "core2"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"node1"},
+				"node2": {"node2"},
+				"node3": {"node3"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=core1,core2",
+				"SwitchName=core1 Switches=spine1",
+				"SwitchName=core2 Switches=spine2",
+				"SwitchName=leaf1 Switches=switch1,switch2",
+				"SwitchName=leaf2 Switches=switch3",
+				"SwitchName=spine1 Switches=leaf1",
+				"SwitchName=spine2 Switches=leaf2",
+				"SwitchName=switch1 Nodes=node1",
+				"SwitchName=switch2 Nodes=node2",
+				"SwitchName=switch3 Nodes=node3",
+			},
+		},
+		{
+			name: "Incomplete tier topology",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "switch1", "tier-2": "leaf1", "tier-3": "spine1"},
+				"node2": {"tier-1": "switch2", "tier-2": "leaf1"},
+				"node3": {"tier-1": "switch3"},
+				"node4": {"tier-2": "leaf2", "tier-3": "spine2"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"node1"},
+				"node2": {"node2"},
+				"node3": {"node3"},
+				"node4": {"node4"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=spine1,switch3,unknown",
+				"SwitchName=leaf1 Switches=switch1,switch2",
+				"SwitchName=spine1 Switches=leaf1",
+				"SwitchName=switch1 Nodes=node1",
+				"SwitchName=switch2 Nodes=node2",
+				"SwitchName=switch3 Nodes=node3",
+				"SwitchName=unknown Nodes=node4",
+			},
+		},
+		{
+			name: "Duplicate devices in same tier",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "switch1", "tier-2": "leaf1"},
+				"node2": {"tier-1": "switch1", "tier-2": "leaf1"},
+				"node3": {"tier-1": "switch2", "tier-2": "leaf1"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"node1"},
+				"node2": {"node2"},
+				"node3": {"node3"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=leaf1",
+				"SwitchName=leaf1 Switches=switch1,switch2",
+				"SwitchName=switch1 Nodes=node1,node2",
+				"SwitchName=switch2 Nodes=node3",
+			},
+		},
+		{
+			name: "Complex topology with many connections",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "switch1", "tier-2": "leaf1"},
+				"node2": {"tier-1": "switch2", "tier-2": "leaf2"},
+				"node3": {"tier-1": "switch3", "tier-2": "leaf3"},
+				"node4": {"tier-1": "switch4", "tier-2": "leaf1"},
+				"node5": {"tier-1": "switch5", "tier-2": "leaf2"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"node1"},
+				"node2": {"node2"},
+				"node3": {"node3"},
+				"node4": {"node4"},
+				"node5": {"node5"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=leaf1,leaf2,leaf3",
+				"SwitchName=leaf1 Switches=switch1,switch4",
+				"SwitchName=leaf2 Switches=switch2,switch5",
+				"SwitchName=leaf3 Switches=switch3",
+				"SwitchName=switch1 Nodes=node1",
+				"SwitchName=switch2 Nodes=node2",
+				"SwitchName=switch3 Nodes=node3",
+				"SwitchName=switch4 Nodes=node4",
+				"SwitchName=switch5 Nodes=node5",
+			},
+		},
+		{
+			name: "Empty tier values",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "", "tier-2": "leaf1"},
+				"node2": {"tier-1": "switch1", "tier-2": ""},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"node1"},
+				"node2": {"node2"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=unknown",
+				"SwitchName=unknown Nodes=node1,node2",
+			},
+		},
+		{
+			name: "Single node per tier level",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "switch1", "tier-2": "leaf1", "tier-3": "spine1"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"node1"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=spine1",
+				"SwitchName=leaf1 Switches=switch1",
+				"SwitchName=spine1 Switches=leaf1",
+				"SwitchName=switch1 Nodes=node1",
+			},
+		},
+		{
+			name: "Check result sorting",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "z-switch", "tier-2": "z-leaf"},
+				"node2": {"tier-1": "a-switch", "tier-2": "a-leaf"},
+				"node3": {"tier-1": "m-switch", "tier-2": "m-leaf"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"node1"},
+				"node2": {"node2"},
+				"node3": {"node3"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=a-leaf,m-leaf,z-leaf",
+				"SwitchName=a-leaf Switches=a-switch",
+				"SwitchName=a-switch Nodes=node2",
+				"SwitchName=m-leaf Switches=m-switch",
+				"SwitchName=m-switch Nodes=node3",
+				"SwitchName=z-leaf Switches=z-switch",
+				"SwitchName=z-switch Nodes=node1",
+			},
+		},
+		{
+			name: "Multiple pods per node",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "switch1", "tier-2": "spine1"},
+				"node2": {"tier-1": "switch2", "tier-2": "spine1"},
+			},
+			podsByNode: map[string][]string{
+				"node1": {"pod1", "pod2", "pod3"},
+				"node2": {"pod4", "pod5"},
+				"":      {"pod6"},
+			},
+			expected: []string{
+				"SwitchName=root Switches=spine1,unknown",
+				"SwitchName=spine1 Switches=switch1,switch2",
+				"SwitchName=switch1 Nodes=pod1,pod2,pod3",
+				"SwitchName=switch2 Nodes=pod4,pod5",
+				"SwitchName=unknown Nodes=pod6",
+			},
+		},
+		{
+			name: "Nodes with missing pod assignments should not create invalid switches",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {"tier-1": "leaf-A", "tier-2": "spine-X"},
+				"node2": {"tier-1": "leaf-B", "tier-2": "spine-X"},
+				"node3": {"tier-1": "leaf-C", "tier-2": "spine-X"}, // This node has no pods!
+			},
+			podsByNode: map[string][]string{
+				"node1": {"worker-1"},
+				"node2": {"worker-2"},
+				// "node3" is missing - this should not create invalid topology
+			},
+			expected: []string{
+				// This is what SHOULD be generated (without leaf-C):
+				"SwitchName=root Switches=spine-X",
+				"SwitchName=leaf-A Nodes=worker-1",
+				"SwitchName=leaf-B Nodes=worker-2",
+				"SwitchName=spine-X Switches=leaf-A,leaf-B", // Should NOT include leaf-C
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			graph := tc.BuildTopologyGraph(context.Background(), tt.labelsByNode, tt.podsByNode)
+			result := graph.RenderConfigLines()
+			require.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/controller/topologyconfcontroller/workertopology_controller.go
+++ b/internal/controller/topologyconfcontroller/workertopology_controller.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -29,7 +28,6 @@ import (
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"nebius.ai/slurm-operator/api/v1alpha1"
-	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
 	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/controllerconfig"
 	"nebius.ai/slurm-operator/internal/utils/resourcegetter"
@@ -77,10 +75,10 @@ func NewWorkerTopologyReconciler(
 }
 
 func (r *WorkerTopologyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx).WithName(WorkerTopologyReconcilerName)
-	logger.Info(
-		"Starting reconciliation", "SlurmCluster", req.Name, "Namespace", req.Namespace,
+	logger := log.FromContext(ctx).WithName(WorkerTopologyReconcilerName).WithValues(
+		"SlurmCluster", req.Name, "Namespace", req.Namespace,
 	)
+	logger.Info("Starting reconciliation")
 
 	slurmCluster := &slurmv1.SlurmCluster{}
 	if err := r.Client.Get(ctx, req.NamespacedName, slurmCluster); err != nil {
@@ -93,20 +91,35 @@ func (r *WorkerTopologyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return DefaultRequeueResult, nil
 	}
 
-	existing, err := r.getNodeTopologyLabelsConfigMap(ctx, req, logger)
+	logger.V(1).Info("Fetching nodeSetList for SlurmCluster")
+	nodeSetList, err := resourcegetter.ListNodeSetsByClusterRef(
+		ctx, r.Client, types.NamespacedName{Namespace: req.Namespace, Name: slurmCluster.Name},
+	)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("get node topology labels ConfigMap: %w", err)
+		return ctrl.Result{}, fmt.Errorf("list NodeSets: %w", err)
 	}
-	logger.Info("Retrieved node topology labels ConfigMap", "configMap", existing.Name, "namespace", existing.Namespace)
 
-	desired, err := r.buildNodeSetTopologyConfig(ctx, req.Namespace, slurmCluster)
+	logger.V(1).Info("Fetched NodeSets for SlurmCluster", "count", len(nodeSetList))
+
+	existingTopologyConfig, err := r.EnsureWorkerTopologyConfigMap(ctx, req.Namespace, logger)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("ensure worker topology ConfigMap: %w", err)
+	}
+
+	desiredTopology, err := r.buildNodeSetTopologyConfig(ctx, req.Namespace, slurmCluster, nodeSetList)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("build NodeSet topology config: %w", err)
 	}
-	logger.Info("Built topology config", "topologyConfig", desired)
+	if desiredTopology == "" {
+		return ctrl.Result{}, fmt.Errorf("built empty topology config")
+	}
 
-	existingTopologyConfig := existing.Data[consts.ConfigMapKeyTopologyConfig]
-	if r.calculateConfigHash(desired) == r.calculateConfigHash(existingTopologyConfig) {
+	existingTopology := existingTopologyConfig.Data[consts.ConfigMapKeyTopologyConfig]
+
+	desiredHash := r.calculateConfigHash(desiredTopology)
+	existingHash := r.calculateConfigHash(existingTopology)
+
+	if desiredHash == existingHash {
 		logger.Info("Topology config unchanged, skipping update")
 		if err := r.ensureJailedConfig(ctx, req.Namespace); err != nil {
 			return ctrl.Result{}, fmt.Errorf("ensure JailedConfig: %w", err)
@@ -114,7 +127,7 @@ func (r *WorkerTopologyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return DefaultRequeueResult, nil
 	}
 
-	if err := r.updateTopologyConfigMap(ctx, req.Namespace, desired); err != nil {
+	if err := r.updateTopologyConfigMap(ctx, req.Namespace, desiredTopology); err != nil {
 		logger.Error(err, "Update ConfigMap with topology config")
 		return ctrl.Result{}, fmt.Errorf("update ConfigMap with topology config: %w", err)
 	}
@@ -123,26 +136,83 @@ func (r *WorkerTopologyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return DefaultRequeueResult, nil
 }
 
+// isClusterReconciliationNeeded checks if the SlurmCluster requires topology reconciliation based on its SlurmConfig.TopologyPlugin setting.
 func isClusterReconciliationNeeded(slurmCluster *slurmv1.SlurmCluster) bool {
 	return slurmCluster.Spec.SlurmConfig.TopologyPlugin == consts.SlurmTopologyTree ||
 		slurmCluster.Spec.SlurmConfig.TopologyPlugin == consts.SlurmTopologyBlock
 }
 
-func (r *WorkerTopologyReconciler) getNodeTopologyLabelsConfigMap(
-	ctx context.Context, req ctrl.Request, logger logr.Logger) (*corev1.ConfigMap, error) {
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: ctrl.ObjectMeta{
-			Name:      consts.ConfigMapNameTopologyNodeLabels,
-			Namespace: r.namespace,
-		},
+// EnsureWorkerTopologyConfigMap checks if the topology ConfigMap and JailedConfig exist, and creates them if they don't.
+func (r *WorkerTopologyReconciler) EnsureWorkerTopologyConfigMap(
+	ctx context.Context, namespace string, logger logr.Logger,
+) (*corev1.ConfigMap, error) {
+	configMapKey := client.ObjectKey{Name: consts.ConfigMapNameTopologyConfig, Namespace: namespace}
+	jailedConfigKey := client.ObjectKey{Name: consts.ConfigMapNameTopologyConfig, Namespace: namespace}
+
+	configMap := &corev1.ConfigMap{}
+	configMapExists := true
+	err := r.Client.Get(ctx, configMapKey, configMap)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			configMapExists = false
+			logger.Info("Worker topology ConfigMap not found")
+		} else {
+			return nil, fmt.Errorf("get ConfigMap %s: %w", consts.ConfigMapNameTopologyConfig, err)
+		}
 	}
 
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(configMap), configMap); err != nil {
-		return configMap, fmt.Errorf("get node topology labels config map in namespace %q: %w", req.Namespace, err)
+	jailedConfig := &v1alpha1.JailedConfig{}
+	jailedConfigExists := true
+	err = r.Client.Get(ctx, jailedConfigKey, jailedConfig)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			jailedConfigExists = false
+			logger.Info("Worker topology JailedConfig not found")
+		} else {
+			return nil, fmt.Errorf("get JailedConfig %s: %w", consts.ConfigMapNameTopologyConfig, err)
+		}
 	}
 
-	logger.Info("Node topology labels ConfigMap found", "configMap", configMap.Name, "namespace", configMap.Namespace)
+	if !configMapExists || !jailedConfigExists {
+		logger.Info("Creating missing topology resources",
+			"configMapExists", configMapExists,
+			"jailedConfigExists", jailedConfigExists)
+
+		if err = r.createDefaultTopologyResources(ctx, namespace); err != nil {
+			return nil, fmt.Errorf("create default topology resources in namespace %q: %w", namespace, err)
+		}
+
+		if err := r.Client.Get(ctx, configMapKey, configMap); err != nil {
+			return nil, fmt.Errorf("get config map after creation in namespace %q: %w", namespace, err)
+		}
+
+		logger.Info("Created and retrieved topology resources",
+			"configMap", configMap.Name,
+			"namespace", configMap.Namespace)
+	}
+
 	return configMap, nil
+}
+
+// createDefaultTopologyResources creates both ConfigMap and JailedConfig resources for topology configuration with default values.
+func (r *WorkerTopologyReconciler) createDefaultTopologyResources(ctx context.Context, namespace string,
+) error {
+
+	// Create ConfigMap
+	configMap := r.renderTopologyConfigMap(namespace, "SwitchName=root")
+	err := r.Client.Create(ctx, configMap)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create ConfigMap %s: %w", configMap.Name, err)
+	}
+
+	// Create JailedConfig
+	jailedConfig := r.renderTopologyJailedConfig(namespace)
+	err = r.Client.Create(ctx, jailedConfig)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create JailedConfig %s: %w", jailedConfig.Name, err)
+	}
+
+	return nil
 }
 
 func (r *WorkerTopologyReconciler) renderTopologyConfigMap(namespace string, config string) *corev1.ConfigMap {
@@ -184,59 +254,145 @@ func (r *WorkerTopologyReconciler) renderTopologyJailedConfig(namespace string) 
 					Path: filepath.Join("/etc/slurm/", consts.ConfigMapKeyTopologyConfig),
 				},
 			},
-			UpdateActions: []v1alpha1.UpdateAction{v1alpha1.UpdateActionReconfigure},
+			UpdateActions: []v1alpha1.UpdateAction{},
 		},
 	}
 }
 
-// BuildNodeSetTopologyConf builds a topology config for the NodeSet mode.
-// All workers are placed under a single "unknown" switch with "root" as the parent.
-func BuildNodeSetTopologyConf(nodeSetsList []slurmv1alpha1.NodeSet) string {
-	var nodes []string
-	for _, ns := range nodeSetsList {
-		if ns.Spec.Replicas <= 0 {
-			continue
-		}
-		nodes = append(nodes, formatNodeRange(ns.Name, int(ns.Spec.Replicas)))
-	}
-
-	if len(nodes) == 0 {
-		return "SwitchName=root Switches=unknown\nSwitchName=unknown"
-	}
-
-	return "SwitchName=root Switches=unknown\nSwitchName=unknown Nodes=" + strings.Join(nodes, ",")
-}
-
-// formatNodeRange formats a node name with Slurm range notation.
-// For 1 replica: "worker-0", for multiple: "worker-[0-N]".
-func formatNodeRange(name string, replicas int) string {
-	if replicas == 1 {
-		return name + "-0"
-	}
-	return name + "-[0-" + strconv.Itoa(replicas-1) + "]"
-}
-
 // buildNodeSetTopologyConfig builds the topology config from NodeSets or worker.Size.
 func (r *WorkerTopologyReconciler) buildNodeSetTopologyConfig(
-	ctx context.Context, namespace string, slurmCluster *slurmv1.SlurmCluster,
+	ctx context.Context, namespace string, slurmCluster *slurmv1.SlurmCluster, nodeSetList []v1alpha1.NodeSet,
 ) (string, error) {
-	nodeSetsList, err := resourcegetter.ListNodeSetsByClusterRef(
-		ctx, r.Client, types.NamespacedName{Namespace: namespace, Name: slurmCluster.Name},
-	)
+	nodeTopologyCM, err := r.getNodeTopologyLabelsConfigMap(ctx)
 	if err != nil {
-		return "", fmt.Errorf("list NodeSets: %w", err)
+		return "", fmt.Errorf("get node topology labels config map: %w", err)
 	}
 
-	return BuildNodeSetTopologyConf(nodeSetsList), nil
+	pods, err := r.CollectRunningWorkerPods(ctx, nodeSetList, slurmCluster.Name, namespace)
+	if err != nil {
+		return "", fmt.Errorf("collect running worker pods: %w", err)
+	}
+	podsByNode := r.GroupPodNamesByNode(pods)
+
+	if slurmCluster.Spec.SlurmConfig.TopologyPlugin == consts.SlurmTopologyBlock {
+		var blockSize *int
+		if slurmCluster.Spec.Topology != nil {
+			blockSize = slurmCluster.Spec.Topology.BlockSize
+		}
+		return r.BuildTopologyBlocks(ctx, blockSize, nodeTopologyCM, podsByNode)
+	}
+
+	return r.BuildTopologyConfig(ctx, nodeTopologyCM, podsByNode)
 }
 
-// GetPodsByNode organizes pods by their node name.
-func (r *WorkerTopologyReconciler) GetPodsByNode(pods []corev1.Pod) map[string][]string {
+// getNodeTopologyLabelsConfigMap retrieves the ConfigMap containing node topology labels, which is used for building the topology config.
+func (r *WorkerTopologyReconciler) getNodeTopologyLabelsConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: ctrl.ObjectMeta{
+			Name:      consts.ConfigMapNameTopologyNodeLabels,
+			Namespace: r.namespace,
+		},
+	}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(configMap), configMap); err != nil {
+		return configMap, fmt.Errorf("get node topology labels config map in namespace %q: %w", r.namespace, err)
+	}
+	return configMap, nil
+}
+
+// CollectRunningWorkerPods retrieves all running worker pods for the given SlurmCluster.
+func (r *WorkerTopologyReconciler) CollectRunningWorkerPods(
+	ctx context.Context, nodeSetList []v1alpha1.NodeSet, slurmClusterName, namespace string,
+) ([]corev1.Pod, error) {
+
+	logger := log.FromContext(ctx).WithValues(
+		"SlurmCluster", slurmClusterName, "Namespace", namespace,
+	)
+
+	fieldSelector := client.MatchingFields{consts.FieldStatusPhase: string(corev1.PodRunning)}
+	var pods []corev1.Pod
+
+	for _, nodeSet := range nodeSetList {
+		labelSelector := client.MatchingLabels{consts.LabelNodeSetKey: nodeSet.Name}
+
+		pl, err := r.listPods(ctx, labelSelector, fieldSelector, namespace)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("list pods for NodeSet %s: %w", nodeSet.Name, err)
+		}
+		if err != nil && apierrors.IsNotFound(err) {
+			logger.Info(
+				"No running pods found for NodeSet, skipping",
+				"NodeSet", nodeSet.Name, "Namespace", namespace,
+			)
+			continue
+		}
+
+		pods = append(pods, pl.Items...)
+
+	}
+
+	return pods, nil
+}
+
+// listPods retrieves the list of pods in the specified namespace with the given label selector.
+func (r *WorkerTopologyReconciler) listPods(
+	ctx context.Context, labelSelector client.MatchingLabels, fieldSelector client.MatchingFields, ns string,
+) (*corev1.PodList, error) {
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(ns),
+		labelSelector,
+		fieldSelector,
+	}
+
+	if err := r.Client.List(ctx, podList, listOpts...); err != nil {
+		return podList, fmt.Errorf("list pods in namespace %s with label selector %v: %w", ns, labelSelector, err)
+	}
+
+	return podList, nil
+}
+
+// GroupPodNamesByNode organizes pods by their node name.
+func (r *WorkerTopologyReconciler) GroupPodNamesByNode(pods []corev1.Pod) map[string][]string {
 	podsByNode := make(map[string][]string, len(pods))
 	for _, pod := range pods {
+		if pod.Spec.NodeName == "" {
+			pod.Spec.NodeName = "unknown"
+		}
 		podsByNode[pod.Spec.NodeName] = append(podsByNode[pod.Spec.NodeName], pod.Name)
 	}
 	return podsByNode
+}
+
+// BuildTopologyBlocks builds topology config.
+func (r *WorkerTopologyReconciler) BuildTopologyBlocks(
+	ctx context.Context, blockSize *int, topologyNodeLabelsCM *corev1.ConfigMap, podsByNode map[string][]string,
+) (string, error) {
+	bs := defBlockSize
+	if blockSize != nil {
+		bs = *blockSize
+	}
+
+	labelsByNode, err := r.ParseNodeTopologyLabels(topologyNodeLabelsCM.Data)
+	if err != nil {
+		return "", fmt.Errorf("deserialize node block topology: %w", err)
+	}
+	blocks := BuildTopologyBlocks(ctx, labelsByNode, podsByNode)
+	config := strings.Join(blocks.RenderConfigLines(), "\n") + "\n"
+	config = fmt.Sprintf("%sBlockSizes=%d\n", config, bs)
+	return config, nil
+}
+
+// BuildTopologyConfig builds topology config.
+func (r *WorkerTopologyReconciler) BuildTopologyConfig(
+	ctx context.Context, topologyNodeLabelsCM *corev1.ConfigMap, podsByNode map[string][]string,
+) (string, error) {
+	labelsByNode, err := r.ParseNodeTopologyLabels(topologyNodeLabelsCM.Data)
+	if err != nil {
+		return "", fmt.Errorf("deserialize node tree topology: %w", err)
+	}
+	graph := BuildTopologyGraph(ctx, labelsByNode, podsByNode)
+	config := strings.Join(graph.RenderConfigLines(), "\n") + "\n"
+	return config, nil
 }
 
 // NodeTopologyLabels represents the labels for a node's topology, e.g.:

--- a/internal/controller/topologyconfcontroller/workertopology_controller_test.go
+++ b/internal/controller/topologyconfcontroller/workertopology_controller_test.go
@@ -1,13 +1,22 @@
 package topologyconfcontroller_test
 
 import (
+	"context"
+	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/stretchr/testify/require"
 
+	"nebius.ai/slurm-operator/api/v1alpha1"
+	"nebius.ai/slurm-operator/internal/consts"
 	tc "nebius.ai/slurm-operator/internal/controller/topologyconfcontroller"
 )
 
@@ -38,13 +47,13 @@ func TestGetPodByNode(t *testing.T) {
 				{Spec: corev1.PodSpec{NodeName: ""}, ObjectMeta: metav1.ObjectMeta{Name: "pod2"}},
 			},
 			expected: map[string][]string{
-				"": {"pod1", "pod2"},
+				"unknown": {"pod1", "pod2"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := reconciler.GetPodsByNode(tt.pods)
+			result := reconciler.GroupPodNamesByNode(tt.pods)
 			require.Equal(t, tt.expected, result, "Test %s failed: expected %v, got %v", tt.name, tt.expected, result)
 		})
 	}
@@ -99,4 +108,106 @@ func TestParseNodeTopologyLabels(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCollectRunningWorkerPods(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespace   = "test-ns"
+		clusterName = "cluster-a"
+	)
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	nodeSetList := []v1alpha1.NodeSet{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nodeset-a",
+				Namespace: namespace,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nodeset-b",
+				Namespace: namespace,
+			},
+		},
+	}
+
+	objects := []client.Object{
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-running-a1",
+				Namespace: namespace,
+				Labels: map[string]string{
+					consts.LabelNodeSetKey: "nodeset-a",
+				},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-pending-a",
+				Namespace: namespace,
+				Labels: map[string]string{
+					consts.LabelNodeSetKey: "nodeset-a",
+				},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodPending},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-running-b1",
+				Namespace: namespace,
+				Labels: map[string]string{
+					consts.LabelNodeSetKey: "nodeset-b",
+				},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-running-other-cluster",
+				Namespace: namespace,
+				Labels: map[string]string{
+					consts.LabelNodeSetKey: "nodeset-other-cluster",
+				},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-running-other-ns",
+				Namespace: "other-ns",
+				Labels: map[string]string{
+					consts.LabelNodeSetKey: "nodeset-a",
+				},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithIndex(&corev1.Pod{}, consts.FieldStatusPhase, func(obj client.Object) []string {
+			pod := obj.(*corev1.Pod)
+			return []string{string(pod.Status.Phase)}
+		}).
+		Build()
+
+	reconciler := tc.NewWorkerTopologyReconciler(fakeClient, scheme, namespace)
+
+	pods, err := reconciler.CollectRunningWorkerPods(context.Background(), nodeSetList, clusterName, namespace)
+	require.NoError(t, err)
+
+	var names []string
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+	slices.Sort(names)
+
+	assert.Equal(t, []string{"pod-running-a1", "pod-running-b1"}, names)
 }


### PR DESCRIPTION
## Problem
After migrating `soperator` to dynamic topology, we found a scheduling regression: without `topology.conf`, job scheduling behaved incorrectly, specifically with invalid `SLURM_TOPOLOGY_ADDR` values.

During investigation and Slurm experiments, we confirmed that topology behavior depends on local `slurmd` state, and `slurmd` initializes this state from `topology.conf`. As a result, dynamic-only topology was not sufficient for stable scheduling.

## Solution
We restored `topology.conf` generation while keeping dynamic topology support, and refactored the controller logic to make this flow reliable:

- Reintroduced/kept topology config generation in the worker topology controller.
- Rolled back structured topology builders:
  - tree mode via `TopologyGraph`
  - block mode via `TopologyBlocks`
- Ensured generated topology includes a stable root-switch model and unknown-node fallback.
- Refactored reconciliation flow:
  - ensure topology resources exist (`ConfigMap` + `JailedConfig`)
  - collect running worker pods
  - build desired topology config
  - compare hash and update only when changed
- Updated worker init behavior to wait until hostname is present in `/etc/slurm/topology.conf` before applying node topology.

## Testing
- `go test ./internal/controller/topologyconfcontroller/...`
- `make lint` (passes; cache warnings may appear in sandboxed environments)
- Updated/added unit tests for:
  - topology graph/block rendering
  - worker pod collection logic
  - worker init topology wait behavior (`worker_init.py`)
  - manually

## Release Notes
- Fixed dynamic-topology scheduling regression related to invalid `SLURM_TOPOLOGY_ADDR`.
- Restored generation/use of `topology.conf` as the authoritative input for `slurmd` topology state.
- Improved topology controller architecture and test coverage for tree/block/fallback cases.