### PR TITLE
Fix E2E debug steps and Slack notification formatting

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -345,7 +345,7 @@ jobs:
           bin/e2e apply
 
       - name: K8s Cluster Info and NodeGroups
-        if: '!cancelled()'
+        if: always()
         shell: bash
         run: |
           echo "=== Listing K8s clusters ==="
@@ -363,17 +363,17 @@ jobs:
           done
 
       - name: "K8s Cluster: Pods"
-        if: '!cancelled()'
+        if: always()
         shell: bash
         run: kubectl get pods -A -o wide
 
       - name: "K8s Cluster: Events"
-        if: '!cancelled()'
+        if: always()
         shell: bash
         run: kubectl get events -A --sort-by='.lastTimestamp'
 
       - name: "K8s Cluster: Nodes"
-        if: '!cancelled()'
+        if: always()
         shell: bash
         run: |
           kubectl get nodes
@@ -381,7 +381,7 @@ jobs:
           kubectl get nodes -o yaml
 
       - name: "K8s Cluster: Jobs"
-        if: '!cancelled()'
+        if: always()
         shell: bash
         run: |
           kubectl -n soperator get job
@@ -389,7 +389,7 @@ jobs:
           kubectl -n soperator get job -o yaml
 
       - name: "K8s Cluster: Helm Releases"
-        if: '!cancelled()'
+        if: always()
         shell: bash
         run: |
           kubectl get helmreleases -n flux-system
@@ -397,7 +397,7 @@ jobs:
           kubectl get helmreleases -n flux-system -o yaml
 
       - name: "K8s Cluster: Slurm Cluster CRs"
-        if: '!cancelled()'
+        if: always()
         shell: bash
         run: |
           kubectl get slurmclusters -A
@@ -405,7 +405,7 @@ jobs:
           kubectl get slurmclusters -A -o yaml
 
       - name: "K8s Cluster: Slurm Active Checks CRs"
-        if: '!cancelled()'
+        if: always()
         shell: bash
         run: |
           kubectl get activechecks -A
@@ -413,7 +413,7 @@ jobs:
           kubectl get activechecks -A -o yaml
 
       - name: Slurm Cluster State
-        if: '!cancelled()'
+        if: always()
         shell: bash
         run: |
           kubectl exec -n soperator controller-0 -- sinfo -N || true
@@ -423,14 +423,14 @@ jobs:
           kubectl exec -n soperator controller-0 -- sacct --parsable2 --allusers --starttime=now-6hours | column -t -s'|'
 
       - name: Collect Full Kubernetes Cluster Info
-        if: '!cancelled()'
+        if: always()
         shell: bash
         run: |
           mkdir -p ./cluster-info
           kubectl cluster-info dump --namespaces=kruise-system,soperator-system,soperator,flux-system --output-directory=./cluster-info
 
       - name: Upload Full Kubernetes Cluster Info
-        if: '!cancelled()'
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: cluster-info
@@ -438,7 +438,7 @@ jobs:
           retention-days: 7
 
       - name: Collect Jail Files
-        if: '!cancelled()'
+        if: always()
         shell: bash
         run: |
           mkdir -p ./jail/etc/slurm ./jail/opt/soperator-outputs
@@ -456,7 +456,7 @@ jobs:
           fi
 
       - name: Upload Jail
-        if: '!cancelled()'
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: jail


### PR DESCRIPTION
## Problems solved

- Debug steps were skipped when the workflow was explicitly cancelled, losing valuable debugging information.
- Separately, the Slack failure notification had broken newline rendering.

## Testing

Manual testing

## Release Notes

None