### PR TITLE
Add e2e-triage skill for analyzing failed e2e test runs

### DIFF
--- a/.agents/skills/e2e-triage/SKILL.md
+++ b/.agents/skills/e2e-triage/SKILL.md
@@ -1,0 +1,170 @@
+---
+# Codex-triggered metadata
+name: e2e-triage
+description: Analyze root cause of soperator e2e test failures from a GitHub Actions run URL. Use when asked to triage, diagnose, or analyze a failed e2e test run.
+# Claude compatibility metadata
+argument-hint: '<github-actions-run-url>'
+allowed-tools: Bash, Read, Glob, Grep, Agent, AskUserQuestion
+---
+
+# E2E Triage
+
+Analyze a failed soperator e2e test run and produce a root cause summary.
+
+Compatibility notes:
+- This is a repo-local Codex skill bundle under `.agents/skills/`.
+- The workflow text stays Claude-compatible where possible, but Claude may not auto-discover this location.
+- Where the instructions mention `AskUserQuestion`, keep the Claude wording for compatibility. In Codex, ask the same question directly in a plain-text chat message.
+- The only intentional command difference is script location: this repo-local version uses `.agents/skills/e2e-triage/scripts/e2e-split-logs.py` instead of `~/.claude/scripts/e2e-split-logs.py`.
+
+## Phase 1: Download, split logs, and ask for Slack URL
+
+**IMPORTANT: Before starting any downloads, immediately ask the user for the Slack thread URL.** This lets them find and paste it while downloads run.
+
+Do not skip this step. If the user already provided a Slack thread URL, reuse it. Otherwise ask before any downloads, log reads, or other tool calls.
+
+1. Use AskUserQuestion to ask: "Paste the Slack failure notification thread URL (or skip if none):"
+   In Codex, ask the same question as a plain-text chat message.
+2. In parallel, run `python3 .agents/skills/e2e-triage/scripts/e2e-split-logs.py <run-url>` to download and split logs
+3. In parallel, fetch run metadata via `gh api repos/{repo}/actions/runs/{run_id} --jq '{date: .run_started_at, branch: .head_branch}'`
+
+Save the Slack URL for use in Phase 4 (HTML output) and Phase 5 (Jira comment).
+
+Read `steps.json` to get the overview of all steps and their conclusions.
+
+## Phase 2: Investigate
+
+1. Find the first step with `"conclusion": "failure"` — this is the root cause step. Later failures are usually consequences.
+2. Read the last ~200 lines of the failed step's log file (errors are at the bottom).
+3. Based on what you see, consult the **Debug Info Reference** below to decide which diagnostic steps to read next. Follow the evidence — there is no fixed decision tree.
+4. If diagnostic step logs are not sufficient, download artifacts for deeper investigation:
+   - `gh run download {run_id} -n cluster-info -D /tmp/e2e-triage-{run_id}/cluster-info` — full `kubectl cluster-info dump` (pod logs, events, resources) for namespaces: kruise-system, soperator-system, soperator, flux-system
+   - `gh run download {run_id} -n jail -D /tmp/e2e-triage-{run_id}/jail` — Slurm config (`/etc/slurm/`) and soperator outputs (`/opt/soperator-outputs/`)
+
+### Debug Info Reference
+
+Diagnostic steps between Terraform Apply and Terraform Destroy:
+
+| Step | What's inside | When to use |
+|---|---|---|
+| K8s Cluster Info and NodeGroups | Brief state for all node groups, full state for PROVISIONING ones (look at "events") | Terraform apply failed creating node groups. Events usually mean NER / quota / mk8s bug |
+| K8s Cluster: Pods | Brief state of all pods | When no active check ran, to find the reason. Focus on soperator namespace: login-*, worker-*, controller-* |
+| K8s Cluster: Events | Kubernetes cluster events | Rarely — e.g. when a pod cannot pull an image |
+| K8s Cluster: Nodes | State of all k8s nodes | Rarely |
+| K8s Cluster: Jobs | State of all k8s jobs | Rarely — e.g. when a k8s active check job failed |
+| K8s Cluster: Helm Releases | Helm releases in flux-system namespace | When a flux HelmRelease install failed |
+| K8s Cluster: Slurm Cluster CRs | SlurmCluster CRs | Rarely |
+| K8s Cluster: Slurm Active Checks CRs | ActiveCheck CRs | When active checks helm release timed out / failed — shows which checks ran / failed |
+
+### Domain knowledge
+
+- NER = Not Enough Resources (Nebius cloud capacity issue, not a bug in soperator)
+- Ignore `opentelemetry-collector-jail-logs-*` pod failures when no active check has run — this is normal, the collector starts after an active check creates jail folders
+- Post-destroy cleanup steps are not failure causes
+- When terraform destroy fails, always identify the specific resources that failed (resource type, name, ID) by searching for `Still destroying` and error lines in the destroy step log. Include them in the report.
+- The HTML/Slack output must contain the same resource IDs as the terminal summary — they are needed for debugging.
+
+## Phase 3: Search Jira for similar issues
+
+Search for existing known e2e failure tickets:
+
+```bash
+acli jira workitem search --jql 'Labels = "soperator-e2e-fail" AND status NOT IN ("Done", "Won'\''t do")' --fields "key,summary,status" --limit 20
+```
+
+If `acli` is not installed, ask the user to install it. Official macOS install:
+
+```bash
+brew tap atlassian/homebrew-acli
+brew install acli
+```
+
+Then ask the user to run:
+
+```bash
+acli auth login
+```
+
+for OAuth authorization.
+
+If `acli` fails because Jira is unavailable or temporarily unreachable, retry the same command before concluding the search failed.
+
+Compare your root cause against the ticket summaries. If a matching ticket exists, mention its key in the output. If no match is found, note that this may be a new issue.
+
+## Phase 4: Output
+
+Print a structured summary to the terminal, then write an HTML version for Slack to `/tmp/e2e-triage-<run_id>/slack-message.html` and print the full path.
+
+Use `<b>` for labels, `<code>` for log snippets, `<br>` for line breaks, `<a href="...">` for Jira links. Keep it compact enough for a single Slack message. The user can open the HTML file in a browser and copy from there.
+
+At the end, ask the user whether they want to open the HTML file in the browser. If they agree, run `open /tmp/e2e-triage-<run_id>/slack-message.html`.
+
+## Phase 5: Report to Jira
+
+**If a matching Jira ticket was found in Phase 3**, post a comment to it immediately (do NOT ask the user for confirmation):
+
+Post a rich-formatted comment using Atlassian Document Format (ADF):
+
+```bash
+acli jira workitem comment create --key "SCHED-XXXX" --body '<ADF JSON>'
+```
+
+If `acli` is not installed, ask the user to install it. Official macOS install:
+
+```bash
+brew tap atlassian/homebrew-acli
+brew install acli
+```
+
+Then ask the user to run:
+
+```bash
+acli auth login
+```
+
+for OAuth authorization.
+
+If an `acli jira` command fails because Jira is unavailable or temporarily unreachable, retry the same command before giving up.
+
+ADF is a JSON format. Build it with these node types:
+- **Link**: `{"type":"text","text":"display text","marks":[{"type":"link","attrs":{"href":"URL"}}]}`
+- **Code**: `{"type":"text","text":"code snippet","marks":[{"type":"code"}]}`
+- **Bold**: `{"type":"text","text":"bold text","marks":[{"type":"strong"}]}`
+
+Example ADF comment structure:
+
+```json
+{"version":1,"type":"doc","content":[{"type":"paragraph","content":[
+  {"type":"text","text":"Reproduced in "},
+  {"type":"text","text":"run #<run_id>","marks":[{"type":"link","attrs":{"href":"<run_url>"}}]},
+  {"type":"text","text":" (<run_date>, <branch>). "},
+  {"type":"text","text":"Slack thread","marks":[{"type":"link","attrs":{"href":"<slack_url>"}}]},
+  {"type":"text","text":". <root cause summary with "},
+  {"type":"text","text":"code snippets","marks":[{"type":"code"}]},
+  {"type":"text","text":" where relevant."}
+]}]}
+```
+
+**If no matching Jira ticket was found in Phase 3**, use AskUserQuestion to ask:
+- Option 1: "Create a new Jira ticket with `soperator-e2e-fail` label"
+- Option 2: "Investigate further"
+- Option 3: "Done, no ticket needed"
+
+In Codex, ask the same question as a plain-text chat message.
+
+If creating a new ticket, use `acli jira workitem create` with the `soperator-e2e-fail` label, appropriate summary and description based on the root cause analysis, then post the triage comment to it as well.
+
+If `acli` is not installed, ask the user to install it with:
+
+```bash
+brew tap atlassian/homebrew-acli
+brew install acli
+```
+
+Then ask the user to run:
+
+```bash
+acli auth login
+```
+
+for OAuth authorization.

