### PR TITLE
SCHED-1146: reduce rebooter memory usage on scale

### DIFF
--- a/cmd/rebooter/main.go
+++ b/cmd/rebooter/main.go
@@ -30,10 +30,13 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/klog/v2"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -159,6 +162,13 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         false,
 		LeaderElectionID:       "rebooter64591po.nebius.ai",
+		// Strip non-essential fields from cached Pod objects to reduce
+		// baseline memory usage.
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Pod{}: {Transform: rebooter.PodCacheTransform},
+			},
+		},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
@@ -200,6 +210,7 @@ func main() {
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		mgr.GetEventRecorderFor(rebooter.ControllerName),
+		mgr.GetAPIReader(),
 		rebooterParams,
 	).SetupWithManager(mgr, maxConcurrency, cacheSyncTimeout, rebooterParams.NodeName); err != nil {
 		cli.Fail(setupLog, err, "unable to create controller", rebooter.ControllerName)

--- a/internal/rebooter/cache.go
+++ b/internal/rebooter/cache.go
@@ -1,0 +1,45 @@
+package rebooter
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PodCacheTransform strips non-essential fields from a Pod before it is stored
+// in the controller-runtime cache, reducing baseline memory usage.
+//
+// Only the minimum fields required by the rebooter are retained:
+//   - Name / Namespace / UID — basic pod identity.
+//   - OwnerReferences — used by IsControlledByDaemonSet.
+//   - Spec.NodeName — used as the field-indexer key ("spec.nodeName").
+//   - Spec.Tolerations — used by HasTolerationForNoExecute / HasTolerationForExists.
+//
+// All other ObjectMeta fields (ManagedFields, Annotations, Labels, …) and all
+// Spec / Status fields are explicitly discarded.  Slices are shallow-copied so
+// the stripped pod does not share underlying arrays with the original object.
+func PodCacheTransform(i any) (any, error) { //nolint:unparam // error is always nil but required by cache.ByObject.Transform signature
+	pod, ok := i.(*corev1.Pod)
+	if !ok {
+		return i, nil
+	}
+
+	ownerRefs := make([]metav1.OwnerReference, len(pod.OwnerReferences))
+	copy(ownerRefs, pod.OwnerReferences)
+
+	tolerations := make([]corev1.Toleration, len(pod.Spec.Tolerations))
+	copy(tolerations, pod.Spec.Tolerations)
+
+	return &corev1.Pod{
+		TypeMeta: pod.TypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pod.Name,
+			Namespace:       pod.Namespace,
+			UID:             pod.UID,
+			OwnerReferences: ownerRefs,
+		},
+		Spec: corev1.PodSpec{
+			NodeName:    pod.Spec.NodeName,
+			Tolerations: tolerations,
+		},
+	}, nil
+}

