### PR TITLE
SCHED-1464: Gate otel-collector jail-logs on soperator-outputs creation

### DIFF
--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -24,6 +24,10 @@ spec:
   dependsOn:
   - name: {{ include "soperator-fluxcd.fullname" . }}-ns
   - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
+  # nodesets itself reaches Ready very quickly (it just creates NodeSet CRs), so this is
+  # not sufficient on its own — the init container below waits for actual worker output.
+  # But the ordering is logically correct: jail logs cannot appear before nodesets exist.
+  - name: {{ include "soperator-fluxcd.fullname" . }}-nodesets
   install:
     {{- toYaml .Values.observability.opentelemetry.logs.install | nindent 4 }}
   upgrade:
@@ -317,8 +321,8 @@ spec:
     {{- end }}
     - mountPath: /var/lib/otelcol-jail
       name: varlibotelcol
-    - mountPath: /mnt/jail/opt/soperator-outputs
-      name: soperator-outputs
+    - mountPath: /mnt/jail
+      name: jail
       readOnly: true
     extraVolumes:
     {{- if $hasPublicEndpoint }}
@@ -332,9 +336,9 @@ spec:
         type: Directory
       {{- end }}
     {{- end }}
-    - name: soperator-outputs
+    - name: jail
       hostPath:
-        path: /mnt/jail/opt/soperator-outputs
+        path: /mnt/jail
         type: Directory
     - hostPath:
         path: /var/lib/otelcol-jail
@@ -357,6 +361,23 @@ spec:
       volumeMounts:
       - mountPath: /var/lib/otelcol-jail
         name: varlibotelcol
+    # /mnt/jail/opt/soperator-outputs is created by complement_jail.sh on first
+    # worker/login startup; we mount the jail NFS root and gate on this directory here
+    # so the HelmRelease does not get marked Stalled before workers come up.
+    - command:
+      - sh
+      - -c
+      - |
+        until [ -d /mnt/jail/opt/soperator-outputs ]; do
+          echo "Waiting for /mnt/jail/opt/soperator-outputs to be created by a worker or login pod"
+          sleep 5
+        done
+      image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
+      name: wait-soperator-outputs
+      volumeMounts:
+      - mountPath: /mnt/jail
+        name: jail
+        readOnly: true
     mode: deployment  # Single deployment on system nodes instead of DaemonSet on all workers
     replicaCount: 1   # Only one replica to avoid file lock conflicts on shared storage and prevent log duplication
     rollout:


### PR DESCRIPTION
## Problem

The `opentelemetry-collector-jail-logs` HelmRelease mounts `/mnt/jail/opt/soperator-outputs` directly as a hostPath with `type: Directory`. On a fresh cluster that directory does not exist yet because `complement_jail.sh` only creates it when the first worker or login pod starts. The hostPath validation fails, the collector pod never becomes ready, and the HelmRelease gets marked Stalled before workers finish provisioning.

This is a frequent cause of the e2e `all HelmReleases are Ready` acceptance test failing: whenever worker provisioning is slow enough that `/mnt/jail/opt/soperator-outputs` is not created within the HelmRelease timeout, the jail-logs release stalls and the acceptance step reports `flux-system-soperator-fluxcd-opentelemetry-collector-jail-logs Ready=False`.

## Solution

- Mount the jail NFS root (`/mnt/jail`) instead of the nested `soperator-outputs` path so the volume check passes at pod start regardless of whether workers have run yet.
- Add a `wait-soperator-outputs` init container that polls until `/mnt/jail/opt/soperator-outputs` appears, so the collector only starts once a worker or login pod has created it.
- Add `dependsOn: nodesets` for correct logical ordering. Note: this alone does not fix the bug (nodesets reaches `Ready` in milliseconds — it just applies CRs — so the init container remains the actual gate on directory existence).

The chart default `timeout: 15m` is left unchanged. In practice the jail output directory appears ~8-12 minutes after install starts (a login pod is typically first to run `complement_jail.sh`), which fits comfortably inside 15m.

## Companion PR

nebius/nebius-solutions-library#928 removes the hardcoded `timeout: 5m` override from the Terraform module's generated Flux values. With that removed, Terraform deployments inherit the chart default (15m) instead of forcing 5m, which is what was actually making the failing run stall — the 5m override left only 3 minutes of slack between install start and the first login pod, nowhere near enough.

Both PRs need to land for e2e to be unblocked.

## Testing

- `helm unittest helm/soperator-fluxcd` — 67/67 pass.
- `helm lint helm/soperator-fluxcd` — clean.
- Manual verification: rendered chart shows the init container mounts `/mnt/jail` (volume name `jail`), polls for the `opt/soperator-outputs` subdirectory, and exits cleanly once workers create it.
- End-to-end: pending a full e2e run on `SB_KCS_B200` once the companion Terraform PR is merged.

## Release Notes

Fix: otel-collector jail-logs no longer stalls the HelmRelease on fresh clusters before the first worker or login pod has created `/mnt/jail/opt/soperator-outputs`.