### PR TITLE
SCHED-957: OOM killer should kill docker containers before slurmd

### DIFF
--- a/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/supervisord.conf
+++ b/fluxcd/environment/nebius-cloud/base/custom-configmaps-soperator/supervisord.conf
@@ -12,6 +12,10 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 redirect_stderr=true
 command=/opt/bin/slurm/slurmd_entrypoint.sh
+# https://slurm.schedmd.com/faq.html#slurmd_oom
+# https://man7.org/linux/man-pages/man5/proc_pid_oom_score_adj.5.html
+# sshd is -17, the default is 2
+environment=SLURMD_OOM_ADJ="-16"
 autostart=true
 autorestart=true
 startsecs=0

--- a/helm/soperator-custom-configmaps/config-files/supervisord.conf
+++ b/helm/soperator-custom-configmaps/config-files/supervisord.conf
@@ -12,6 +12,10 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 redirect_stderr=true
 command=/opt/bin/slurm/slurmd_entrypoint.sh
+# https://slurm.schedmd.com/faq.html#slurmd_oom
+# https://man7.org/linux/man-pages/man5/proc_pid_oom_score_adj.5.html
+# sshd is -17, the default is 2
+environment=SLURMD_OOM_ADJ="-16"
 autostart=true
 autorestart=true
 startsecs=0

--- a/internal/render/worker/configmap.go
+++ b/internal/render/worker/configmap.go
@@ -70,6 +70,10 @@ func generateDefaultSupervisordConfig() renderutils.ConfigFile {
 	res.AddLine("stderr_logfile_maxbytes=0")
 	res.AddLine("redirect_stderr=true")
 	res.AddLine("command=/opt/bin/slurm/slurmd_entrypoint.sh")
+	// https://slurm.schedmd.com/faq.html#slurmd_oom
+	// https://man7.org/linux/man-pages/man5/proc_pid_oom_score_adj.5.html
+	// sshd is -17, the default is 2
+	res.AddLine(`environment=SLURMD_OOM_ADJ="-16"`)
 	res.AddLine("autostart=true")
 	res.AddLine("autorestart=true")
 	res.AddLine("startsecs=0")


### PR DESCRIPTION
## Problem

When users spawn memory-heavy processes, e.g. docker containers, the OOM killer can kill slurmd instead of the processes.

## Solution

Tuned the OOM killer a bit. Can extend this to other important processes, e.g. supervisord.

## Testing

manual

## Release Notes

Adjust the slurmd OOM score to be lower than the one of users' jobs.
