### PR TITLE
SCHED-1401: Empty e2e backups bucket before init-time destroy

### DIFF
--- a/internal/e2e/backups_bucket_cleanup.go
+++ b/internal/e2e/backups_bucket_cleanup.go
@@ -1,0 +1,42 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+)
+
+// backupsBucketName is the deterministic name of the e2e backups bucket,
+// matching ${instance_name}-backups in soperator/modules/backups_store/main.tf
+// where instance_name = k8s_cluster_name = soperator-e2e-test.
+const backupsBucketName = k8sClusterName + "-backups"
+
+// bestEffortEmptyBackupsBucket removes all objects from the e2e backups bucket.
+// It is called before init-time `tf destroy` to recover from a previous run
+// where terraform destroy failed with BucketNotEmpty and left the bucket
+// behind. It is best-effort: any failure is logged and swallowed so init can
+// proceed to `tf destroy`, which will report the real error if the bucket
+// genuinely can't be deleted.
+//
+// The AWS CLI is pre-configured by the calling workflow step with the bucket's
+// region and nebius storage endpoint, so we just shell out.
+func bestEffortEmptyBackupsBucket(ctx context.Context) {
+	if _, err := exec.LookPath("aws"); err != nil {
+		log.Printf("aws CLI not found, skipping pre-init backups bucket cleanup: %v", err)
+		return
+	}
+
+	if err := exec.CommandContext(ctx, "aws", "s3api", "head-bucket", "--bucket", backupsBucketName).Run(); err != nil {
+		log.Printf("Backups bucket %s does not exist or is not accessible, skipping pre-init cleanup", backupsBucketName)
+		return
+	}
+
+	log.Printf("Emptying backups bucket %s before init-time destroy", backupsBucketName)
+	out, err := exec.CommandContext(ctx, "aws", "s3", "rm", fmt.Sprintf("s3://%s/", backupsBucketName), "--recursive").CombinedOutput()
+	if err != nil {
+		log.Printf("Best-effort empty of bucket %s failed: %v\nOutput: %s", backupsBucketName, err, string(out))
+		return
+	}
+	log.Printf("Backups bucket %s emptied", backupsBucketName)
+}

--- a/internal/e2e/e2e_init.go
+++ b/internal/e2e/e2e_init.go
@@ -11,5 +11,11 @@ func RunInit(ctx context.Context, cfg Config) error {
 	}
 	defer cleanup()
 
+	// Recover from the SCHED-1401 leak pattern: a previous run's terraform
+	// destroy failed with BucketNotEmpty and left the backups bucket (plus
+	// objects) behind. On that next run cleanup_bucket is already out of
+	// state so tf destroy can't re-empty the bucket; empty it here first.
+	bestEffortEmptyBackupsBucket(ctx)
+
 	return destroyWithK8sRecovery(ctx, tf, varFilePath, cfg.Profile.NebiusProjectID)
 }


### PR DESCRIPTION
## Problem

When a previous e2e run's `terraform destroy` fails with `BucketNotEmpty`, the backups bucket (and its objects) is left behind. On the next run, `cleanup_bucket` is already out of terraform state, so the init-time `tf destroy` cannot re-empty the bucket and the teardown stays stuck across runs.

## Solution

- Run `s3 rm --recursive` on the `soperator-e2e-test-backups` bucket before init-time destroy.

## Testing

- https://github.com/nebius/soperator/actions/runs/24193197140

## Related

- nebius/nebius-solutions-library#909 — Terraform fix that addresses the root cause of the race: reorders destroy so the bucket cleanup runs after `module.slurm` teardown so backup pods stop writing before the bucket is emptied. This PR is the recovery-side patch that lets already-leaked state from pre-fix runs self-heal.

## Release Notes

None