### PR TITLE
fix: avoid nil pointer to empty string for ProcMount in slurmd contai…

### DIFF
--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -252,7 +252,13 @@ func renderContainerNodeSetSlurmd(
 			SeccompProfile: &corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeUnconfined,
 			},
-			ProcMount:       func() *corev1.ProcMountType { if nodeSet.ContainerSlurmd.ProcMount == "" { return nil }; v := nodeSet.ContainerSlurmd.ProcMount; return &v }(),
+			ProcMount: func() *corev1.ProcMountType {
+				if nodeSet.ContainerSlurmd.ProcMount == "" {
+					return nil
+				}
+				v := nodeSet.ContainerSlurmd.ProcMount
+				return &v
+			}(),
 			AppArmorProfile: common.ParseAppArmorProfile(appArmorProfile),
 		},
 		Resources:                resources,


### PR DESCRIPTION
## Problem

When `ContainerSlurmd.ProcMount` is not set (empty string), `ptr.To()` converts it
to a pointer to an empty string. Kubernetes rejects an empty-string `ProcMount` value
as invalid, causing slurmd pod creation to fail for node sets that don't explicitly
configure a ProcMount.

## Solution

Replace `ptr.To(nodeSet.ContainerSlurmd.ProcMount)` with a nil-returning guard:
if `ProcMount` is empty, return `nil` (omitting the field from the pod spec);
otherwise return a pointer to the configured value.

## Testing

Manual: verified that slurmd pods for node sets without an explicit `ProcMount` are
created successfully and that node sets with a configured `ProcMount` still apply it.

## Release Notes

Fix: Slurmd pods no longer fail to start when `ProcMount` is not explicitly configured
in the node set spec.