--- a/internal/rebooter/cache_test.go
+++ b/internal/rebooter/cache_test.go
@@ -1,0 +1,82 @@
+package rebooter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "nebius.ai/slurm-operator/internal/rebooter"
+)
+
+func TestPodCacheTransform(t *testing.T) {
+	fullPod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "DaemonSet", Name: "ds"},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+			Tolerations: []corev1.Toleration{
+				{Effect: corev1.TaintEffectNoExecute},
+			},
+			Containers: []corev1.Container{
+				{Name: "main", Image: "busybox"},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "data"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	t.Run("returns stripped Pod with required fields only", func(t *testing.T) {
+		result, err := PodCacheTransform(fullPod)
+		require.NoError(t, err)
+
+		got, ok := result.(*corev1.Pod)
+		require.True(t, ok, "result must be *corev1.Pod")
+
+		// TypeMeta preserved as-is.
+		assert.Equal(t, fullPod.TypeMeta, got.TypeMeta)
+
+		// Only minimal identity fields are kept; large ObjectMeta fields are dropped.
+		assert.Equal(t, fullPod.Name, got.Name)
+		assert.Equal(t, fullPod.Namespace, got.Namespace)
+		assert.Equal(t, fullPod.UID, got.UID)
+		assert.Equal(t, fullPod.OwnerReferences, got.OwnerReferences)
+		assert.Empty(t, got.Annotations, "Annotations must be stripped")
+		assert.Empty(t, got.Labels, "Labels must be stripped")
+		assert.Empty(t, got.ManagedFields, "ManagedFields must be stripped")
+
+		// Required Spec fields preserved; rest dropped.
+		assert.Equal(t, fullPod.Spec.NodeName, got.Spec.NodeName)
+		assert.Equal(t, fullPod.Spec.Tolerations, got.Spec.Tolerations)
+		assert.Empty(t, got.Spec.Containers, "Containers must be stripped")
+		assert.Empty(t, got.Spec.Volumes, "Volumes must be stripped")
+
+		// Status fully dropped.
+		assert.Empty(t, got.Status.Phase, "Status must be stripped")
+
+		// Slices are independent copies — mutating the original must not affect the cached pod.
+		fullPod.OwnerReferences[0].Name = "mutated"
+		assert.NotEqual(t, "mutated", got.OwnerReferences[0].Name, "OwnerReferences must be a copy")
+		fullPod.Spec.Tolerations[0].Effect = corev1.TaintEffectNoSchedule
+		assert.NotEqual(t, corev1.TaintEffectNoSchedule, got.Spec.Tolerations[0].Effect, "Tolerations must be a copy")
+	})
+
+	t.Run("passes through non-Pod objects unchanged", func(t *testing.T) {
+		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+		result, err := PodCacheTransform(node)
+		require.NoError(t, err)
+		assert.Equal(t, node, result, "non-Pod input must be returned as-is")
+	})
+}

--- a/internal/rebooter/reconcile.go
+++ b/internal/rebooter/reconcile.go
@@ -34,6 +34,19 @@ var (
 	ControllerName = "rebooter"
 )
 
