### PR TITLE
SCHED-1474: Publish acceptance test artifacts and summary from CI

### DIFF
--- a/.github/scripts/acceptance_summary.py
+++ b/.github/scripts/acceptance_summary.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Render a godog cucumber JSON report as markdown for GitHub step summary."""
+import json
+import sys
+
+NS_PER_SEC = 1_000_000_000
+
+# Worst-step-wins priority. Matches godog's JUnit formatter behavior.
+_STATUS_PRIORITY = {
+    "failed": 4,
+    "undefined": 3,
+    "pending": 3,
+    "ambiguous": 3,
+    "skipped": 2,
+    "passed": 1,
+}
+
+
+def fmt_s(ns):
+    return f"{(ns or 0) / NS_PER_SEC:.1f}s"
+
+
+def cell(s):
+    return str(s).replace("|", "\\|")
+
+
+def scenario_status(steps):
+    if not steps:
+        return "skipped"
+    return max(
+        (s.get("result", {}).get("status", "") for s in steps),
+        key=lambda st: _STATUS_PRIORITY.get(st, 0),
+    )
+
+
+def render(features, out):
+    out.write("### Acceptance\n")
+    for feat in features:
+        for scen in feat.get("elements", []):
+            steps = scen.get("steps", [])
+            total_ns = sum(s.get("result", {}).get("duration", 0) for s in steps)
+            status = scenario_status(steps)
+            out.write("\n")
+            out.write(
+                f"#### {cell(feat.get('name', ''))} / "
+                f"{cell(scen.get('name', ''))} / {status} / {fmt_s(total_ns)}\n"
+            )
+            if not steps:
+                continue
+            out.write("\n| Step | Status | Time |\n")
+            out.write("| --- | --- | --- |\n")
+            for s in steps:
+                keyword = s.get("keyword", "").strip()
+                name = s.get("name", "")
+                label = f"{keyword} {name}".strip()
+                res = s.get("result", {})
+                out.write(
+                    f"| {cell(label)} | {res.get('status', '')} | "
+                    f"{fmt_s(res.get('duration', 0))} |\n"
+                )
+
+
+def main():
+    with open(sys.argv[1]) as f:
+        features = json.load(f)
+    render(features, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -375,8 +375,29 @@ jobs:
 
       - name: Acceptance Tests
         timeout-minutes: 90
+        env:
+          E2E_REPORT_DIR: e2e-reports/acceptance
         run: |
           bin/e2e acceptance
+
+      - name: Acceptance Summary
+        if: always()
+        shell: bash
+        run: |
+          json="e2e-reports/acceptance/acceptance.cucumber.json"
+          if [[ ! -f "$json" ]]; then
+            echo "no cucumber report at $json"
+            exit 0
+          fi
+          python3 .github/scripts/acceptance_summary.py "$json" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Acceptance Reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: acceptance-reports
+          path: e2e-reports/acceptance/
+          retention-days: 14
 
       - name: K8s Cluster Info and NodeGroups
         if: always()

--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -61,11 +63,22 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	tags := r.tagFilter()
 
+	format := "pretty"
+	if dir := os.Getenv("E2E_REPORT_DIR"); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create report dir %q: %w", dir, err)
+		}
+		format = fmt.Sprintf("pretty,cucumber:%s,junit:%s",
+			filepath.Join(dir, "acceptance.cucumber.json"),
+			filepath.Join(dir, "acceptance.junit.xml"),
+		)
+	}
+
 	suite := godog.TestSuite{
 		Name:                "soperator-acceptance",
 		ScenarioInitializer: r.initializeScenario,
 		Options: &godog.Options{
-			Format:         "pretty",
+			Format:         format,
 			FS:             acceptanceFeatures,
 			Paths:          features,
 			TestingT:       nil,


### PR DESCRIPTION
## Problem

Acceptance test runs in CI don't leave a structured record. Failures require scraping the raw Go log, and there's no per-scenario breakdown in the job summary.

## Solution

- Runner writes cucumber JSON + JUnit XML to `$E2E_REPORT_DIR` when set, alongside the existing `pretty` format.
- Workflow sets `E2E_REPORT_DIR=e2e-reports/acceptance`, renders the JUnit output as a markdown table into `$GITHUB_STEP_SUMMARY`, and uploads the full `e2e-reports/acceptance/` directory as a 14-day artifact.

## Testing

https://github.com/nebius/soperator/actions/runs/24583671320

## Release Notes

None