### PR TITLE
SLURMSUPPORT-320: fix spo version kube rbac proxy

### DIFF
--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -379,7 +379,7 @@ securityProfilesOperator:
   enabled: true
   interval: 5m
   timeout: 5m
-  version: 0.8.4-soperator
+  version: 0.8.5-soperator
   releaseName: security-profiles-operator
   namespace: security-profiles-operator-system
   install:


### PR DESCRIPTION
## Problem
kube-rbac-proxy was moved to a different registry.

## Solution
Update chart version.

## Release Notes
Update kube-rbac-proxy chart due to registry change.


