### PR TITLE
Requeue waiting for dependencies every 10 sec

### DIFF
--- a/internal/controller/soperatorchecks/activecheck_controller.go
+++ b/internal/controller/soperatorchecks/activecheck_controller.go
@@ -157,9 +157,9 @@ func (r *ActiveCheckReconciler) Reconcile(
 		return ctrl.Result{}, err
 	}
 	if !dependenciesReady {
-		logger.Info("Not all dependencies are ready, requeueing in 1 minute.")
+		logger.Info("Not all dependencies are ready, requeueing in 10 seconds.")
 		return ctrl.Result{
-			RequeueAfter: time.Minute,
+			RequeueAfter: time.Second * 10,
 		}, nil
 	}
 


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
We have ~4 dependency steps during cluster creation, current requeueAfter duration increate cluster creation time for few minutes (and it may be more in future with more checks)

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
