### PR TITLE
SCHED-1306: Add acceptance test for network topology

### DIFF
--- a/images/worker/worker_init_test.py
+++ b/images/worker/worker_init_test.py
@@ -696,8 +696,8 @@ class TestEdgeCases(unittest.TestCase):
 
     def test_topology_with_special_characters(self):
         """Topology with special characters and 2 parts gets root inserted."""
-        result = worker_init.format_slurm_topology("default:switch_rack-1.leaf")
-        self.assertEqual(result, "topology=default:root:switch_rack-1.leaf")
+        result = worker_init.format_slurm_topology("default:switch_rack-1-leaf")
+        self.assertEqual(result, "topology=default:root:switch_rack-1-leaf")
 
     def test_topology_with_numbers(self):
         """Topology with 3+ parts is preserved (already has intermediates)."""

--- a/internal/e2e/acceptance/features/topology.feature
+++ b/internal/e2e/acceptance/features/topology.feature
@@ -1,0 +1,7 @@
+Feature: Slurm network topology
+  Scenario: scontrol topology and SLURM_TOPOLOGY_ADDR agree across workers
+    Given the Slurm topology plugin is topology/tree
+    When scontrol show topology is parsed into a switch tree
+    Then every worker in the main partition is present in the topology
+    When a job runs on all available workers and reports SLURM_TOPOLOGY_ADDR
+    Then each task's SLURM_TOPOLOGY_ADDR matches its position in the topology

--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -165,6 +165,7 @@ func featurePaths() []string {
 		"features/internal_ssh.feature",
 		"features/package_installation.feature",
 		"features/node_replacement.feature",
+		"features/topology.feature",
 	}
 }
 
