### PR TITLE
SCHED-1134 Fix Pyxis importer image URI handling and slurm-scripts defaultMode

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/pyxis_caching_importer.sh
+++ b/helm/slurm-cluster/slurm_scripts/pyxis_caching_importer.sh
@@ -20,10 +20,11 @@ case "${cmd}" in
         fi
 
         readonly image_uri="$2"
+        readonly enroot_image_uri="docker://${image_uri/\#//}"
 
         mkdir -p -m 700 "${cache_dir}"
 
-        readonly digest=$(enroot digest "${image_uri}")
+        readonly digest=$(enroot digest "${enroot_image_uri}")
         if [ -z "${digest}" ]; then
             echo "error: could not retrieve digest for image: ${image_uri}" >&2
             exit 1
@@ -44,7 +45,7 @@ case "${cmd}" in
             #     # Add the digest to the URI.
             #     enroot import --output "${squashfs_temp_path}" "${image_uri}@${digest}" >&2
             # fi
-            enroot import --output "${squashfs_temp_path}" "${image_uri}" >&2
+            enroot import --output "${squashfs_temp_path}" "${enroot_image_uri}" >&2
 
             # Save the URI as an extended attribute.
             if command -v "setfattr" >/dev/null; then

--- a/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
+++ b/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
@@ -94,7 +94,7 @@ spec:
     - name: slurm-scripts
       configMap:
         name: slurm-scripts
-        defaultMode: 0755
+        defaultMode: 493
     {{- range .Values.volumeSources }}
     - name: {{ .name | quote }}
       {{- omit . "name" "createPVC" "storageClassName" "size" | toYaml | nindent 6 }}

--- a/helm/slurm-cluster/tests/default-values_test.yaml
+++ b/helm/slurm-cluster/tests/default-values_test.yaml
@@ -76,6 +76,9 @@ tests:
       clusterName: test-cluster
     asserts:
       - equal:
+          path: spec.volumeSources[0].configMap.defaultMode
+          value: 493
+      - equal:
           path: spec.plugStackConfig.pyxis.required
           value: true
       - equal:


### PR DESCRIPTION
## Problem

The importer passed Pyxis-style image references like registry#repo:tag directly to Enroot, which Enroot rejects as
an invalid image URI.

## Solution

The importer now converts Pyxis image references into Enroot-compatible docker://registry/repo:tag URIs before calling enroot digest and enroot import. 

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
