### PR TITLE
SCHED-1402: Requeue when populate jail job exists but has not completed yet

### DIFF
--- a/internal/controller/clustercontroller/populate_job.go
+++ b/internal/controller/clustercontroller/populate_job.go
@@ -30,9 +30,10 @@ func (r SlurmClusterReconciler) ReconcilePopulateJail(
 	ctx context.Context,
 	clusterValues *values.SlurmCluster,
 	cluster *slurmv1.SlurmCluster,
-) (ctrl.Result, error) {
+) (res ctrl.Result, notReady bool, err error) {
 	logger := log.FromContext(ctx)
 	populateJailRequeue := false
+	populateJailNotReady := false
 
 	reconcilePopulateJailImpl := func() error {
 		return utils.ExecuteMultiStep(ctx,
@@ -78,7 +79,12 @@ func (r SlurmClusterReconciler) ReconcilePopulateJail(
 							}
 							return nil
 						}
-						stepLogger.V(1).Info("Skipping creation: Populate jail Job already exists")
+						if desired.Status.Succeeded == 0 {
+							stepLogger.Info("Populate jail Job exists but not yet completed, requeueing")
+							populateJailNotReady = true
+							return nil
+						}
+						stepLogger.V(1).Info("Skipping creation: Populate jail Job already completed")
 						return nil
 					}
 
@@ -170,15 +176,18 @@ func (r SlurmClusterReconciler) ReconcilePopulateJail(
 
 	if err := reconcilePopulateJailImpl(); err != nil {
 		logger.Error(err, "Failed to reconcile Populate jail Job")
-		return ctrl.Result{}, fmt.Errorf("reconciling Populate jail Job: %w", err)
+		return ctrl.Result{}, false, fmt.Errorf("reconciling Populate jail Job: %w", err)
+	}
+	if populateJailNotReady {
+		return ctrl.Result{RequeueAfter: populateJailRequeueDuration}, true, nil
 	}
 	if populateJailRequeue {
 		logger.Info("Populate jail reconciliation requeue requested: waiting for login/worker pods termination")
-		return ctrl.Result{RequeueAfter: populateJailRequeueDuration}, nil
+		return ctrl.Result{RequeueAfter: populateJailRequeueDuration}, false, nil
 	}
 	logger.Info("Reconciled Populate jail Job")
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, false, nil
 }
 
 func isConditionNonOverwrite(conditions []metav1.Condition) bool {

--- a/internal/controller/clustercontroller/populate_job.go
+++ b/internal/controller/clustercontroller/populate_job.go
@@ -77,6 +77,11 @@ func (r SlurmClusterReconciler) ReconcilePopulateJail(
 								}
 								stepLogger.V(1).Info("Successfully deleted Populate Jail Job")
 							}
+							if desired.Status.Succeeded == 0 {
+								stepLogger.Info("Populate jail Job exists but not yet completed, requeueing")
+								populateJailNotReady = true
+								return nil
+							}
 							return nil
 						}
 						if desired.Status.Succeeded == 0 {

--- a/internal/controller/clustercontroller/populate_job_test.go
+++ b/internal/controller/clustercontroller/populate_job_test.go
@@ -1,0 +1,168 @@
+package clustercontroller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	slurmv1 "nebius.ai/slurm-operator/api/v1"
+	"nebius.ai/slurm-operator/internal/consts"
+	"nebius.ai/slurm-operator/internal/controller/reconciler"
+	"nebius.ai/slurm-operator/internal/values"
+)
+
+func newTestReconciler(t *testing.T, objects ...client.Object) SlurmClusterReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add batchv1 to scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+	if err := slurmv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add slurmv1 to scheme: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+
+	return SlurmClusterReconciler{
+		Reconciler: reconciler.NewReconciler(fakeClient, scheme, nil),
+	}
+}
+
+func TestReconcilePopulateJail_ExistingJob(t *testing.T) {
+	const (
+		namespace = "test-ns"
+		jobName   = "test-cluster-populate-jail"
+	)
+
+	clusterValues := &values.SlurmCluster{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      "test-cluster",
+		},
+		PopulateJail: values.PopulateJail{
+			Name: jobName,
+		},
+	}
+	cluster := &slurmv1.SlurmCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: namespace,
+		},
+	}
+
+	tests := []struct {
+		name           string
+		jobSucceeded   int32
+		expectNotReady bool
+		expectRequeue  time.Duration
+	}{
+		{
+			name:           "completed job proceeds normally",
+			jobSucceeded:   1,
+			expectNotReady: false,
+			expectRequeue:  0,
+		},
+		{
+			name:           "incomplete job returns notReady",
+			jobSucceeded:   0,
+			expectNotReady: true,
+			expectRequeue:  10 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      jobName,
+					Namespace: namespace,
+				},
+				Status: batchv1.JobStatus{
+					Succeeded: tt.jobSucceeded,
+				},
+			}
+
+			r := newTestReconciler(t, job)
+			res, notReady, err := r.ReconcilePopulateJail(context.Background(), clusterValues, cluster)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if notReady != tt.expectNotReady {
+				t.Errorf("notReady = %v, want %v", notReady, tt.expectNotReady)
+			}
+			if res.RequeueAfter != tt.expectRequeue {
+				t.Errorf("RequeueAfter = %v, want %v", res.RequeueAfter, tt.expectRequeue)
+			}
+		})
+	}
+}
+
+// TestReconcilePopulateJail_MaintenanceOverwriteWithActivePods verifies PR #2183
+// logic: in maintenance overwrite mode with active login pods and no Job,
+// notReady must be false (so ReconcileLogin/Worker run to scale pods down)
+// while RequeueAfter is set (to retry populate-jail creation after scale-down).
+func TestReconcilePopulateJail_MaintenanceOverwriteWithActivePods(t *testing.T) {
+	const (
+		namespace   = "test-ns"
+		clusterName = "test-cluster"
+		jobName     = "test-cluster-populate-jail"
+	)
+
+	maintenanceMode := consts.ModeDownscaleAndOverwritePopulate
+	clusterValues := &values.SlurmCluster{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      clusterName,
+		},
+		PopulateJail: values.PopulateJail{
+			Name:        jobName,
+			Maintenance: &maintenanceMode,
+		},
+	}
+	cluster := &slurmv1.SlurmCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+		},
+	}
+
+	loginPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "login-0",
+			Namespace: namespace,
+			Labels: map[string]string{
+				consts.LabelInstanceKey:  clusterName,
+				consts.LabelComponentKey: consts.ComponentTypeLogin.String(),
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	r := newTestReconciler(t, loginPod)
+	res, notReady, err := r.ReconcilePopulateJail(context.Background(), clusterValues, cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if notReady {
+		t.Errorf("notReady = true, want false (rest of reconciliation must run to scale down pods)")
+	}
+	if res.RequeueAfter != 10*time.Second {
+		t.Errorf("RequeueAfter = %v, want %v", res.RequeueAfter, 10*time.Second)
+	}
+}

--- a/internal/controller/clustercontroller/populate_job_test.go
+++ b/internal/controller/clustercontroller/populate_job_test.go
@@ -166,3 +166,63 @@ func TestReconcilePopulateJail_MaintenanceOverwriteWithActivePods(t *testing.T) 
 		t.Errorf("RequeueAfter = %v, want %v", res.RequeueAfter, 10*time.Second)
 	}
 }
