### PR TITLE
SCHED-1037: Fix secrets access

### DIFF
--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -4,6 +4,9 @@ permissions:
   contents: read
 
 on:
+  # TODO: remove pull_request trigger after merging (kept for transition).
+  pull_request:
+    types: [opened, synchronize, reopened]
   pull_request_target:
     types: [opened, synchronize, reopened]
     paths-ignore:

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -26,6 +26,9 @@ on:
 
   # pull_request_target runs in base branch context, giving fork PRs access to secrets.
   # The "authorize" job gates fork PRs behind environment approval.
+  # TODO: remove pull_request trigger after merging (kept for transition, causes double runs).
+  pull_request:
+    types: [opened, synchronize, reopened]
   pull_request_target:
     types: [opened, synchronize, reopened]
 
@@ -36,8 +39,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' || github.event_name == 'pull_request' }}
 
 jobs:
   authorize:
@@ -57,7 +60,7 @@ jobs:
     needs: [authorize]
     runs-on: ubuntu-latest
     outputs:
-      should_build: ${{ steps.filter.outputs.has_code_changes == 'true' || github.event_name != 'pull_request_target' }}
+      should_build: ${{ steps.filter.outputs.has_code_changes == 'true' || (github.event_name != 'pull_request_target' && github.event_name != 'pull_request') }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -1,6 +1,14 @@
 ---
 name: Label Checker
 on:
+  # TODO: remove pull_request trigger after merging (kept for transition).
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
## Problem

PRs from forks are not runnable: these runs don't have access to the secrets.

## Solution

Use pull_request_target instead of pull_request, in that case the runs will have the access.

## Testing

TODO

## Release Notes

None