### PR TITLE
fix wrong cleanup_enroot execution

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/cleanup_enroot.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/cleanup_enroot.sh.json
@@ -11,7 +11,7 @@
   "on_ok": "none",
   "reason_base": "",
   "reason_append_details": false,
-  "run_in_jail": false,
+  "run_in_jail": true,
   "log": "slurm_scripts/$worker.$name.$context.out",
   "need_env": []
 }


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
`cleanup_enroot.sh` should run in jail, not on the worker host

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
run in jail

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Fix: cleanup enroot doesn't work.
