### PR TITLE
SCHED-1402: Wait for populate-jail before complementing jail

### DIFF
--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -22,6 +22,16 @@ if [ -z "$jaildir" ] || [ -z "$upperdir" ]; then
     usage
 fi
 
+echo "Waiting for populate-jail to complete..."
+timeout=600; elapsed=0
+while [ ! -f "${jaildir}/.populated" ] && [ $elapsed -lt $timeout ]; do
+    sleep 5; elapsed=$((elapsed + 5))
+done
+if [ ! -f "${jaildir}/.populated" ]; then
+    echo "ERROR: populate-jail did not complete within ${timeout}s"
+    exit 1
+fi
+
 ALT_ARCH="$(uname -m)"
 echo "🔧 Using ALT_ARCH = ${ALT_ARCH}"
 


### PR DESCRIPTION
## Problem

`complement_jail.sh` can start before `populate_jail_entrypoint.sh` finishes the restic restore. When restic runs with `--delete`, it removes the 0-byte bind mount targets (`chroot.so`, `spanknccldebug.so`, `spank_pyxis.so`) that `complement_jail` creates while restic is still writing. This causes `dlopen(chroot.so): No such file or directory` on node replacement, with roughly 30% e2e failure rate.

## Solution

- Add a wait loop at the top of `complement_jail.sh` that blocks until the `.populated` sentinel file exists, matching the existing pattern in `sconfigcontroller`
- 600-second timeout with 5-second poll interval

## Testing

Manual verification that login/worker logs show the wait message before proceeding. E2e acceptance tests (sbatch in node replacement) should now pass consistently.

## Release Notes

Fix: node replacement no longer fails intermittently due to a race between jail population and jail complementing.