### PR TITLE
test: verify pull_request_target CI trigger

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -24,7 +24,7 @@ on:
     tags:
       - "**" # Trigger on any tag
 
-  # pull_request_target runs in base branch context, giving fork PRs access to secrets.
+  # pull_request_target runs in the base branch context, giving fork PRs access to secrets.
   # The "authorize" job gates fork PRs behind environment approval.
   pull_request_target:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Trivial comment change to verify CI workflows run correctly with `pull_request_target`.

Close after confirming builds trigger.