### PR TITLE
[cherry-pick] SCHED-951: e2e jail upload should not fail on semicolons

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -511,7 +511,7 @@ jobs:
             echo "No running sconfigcontroller pod found, skipping jail files collection"
           fi
 
-      - name: Tar Jail
+      - name: Zip Jail
         if: always()
         run: |
           zip -r jail jail

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -511,12 +511,18 @@ jobs:
             echo "No running sconfigcontroller pod found, skipping jail files collection"
           fi
 
+      - name: Tar Jail
+        if: always()
+        run: |
+          zip -r jail jail
+
       - name: Upload Jail
         if: always()
         uses: actions/upload-artifact@v6
         with:
+          archive: false
           name: jail
-          path: ./jail
+          path: jail.zip
           retention-days: 7
 
       - name: Terraform Destroy


### PR DESCRIPTION
Cherry-picked from #2358

https://github.com/nebius/soperator/actions/runs/23494423073/job/68371357306