### PR TITLE
SCHED-1471: helm/nodesets: render initialNumberEphemeralNodes when set to 0

### DIFF
--- a/helm/nodesets/templates/nodeset.yaml
+++ b/helm/nodesets/templates/nodeset.yaml
@@ -31,8 +31,8 @@ spec:
   ephemeralNodes: {{ .ephemeralNodes }}
   {{- end }}
 
-  {{- with .initialNumberEphemeralNodes }}
-  initialNumberEphemeralNodes: {{ . }}
+  {{- if hasKey . "initialNumberEphemeralNodes" }}
+  initialNumberEphemeralNodes: {{ .initialNumberEphemeralNodes }}
   {{- end }}
 
   {{- with .ephemeralTopologyWaitTimeout }}

--- a/helm/nodesets/tests/ephemeral_nodes_test.yaml
+++ b/helm/nodesets/tests/ephemeral_nodes_test.yaml
@@ -1,0 +1,106 @@
+suite: test nodesets ephemeral settings
+templates:
+  - templates/nodeset.yaml
+tests:
+  - it: should render zero initial ephemeral nodes
+    set:
+      nodesets:
+        - name: worker-payg
+          replicas: 2
+          maxUnavailable: "20%"
+          ephemeralNodes: true
+          initialNumberEphemeralNodes: 0
+          slurmd:
+            image:
+              repository: "test/slurm"
+            resources:
+              cpu: "4"
+              memory: "8Gi"
+            volumes:
+              spool:
+                emptyDir: {}
+              jail:
+                emptyDir: {}
+              jailSubMounts: []
+          munge:
+            image:
+              repository: "test/munge"
+            resources:
+              cpu: "100m"
+              memory: "128Mi"
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.maxUnavailable
+          value: "20%"
+      - equal:
+          path: spec.ephemeralNodes
+          value: true
+      - equal:
+          path: spec.initialNumberEphemeralNodes
+          value: 0
+
+  - it: should keep zero initial ephemeral nodes when ephemeralNodes is false
+    set:
+      nodesets:
+        - name: worker-static
+          replicas: 2
+          ephemeralNodes: false
+          initialNumberEphemeralNodes: 0
+          slurmd:
+            image:
+              repository: "test/slurm"
+            resources:
+              cpu: "4"
+              memory: "8Gi"
+            volumes:
+              spool:
+                emptyDir: {}
+              jail:
+                emptyDir: {}
+              jailSubMounts: []
+          munge:
+            image:
+              repository: "test/munge"
+            resources:
+              cpu: "100m"
+              memory: "128Mi"
+    asserts:
+      - equal:
+          path: spec.initialNumberEphemeralNodes
+          value: 0
+      - notExists:
+          path: spec.ephemeralNodes
+
+  - it: should not render initial ephemeral nodes when the value is omitted
+    set:
+      nodesets:
+        - name: worker-default
+          replicas: 2
+          ephemeralNodes: true
+          slurmd:
+            image:
+              repository: "test/slurm"
+            resources:
+              cpu: "4"
+              memory: "8Gi"
+            volumes:
+              spool:
+                emptyDir: {}
+              jail:
+                emptyDir: {}
+              jailSubMounts: []
+          munge:
+            image:
+              repository: "test/munge"
+            resources:
+              cpu: "100m"
+              memory: "128Mi"
+    asserts:
+      - equal:
+          path: spec.ephemeralNodes
+          value: true
+      - notExists:
+          path: spec.initialNumberEphemeralNodes


### PR DESCRIPTION
## Problem
initialNumberEphemeralNodes: 0 was not rendered by the helm/nodesets chart because the template used with, which treats 0 as empty. As a result, the field was omitted from the NodeSet manifest and the CRD default value 1 was applied instead.


## Testing
helm unittest

## Release Notes
Fixed the helm/nodesets chart to preserve explicit initialNumberEphemeralNodes: 0 values. Previously, zero was dropped during template rendering, causing the NodeSet CRD default of 1 to be applied unexpectedly.
