### PR TITLE
SCHED-951: e2e jail upload should not fail on semicolons

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -511,7 +511,7 @@ jobs:
             echo "No running sconfigcontroller pod found, skipping jail files collection"
           fi
 
-      - name: Tar Jail
+      - name: Zip Jail
         if: always()
         run: |
           zip -r jail jail


### PR DESCRIPTION
https://github.com/nebius/soperator/actions/runs/23494423073/job/68371357306