+
+// TestReconcilePopulateJail_MaintenanceOverwriteIncompleteJob verifies that in
+// overwrite mode, if the new overwrite Job exists but hasn't completed yet
+// (e.g. operator restarted during poll loop), notReady is true so the
+// reconciler doesn't proceed to create login/worker pods.
+func TestReconcilePopulateJail_MaintenanceOverwriteIncompleteJob(t *testing.T) {
+	const (
+		namespace   = "test-ns"
+		clusterName = "test-cluster"
+		jobName     = "test-cluster-populate-jail"
+	)
+
+	maintenanceMode := consts.ModeDownscaleAndOverwritePopulate
+	clusterValues := &values.SlurmCluster{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      clusterName,
+		},
+		PopulateJail: values.PopulateJail{
+			Name:        jobName,
+			Maintenance: &maintenanceMode,
+		},
+	}
+	cluster := &slurmv1.SlurmCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+		},
+		Status: slurmv1.SlurmClusterStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   slurmv1.ConditionClusterPopulateJailMode,
+					Reason: string(consts.ModeDownscaleAndOverwritePopulate),
+				},
+			},
+		},
+	}
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespace,
+		},
+		Status: batchv1.JobStatus{
+			Succeeded: 0,
+		},
+	}
+
+	r := newTestReconciler(t, job)
+	res, notReady, err := r.ReconcilePopulateJail(context.Background(), clusterValues, cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !notReady {
+		t.Errorf("notReady = false, want true (incomplete overwrite Job must block reconciliation)")
+	}
+	if res.RequeueAfter != 10*time.Second {
+		t.Errorf("RequeueAfter = %v, want %v", res.RequeueAfter, 10*time.Second)
+	}
+}

--- a/internal/controller/clustercontroller/reconcile.go
+++ b/internal/controller/clustercontroller/reconcile.go
@@ -260,9 +260,18 @@ func (r *SlurmClusterReconciler) reconcile(ctx context.Context, cluster *slurmv1
 	populateJailRes := ctrl.Result{}
 
 	if !check.IsModeSkipPopulateJail(clusterValues.PopulateJail.Maintenance) {
-		populateJailRes, err = r.ReconcilePopulateJail(ctx, clusterValues, cluster)
+		var populateJailNotReady bool
+		populateJailRes, populateJailNotReady, err = r.ReconcilePopulateJail(ctx, clusterValues, cluster)
 		if err != nil {
 			return ctrl.Result{}, err
+		}
+		// Skip rest of reconciliation if the populate-jail Job exists but hasn't
+		// completed yet — login/worker pods must not be created while restic
+		// restore is still running. Independent of the maintenance-overwrite
+		// requeue handled at the end of this function (which deliberately lets
+		// login/worker reconcilers run so they can scale to zero).
+		if populateJailNotReady {
+			return populateJailRes, nil
 		}
 	}
 


### PR DESCRIPTION
## Problem

When a populate-jail Job already exists (e.g. from a previous reconciliation cycle), `ReconcilePopulateJail` returned success without checking whether the Job had actually completed. This let the reconciler proceed to create login/worker pods while restic restore was still running — restic's `--delete` pass could then remove files that `complement_jail.sh` had already written, causing ~30% e2e failure rate (`dlopen(chroot.so): No such file or directory`).

## Solution

`ReconcilePopulateJail` now checks `Status.Succeeded` when the Job already exists:
- `Succeeded > 0` → return normally, reconciliation continues
- `Succeeded == 0` → return `notReady = true`, caller early-returns before `ReconcileLogin`/`ReconcileWorker` and requeues after 10s

This is intentionally separate from PR #2183's `populateJailRequeue` mechanism (maintenance overwrite mode), which must let the rest of the reconciliation run so that login/worker StatefulSets get scaled to zero.

## Testing

[E2E runs](https://github.com/nebius/soperator/actions/workflows/e2e_test.yml?query=branch%3ASCHED-1402%2Ffix-node-replacement-2)

## Release Notes

Fix: populate-jail reconciliation no longer skips incomplete jobs, preventing broken node replacements caused by a race between restic restore and login/worker pod creation.