+const (
+	// podEvictionPageSize is the number of pods fetched per page when using the
+	// paginated API-server path in AreAllPodsEvicted.
+	podEvictionPageSize int64 = 64
+
+	// podEvictionCacheThreshold is the number of pods on a node above which
+	// AreAllPodsEvicted switches from a single cached List to a paginated
+	// API-server read with early exit. Below this threshold the cheaper cache
+	// path avoids extra API-server calls; above it pagination avoids
+	// materialising the full PodList in memory at once.
+	podEvictionCacheThreshold int64 = 1000
+)
+
 type RebooterParams struct {
 	ReconcileTimeout time.Duration
 	NodeName         string
@@ -42,20 +55,27 @@ type RebooterParams struct {
 
 type RebooterReconciler struct {
 	*reconciler.Reconciler
+	// APIReader is a direct API-server reader used for paginated pod listing.
+	// It bypasses the controller-runtime cache, which does not support server-side
+	// pagination via client.Limit/Continue.
+	// See https://github.com/kubernetes-sigs/controller-runtime/issues/3044
+	APIReader        client.Reader
 	reconcileTimeout time.Duration
 	nodeName         string
 	evictionMethod   consts.RebooterMethod
 }
 
 func NewRebooterReconciler(
-	client client.Client,
+	c client.Client,
 	scheme *runtime.Scheme,
 	recorder record.EventRecorder,
+	apiReader client.Reader,
 	rebooterParams RebooterParams,
 ) *RebooterReconciler {
-	r := reconciler.NewReconciler(client, scheme, recorder)
+	r := reconciler.NewReconciler(c, scheme, recorder)
 	return &RebooterReconciler{
 		Reconciler:       r,
+		APIReader:        apiReader,
 		reconcileTimeout: rebooterParams.ReconcileTimeout,
 		nodeName:         rebooterParams.NodeName,
 		evictionMethod:   rebooterParams.EvictionMethod,
@@ -405,31 +425,86 @@ func (r *RebooterReconciler) IsNodeTaintedWithNoExecute(node *corev1.Node) bool 
 }
 
 // AreAllPodsEvicted checks if all pods on the node with the given name are evicted.
+//
+// Strategy:
+//   - First, list pods from the local cache (cheap, no API-server load).
+//   - If the node has more than podEvictionCacheThreshold pods, discard the
+//     cached result and re-query the API server in pages of podEvictionPageSize.
+//     This avoids materialising a huge PodList in memory and allows an early
+//     exit as soon as the first blocking pod is found.
 func (r *RebooterReconciler) AreAllPodsEvicted(ctx context.Context, nodeName string) error {
-	logger := log.FromContext(ctx).WithName("EvictPodsFromNode").WithValues("nodeName", nodeName).V(1)
+	logger := log.FromContext(ctx).WithName("AreAllPodsEvicted").WithValues("nodeName", nodeName).V(1)
 	logger.Info("Listing pods on node")
 
+	nodeSelector := client.MatchingFields{"spec.nodeName": nodeName}
+
 	podList := &corev1.PodList{}
-	if err := r.List(ctx, podList, client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
+	if err := r.List(ctx, podList, nodeSelector); err != nil {
 		return fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
 	}
 
-	for _, pod := range podList.Items {
+	if int64(len(podList.Items)) <= podEvictionCacheThreshold {
+		return checkPodsEvicted(podList.Items)
+	}
+
+	logger.Info("Node has many pods, switching to paginated API-server listing",
+		"count", len(podList.Items), "threshold", podEvictionCacheThreshold)
+	return r.areAllPodsEvictedPaginated(ctx, nodeName)
+}
+
+// areAllPodsEvictedPaginated queries the API server directly, page by page,
+// and returns as soon as the first blocking pod is found.  It does NOT use
+// the controller-runtime cache so that client.Limit/Continue work as
+// proper server-side pagination.
+func (r *RebooterReconciler) areAllPodsEvictedPaginated(ctx context.Context, nodeName string) error {
+	logger := log.FromContext(ctx).WithName("areAllPodsEvictedPaginated").WithValues("nodeName", nodeName).V(1)
+
+	continueToken := ""
+	for {
+		page := &corev1.PodList{}
+		opts := []client.ListOption{
+			client.MatchingFields{"spec.nodeName": nodeName},
+			client.Limit(podEvictionPageSize),
+		}
+		if continueToken != "" {
+			opts = append(opts, client.Continue(continueToken))
+		}
+
+		if err := r.APIReader.List(ctx, page, opts...); err != nil {
+			return fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
+		}
+
+		logger.Info("Processing pod page", "pageSize", len(page.Items))
+
+		if err := checkPodsEvicted(page.Items); err != nil {
+			return err
+		}
+
+		continueToken = page.Continue
+		if continueToken == "" {
+			break
+		}
+	}
+
+	return nil
+}
+
+// checkPodsEvicted iterates a slice of pods and returns a PodNotEvictableError
+// for the first pod that is still blocking eviction, or nil if all pods are
+// either evictable or exempt.
+func checkPodsEvicted(pods []corev1.Pod) error {
+	for _, pod := range pods {
 		if IsControlledByDaemonSet(pod) {
 			continue
 		}
-
 		if HasTolerationForNoExecute(pod) {
 			continue
 		}
-
 		if HasTolerationForExists(pod) {
 			continue
 		}
-
 		return &PodNotEvictableError{PodName: pod.Name}
 	}
-
 	return nil
 }
 

--- a/internal/rebooter/reconcile_test.go
+++ b/internal/rebooter/reconcile_test.go
@@ -2,13 +2,16 @@ package rebooter_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"nebius.ai/slurm-operator/internal/consts"
@@ -346,6 +349,164 @@ func TestIsNodeTaintedWithNoExecute(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newRebooterWithFakeClient(scheme *runtime.Scheme, objs ...client.Object) *RebooterReconciler {
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithIndex(&corev1.Pod{}, "spec.nodeName", func(obj client.Object) []string {
+			pod := obj.(*corev1.Pod)
+			if pod.Spec.NodeName != "" {
+				return []string{pod.Spec.NodeName}
+			}
+			return nil
+		}).
+		Build()
+	return &RebooterReconciler{
+		Reconciler: &reconciler.Reconciler{
+			Client: fakeClient,
+		},
+		APIReader: fakeClient,
+	}
+}
+
+func TestAreAllPodsEvicted(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	const nodeName = "test-node"
+
+	daemonSetOwner := []metav1.OwnerReference{{Kind: "DaemonSet", Name: "ds", APIVersion: "apps/v1"}}
+	noExecuteToleration := corev1.Toleration{Effect: corev1.TaintEffectNoExecute}
+	existsToleration := corev1.Toleration{Operator: corev1.TolerationOpExists}
+
+	tests := []struct {
+		name    string
+		pods    []corev1.Pod
+		wantErr bool
+	}{
+		{
+			name:    "no pods — node is drained",
+			pods:    nil,
+			wantErr: false,
+		},
+		{
+			name: "only DaemonSet pods — exempt",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "ds-pod", Namespace: "default", OwnerReferences: daemonSetOwner},
+					Spec:       corev1.PodSpec{NodeName: nodeName},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "pod with NoExecute toleration — exempt",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "tolerated-pod", Namespace: "default"},
+					Spec:       corev1.PodSpec{NodeName: nodeName, Tolerations: []corev1.Toleration{noExecuteToleration}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "pod with Exists toleration — exempt",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "exists-tolerated-pod", Namespace: "default"},
+					Spec:       corev1.PodSpec{NodeName: nodeName, Tolerations: []corev1.Toleration{existsToleration}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "blocking pod — not evicted",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "blocking-pod", Namespace: "default"},
+					Spec:       corev1.PodSpec{NodeName: nodeName},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "mix of exempt and blocking pods — returns error for blocking",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "ds-pod", Namespace: "default", OwnerReferences: daemonSetOwner},
+					Spec:       corev1.PodSpec{NodeName: nodeName},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "blocking-pod", Namespace: "default"},
+					Spec:       corev1.PodSpec{NodeName: nodeName},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "pod on different node — not counted",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "other-node-pod", Namespace: "default"},
+					Spec:       corev1.PodSpec{NodeName: "other-node"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := make([]client.Object, len(tt.pods))
+			for i := range tt.pods {
+				objs[i] = &tt.pods[i]
+			}
+			r := newRebooterWithFakeClient(scheme, objs...)
+
+			err := r.AreAllPodsEvicted(context.Background(), nodeName)
+			if tt.wantErr {
+				require.Error(t, err)
+				var podErr *PodNotEvictableError
+				assert.ErrorAs(t, err, &podErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestAreAllPodsEvictedCacheThreshold verifies that a blocking pod is still
+// detected when the total pod count exceeds podEvictionCacheThreshold and the
+// paginated API-reader path is taken.  The fake client used as APIReader does
+// not support real server-side pagination, but it does return all objects, so
+// the correctness of the filtering logic is exercised end-to-end.
+func TestAreAllPodsEvictedCacheThreshold(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	const nodeName = "big-node"
+	// Build just over the threshold (1001 pods) to force the paginated path.
+	const podCount = 1001
+
+	objs := make([]client.Object, podCount)
+	for i := range podCount {
+		objs[i] = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("pod-%d", i),
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{NodeName: nodeName},
+		}
+	}
+
+	r := newRebooterWithFakeClient(scheme, objs...)
+
+	err := r.AreAllPodsEvicted(context.Background(), nodeName)
+	require.Error(t, err)
+	var podErr *PodNotEvictableError
+	assert.ErrorAs(t, err, &podErr, "expected PodNotEvictableError for blocking pod on large node")
 }
 
 func TestHasTolerationForExists(t *testing.T) {


### PR DESCRIPTION
## Problem
rebooter uses too much memory on large clusters during node drain / reboot reconciliation.

## Solution

- Add a controller-runtime cache transform for Pod objects to strip non-essential fields before caching.
- Update AreAllPodsEvicted to switch to API-server pagination (via APIReader) when pod count on a node exceeds a threshold.
- Add unit tests covering AreAllPodsEvicted behavior and the cache transform.

## Testing

- unit-test
- manually

## Release Notes
reduce rebooter memory usage on large clusters during node drain / reboot reconciliation.
