### PR TITLE
SCHED-1260: add the initial number of powered up nodes

### DIFF
--- a/api/v1alpha1/nodeset_types.go
+++ b/api/v1alpha1/nodeset_types.go
@@ -142,6 +142,16 @@ type NodeSetSpec struct {
 	// +kubebuilder:default=false
 	EphemeralNodes *bool `json:"ephemeralNodes,omitempty"`
 
+	// InitialNumberEphemeralNodes specifies the initial number of nodes to be created when EphemeralNodes is true.
+	// This field is used to set the initial size of the NodeSet when using ephemeral nodes.
+	// It can be updated later to scale the NodeSet up or down.
+	// Defaults to 1.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:default=1
+	InitialNumberEphemeralNodes int32 `json:"initialNumberEphemeralNodes,omitempty"`
+
 	// EphemeralTopologyWaitTimeout specifies the maximum time (in seconds) to wait
 	// for topology data to become available before starting slurmd.
 	// Only used when EphemeralNodes is true.

--- a/api/v1alpha1/nodeset_types.go
+++ b/api/v1alpha1/nodeset_types.go
@@ -142,9 +142,10 @@ type NodeSetSpec struct {
 	// +kubebuilder:default=false
 	EphemeralNodes *bool `json:"ephemeralNodes,omitempty"`
 
-	// InitialNumberEphemeralNodes specifies the initial number of nodes to be created when EphemeralNodes is true.
-	// This field is used to set the initial size of the NodeSet when using ephemeral nodes.
-	// It can be updated later to scale the NodeSet up or down.
+	// InitialNumberEphemeralNodes specifies the initial number of powered-up nodes
+	// when the NodeSetPowerState is first created and EphemeralNodes is true.
+	// Changing this value after the initial creation has no effect; use NodeSetPowerState
+	// directly to scale active nodes up or down.
 	// Defaults to 1.
 	//
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/slurm.nebius.ai_nodesets.yaml
+++ b/config/crd/bases/slurm.nebius.ai_nodesets.yaml
@@ -2554,9 +2554,10 @@ spec:
               initialNumberEphemeralNodes:
                 default: 1
                 description: |-
-                  InitialNumberEphemeralNodes specifies the initial number of nodes to be created when EphemeralNodes is true.
-                  This field is used to set the initial size of the NodeSet when using ephemeral nodes.
-                  It can be updated later to scale the NodeSet up or down.
+                  InitialNumberEphemeralNodes specifies the initial number of powered-up nodes
+                  when the NodeSetPowerState is first created and EphemeralNodes is true.
+                  Changing this value after the initial creation has no effect; use NodeSetPowerState
+                  directly to scale active nodes up or down.
                   Defaults to 1.
                 format: int32
                 minimum: 1

--- a/config/crd/bases/slurm.nebius.ai_nodesets.yaml
+++ b/config/crd/bases/slurm.nebius.ai_nodesets.yaml
@@ -2551,6 +2551,16 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              initialNumberEphemeralNodes:
+                default: 1
+                description: |-
+                  InitialNumberEphemeralNodes specifies the initial number of nodes to be created when EphemeralNodes is true.
+                  This field is used to set the initial size of the NodeSet when using ephemeral nodes.
+                  It can be updated later to scale the NodeSet up or down.
+                  Defaults to 1.
+                format: int32
+                minimum: 1
+                type: integer
               maxUnavailable:
                 anyOf:
                 - type: integer

--- a/helm/nodesets/templates/nodeset.yaml
+++ b/helm/nodesets/templates/nodeset.yaml
@@ -31,6 +31,10 @@ spec:
   ephemeralNodes: {{ .ephemeralNodes }}
   {{- end }}
 
+  {{- with .initialNumberEphemeralNodes }}
+  initialNumberEphemeralNodes: {{ . }}
+  {{- end }}
+
   {{- with .ephemeralTopologyWaitTimeout }}
   ephemeralTopologyWaitTimeout: {{ . }}
   {{- end }}

--- a/helm/nodesets/values.yaml
+++ b/helm/nodesets/values.yaml
@@ -54,6 +54,9 @@ nodesets:
     # Topology data is read from the topology-node-labels ConfigMap at runtime.
     # Optional, defaults to false
     ephemeralNodes: false
+    # Initial number of nodes when ephemeralNodes is true.
+    # Optional, defaults to 1
+    initialNumberEphemeralNodes: 1
     # Maximum time (in seconds) to wait for topology data before starting slurmd.
     # Only used when ephemeralNodes is true.
     # Optional, defaults to 180

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -17648,9 +17648,10 @@ spec:
               initialNumberEphemeralNodes:
                 default: 1
                 description: |-
-                  InitialNumberEphemeralNodes specifies the initial number of nodes to be created when EphemeralNodes is true.
-                  This field is used to set the initial size of the NodeSet when using ephemeral nodes.
-                  It can be updated later to scale the NodeSet up or down.
+                  InitialNumberEphemeralNodes specifies the initial number of powered-up nodes
+                  when the NodeSetPowerState is first created and EphemeralNodes is true.
+                  Changing this value after the initial creation has no effect; use NodeSetPowerState
+                  directly to scale active nodes up or down.
                   Defaults to 1.
                 format: int32
                 minimum: 1

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -17645,6 +17645,16 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              initialNumberEphemeralNodes:
+                default: 1
+                description: |-
+                  InitialNumberEphemeralNodes specifies the initial number of nodes to be created when EphemeralNodes is true.
+                  This field is used to set the initial size of the NodeSet when using ephemeral nodes.
+                  It can be updated later to scale the NodeSet up or down.
+                  Defaults to 1.
+                format: int32
+                minimum: 1
+                type: integer
               maxUnavailable:
                 anyOf:
                 - type: integer

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -17648,9 +17648,10 @@ spec:
               initialNumberEphemeralNodes:
                 default: 1
                 description: |-
-                  InitialNumberEphemeralNodes specifies the initial number of nodes to be created when EphemeralNodes is true.
-                  This field is used to set the initial size of the NodeSet when using ephemeral nodes.
-                  It can be updated later to scale the NodeSet up or down.
+                  InitialNumberEphemeralNodes specifies the initial number of powered-up nodes
+                  when the NodeSetPowerState is first created and EphemeralNodes is true.
+                  Changing this value after the initial creation has no effect; use NodeSetPowerState
+                  directly to scale active nodes up or down.
                   Defaults to 1.
                 format: int32
                 minimum: 1

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -17645,6 +17645,16 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              initialNumberEphemeralNodes:
+                default: 1
+                description: |-
+                  InitialNumberEphemeralNodes specifies the initial number of nodes to be created when EphemeralNodes is true.
+                  This field is used to set the initial size of the NodeSet when using ephemeral nodes.
+                  It can be updated later to scale the NodeSet up or down.
+                  Defaults to 1.
+                format: int32
+                minimum: 1
+                type: integer
               maxUnavailable:
                 anyOf:
                 - type: integer

--- a/internal/controller/nodesetcontroller/reconcile.go
+++ b/internal/controller/nodesetcontroller/reconcile.go
@@ -609,8 +609,8 @@ func (r *NodeSetReconciler) reconcileNodeSetPowerState(
 
 	if apierrors.IsNotFound(err) {
 		logger.V(1).Info("NodeSetPowerState not found, it will be created")
-		activeNodes := make([]int32, nodeSet.Spec.Replicas)
-		for i := int32(0); i < nodeSet.Spec.Replicas; i++ {
+		activeNodes := make([]int32, nodeSet.Spec.InitialNumberEphemeralNodes)
+		for i := int32(0); i < nodeSet.Spec.InitialNumberEphemeralNodes; i++ {
 			activeNodes[i] = i
 		}
 		desired.Spec.ActiveNodes = activeNodes


### PR DESCRIPTION
## Problem
Ephemeral NodeSets always powered up all replicas on first creation, because NodeSetPowerState was initialized with every node index (0..replicas-1). Operators had no way to start with a smaller warm pool and scale up later.


## Solution
Added NodeSetSpec.InitialNumberEphemeralNodes field (default 1, minimum 1). When the NodeSetPowerState CR is first created, only that many nodes are listed as active instead of the full replica count. The field is exposed in the nodesets Helm chart values and templates.

## Testing
Verified CRD generation (make sync-version-from-scratch) passes.
Helm template renders initialNumberEphemeralNodes when set.
Needs e2e validation: create an ephemeral NodeSet with replicas: 8, initialNumberEphemeralNodes: 2 and confirm only 2 nodes start powered-up.


## Release Notes
Feature: New initialNumberEphemeralNodes field on NodeSet allows controlling how many ephemeral nodes are powered up at creation time, instead of always starting all replicas. Defaults to 1.
