### PR TITLE
SCHED-1041: Add diagnostic logging to complement_jail

### DIFF
--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -106,6 +106,13 @@ pushd "${jaildir}"
             --device=all \
             "${cap_args[@]}" \
             "${jaildir}"
+
+        echo "Checking NVIDIA lib state after nvidia-container-cli:"
+        echo "  /lib symlink: $(readlink lib 2>/dev/null || echo 'NOT a symlink')"
+        echo "  libnvidia-ml.so.1 exists: $(test -e usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.1 && echo 'yes' || echo 'NO')"
+        echo "  libnvidia-ml.so.1 target: $(readlink usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.1 2>/dev/null || echo 'MISSING')"
+        echo "  libnvidia-ml.so versioned file size: $(stat -c%s usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.*.* 2>/dev/null || echo 'NOT FOUND')"
+
         touch "etc/gpu_libs_installed.flag"
     fi
 
@@ -180,6 +187,17 @@ pushd "${jaildir}"
     # For worker node only
     if [ -n "$worker" ]; then
         echo "Update linker cache inside the jail"
-        flock --nonblock etc/complement_jail_ldconfig.lock -c "chroot \"${jaildir}\" /usr/sbin/ldconfig" || true
+        echo "  libnvidia-ml.so.1 exists before ldconfig: $(test -e usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.1 && echo 'yes' || echo 'NO')"
+        echo "  libnvidia-ml versioned file size before ldconfig: $(stat -c%s usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.*.* 2>/dev/null || echo 'NOT FOUND')"
+        ldconfig_rc=0
+        flock --nonblock etc/complement_jail_ldconfig.lock -c "chroot \"${jaildir}\" /usr/sbin/ldconfig" || ldconfig_rc=$?
+        if [ "$ldconfig_rc" -eq 0 ]; then
+            echo "ldconfig completed successfully (got flock)"
+        elif [ "$ldconfig_rc" -eq 1 ]; then
+            echo "ldconfig SKIPPED (flock busy)"
+        else
+            echo "ldconfig FAILED with exit code ${ldconfig_rc}"
+        fi
+        echo "  libnvidia-ml.so.1 exists after ldconfig: $(test -e usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.1 && echo 'yes' || echo 'NO')"
     fi
 popd


### PR DESCRIPTION
## Problem

We lack visibility into the state of NVIDIA libraries inside the jail after `nvidia-container-cli` runs and after `ldconfig`. When something goes wrong with GPU library resolution, there is no diagnostic output to narrow down the root cause.

## Solution

Added diagnostic `echo` statements to `complement_jail.sh` that log:
- The `/lib` symlink state after `nvidia-container-cli` completes
- Whether `libnvidia-ml.so.1` exists and what it points to
- The versioned `.so` file size before and after `ldconfig`
- Whether `ldconfig` actually ran or was skipped due to `flock`

The `ldconfig` call was also restructured from a silent `|| true` to an if/else that reports whether it got the lock.

## Testing

- Other LLM review
- e2e run: https://github.com/nebius/soperator/actions/runs/23338264092

## Release Notes

None