### PR TITLE
SCHED-1302 Add RUN_UNSTABLE_TESTS flag

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: ""
         type: string
+      run_unstable_tests:
+        description: "Run acceptance scenarios tagged @unstable"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -158,6 +163,7 @@ jobs:
       O11Y_ACCESS_TOKEN: ${{ secrets.E2E_O11Y_ACCESS_TOKEN }}
       PROFILE_ENV_VAR: ${{ inputs.profile_env_var || vars.PROFILE_ENV_VAR }}
       E2E_PROFILE: ${{ vars[inputs.profile_env_var || vars.PROFILE_ENV_VAR] }}
+      RUN_UNSTABLE_TESTS: ${{ inputs.run_unstable_tests }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -21,8 +21,8 @@ on:
       run_unstable_tests:
         description: "Run acceptance scenarios tagged @unstable"
         required: false
-        default: false
-        type: boolean
+        default: "false"
+        type: string
 
 permissions:
   contents: read
@@ -163,7 +163,7 @@ jobs:
       O11Y_ACCESS_TOKEN: ${{ secrets.E2E_O11Y_ACCESS_TOKEN }}
       PROFILE_ENV_VAR: ${{ inputs.profile_env_var || vars.PROFILE_ENV_VAR }}
       E2E_PROFILE: ${{ vars[inputs.profile_env_var || vars.PROFILE_ENV_VAR] }}
-      RUN_UNSTABLE_TESTS: ${{ inputs.run_unstable_tests }}
+      RUN_UNSTABLE_TESTS: ${{ inputs.run_unstable_tests || 'false' }}
 
     steps:
       - name: Checkout repository

--- a/internal/e2e/acceptance.go
+++ b/internal/e2e/acceptance.go
@@ -21,7 +21,7 @@ func RunAcceptance(ctx context.Context, cfg Config) error {
 		})
 	}
 
