### PR TITLE
SCHED-1074: Replace deprecated gcr.io registry

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/soperatorchecks/manager_auth_proxy_patch.yaml
+++ b/config/soperatorchecks/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/helm/soperator-fluxcd/templates/soperator.yaml
+++ b/helm/soperator-fluxcd/templates/soperator.yaml
@@ -47,7 +47,7 @@ spec:
     controllerManager:
       kubeRbacProxy:
         image:
-          repository: gcr.io/kubebuilder/kube-rbac-proxy
+          repository: registry.k8s.io/kubebuilder/kube-rbac-proxy
           tag: v0.15.0
       manager:
         {{- if .Values.soperator.featureGates }}

--- a/helm/soperator/values.yaml
+++ b/helm/soperator/values.yaml
@@ -11,7 +11,7 @@ controllerManager:
         drop:
           - ALL
     image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
+      repository: registry.k8s.io/kubebuilder/kube-rbac-proxy
       tag: v0.15.0
     resources:
       limits:

--- a/helm/soperatorchecks/values.yaml
+++ b/helm/soperatorchecks/values.yaml
@@ -11,7 +11,7 @@ checks:
         drop:
           - ALL
     image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
+      repository: registry.k8s.io/kubebuilder/kube-rbac-proxy
       tag: v0.15.0
     resources:
       limits:


### PR DESCRIPTION
## Problem

Soperator helm chart installation failed:

```
security-profiles-operator-system   49m         Warning   Failed                    pod/spod-lzcbx                                                                         Error: ImagePullBackOff
security-profiles-operator-system   49m         Normal    BackOff                   pod/spod-lzcbx                                                                         Back-off pulling image "gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0"
```

Because kubebuilder images gcr.io were deprecated and maybe in March 2026 at last removed: https://github.com/kubernetes-sigs/kubebuilder/discussions/3907

## Solution

Short term one: migrate to `registry.k8s.io/kubebuilder/kube-rbac-proxy`

## Testing

E2E run: https://github.com/nebius/soperator/actions/runs/22844725859

## Release Notes

`kube-rbac-proxy` image is taken from `registry.k8s.io` instead of `gcr.io`
