### PR TITLE
SCHED-1320 Make Internal SSH test up to date

### DIFF
--- a/internal/e2e/acceptance/features/internal_ssh.feature
+++ b/internal/e2e/acceptance/features/internal_ssh.feature
@@ -1,5 +1,6 @@
 Feature: Internal SSH
   Scenario: A regular user can SSH to a worker without extra options
     Given a regular user account exists on the login node
+    And the selected worker host key is not present for that user
     When the user SSHs from the login node to a worker
     Then the connection succeeds without extra SSH options

--- a/internal/e2e/acceptance/features/internal_ssh.feature
+++ b/internal/e2e/acceptance/features/internal_ssh.feature
@@ -1,6 +1,5 @@
 Feature: Internal SSH
   Scenario: A regular user can SSH to a worker without extra options
     Given a regular user account exists on the login node
-    And the selected worker host key is not present for that user
     When the user SSHs from the login node to a worker
     Then the connection succeeds without extra SSH options

--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cucumber/godog"
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +20,13 @@ import (
 
 //go:embed features/*.feature
 var acceptanceFeatures embed.FS
+
+type timingCtxKey string
+
+const (
+	scenarioStartTimeKey timingCtxKey = "acceptance_scenario_start_time"
+	stepStartTimeKey     timingCtxKey = "acceptance_step_start_time"
+)
 
 type Runner struct {
 	state *framework.ClusterState
@@ -69,7 +77,10 @@ func (r *Runner) Run(ctx context.Context) error {
 		},
 	}
 
-	if status := suite.Run(); status != 0 {
+	suiteStart := time.Now()
+	status := suite.Run()
+	log.Printf("acceptance: suite finished duration=%s", time.Since(suiteStart).Round(time.Millisecond))
+	if status != 0 {
 		return fmt.Errorf("godog suite exited with status %d", status)
 	}
 
@@ -132,12 +143,51 @@ func featurePaths() []string {
 }
 
 func (r *Runner) initializeScenario(sc *godog.ScenarioContext) {
+	registerTimingHooks(sc)
+
 	w := newWorld(r.state)
 
 	steps.NewClusterCreation(r.state, w).Register(sc)
 	steps.NewInternalSSH(w).Register(sc)
 	steps.NewPackageInstallation(w).Register(sc)
 	steps.NewNodeReplacement(w).Register(sc)
+}
+
+func registerTimingHooks(sc *godog.ScenarioContext) {
+	sc.Before(func(ctx context.Context, scenario *godog.Scenario) (context.Context, error) {
+		log.Printf("acceptance: scenario started: %q", scenario.Name)
+		return context.WithValue(ctx, scenarioStartTimeKey, time.Now()), nil
+	})
+
+	sc.StepContext().Before(func(ctx context.Context, step *godog.Step) (context.Context, error) {
+		return context.WithValue(ctx, stepStartTimeKey, time.Now()), nil
+	})
+
+	sc.StepContext().After(func(ctx context.Context, step *godog.Step, status godog.StepResultStatus, err error) (context.Context, error) {
+		duration := "unknown"
+		if startedAt, ok := ctx.Value(stepStartTimeKey).(time.Time); ok && !startedAt.IsZero() {
+			duration = time.Since(startedAt).Round(time.Millisecond).String()
+		}
+		if err != nil {
+			log.Printf("acceptance: step finished: %q status=%s duration=%s err=%v", step.Text, status, duration, err)
+			return ctx, nil
+		}
+		log.Printf("acceptance: step finished: %q status=%s duration=%s", step.Text, status, duration)
+		return ctx, nil
+	})
+
+	sc.After(func(ctx context.Context, scenario *godog.Scenario, err error) (context.Context, error) {
+		duration := "unknown"
+		if startedAt, ok := ctx.Value(scenarioStartTimeKey).(time.Time); ok && !startedAt.IsZero() {
+			duration = time.Since(startedAt).Round(time.Millisecond).String()
+		}
+		if err != nil {
+			log.Printf("acceptance: scenario finished: %q duration=%s err=%v", scenario.Name, duration, err)
+			return ctx, nil
+		}
+		log.Printf("acceptance: scenario finished: %q duration=%s", scenario.Name, duration)
+		return ctx, nil
+	})
 }
 
 func newWorld(state *framework.ClusterState) *world {

--- a/internal/e2e/acceptance/steps/internal_ssh.go
+++ b/internal/e2e/acceptance/steps/internal_ssh.go
@@ -24,6 +24,7 @@ func NewInternalSSH(exec framework.Exec) *InternalSSH {
 
 func (s *InternalSSH) Register(sc *godog.ScenarioContext) {
 	sc.Step(`^a regular user account exists on the login node$`, s.aRegularUserAccountExistsOnTheLoginNode)
+	sc.Step(`^the selected worker host key is not present for that user$`, s.theSelectedWorkerHostKeyIsNotPresentForThatUser)
 	sc.Step(`^the user SSHs from the login node to a worker$`, s.theUserSSHsFromTheLoginNodeToAWorker)
 	sc.Step(`^the connection succeeds without extra SSH options$`, s.theConnectionSucceedsWithoutExtraSSHOptions)
 }
@@ -44,10 +45,22 @@ func (s *InternalSSH) aRegularUserAccountExistsOnTheLoginNode(ctx context.Contex
 	return nil
 }
 
+func (s *InternalSSH) theSelectedWorkerHostKeyIsNotPresentForThatUser(ctx context.Context) error {
+	cmd := fmt.Sprintf(
+		"su - %s -c 'mkdir -p ~/.ssh && touch ~/.ssh/known_hosts && ssh-keygen -R %s -f ~/.ssh/known_hosts >/dev/null 2>&1 || true'",
+		framework.ShellQuote(sshUserName),
+		framework.ShellQuote(s.targetWorker.Name),
+	)
+	if _, err := s.exec.ExecJail(ctx, cmd); err != nil {
+		return fmt.Errorf("remove existing host key for %s and user %s: %w", s.targetWorker.Name, sshUserName, err)
+	}
+	return nil
+}
+
 func (s *InternalSSH) theUserSSHsFromTheLoginNodeToAWorker(ctx context.Context) error {
 	cmd := fmt.Sprintf("su - %s -c 'timeout 30 ssh %s hostname </dev/null'",
 		framework.ShellQuote(sshUserName), framework.ShellQuote(s.targetWorker.Name))
-	out, err := framework.ExecJailWithDefaultRetry(ctx, s.exec, cmd)
+	out, err := s.exec.ExecJail(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("ssh from login to worker as %s: %w", sshUserName, err)
 	}

--- a/internal/e2e/acceptance/steps/internal_ssh.go
+++ b/internal/e2e/acceptance/steps/internal_ssh.go
@@ -24,7 +24,6 @@ func NewInternalSSH(exec framework.Exec) *InternalSSH {
 
 func (s *InternalSSH) Register(sc *godog.ScenarioContext) {
 	sc.Step(`^a regular user account exists on the login node$`, s.aRegularUserAccountExistsOnTheLoginNode)
-	sc.Step(`^the selected worker host key is not present for that user$`, s.theSelectedWorkerHostKeyIsNotPresentForThatUser)
 	sc.Step(`^the user SSHs from the login node to a worker$`, s.theUserSSHsFromTheLoginNodeToAWorker)
 	sc.Step(`^the connection succeeds without extra SSH options$`, s.theConnectionSucceedsWithoutExtraSSHOptions)
 }
@@ -45,22 +44,19 @@ func (s *InternalSSH) aRegularUserAccountExistsOnTheLoginNode(ctx context.Contex
 	return nil
 }
 
-func (s *InternalSSH) theSelectedWorkerHostKeyIsNotPresentForThatUser(ctx context.Context) error {
-	cmd := fmt.Sprintf(
-		"su - %s -c 'mkdir -p ~/.ssh && touch ~/.ssh/known_hosts && ssh-keygen -R %s -f ~/.ssh/known_hosts >/dev/null 2>&1 || true'",
-		framework.ShellQuote(sshUserName),
-		framework.ShellQuote(s.targetWorker.Name),
-	)
-	if _, err := s.exec.ExecJail(ctx, cmd); err != nil {
-		return fmt.Errorf("remove existing host key for %s and user %s: %w", s.targetWorker.Name, sshUserName, err)
-	}
-	return nil
-}
-
 func (s *InternalSSH) theUserSSHsFromTheLoginNodeToAWorker(ctx context.Context) error {
-	cmd := fmt.Sprintf("su - %s -c 'timeout 30 ssh %s hostname </dev/null'",
-		framework.ShellQuote(sshUserName), framework.ShellQuote(s.targetWorker.Name))
-	out, err := s.exec.ExecJail(ctx, cmd)
+	worker := framework.ShellQuote(s.targetWorker.Name)
+	// Remove the worker key before each SSH attempt so retries don't depend on
+	// persisted known_hosts state from previous attempts.
+	cmd := fmt.Sprintf("su - %s -c %s",
+		framework.ShellQuote(sshUserName),
+		framework.ShellQuote(fmt.Sprintf(
+			"mkdir -p ~/.ssh && touch ~/.ssh/known_hosts && (ssh-keygen -R %s -f ~/.ssh/known_hosts >/dev/null 2>&1 || true) && timeout 30 ssh %s hostname </dev/null",
+			worker,
+			worker,
+		)),
+	)
+	out, err := framework.ExecJailWithDefaultRetry(ctx, s.exec, cmd)
 	if err != nil {
 		return fmt.Errorf("ssh from login to worker as %s: %w", sshUserName, err)
 	}


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
1. Current internal ssh test is not fully compatible with the scenario from confluence.
2. There are no information about step/test duration in the logs

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
1. Make it compatible
2. Add hooks to track execution time.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
E2e test - https://github.com/nebius/soperator/actions/runs/24453565524

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