--- a/.agents/skills/e2e-triage/scripts/e2e-split-logs.py
+++ b/.agents/skills/e2e-triage/scripts/e2e-split-logs.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Downloads and splits GitHub Actions e2e-test job logs into per-step files.
+
+Usage: e2e-split-logs.py <run-url-or-id> [repo]
+
+Output: prints the path to a directory containing:
+  steps.json          - step metadata array
+  NN-step-name.log    - per-step log files
+
+Requires: gh CLI
+"""
+
+import dataclasses
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+
+MAX_RETRIES = 5
+RETRY_DELAY_SECONDS = 5
+
+
+@dataclasses.dataclass
+class Step:
+    number: int
+    name: str
+    conclusion: str
+    started_at: str
+    started_dt: datetime
+
+    @property
+    def file(self) -> str:
+        num_str = f"{self.number:02d}"
+        return f"{num_str}-{slugify(self.name)}.log"
+
+
+def usage():
+    print(f"Usage: {sys.argv[0]} <run-url-or-id> [repo]", file=sys.stderr)
+    print("  run-url-or-id: GitHub Actions run URL or numeric run ID", file=sys.stderr)
+    print("  repo: owner/repo (default: nebius/soperator)", file=sys.stderr)
+    sys.exit(1)
+
+
+def _run_with_retries(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    for attempt in range(MAX_RETRIES):
+        result = subprocess.run(cmd, capture_output=True, **kwargs)
+        if result.returncode == 0:
+            return result
+        if attempt < MAX_RETRIES - 1:
+            print(
+                f"Attempt {attempt + 1}/{MAX_RETRIES} failed, retrying in {RETRY_DELAY_SECONDS}s...",
+                file=sys.stderr,
+            )
+            time.sleep(RETRY_DELAY_SECONDS)
+    result.check_returncode()
+    return result  # unreachable, but makes mypy happy
+
+
+def gh_api(endpoint: str) -> str:
+    result = _run_with_retries(["gh", "api", endpoint, "--paginate"], text=True)
+    return result.stdout
+
+
+def gh_api_raw(endpoint: str) -> bytes:
+    result = _run_with_retries(["gh", "api", endpoint])
+    return result.stdout
+
+
+def slugify(name: str) -> str:
+    """Convert step name to a file-safe slug."""
+    slug = re.sub(r"[^a-zA-Z0-9 -]", "", name)
+    slug = re.sub(r"\s+", "-", slug).lower()
+    return slug
+
+
+def parse_log_timestamp(line: str) -> datetime | None:
+    """Extract and parse the ISO timestamp from a log line.
+
+    Log lines look like: 2026-03-15T00:06:57.4345550Z Some text here
+    Some lines are continuation of multiline output with no timestamp.
+    """
+    # Remove BOM if present
+    line = line.lstrip("\ufeff")
+
+    match = re.match(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?)Z\s", line)
+    if not match:
+        return None
+
+    ts_str = match.group(1)
+    # Truncate fractional seconds to 6 digits (Python limit)
+    ts_str = re.sub(r"(\.\d{6})\d+$", r"\1", ts_str)
+    try:
+        return datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def parse_step_timestamp(ts_str: str) -> datetime:
+    """Parse API step timestamp like '2026-03-15T00:06:57Z'."""
+    return datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+
+
+def steps_from_job(job: dict) -> list[Step]:
+    """Extract and sort steps from a GitHub Actions job dict."""
+    steps = [
+        Step(
+            number=s["number"],
+            name=s["name"],
+            conclusion=s["conclusion"],
+            started_at=s["started_at"],
+            started_dt=parse_step_timestamp(s["started_at"]),
+        )
+        for s in job["steps"]
+        if s["started_at"] is not None
+    ]
+    steps.sort(key=lambda s: (s.started_at, s.number))
+    return steps
+
+
+def split_log_lines(steps: list[Step], log_lines: list[str]) -> dict[str, list[str]]:
+    """Split log lines into per-step buckets using a forward-scanning state machine.
+
+    Advances to the next step only when a ##[group] marker is seen AND the timestamp
+    is >= the next step's started_at. This avoids misattributing lines when steps share
+    the same second (GitHub API has only second-precision timestamps).
+
+    Returns a dict mapping step file names to their log lines.
+    """
+    step_lines: dict[str, list[str]] = {s.file: [] for s in steps}
+    current_idx = 0
+    next_idx = 1
+
+    for line in log_lines:
+        ts = parse_log_timestamp(line)
+
+        if ts is not None and next_idx < len(steps):
+            is_group_marker = "##[group]" in line
+            if is_group_marker and ts >= steps[next_idx].started_dt:
+                while next_idx < len(steps) and ts >= steps[next_idx].started_dt:
+                    current_idx = next_idx
+                    next_idx += 1
+
+        step_lines[steps[current_idx].file].append(line)
+
+    return step_lines
+
+
+def main():
+    if len(sys.argv) < 2:
+        usage()
+
+    input_arg = sys.argv[1]
+    repo = sys.argv[2] if len(sys.argv) > 2 else "nebius/soperator"
+
+    # Parse input: accept URL or bare run ID
+    url_match = re.search(r"github\.com/([^/]+/[^/]+)/actions/runs/(\d+)", input_arg)
+    if url_match:
+        repo = url_match.group(1)
+        run_id = url_match.group(2)
+    elif re.match(r"^\d+$", input_arg):
+        run_id = input_arg
+    else:
+        print(f"Error: invalid input '{input_arg}' — expected a run URL or numeric run ID", file=sys.stderr)
+        sys.exit(1)
+
+    out_dir = f"/tmp/e2e-triage-{run_id}"
+    if os.path.exists(out_dir):
+        shutil.rmtree(out_dir)
+    os.makedirs(out_dir)
+
+    # Fetch job metadata
+    print(f"Fetching job metadata for run {run_id}...", file=sys.stderr)
+    jobs_data = json.loads(gh_api(f"repos/{repo}/actions/runs/{run_id}/jobs"))
+
+    e2e_jobs = [j for j in jobs_data["jobs"] if j["name"] == "e2e-test"]
+    if not e2e_jobs:
+        available = [j["name"] for j in jobs_data["jobs"]]
+        print(f"Error: no 'e2e-test' job found in run {run_id}", file=sys.stderr)
+        print(f"Available jobs: {available}", file=sys.stderr)
+        sys.exit(1)
+
+    job = e2e_jobs[0]
+    job_id = job["id"]
+    steps = steps_from_job(job)
+
+    # Download job log
+    print("Downloading job logs...", file=sys.stderr)
+    log_bytes = gh_api_raw(f"repos/{repo}/actions/jobs/{job_id}/logs")
+    log_text = log_bytes.decode("utf-8", errors="replace")
+    log_lines = log_text.splitlines()
+    print(f"Downloaded {len(log_lines)} lines", file=sys.stderr)
+
+    # Split logs
+    print("Splitting logs into per-step files...", file=sys.stderr)
+    step_lines = split_log_lines(steps, log_lines)
+
+    # Write per-step files
+    for filename, lines in step_lines.items():
+        if lines:
+            filepath = os.path.join(out_dir, filename)
+            with open(filepath, "w") as f:
+                f.write("\n".join(lines) + "\n")
+
+    # Write steps.json
+    steps_output = [
+        {
+            "number": s.number,
+            "name": s.name,
+            "conclusion": s.conclusion,
+            "file": s.file,
+            "line_count": len(step_lines[s.file]),
+        }
+        for s in steps
+    ]
+
+    with open(os.path.join(out_dir, "steps.json"), "w") as f:
+        json.dump(steps_output, f, indent=2)
+
+    # Print summary
+    print("\nSteps:", file=sys.stderr)
+    max_name_len = max(len(s["file"]) for s in steps_output)
+    for s in steps_output:
+        print(f"  {s['file']:<{max_name_len}}  {s['conclusion']:<8}  {s['line_count']} lines", file=sys.stderr)
+    print(file=sys.stderr)
+
+    # Output the directory path
+    print(out_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

No automated way to triage failed e2e test runs. Diagnosing failures required manually downloading logs, finding the failed step, and cross-referencing with Jira.

## Solution

Added a repo-local Codex/Claude skill under `.agents/skills/e2e-triage/` with two files:
- `SKILL.md` — multi-phase workflow: download logs, identify root cause, search Jira for known issues, produce Slack-ready HTML report, and optionally create/update Jira tickets
- `scripts/e2e-split-logs.py` — Python helper that downloads GitHub Actions job logs via `gh` CLI and splits them into per-step files with a `steps.json` index

## Testing

None (agent skill definition and helper script, not runtime code).

## Release Notes

None