### PR TITLE
SCHED-1037: Switch CI workflows to pull_request_target for fork PR secrets access

### DIFF
--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - "docs/**"
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Set up Python

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -24,8 +24,9 @@ on:
     tags:
       - "**" # Trigger on any tag
 
-  # pull_request are defined separately to allow to run CI from forks.
-  pull_request:
+  # pull_request_target runs in base branch context, giving fork PRs access to secrets.
+  # The "authorize" job gates fork PRs behind environment approval.
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -36,16 +37,31 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 
 jobs:
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-latest
+    environment: >-
+      ${{
+        github.event_name == 'pull_request_target'
+        && github.event.pull_request.head.repo.full_name != github.repository
+        && 'fork-ci' || ''
+      }}
+    steps:
+      - run: echo "Authorized"
+
   changes:
     name: Detect Changes
+    needs: [authorize]
     runs-on: ubuntu-latest
     outputs:
-      should_build: ${{ steps.filter.outputs.has_code_changes == 'true' || github.event_name != 'pull_request' }}
+      should_build: ${{ steps.filter.outputs.has_code_changes == 'true' || github.event_name != 'pull_request_target' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -76,6 +92,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch git history for the VERSION file changes detection
 
       - name: Install GO
@@ -120,13 +137,15 @@ jobs:
           fi
 
   lint:
-    needs: [changes]
+    needs: [changes, authorize]
     if: needs.changes.outputs.should_build == 'true'
     runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install GO
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -186,6 +205,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install GO
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -301,6 +322,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install GO
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -438,6 +461,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install GO
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -515,6 +540,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Nebius CLI
         shell: bash
@@ -627,6 +654,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Nebius CLI
         shell: bash
@@ -676,6 +705,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install GO
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -719,6 +750,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -1,7 +1,7 @@
 ---
 name: Label Checker
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
## Problem

Fork PRs cannot access repository secrets when triggered by `pull_request` events, blocking CI jobs that need credentials (e.g., Nebius CLI, container registry).

## Solution

- Switch `one_job`, `pr_labels`, and `ansible_lint` workflows from `pull_request` to `pull_request_target`
- Add an `authorize` job in `one_job.yml` gated behind a `fork-ci` environment for fork PRs, so maintainers must approve before CI runs untrusted code
- Explicitly checkout the PR head SHA in all checkout steps, since `pull_request_target` defaults to the base branch

## Testing

Manual -- verified workflow YAML parses correctly and the authorize gate logic is sound.

## Release Notes

None