### PR TITLE
SCHED-957: isolate Docker containers from slurmd cgroup to prevent pod OOM kills

### DIFF
--- a/ansible/roles/docker-cli/files/docker.sh
+++ b/ansible/roles/docker-cli/files/docker.sh
@@ -2,6 +2,42 @@
 
 BASE_DIR="/mnt/jail"  # Base directory for chroot
 
+# get_docker_cgroup_parent returns the path of the dedicated Docker cgroup that
+# was created once at pod startup by supervisord_entrypoint.sh.
+#
+# All Docker containers (across all Slurm jobs) share this single cgroup.
+# Its memory.max is set to REAL_MEMORY, so containers are OOM-killed
+# at the Docker-cgroup level before the pod limit is reached, keeping slurmd stable.
+get_docker_cgroup_parent() {
+    local cgroup_file="/run/docker-cgroup-parent"
+    [[ ! -f "$cgroup_file" ]] && return
+    local cgroup_path
+    cgroup_path=$(cat "$cgroup_file")
+    [[ -z "$cgroup_path" ]] && return
+    [[ -d "/sys/fs/cgroup/${cgroup_path}" ]] && echo "$cgroup_path"
+}
+
+# Pre-scan original arguments to find the Docker subcommand and whether
+# --cgroup-parent has already been explicitly provided by the caller.
+DOCKER_SUBCOMMAND=""
+CGROUP_PARENT_SPECIFIED=false
+
+for arg in "$@"; do
+    if [[ -z "$DOCKER_SUBCOMMAND" ]] && [[ "$arg" != -* ]]; then
+        DOCKER_SUBCOMMAND="$arg"
+    fi
+    if [[ "$arg" == "--cgroup-parent" ]] || [[ "$arg" == --cgroup-parent=* ]]; then
+        CGROUP_PARENT_SPECIFIED=true
+    fi
+done
+
+# Resolve the Docker cgroup parent once, before rebuilding arguments.
+INJECT_CGROUP_PARENT=""
+if [[ ("$DOCKER_SUBCOMMAND" == "run" || "$DOCKER_SUBCOMMAND" == "create") \
+        && "$CGROUP_PARENT_SPECIFIED" == "false" ]]; then
+    INJECT_CGROUP_PARENT=$(get_docker_cgroup_parent)
+fi
+
 ADJUSTED_ARGS=()
 SKIP_NEXT_ARG=false
 
