### PR TITLE
SCHED-1135 Ignore comment checks in wait-for-checks-job

### DIFF
--- a/helm/soperator-activechecks/templates/wait-for-checks-job.yaml
+++ b/helm/soperator-activechecks/templates/wait-for-checks-job.yaml
@@ -25,9 +25,9 @@ spec:
               CRD_KIND="activechecks.slurm.nebius.ai"
 
               echo "Fetching ActiveCheck list..."
-              # Only wait for checks that run on creation and have drainSlurmNode configured.
+              # Only wait for checks that run on creation and ignore flappy comment-only checks.
               active_check_names=$(kubectl get "$CRD_KIND" -n "$NAMESPACE" -o json \
-                | jq -r '.items[] | select(.spec.runAfterCreation == true and .spec.failureReactions.drainSlurmNode != null) | .metadata.name')
+                | jq -r '.items[] | select(.spec.runAfterCreation == true and .spec.failureReactions.commentSlurmNode == null) | .metadata.name')
 
               if [ -z "$active_check_names" ]; then
                 echo "No CRs with runAfterCreation=true found. Exiting."


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Currently failing checks without reactions (like prepull contrainer image) doesn't instantly fail helm release

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Fix initial intention of skipping comment only checks by actually skipping only comment only checks

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
