### PR TITLE
SCHED-1254: Pin yq install action to SHA with explicit version

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -35,7 +35,9 @@ jobs:
       E2E_PROFILE: ${{ vars[inputs.profile_env_var || vars.PROFILE_ENV_VAR] }}
     steps:
       - name: Install yq
-        uses: frenck/action-setup-yq@v1
+        uses: frenck/action-setup-yq@c4b5be8b4a215c536a41d436757d9feb92836d4f # v1.0.2
+        with:
+          version: v4.44.6
 
       - name: Resolve profile
         id: resolve

--- a/.github/workflows/e2e_test_scheduler.yml
+++ b/.github/workflows/e2e_test_scheduler.yml
@@ -18,7 +18,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install yq
-        uses: frenck/action-setup-yq@v1
+        uses: frenck/action-setup-yq@c4b5be8b4a215c536a41d436757d9feb92836d4f # v1.0.2
+        with:
+          version: v4.44.6
 
       - name: Determine branch and terraform ref
         id: select_params


### PR DESCRIPTION
## Problem

The e2e workflows used `frenck/action-setup-yq@v1` without pinning a SHA or specifying a yq version. Upstream changes to the action or to the default yq version could break our CI without warning.

## Solution

- Pin `frenck/action-setup-yq` to commit SHA `c4b5be8` (v1.0.2) in both `e2e_test.yml` and `e2e_test_scheduler.yml`.
- Pass an explicit `version: v4.44.6` for yq.

## Testing

CI runs on this PR exercise the updated workflows.

## Release Notes

None