### PR TITLE
fix: handle unregistered node in scontrol update during worker init

### DIFF
--- a/images/worker/worker_init.py
+++ b/images/worker/worker_init.py
@@ -373,6 +373,13 @@ def apply_node_topology(hostname: str, topology: str) -> None:
         )
         if result.returncode != 0:
             output = (result.stdout + result.stderr).strip()
+            if "Invalid node name" in output:
+                logger.warning(
+                    "scontrol update: node %s not yet registered (dynamic node first start), skipping: %s",
+                    hostname,
+                    output,
+                )
+                return
             logger.error("scontrol update failed (rc=%d): %s", result.returncode, output)
             sys.exit(1)
 


### PR DESCRIPTION
## Problem

During worker pod initialization, `worker_init.py` runs `scontrol update` to
set node address, topology, and state. If the node is not yet registered in
slurmctld, the command fails with "Invalid node name" and the init container
exits with code 1, causing the pod to crash-loop.

## Solution

Detect the "Invalid node name" error in `scontrol update` output and treat it
as a non-fatal warning instead of a fatal error. The node will register itself
when slurmd starts, and `scontrol update` will succeed on subsequent restarts.

## Testing

Manual: verified that worker pods with unregistered nodes complete init
successfully with a warning logged, and that real scontrol failures still
cause a fatal exit.

## Release Notes

Fix: Worker pods no longer crash-loop when `scontrol update` runs before the
node is registered in slurmctld.