### PR TITLE
Add procMount to nodesets Helm template

### DIFF
--- a/helm/nodesets/templates/nodeset.yaml
+++ b/helm/nodesets/templates/nodeset.yaml
@@ -173,6 +173,9 @@ spec:
     security:
       limitsConfig: {{ get (.security | default dict) "limitsConfig" | quote }}
       appArmorProfile: {{ get (.security | default dict) "appArmorProfile" | default "unconfined" | quote }}
+      {{- with (get (.security | default dict) "procMount") }}
+      procMount: {{ . | quote }}
+      {{- end }}
   {{- end }}
 
   {{- $sssd := (.sssd | default dict) }}

--- a/helm/nodesets/values.yaml
+++ b/helm/nodesets/values.yaml
@@ -173,7 +173,7 @@ nodesets:
         limitsConfig: ""
         # Proc mount type for the slurmd container
         # Optional, valid values: "Default", "Unmasked"
-        # procMount: ""
+        # procMount: "Default"
     # Munge configuration
     munge:
       # Each particular NodeSet's containers can have images other than default ones


### PR DESCRIPTION
Add procMount passthrough to nodesets Helm template. The CRD supports it (#1980) but the Helm template omits it.