@@ -114,6 +150,21 @@ for ((i = 1; i <= $#; i++)); do
     ADJUSTED_ARGS+=("$arg")
   fi
 done
+
+# Inject --cgroup-parent after the subcommand so Docker places new containers
+# inside the dedicated Docker cgroup instead of dockerd's own cgroup.
+if [[ -n "$INJECT_CGROUP_PARENT" ]]; then
+    NEW_ADJUSTED_ARGS=()
+    INJECTED=false
+    for arg in "${ADJUSTED_ARGS[@]}"; do
+        NEW_ADJUSTED_ARGS+=("$arg")
+        if [[ "$INJECTED" == "false" ]] && [[ "$arg" == "$DOCKER_SUBCOMMAND" ]]; then
+            NEW_ADJUSTED_ARGS+=("--cgroup-parent=${INJECT_CGROUP_PARENT}")
+            INJECTED=true
+        fi
+    done
+    ADJUSTED_ARGS=("${NEW_ADJUSTED_ARGS[@]}")
+fi
 
 # Debug: Print adjusted arguments
 # echo "Real args:" "$(printf "'%s' " "${ADJUSTED_ARGS[@]}")"

--- a/images/worker/supervisord_entrypoint.sh
+++ b/images/worker/supervisord_entrypoint.sh
@@ -11,6 +11,29 @@ if [ -n "${CGROUP_V2}" ]; then
         mkdir -p /sys/fs/cgroup/"${CGROUP_PATH}"/../system.slice
         # TODO: uncomment this line when 24.11 will be tested. It is OOMKillStep for taskPluginParam
         # echo "1" > /sys/fs/cgroup/${CGROUP_PATH}/../system.slice/memory.oom.group
+
+        # Create a single dedicated cgroup for all Docker containers launched within Slurm jobs.
+        # All jobs share this cgroup (it is created once at pod startup, not per job).
+        # Placing containers here isolates them from slurmd: Docker OOM events cannot evict
+        # the slurmd pod because slurmd remains in its own sibling cgroup.
+        #
+        # memory.max is set to REAL_MEMORY (in MiB, matching Slurm's RealMemory unit).
+        # This equals the node's allocatable memory for jobs, so Docker containers are
+        # OOM-killed at the node allocation boundary, leaving slurmd headroom unaffected.
+        DOCKER_CGROUP_PATH="${CGROUP_PATH%/*}/docker"
+        mkdir -p /sys/fs/cgroup/"${DOCKER_CGROUP_PATH}"
+
+        if [ -n "${REAL_MEMORY}" ]; then
+            DOCKER_MEM_MAX_BYTES=$((REAL_MEMORY * 1024 * 1024))
+            echo "${DOCKER_MEM_MAX_BYTES}" > /sys/fs/cgroup/"${DOCKER_CGROUP_PATH}"/memory.max
+            echo "Docker cgroup memory.max set to ${DOCKER_MEM_MAX_BYTES} bytes (REAL_MEMORY=${REAL_MEMORY} MiB)"
+        else
+            echo "REAL_MEMORY not set, Docker cgroup memory.max left unlimited"
+        fi
+
+        # Persist the path so that docker.sh can inject it as --cgroup-parent
+        echo "${DOCKER_CGROUP_PATH}" > /run/docker-cgroup-parent
+        echo "Docker cgroup created at ${DOCKER_CGROUP_PATH}"
     else
         echo "cgroup v2 detected, but cgroup path is empty"
         exit 1

--- a/internal/consts/cgroup.go
+++ b/internal/consts/cgroup.go
@@ -1,7 +1,8 @@
 package consts
 
 const (
-	CGroupV2    = "v2"
-	CGroupV1    = "v1"
-	EnvCGroupV2 = "CGROUP_V2"
+	CGroupV2      = "v2"
+	CGroupV1      = "v1"
+	EnvCGroupV2   = "CGROUP_V2"
+	EnvRealMemory = "REAL_MEMORY"
 )

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -227,6 +227,7 @@ func renderContainerNodeSetSlurmd(
 				utils.Ternary(nodeSet.GPU.Enabled, consts.ClusterTypeGPU, consts.ClusterTypeCPU),
 				nodeSet.GPU.Nvidia.GDRCopyEnabled,
 				nodeSet.NodeExtra,
+				common.RenderRealMemorySlurmd(corev1.ResourceRequirements{Requests: nodeSet.ContainerSlurmd.Resources}),
 			),
 			nodeSet.ContainerSlurmd.CustomEnv...,
 		),
@@ -268,6 +269,7 @@ func renderNodeSetSlurmdEnv(
 	clusterType consts.ClusterType,
 	enableGDRCopy bool,
 	slurmNodeExtra string,
+	realMemoryMiB int64,
 ) []corev1.EnvVar {
 	envVar := []corev1.EnvVar{
 		{
@@ -301,6 +303,13 @@ func renderNodeSetSlurmdEnv(
 		envVar = append(envVar, corev1.EnvVar{
 			Name:  consts.EnvNvidiaGDRCopy,
 			Value: "enabled",
+		})
+	}
+
+	if realMemoryMiB > 0 {
+		envVar = append(envVar, corev1.EnvVar{
+			Name:  consts.EnvRealMemory,
+			Value: strconv.FormatInt(realMemoryMiB, 10),
 		})
 	}
 

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -227,7 +227,7 @@ func renderContainerNodeSetSlurmd(
 				utils.Ternary(nodeSet.GPU.Enabled, consts.ClusterTypeGPU, consts.ClusterTypeCPU),
 				nodeSet.GPU.Nvidia.GDRCopyEnabled,
 				nodeSet.NodeExtra,
-				common.RenderRealMemorySlurmd(corev1.ResourceRequirements{Requests: nodeSet.ContainerSlurmd.Resources}),
+				common.RenderRealMemorySlurmd(resources),
 			),
 			nodeSet.ContainerSlurmd.CustomEnv...,
 		),

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -139,6 +139,80 @@ func Test_RenderContainerWorkerInit_K8SServiceName(t *testing.T) {
 	}
 }
 
+func TestRenderNodeSetStatefulSet_RealMemoryEnv(t *testing.T) {
+	findEnvInContainer := func(containers []corev1.Container, containerName, envName string) (corev1.EnvVar, bool) {
+		for _, c := range containers {
+			if c.Name == containerName {
+				for _, e := range c.Env {
+					if e.Name == envName {
+						return e, true
+					}
+				}
+				return corev1.EnvVar{}, false
+			}
+		}
+		return corev1.EnvVar{}, false
+	}
+
+	makeNodeSet := func(resources corev1.ResourceList) *values.SlurmNodeSet {
+		return &values.SlurmNodeSet{
+			Name: "test-nodeset",
+			ParentalCluster: client.ObjectKey{
+				Namespace: "test-namespace",
+				Name:      "test-cluster",
+			},
+			ContainerSlurmd: values.Container{
+				NodeContainer: slurmv1.NodeContainer{
+					Image:           "test-image",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Resources:       resources,
+				},
+			},
+			ContainerMunge: values.Container{
+				NodeContainer: slurmv1.NodeContainer{Image: "munge-image"},
+			},
+			VolumeSpool:              corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/spool"}},
+			VolumeJail:               corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/jail"}},
+			StatefulSet:              values.StatefulSet{Replicas: 1},
+			SupervisorDConfigMapName: "supervisord-config",
+			SSHDConfigMapName:        "sshd-config",
+			GPU:                      &slurmv1alpha1.GPUSpec{Enabled: false},
+		}
+	}
+
+	t.Run("REAL_MEMORY present and correct when memory request is set", func(t *testing.T) {
+		// 2 GiB = 2048 MiB
+		nodeSet := makeNodeSet(corev1.ResourceList{
+			corev1.ResourceMemory:           resource.MustParse("2Gi"),
+			corev1.ResourceCPU:              resource.MustParse("1"),
+			corev1.ResourceEphemeralStorage: resource.MustParse("10Gi"),
+		})
+
+		result, err := worker.RenderNodeSetStatefulSet("test-cluster", nodeSet, &slurmv1.Secrets{}, consts.CGroupV2, false)
+		assert.NoError(t, err)
+
+		env, found := findEnvInContainer(result.Spec.Template.Spec.Containers, consts.ContainerNameSlurmd, consts.EnvRealMemory)
+		assert.True(t, found, "REAL_MEMORY env var must be present when memory request is set")
+		assert.Equal(t, "2048", env.Value, "REAL_MEMORY should be 2048 MiB for a 2Gi memory request")
+	})
+
+	t.Run("REAL_MEMORY absent when memory request is sub-MiB (rounds to zero)", func(t *testing.T) {
+		// RenderRealMemorySlurmd does integer division by 1_048_576; a quantity
+		// smaller than 1 MiB produces 0, so REAL_MEMORY must not be injected.
+		nodeSet := makeNodeSet(corev1.ResourceList{
+			corev1.ResourceMemory:           resource.MustParse("512Ki"),
+			corev1.ResourceCPU:              resource.MustParse("1"),
+			corev1.ResourceEphemeralStorage: resource.MustParse("10Gi"),
+		})
+
+		result, err := worker.RenderNodeSetStatefulSet("test-cluster", nodeSet, &slurmv1.Secrets{}, consts.CGroupV2, false)
+		assert.NoError(t, err)
+
+		_, found := findEnvInContainer(result.Spec.Template.Spec.Containers, consts.ContainerNameSlurmd, consts.EnvRealMemory)
+		assert.False(t, found, "REAL_MEMORY env var must be absent when memory rounds to 0 MiB")
+	})
+}
+
 func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 	createNodeSet := func(ephemeralNodes *bool, waitTimeout int32) *values.SlurmNodeSet {
 		return &values.SlurmNodeSet{


### PR DESCRIPTION
## Problem

When a user runs Docker inside a Slurm job, Docker containers are spawned by `dockerd` as its own children and inherit `dockerd`'s cgroup -which is the pod-level cgroup, not the Slurm job cgroup. As a result:

- Container memory usage bypasses Slurm's per-job `memory.max` constraint
- All Docker memory accumulates in the pod cgroup alongside `slurmd`, `sshd`, and `dockerd`
- When total pod memory exceeds the Kubernetes limit, kubelet OOM-kills the entire pod, taking `slurmd` down with it


## Solution

A single dedicated Docker cgroup is created once at pod startup (in `supervisord_entrypoint.sh`) as a sibling of the main container cgroup:

Pod cgroup (K8s limit, e.g. 1600G)
├── <container>/       ← slurmd, dockerd, sshd  (unaffected by Docker OOMs)
└── docker/            ← ALL Docker containers from ALL jobs
memory.max = REAL_MEMORY 



`memory.max` on the Docker cgroup is set to `REAL_MEMORY` (in MiB) — the node's allocatable memory as configured in Slurm. This ensures Docker containers are OOM-killed at the job allocation boundary before the pod-level limit is reached, leaving `slurmd` with its intended headroom.

The existing `docker.sh` wrapper (installed as `/usr/bin/docker`

## Testing
- manually  

## Release Notes
**Fix:** Docker containers launched inside Slurm jobs are now placed in a dedicated isolated cgroup (`docker/`) with `memory.max` set to the node's `REAL_MEMORY` value. This prevents Docker workload memory from causing pod-level OOM kills and `slurmd` restarts.