-	runner := acceptance.NewRunner(state)
+	runner := acceptance.NewRunner(state, cfg.RunUnstableTests)
 
 	if err := runner.Run(ctx); err != nil {
 		return fmt.Errorf("run acceptance suite: %w", err)

--- a/internal/e2e/acceptance/features/node_replacement.feature
+++ b/internal/e2e/acceptance/features/node_replacement.feature
@@ -1,5 +1,6 @@
 Feature: Node replacement
   @gpu
+  @unstable
   Scenario: A maintenance event replaces the selected worker node
     Given a test job is submitted and running on a worker node
     When a maintenance event is triggered for that node

--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -29,10 +29,11 @@ const (
 )
 
 type Runner struct {
-	state *framework.ClusterState
+	state            *framework.ClusterState
+	runUnstableTests bool
 }
 
-func NewRunner(state *framework.ClusterState) *Runner {
+func NewRunner(state *framework.ClusterState, runUnstableTests bool) *Runner {
 	if state == nil {
 		state = &framework.ClusterState{
 			WorkersByNodeSet: make(map[string][]framework.WorkerRef),
@@ -42,7 +43,8 @@ func NewRunner(state *framework.ClusterState) *Runner {
 		state.WorkersByNodeSet = make(map[string][]framework.WorkerRef)
 	}
 	return &Runner{
-		state: state,
+		state:            state,
+		runUnstableTests: runUnstableTests,
 	}
 }
 
@@ -57,11 +59,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		return fmt.Errorf("no acceptance feature files configured")
 	}
 
-	tags := ""
-	if !r.state.HasGPUWorkers() {
-		log.Printf("acceptance: no GPU workers found, excluding @gpu scenarios")
-		tags = "~@gpu"
-	}
+	tags := r.tagFilter()
 
 	suite := godog.TestSuite{
 		Name:                "soperator-acceptance",
@@ -85,6 +83,21 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (r *Runner) tagFilter() string {
+	var filters []string
+
+	if !r.runUnstableTests {
+		log.Printf("acceptance: RUN_UNSTABLE_TESTS=false, excluding @unstable scenarios")
+		filters = append(filters, "~@unstable")
+	}
+	if !r.state.HasGPUWorkers() {
+		log.Printf("acceptance: no GPU workers found, excluding @gpu scenarios")
+		filters = append(filters, "~@gpu")
+	}
+
+	return strings.Join(filters, " && ")
 }
 
 func discoverCluster(ctx context.Context, w *world, state *framework.ClusterState) error {

--- a/internal/e2e/acceptance/steps/node_replacement.go
+++ b/internal/e2e/acceptance/steps/node_replacement.go
@@ -27,6 +27,7 @@ const (
 var (
 	instanceIDPattern = regexp.MustCompile(`InstanceId=([^\s]+)`)
 	reasonPattern     = regexp.MustCompile(`Reason=([^\n]+)`)
+	statePattern      = regexp.MustCompile(`State=([^\s]+)`)
 )
 
 type NodeReplacement struct {
@@ -67,7 +68,7 @@ func (s *NodeReplacement) aTestJobIsSubmittedAndRunningOnAWorkerNode(ctx context
 	}
 	s.replacementWorker = worker
 
-	nodeState, err := s.exec.ExecController(ctx, fmt.Sprintf("scontrol show node %s", framework.ShellQuote(worker.Name)))
+	nodeState, err := framework.ExecControllerWithDefaultRetry(ctx, s.exec, fmt.Sprintf("scontrol show node %s", framework.ShellQuote(worker.Name)))
 	if err != nil {
 		return fmt.Errorf("read original node state: %w", err)
 	}
@@ -154,16 +155,27 @@ func (s *NodeReplacement) aReplacementNodeJoinsTheCluster(ctx context.Context) e
 		}
 
 		newInstanceID := parseInstanceID(state)
-		if newInstanceID == "" || newInstanceID == originalInstanceID || strings.Contains(state, "DRAIN") {
+		if newInstanceID == "" || newInstanceID == originalInstanceID {
 			return false, nil
 		}
+
+		nodeState := parseNodeState(state)
+		if nodeState == "" {
+			return false, nil
+		}
+		for _, bad := range []string{"DRAIN", "DOWN", "NOT_RESPONDING", "FAIL", "INVALID_REG"} {
+			if strings.Contains(nodeState, bad) {
+				return false, nil
+			}
+		}
+
 		return true, nil
 	})
 }
 
 func (s *NodeReplacement) theReplacementNodePassesGPUValidation(ctx context.Context) error {
 	workerName := s.replacementWorker.Name
-	if _, err := s.exec.ExecJail(ctx, fmt.Sprintf("srun -w %s nvidia-smi -L >/dev/null", framework.ShellQuote(workerName))); err != nil {
+	if _, err := s.exec.ExecJail(ctx, fmt.Sprintf("srun -w %s --gpus-per-node=8 nvidia-smi -L >/dev/null", framework.ShellQuote(workerName))); err != nil {
 		output, stateErr := s.exec.ExecController(ctx, fmt.Sprintf("scontrol show node %s", framework.ShellQuote(workerName)))
 		if stateErr == nil {
 			s.exec.Logf("replacement worker state after failed final validation:\n%s", strings.TrimSpace(output))
@@ -194,6 +206,14 @@ func parseInstanceID(state string) string {
 
 func parseReason(state string) string {
 	match := reasonPattern.FindStringSubmatch(state)
+	if len(match) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(match[1])
+}
+
+func parseNodeState(state string) string {
+	match := statePattern.FindStringSubmatch(state)
 	if len(match) != 2 {
 		return ""
 	}

--- a/internal/e2e/config.go
+++ b/internal/e2e/config.go
@@ -95,6 +95,7 @@ func LoadProfile() (Profile, error) {
 type Config struct {
 	SoperatorVersion   string `split_words:"true" required:"true"`                // SOPERATOR_VERSION
 	SoperatorUnstable  bool   `split_words:"true" required:"true"`                // SOPERATOR_UNSTABLE
+	RunUnstableTests   bool   `split_words:"true" default:"false"`                // RUN_UNSTABLE_TESTS
 	PathToInstallation string `split_words:"true" required:"true"`                // PATH_TO_INSTALLATION
 	O11yAccessToken    string `split_words:"true" required:"true"`                // O11Y_ACCESS_TOKEN
 	O11ySecretName     string `split_words:"true" default:"o11y-writer-sa-token"` // O11Y_SECRET_NAME


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Not up to date node replacement test after PoC
It also flaps a lot, so we need to have a way to skip it

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Adding --gpus-per-node=8 to make it up to date with confluence scenario
Adding RUN_UNSTABLE_TEST flag to github action with defailt false

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
