### PR TITLE
SCHED-1177: Include cert-manager-system namespace in E2E cluster-info dump

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -427,7 +427,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ./cluster-info
-          kubectl cluster-info dump --namespaces=kruise-system,soperator-system,soperator,flux-system --output-directory=./cluster-info
+          kubectl cluster-info dump --namespaces=kruise-system,soperator-system,soperator,flux-system,cert-manager-system --output-directory=./cluster-info
 
       - name: Upload Full Kubernetes Cluster Info
         if: always()


### PR DESCRIPTION
## Problem

The `cert-manager-system` namespace is missing from the `kubectl cluster-info dump` step in the E2E workflow, so cert-manager pod logs and events are not captured when debugging failures.

## Solution

Added `cert-manager-system` to the `--namespaces` list in the cluster-info dump step.

## Testing

None

## Release Notes

None