@@ -177,6 +178,7 @@ func (r *Runner) initializeScenario(sc *godog.ScenarioContext) {
 	steps.NewInternalSSH(w).Register(sc)
 	steps.NewPackageInstallation(w).Register(sc)
 	steps.NewNodeReplacement(w).Register(sc)
+	steps.NewTopology(r.state, w).Register(sc)
 }
 
 func registerTimingHooks(sc *godog.ScenarioContext) {

--- a/internal/e2e/acceptance/steps/topology.go
+++ b/internal/e2e/acceptance/steps/topology.go
@@ -1,0 +1,406 @@
+package steps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
+)
+
+const topologyJobTimeout = 10 * time.Minute
+
+var (
+	topologySwitchNamePattern = regexp.MustCompile(`SwitchName=(\S+)`)
+	topologyLevelPattern      = regexp.MustCompile(`Level=(\d+)`)
+	topologyNodesPattern      = regexp.MustCompile(`Nodes=(\S+)`)
+	topologySwitchesPattern   = regexp.MustCompile(`Switches=(\S+)`)
+)
+
+type topologyNode struct {
+	level    int
+	isRoot   bool
+	isWorker bool
+	targets  map[string]bool
+}
+
+// topologyGraph is a directed edge-set view of `scontrol show topology`.
+type topologyGraph struct {
+	nodes map[string]*topologyNode
+}
+
+type Topology struct {
+	exec  framework.Exec
+	state *framework.ClusterState
+
+	graph         *topologyGraph
+	reportedAddrs map[string]string
+}
+
+func NewTopology(state *framework.ClusterState, exec framework.Exec) *Topology {
+	return &Topology{exec: exec, state: state}
+}
+
+func (s *Topology) Register(sc *godog.ScenarioContext) {
+	sc.Step(`^the Slurm topology plugin is topology/tree$`, s.theSlurmTopologyPluginIsTree)
+	sc.Step(`^scontrol show topology is parsed into a switch tree$`, s.scontrolTopologyIsParsedIntoASwitchTree)
+	sc.Step(`^every worker in the main partition is present in the topology$`, s.everyWorkerIsPresentInTheTopology)
+	sc.Step(`^a job runs on all available workers and reports SLURM_TOPOLOGY_ADDR$`, s.aJobRunsOnAllAvailableWorkers)
+	sc.Step(`^each task's SLURM_TOPOLOGY_ADDR matches its position in the topology$`, s.eachTaskAddrMatchesTheTree)
+}
+
+func (s *Topology) theSlurmTopologyPluginIsTree(ctx context.Context) error {
+	out, err := framework.ExecControllerWithDefaultRetry(ctx, s.exec,
+		`scontrol show config | awk -F'= *' '/^TopologyPlugin /{print $2; exit}'`)
+	if err != nil {
+		return fmt.Errorf("read TopologyPlugin from scontrol: %w", err)
+	}
+	plugin := strings.TrimSpace(out)
+	if plugin != "topology/tree" {
+		s.exec.Logf("topology plugin is %q, skipping scenario", plugin)
+		return godog.ErrSkip
+	}
+	return nil
+}
+
+func (s *Topology) scontrolTopologyIsParsedIntoASwitchTree(ctx context.Context) error {
+	raw, err := framework.ExecControllerWithDefaultRetry(ctx, s.exec, "scontrol show topology")
+	if err != nil {
+		return fmt.Errorf("scontrol show topology: %w", err)
+	}
+	s.exec.Logf("scontrol show topology:\n%s", strings.TrimSpace(raw))
+
+	workerNames := make([]string, 0, len(s.state.Workers))
+	for _, w := range s.state.Workers {
+		workerNames = append(workerNames, w.Name)
+	}
+
+	expand := func(hostlist string) ([]string, error) {
+		cmd := fmt.Sprintf("scontrol show hostnames %s", framework.ShellQuote(hostlist))
+		out, err := framework.ExecControllerWithDefaultRetry(ctx, s.exec, cmd)
+		if err != nil {
+			return nil, err
+		}
+		var names []string
+		for _, line := range strings.Split(out, "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				names = append(names, line)
+			}
+		}
+		return names, nil
+	}
+
+	graph, err := parseTopology(raw, workerNames, expand)
+	if err != nil {
+		return fmt.Errorf("parse topology: %w", err)
+	}
+	s.graph = graph
+	return nil
+}
+
+func (s *Topology) everyWorkerIsPresentInTheTopology() error {
+	if s.graph == nil {
+		return fmt.Errorf("topology graph not parsed yet")
+	}
+	var missing []string
+	for _, worker := range s.state.Workers {
+		n := s.graph.nodes[worker.Name]
+		if n == nil || !n.isWorker {
+			missing = append(missing, worker.Name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("workers missing from topology: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func (s *Topology) aJobRunsOnAllAvailableWorkers(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, topologyJobTimeout)
+	defer cancel()
+
+	if len(s.state.Workers) == 0 {
+		return fmt.Errorf("no workers discovered")
+	}
+	// We target every discovered worker without re-filtering by Slurm state.
+	// The acceptance suite expects the cluster it owns to have all nodes
+	// IDLE at this point; a drained/down/suspended node would be a symptom
+	// of a prior failure worth surfacing, not something to silently skip.
+	// If the cluster is genuinely in a bad state, the srun call fails within
+	// the 10-minute context timeout rather than hanging.
+	names := make([]string, 0, len(s.state.Workers))
+	for _, w := range s.state.Workers {
+		names = append(names, w.Name)
+	}
+
+	inner := `printf "%s %s\n" "$SLURMD_NODENAME" "$SLURM_TOPOLOGY_ADDR"`
+	cmd := fmt.Sprintf("srun -N %d -w %s --time=1:00 --cpu-bind=none bash -c %s",
+		len(names),
+		framework.ShellQuote(strings.Join(names, ",")),
+		framework.ShellQuote(inner))
+	out, err := s.exec.ExecJail(ctx, cmd)
+	s.exec.Logf("srun topology addrs output:\n%s", strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("srun for topology addrs: %w", err)
+	}
+
+	s.reportedAddrs = make(map[string]string, len(names))
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		s.reportedAddrs[parts[0]] = parts[1]
+	}
+	if len(s.reportedAddrs) != len(names) {
+		return fmt.Errorf("collected %d topology addrs from %d workers\noutput:\n%s",
+			len(s.reportedAddrs), len(names), strings.TrimSpace(out))
+	}
+	return nil
+}
+
+func (s *Topology) eachTaskAddrMatchesTheTree() error {
+	if s.graph == nil {
+		return fmt.Errorf("topology graph not parsed yet")
+	}
+	if len(s.reportedAddrs) == 0 {
+		return fmt.Errorf("no SLURM_TOPOLOGY_ADDR values collected")
+	}
+	var mismatches []string
+	for worker, reported := range s.reportedAddrs {
+		if err := validateReportedPath(s.graph, reported, worker); err != nil {
+			mismatches = append(mismatches, fmt.Sprintf("%s: %v", worker, err))
+		}
+	}
+	if len(mismatches) > 0 {
+		return fmt.Errorf("topology address mismatches:\n  %s", strings.Join(mismatches, "\n  "))
+	}
+	return nil
+}
+
+// hostlistExpander turns a Slurm hostlist value that contains `[` into the
+// concrete list of hostnames. Production wires it to `scontrol show hostnames`;
+// tests with plain comma-separated values can pass nil.
+type hostlistExpander func(value string) ([]string, error)
+
+// parseTopology turns `scontrol show topology` output into a topologyGraph.
+// `allWorkers` is consulted only when a switch declares `Nodes=ALL`. `expand`
+// is only called for values containing `[`; plain comma-separated lists are
+// split in-process.
+func parseTopology(raw string, allWorkers []string, expand hostlistExpander) (*topologyGraph, error) {
+	graph := &topologyGraph{nodes: make(map[string]*topologyNode)}
+
+	switchNames := make(map[string]bool)
+	childSwitches := make(map[string]bool)
+	var parseErrs []error
+
+	ensure := func(name string) *topologyNode {
+		n := graph.nodes[name]
+		if n == nil {
+			n = &topologyNode{}
+			graph.nodes[name] = n
+		}
+		return n
+	}
+	addEdge := func(source, target string) {
+		src := ensure(source)
+		if src.targets == nil {
+			src.targets = make(map[string]bool)
+		}
+		src.targets[target] = true
+	}
+	maybeExpand := func(value string) ([]string, error) {
+		if strings.Contains(value, "[") {
+			if expand == nil {
+				return nil, fmt.Errorf("hostlist expansion required for %q but no expander configured", value)
+			}
+			return expand(value)
+		}
+		var out []string
+		for _, part := range strings.Split(value, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				out = append(out, part)
+			}
+		}
+		return out, nil
+	}
+
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		m := topologySwitchNamePattern.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		switchName := m[1]
+		if strings.Contains(switchName, ".") {
+			// $SLURM_TOPOLOGY_ADDR is dot-separated, so a dotted switch
+			// name is ambiguous with level boundaries. Reject explicitly
+			// rather than silently mis-splitting during validation.
+			parseErrs = append(parseErrs, fmt.Errorf("switch name contains '.' which is not supported: %q", switchName))
+			continue
+		}
+		switchNames[switchName] = true
+		ensure(switchName)
+
+		if lm := topologyLevelPattern.FindStringSubmatch(line); lm != nil {
+			lvl, err := strconv.Atoi(lm[1])
+			if err != nil {
+				parseErrs = append(parseErrs, fmt.Errorf("parse Level in %q: %w", line, err))
+				continue
+			}
+			graph.nodes[switchName].level = lvl
+		}
+
+		if sm := topologySwitchesPattern.FindStringSubmatch(line); sm != nil && sm[1] != "(null)" {
+			children, err := maybeExpand(sm[1])
+			if err != nil {
+				parseErrs = append(parseErrs, fmt.Errorf("expand Switches %q: %w", sm[1], err))
+				continue
+			}
+			for _, child := range children {
+				if strings.Contains(child, ".") {
+					parseErrs = append(parseErrs, fmt.Errorf("child switch name contains '.' which is not supported: %q", child))
+					continue
+				}
+				addEdge(switchName, child)
+				childSwitches[child] = true
+			}
+		}
+
+		if nm := topologyNodesPattern.FindStringSubmatch(line); nm != nil {
+			value := nm[1]
+			var nodes []string
+			switch value {
+			case "", "(null)":
+				// no attached nodes
+			case "ALL":
+				nodes = allWorkers
+			default:
+				expanded, err := maybeExpand(value)
+				if err != nil {
+					parseErrs = append(parseErrs, fmt.Errorf("expand Nodes %q: %w", value, err))
+					continue
+				}
+				nodes = expanded
+			}
+			for _, n := range nodes {
+				addEdge(switchName, n)
+			}
+		}
+	}
+
+	if len(parseErrs) > 0 {
+		return nil, errors.Join(parseErrs...)
+	}
+	if len(switchNames) == 0 {
+		return nil, fmt.Errorf("no switches parsed from topology output")
+	}
+
+	// Switches that never appear as a child become roots; edge targets that
+	// aren't themselves switches become workers.
+	for name := range switchNames {
+		if !childSwitches[name] {
+			graph.nodes[name].isRoot = true
+		}
+	}
+	rootCount := 0
+	for _, n := range graph.nodes {
+		if n.isRoot {
+			rootCount++
+		}
+	}
+	if rootCount == 0 {
+		return nil, fmt.Errorf("no root switch found in topology (all switches appear as children)")
+	}
+
+	for _, n := range graph.nodes {
+		for target := range n.targets {
+			if !switchNames[target] {
+				tn := ensure(target)
+				tn.isWorker = true
+			}
+		}
+	}
+
+	return graph, nil
+}
+
+// validateReportedPath accepts a $SLURM_TOPOLOGY_ADDR reported by srun and
+// verifies it is a valid walk through the parsed graph. Slurm emits one
+// segment per level (with empty segments for skipped levels), so the path
+// has exactly rootLevel+2 segments: the root, one slot per intermediate
+// level, and the worker at the tail. Anchoring each non-empty switch to
+// its declared Level catches truncated paths like "root.worker-0" where
+// the worker slips into a switch slot.
+func validateReportedPath(g *topologyGraph, reported, worker string) error {
+	segments := strings.Split(reported, ".")
+	if len(segments) < 2 {
+		return fmt.Errorf("malformed path %q", reported)
+	}
+	if segments[len(segments)-1] != worker {
+		return fmt.Errorf("path %q does not end with worker %q", reported, worker)
+	}
+
+	rootName := segments[0]
+	if rootName == "" {
+		return fmt.Errorf("path %q starts with empty root segment", reported)
+	}
+	root := g.nodes[rootName]
+	if root == nil || !root.isRoot {
+		return fmt.Errorf("path %q does not start at a root switch (got %q)", reported, rootName)
+	}
+	wantSegments := root.level + 2
+	if len(segments) != wantSegments {
+		return fmt.Errorf("path %q has %d segments, expected %d (root %q is at level %d)",
+			reported, len(segments), wantSegments, rootName, root.level)
+	}
+	// The leaf slot (just before the worker) must be filled. Slurm always
+	// emits the worker's direct leaf switch there; an empty slot would mean
+	// the path skipped the leaf level entirely, e.g. "root...worker-0",
+	// which would otherwise slip through because ancestor switches list
+	// descendant workers in their Nodes= field.
+	if segments[len(segments)-2] == "" {
+		return fmt.Errorf("path %q: leaf slot at position %d is empty", reported, len(segments)-2)
+	}
+
+	var prev *topologyNode
+	var prevName string
+	for i := 0; i < len(segments)-1; i++ {
+		name := segments[i]
+		if name == "" {
+			continue
+		}
+		n := g.nodes[name]
+		if n == nil || n.isWorker {
+			return fmt.Errorf("path %q: unknown switch %q at position %d", reported, name, i)
+		}
+		if n.level != root.level-i {
+			return fmt.Errorf("path %q: switch %q at position %d has level %d, expected %d",
+				reported, name, i, n.level, root.level-i)
+		}
+		if prev != nil && !prev.targets[name] {
+			return fmt.Errorf("path %q: no edge %s -> %s in topology", reported, prevName, name)
+		}
+		prev, prevName = n, name
+	}
+
+	if prev == nil || !prev.targets[worker] {
+		return fmt.Errorf("path %q: worker %s is not attached to switch %s", reported, worker, prevName)
+	}
+	return nil
+}

--- a/internal/e2e/acceptance/steps/topology_test.go
+++ b/internal/e2e/acceptance/steps/topology_test.go
@@ -1,0 +1,329 @@
+package steps
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Note: sampleTopologyOutput uses literal comma-separated node lists instead
+// of Slurm's bracket-compressed form so tests can call parseTopology with a
+// nil expander. Bracket expansion is tested separately in
+// TestParseTopologyExpandsHostlistInSwitches.
+const sampleTopologyOutput = `
+SwitchName=185ccb815910fcd0a3d1693651b78d1d Level=0 LinkSpeed=1 Nodes=worker-1
+SwitchName=4d63b28c08a3871d951ee886e3e35f14 Level=0 LinkSpeed=1 Nodes=worker-0
+SwitchName=c77d58ca27418e0713112f6974e3a7e3 Level=1 LinkSpeed=1 Nodes=worker-0 Switches=4d63b28c08a3871d951ee886e3e35f14
+SwitchName=e4408eeb4933a2a8c6141a1066a974d8 Level=1 LinkSpeed=1 Nodes=worker-1 Switches=185ccb815910fcd0a3d1693651b78d1d
+SwitchName=root Level=2 LinkSpeed=1 Nodes=worker-0,worker-1,worker-dynamic-0,worker-payg-0 Switches=c77d58ca27418e0713112f6974e3a7e3,e4408eeb4933a2a8c6141a1066a974d8,unknown
+SwitchName=unknown Level=0 LinkSpeed=1 Nodes=worker-dynamic-0,worker-payg-0
+`
+
+func assertEdgeSet(t *testing.T, label string, got map[string]bool, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s: size=%d want %d (got=%v want=%v)", label, len(got), len(want), keys(got), want)
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("%s: missing %q", label, w)
+		}
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func collectRoots(g *topologyGraph) map[string]bool {
+	out := map[string]bool{}
+	for name, n := range g.nodes {
+		if n.isRoot {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+func collectWorkers(g *topologyGraph) map[string]bool {
+	out := map[string]bool{}
+	for name, n := range g.nodes {
+		if n.isWorker {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+func targetsOf(g *topologyGraph, name string) map[string]bool {
+	n := g.nodes[name]
+	if n == nil {
+		return nil
+	}
+	return n.targets
+}
+
+func boolSet(m map[string]string) map[string]bool {
+	out := make(map[string]bool, len(m))
+	for k := range m {
+		out[k] = true
+	}
+	return out
+}
+
+func TestParseTopologyGraphFromSampleOutput(t *testing.T) {
+	g, err := parseTopology(sampleTopologyOutput, nil, nil)
+	if err != nil {
+		t.Fatalf("parseTopology: %v", err)
+	}
+
+	assertEdgeSet(t, "roots", collectRoots(g), []string{"root"})
+
+	// root has both child switches and Nodes=worker-0,worker-1,... attached
+	// directly, so its target set is the union of both.
+	assertEdgeSet(t, "nodes[root].targets", targetsOf(g, "root"), []string{
+		"c77d58ca27418e0713112f6974e3a7e3",
+		"e4408eeb4933a2a8c6141a1066a974d8",
+		"unknown",
+		"worker-0",
+		"worker-1",
+		"worker-dynamic-0",
+		"worker-payg-0",
+	})
+	assertEdgeSet(t, "nodes[c77d58...].targets", targetsOf(g, "c77d58ca27418e0713112f6974e3a7e3"),
+		[]string{"4d63b28c08a3871d951ee886e3e35f14", "worker-0"})
+	assertEdgeSet(t, "nodes[e4408e...].targets", targetsOf(g, "e4408eeb4933a2a8c6141a1066a974d8"),
+		[]string{"185ccb815910fcd0a3d1693651b78d1d", "worker-1"})
+	assertEdgeSet(t, "nodes[unknown].targets", targetsOf(g, "unknown"),
+		[]string{"worker-dynamic-0", "worker-payg-0"})
+	assertEdgeSet(t, "nodes[4d63b28c...].targets", targetsOf(g, "4d63b28c08a3871d951ee886e3e35f14"),
+		[]string{"worker-0"})
+	assertEdgeSet(t, "nodes[185ccb...].targets", targetsOf(g, "185ccb815910fcd0a3d1693651b78d1d"),
+		[]string{"worker-1"})
+
+	assertEdgeSet(t, "workers", collectWorkers(g),
+		[]string{"worker-0", "worker-1", "worker-dynamic-0", "worker-payg-0"})
+
+	wantLevels := map[string]int{
+		"185ccb815910fcd0a3d1693651b78d1d": 0,
+		"4d63b28c08a3871d951ee886e3e35f14": 0,
+		"c77d58ca27418e0713112f6974e3a7e3": 1,
+		"e4408eeb4933a2a8c6141a1066a974d8": 1,
+		"root":                             2,
+		"unknown":                          0,
+	}
+	for sw, want := range wantLevels {
+		n := g.nodes[sw]
+		if n == nil {
+			t.Errorf("levels[%s]: node missing", sw)
+			continue
+		}
+		if n.level != want {
+			t.Errorf("levels[%s]=%d, want %d", sw, n.level, want)
+		}
+	}
+}
+
+func TestValidateReportedPathAcceptsObservedOutput(t *testing.T) {
+	g, err := parseTopology(sampleTopologyOutput, nil, nil)
+	if err != nil {
+		t.Fatalf("parseTopology: %v", err)
+	}
+
+	accepted := map[string]string{
+		"worker-0":         "root.c77d58ca27418e0713112f6974e3a7e3.4d63b28c08a3871d951ee886e3e35f14.worker-0",
+		"worker-1":         "root.e4408eeb4933a2a8c6141a1066a974d8.185ccb815910fcd0a3d1693651b78d1d.worker-1",
+		"worker-dynamic-0": "root..unknown.worker-dynamic-0",
+		"worker-payg-0":    "root..unknown.worker-payg-0",
+	}
+
+	workers := keys(boolSet(accepted))
+	for _, worker := range workers {
+		if err := validateReportedPath(g, accepted[worker], worker); err != nil {
+			t.Errorf("validateReportedPath(%q, %q): %v", accepted[worker], worker, err)
+		}
+	}
+}
+
+func TestValidateReportedPathRejectsBadPaths(t *testing.T) {
+	g, err := parseTopology(sampleTopologyOutput, nil, nil)
+	if err != nil {
+		t.Fatalf("parseTopology: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		path     string
+		worker   string
+		wantSubs string // substring we expect in the error
+	}{
+		{
+			name:     "tail is a different worker than claimed",
+			path:     "root.c77d58ca27418e0713112f6974e3a7e3.4d63b28c08a3871d951ee886e3e35f14.worker-0",
+			worker:   "worker-1",
+			wantSubs: "does not end with worker",
+		},
+		{
+			name:     "non-root prefix",
+			path:     "badroot.c77d58ca27418e0713112f6974e3a7e3.4d63b28c08a3871d951ee886e3e35f14.worker-0",
+			worker:   "worker-0",
+			wantSubs: "does not start at a root",
+		},
+		{
+			name:     "crossed branches (no such edge)",
+			path:     "root.e4408eeb4933a2a8c6141a1066a974d8.4d63b28c08a3871d951ee886e3e35f14.worker-0",
+			worker:   "worker-0",
+			wantSubs: "no edge",
+		},
+		{
+			name:     "worker not attached to claimed leaf",
+			path:     "root.c77d58ca27418e0713112f6974e3a7e3.4d63b28c08a3871d951ee886e3e35f14.worker-dynamic-0",
+			worker:   "worker-dynamic-0",
+			wantSubs: "is not attached",
+		},
+		{
+			name:     "single segment",
+			path:     "worker-0",
+			worker:   "worker-0",
+			wantSubs: "malformed path",
+		},
+		{
+			name:     "path truncated to root (worker slips into switch slot)",
+			path:     "root.worker-0",
+			worker:   "worker-0",
+			wantSubs: "has 2 segments, expected 4",
+		},
+		{
+			name:     "path truncated to mid-level switch",
+			path:     "root.c77d58ca27418e0713112f6974e3a7e3.worker-0",
+			worker:   "worker-0",
+			wantSubs: "has 3 segments, expected 4",
+		},
+		{
+			name:     "switch appears at wrong level",
+			path:     "root.4d63b28c08a3871d951ee886e3e35f14.c77d58ca27418e0713112f6974e3a7e3.worker-0",
+			worker:   "worker-0",
+			wantSubs: "expected 1",
+		},
+		{
+			name:     "path skips leaf level entirely (all intermediate slots empty)",
+			path:     "root...worker-0",
+			worker:   "worker-0",
+			wantSubs: "leaf slot at position 2 is empty",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateReportedPath(g, tc.path, tc.worker)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantSubs) {
+				t.Errorf("err=%q, want substring %q", err, tc.wantSubs)
+			}
+		})
+	}
+}
+
+func TestParseTopologyFlatNodesALL(t *testing.T) {
+	raw := "SwitchName=root Level=0 Nodes=ALL"
+	g, err := parseTopology(raw, []string{"worker-0", "worker-1"}, nil)
+	if err != nil {
+		t.Fatalf("parseTopology: %v", err)
+	}
+	assertEdgeSet(t, "roots", collectRoots(g), []string{"root"})
+	// Flat topology: the only switch (root) has workers as direct edge
+	// targets, and no switch has any outgoing edge to another switch.
+	assertEdgeSet(t, "nodes[root].targets", targetsOf(g, "root"), []string{"worker-0", "worker-1"})
+	for name, n := range g.nodes {
+		if n.isWorker || name == "root" {
+			continue
+		}
+		t.Errorf("unexpected extra switch %q with targets %v", name, n.targets)
+	}
+
+	for _, worker := range []string{"worker-0", "worker-1"} {
+		path := "root." + worker
+		if err := validateReportedPath(g, path, worker); err != nil {
+			t.Errorf("validateReportedPath(%q, %q): %v", path, worker, err)
+		}
+	}
+}
+
+func TestParseTopologyRejectsDottedSwitchNames(t *testing.T) {
+	cases := []string{
+		"SwitchName=rack-1.leaf Level=0 Nodes=worker-0",
+		"SwitchName=root Level=1 Switches=rack-1.leaf Nodes=worker-0",
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			_, err := parseTopology(raw, nil, nil)
+			if err == nil {
+				t.Fatal("expected error for dotted switch name, got nil")
+			}
+			if !strings.Contains(err.Error(), "'.'") {
+				t.Errorf("err=%q, want substring %q", err, "'.'")
+			}
+		})
+	}
+}
+
+func TestParseTopologyExpandsHostlistInSwitches(t *testing.T) {
+	raw := `
+SwitchName=leaf01 Level=0 Nodes=worker-0
+SwitchName=leaf02 Level=0 Nodes=worker-1
+SwitchName=root Level=1 Switches=leaf[01-02] Nodes=worker-[0-1]
+`
+	expand := func(value string) ([]string, error) {
+		switch value {
+		case "leaf[01-02]":
+			return []string{"leaf01", "leaf02"}, nil
+		case "worker-[0-1]":
+			return []string{"worker-0", "worker-1"}, nil
+		}
+		return nil, fmt.Errorf("unexpected expand %q", value)
+	}
+	g, err := parseTopology(raw, nil, expand)
+	if err != nil {
+		t.Fatalf("parseTopology: %v", err)
+	}
+	assertEdgeSet(t, "roots", collectRoots(g), []string{"root"})
+	assertEdgeSet(t, "nodes[root].targets", targetsOf(g, "root"),
+		[]string{"leaf01", "leaf02", "worker-0", "worker-1"})
+	assertEdgeSet(t, "nodes[leaf01].targets", targetsOf(g, "leaf01"), []string{"worker-0"})
+	assertEdgeSet(t, "nodes[leaf02].targets", targetsOf(g, "leaf02"), []string{"worker-1"})
+}
+
+func TestParseTopologyForestHasMultipleRoots(t *testing.T) {
+	raw := `
+SwitchName=treeA Level=0 Nodes=worker-a
+SwitchName=treeB Level=0 Nodes=worker-b
+`
+	g, err := parseTopology(raw, nil, nil)
+	if err != nil {
+		t.Fatalf("parseTopology: %v", err)
+	}
+	assertEdgeSet(t, "roots", collectRoots(g), []string{"treeA", "treeB"})
+	assertEdgeSet(t, "nodes[treeA].targets", targetsOf(g, "treeA"), []string{"worker-a"})
+	assertEdgeSet(t, "nodes[treeB].targets", targetsOf(g, "treeB"), []string{"worker-b"})
+
+	// Each worker is accepted on its own root.
+	if err := validateReportedPath(g, "treeA.worker-a", "worker-a"); err != nil {
+		t.Errorf("treeA.worker-a: %v", err)
+	}
+	if err := validateReportedPath(g, "treeB.worker-b", "worker-b"); err != nil {
+		t.Errorf("treeB.worker-b: %v", err)
+	}
+
+	// Cross-root: worker-a claimed under treeB should fail (not attached).
+	if err := validateReportedPath(g, "treeB.worker-a", "worker-a"); err == nil {
+		t.Errorf("cross-root should fail, got nil")
+	}
+}


### PR DESCRIPTION
## Problem

We have no acceptance test that verifies the Slurm network topology is wired up correctly. If `scontrol show topology` disagrees with what workers see in `SLURM_TOPOLOGY_ADDR`, jobs land on the wrong leaves and rebuilds of `topology.conf` go unnoticed.

## Solution

- New acceptance scenario `topology.feature` that runs only when `TopologyPlugin=topology/tree`.
- Parse `scontrol show topology` into a switch tree, check every worker in the main partition is present.
- Launch an srun job across all available workers, collect `SLURM_TOPOLOGY_ADDR` per task, and assert each address matches the node's path in the parsed tree.
- Unrelated small fix in `worker_init_test.py`: the `special_characters` test input actually had a hyphen, not a period; updated the expected value to match.

## Testing

- Unit tests for the topology parser and matcher in `topology_test.go`.
- E2E run: https://github.com/nebius/soperator/actions/runs/24783793130

## Release Notes

None