### PR TITLE
SCHED-1199: Otel-collector setup for NCCL profiles

### DIFF
--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -34,6 +34,9 @@ spec:
   targetNamespace: {{ .Values.observability.vmStack.namespace }}
 
   values:
+  {{- if .Values.observability.ncclProfiles.configMapOverrideValues }}
+    {{- toYaml .Values.observability.ncclProfiles.configMapOverrideValues | nindent 4 }}
+  {{- else }}
     resources:
     - apiVersion: v1
       kind: ConfigMap
@@ -125,7 +128,18 @@ spec:
             {{- end }}
             health_check:
               endpoint: 0.0.0.0:13133
+  {{- end }}
 
+  valuesFrom:
+    - kind: ConfigMap
+      name: terraform-opentelemetry-collector-nccl-profiles-cm
+      optional: true
+      valuesKey: values.yaml
+
+    - kind: ConfigMap
+      name: opentelemetry-collector-nccl-profiles-cm
+      optional: true
+      valuesKey: values.yaml
 ---
 
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -164,8 +178,8 @@ spec:
   targetNamespace: {{ .Values.observability.vmStack.namespace }}
 
   values:
-  {{- if .Values.observability.ncclProfiles.overrideValues }}
-    {{- toYaml .Values.observability.ncclProfiles.overrideValues | nindent 4 }}
+  {{- if .Values.observability.ncclProfiles.collectorOverrideValues }}
+    {{- toYaml .Values.observability.ncclProfiles.collectorOverrideValues | nindent 4 }}
   {{- else }}
     clusterRole:
       create: true

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -199,10 +199,13 @@ spec:
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
       tag: {{ .Values.observability.ncclProfiles.values.nebiusO11yAgentVersion | default "2.0.3" }}
 
-    mode: deployment  # Single deployment on system nodes instead of DaemonSet on all workers
+    {{- if eq (.Values.observability.ncclProfiles.values.mode | default "shared") "shared" }}
+    mode: deployment
     replicaCount: 1   # Only one replica to avoid file lock conflicts on shared storage and prevent log duplication
+
     rollout:
       strategy: Recreate  # Ensure old pod terminates before new one starts to maintain max one pod running
+
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
@@ -210,7 +213,31 @@ spec:
             - matchExpressions:
                 - key: slurm.nebius.ai/nodeset
                   operator: In
-                  values: ["system"]
+                  values:
+                    - "system"
+    {{- else }}{{- if eq (.Values.observability.ncclProfiles.values.mode | default "shared") "nodeLocal" }}
+    mode: daemonset
+
+    rollout:
+      rollingUpdate:
+        maxUnavailable: 50%
+      strategy: RollingUpdate
+
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: slurm.nebius.ai/nodeset
+                  operator: In
+                  values:
+                    - "worker"
+
+    tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+    {{- end }}{{- end }}
 
     extraVolumes:
       - name: nccl-profiles

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -101,7 +101,12 @@ spec:
             {{- if .Values.observability.opentelemetry.metrics.enabled }}
             telemetry:
               metrics:
-                address: 0.0.0.0:8889
+                readers:
+                  - pull:
+                      exporter:
+                        prometheus:
+                          host: 0.0.0.0
+                          port: 8889
             {{- end }}
             extensions:
               - health_check

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -1,0 +1,322 @@
+{{- if and .Values.observability.enabled .Values.observability.vmStack.enabled .Values.observability.ncclProfiles.enabled -}}
+
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: {{ include "soperator-fluxcd.fullname" . }}-otelcol-nccl-profiles-cm
+  labels:
+  {{- include "soperator-fluxcd.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.observability.ncclProfiles.driftDetection }}
+  driftDetection:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  chart:
+    spec:
+      chart: raw
+      interval: {{ .Values.observability.ncclProfiles.interval }}
+      sourceRef:
+        kind: HelmRepository
+        name: {{ include "soperator-fluxcd.fullname" . }}-bedag
+      version: {{ .Values.observability.ncclProfiles.version.bedag }}
+
+  dependsOn:
+    - name: {{ include "soperator-fluxcd.fullname" . }}-ns
+
+  install:
+    {{- toYaml .Values.observability.ncclProfiles.install | nindent 4 }}
+  upgrade:
+    {{- toYaml .Values.observability.ncclProfiles.upgrade | nindent 4 }}
+  interval: {{ .Values.observability.ncclProfiles.interval }}
+  timeout: {{ .Values.observability.ncclProfiles.timeout }}
+  releaseName: {{ .Values.observability.ncclProfiles.releaseName }}-cm
+  targetNamespace: {{ .Values.observability.vmStack.namespace }}
+
+  values:
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        namespace: {{ .Values.observability.vmStack.namespace }}
+        name: {{ .Values.observability.ncclProfiles.releaseName }}-agent
+      data:
+        relay: |
+          exporters:
+            otlphttp/victoriametrics:
+              compression: gzip
+              encoding: proto
+              metrics_endpoint: {{ .Values.observability.ncclProfiles.values.metricsEndpoint | default "http://vmsingle-metrics-victoria-metrics-k8s-stack:8429/opentelemetry/v1/metrics" }}
+              retry_on_failure:
+                initial_interval: 200ms
+              timeout: 5s
+
+          receivers:
+            filelog/nccl_metrics:
+              include:
+                - {{ .Values.observability.ncclProfiles.values.dumpDir }}/*/*/*.log
+              poll_interval: {{ .Values.observability.ncclProfiles.values.pollInterval | default "30s" }}
+              retry_on_failure:
+                enabled: true
+              include_file_path: true
+              start_at: beginning
+              {{- if .Values.observability.ncclProfiles.values.deleteAfterRead.enabled }}
+              delete_after_read: true
+              delete_after_read_min_age: {{ .Values.observability.ncclProfiles.values.deleteAfterRead.minAge | default "1m" }}
+              {{- else }}
+              delete_after_read: false
+              {{- end }}
+              {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+              storage: file_storage
+              {{- end }}
+
+              operators:
+                - id: parse_nccl_profile_path
+                  type: regex_parser
+                  parse_from: attributes["log.file.path"]
+                  regex: ^.*/(?P<job_id>[^/]+)/(?P<step_id>[^/]+)/(?P<worker_name>.+)-pid(?P<hostname_pid>[^/]+)\.log$
+
+                - if: attributes["job_id"] != nil
+                  type: copy
+                  from: attributes.job_id
+                  to: resource["{{ .Values.observability.ncclProfiles.values.exportLabels.slurmJobId | default "slurm_job_id" }}"]
+
+                - if: attributes["step_id"] != nil
+                  type: copy
+                  from: attributes.step_id
+                  to: resource["{{ .Values.observability.ncclProfiles.values.exportLabels.slurmStepId | default "slurm_step_id" }}"]
+
+                - if: attributes["hostname_pid"] != nil
+                  type: copy
+                  from: attributes.hostname_pid
+                  to: resource["{{ .Values.observability.ncclProfiles.values.exportLabels.hostnamePid | default "hostname_pid" }}"]
+
+          connectors:
+            ncclmetrics:
+
+          service:
+            {{- if .Values.observability.opentelemetry.metrics.enabled }}
+            telemetry:
+              metrics:
+                address: 0.0.0.0:8889
+            {{- end }}
+            extensions:
+              - health_check
+              {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+              - file_storage
+              {{- end }}
+            pipelines:
+              logs/nccl_metrics:
+                receivers:
+                  - filelog/nccl_metrics
+                exporters:
+                  - ncclmetrics
+
+              metrics/nccl_metrics:
+                receivers:
+                  - ncclmetrics
+                exporters:
+                  - otlphttp/victoriametrics
+
+          extensions:
+            {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+            file_storage:
+              directory: /var/lib/otelcol
+            {{- end }}
+            health_check:
+              endpoint: 0.0.0.0:13133
+
+---
+
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: {{ include "soperator-fluxcd.fullname" . }}-otelcol-nccl-profiles
+  labels:
+  {{- include "soperator-fluxcd.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.observability.ncclProfiles.driftDetection }}
+  driftDetection:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  chart:
+    spec:
+      chart: opentelemetry-collector
+      interval: {{ .Values.observability.ncclProfiles.interval }}
+      sourceRef:
+        kind: HelmRepository
+        name: {{ include "soperator-fluxcd.fullname" . }}-opentelemetry-collector
+      version: {{ .Values.observability.ncclProfiles.version.opentelemetryCollector }}
+
+  dependsOn:
+    - name: {{ include "soperator-fluxcd.fullname" . }}-ns
+    - name: {{ include "soperator-fluxcd.fullname" . }}-vm-stack
+    - name: {{ include "soperator-fluxcd.fullname" . }}-otelcol-nccl-profiles-cm
+
+  install:
+    {{- toYaml .Values.observability.ncclProfiles.install | nindent 4 }}
+  upgrade:
+    {{- toYaml .Values.observability.ncclProfiles.upgrade | nindent 4 }}
+  interval: {{ .Values.observability.ncclProfiles.interval }}
+  timeout: {{ .Values.observability.ncclProfiles.timeout }}
+  releaseName: {{ .Values.observability.ncclProfiles.releaseName }}
+  targetNamespace: {{ .Values.observability.vmStack.namespace }}
+
+  values:
+  {{- if .Values.observability.ncclProfiles.overrideValues }}
+    {{- toYaml .Values.observability.ncclProfiles.overrideValues | nindent 4 }}
+  {{- else }}
+    clusterRole:
+      create: true
+      rules:
+        - apiGroups:
+            - ""
+          resources:
+            - pods
+            - namespaces
+          verbs:
+            - get
+            - watch
+            - list
+
+    image:
+      pullPolicy: IfNotPresent
+      repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
+      tag: {{ .Values.observability.ncclProfiles.values.nebiusO11yAgentVersion | default "2.0.3" }}
+
+    mode: deployment  # Single deployment on system nodes instead of DaemonSet on all workers
+    replicaCount: 1   # Only one replica to avoid file lock conflicts on shared storage and prevent log duplication
+    rollout:
+      strategy: Recreate  # Ensure old pod terminates before new one starts to maintain max one pod running
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: slurm.nebius.ai/nodeset
+                  operator: In
+                  values: ["system"]
+
+    extraVolumes:
+      - name: nccl-profiles
+        hostPath:
+          path: {{ .Values.observability.ncclProfiles.values.dumpDir }}
+          type: Directory
+
+      {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+      - name: varlibotelcol
+        hostPath:
+          path: /var/lib/otelcol
+          type: DirectoryOrCreate
+      {{- end }}
+
+    extraVolumeMounts:
+      - name: nccl-profiles
+        mountPath: /mnt/jail/opt/soperator-outputs/nccl_profiles/
+        readOnly: true
+
+      {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+      - name: varlibotelcol
+        mountPath: /var/lib/otelcol
+      {{- end }}
+
+    extraEnvs:
+      - name: GOMAXPROCS
+        value: "1"
+
+    securityContext:
+      runAsGroup: 0
+      runAsUser: 10001
+    service: # No external access needed - this collector only reads files and sends to Victoria Logs
+      enabled: false
+    serviceAccount:
+      create: true
+
+    {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+    initContainers:
+      - command:
+          - sh
+          - "-c"
+          - 'chown -R 10001: /var/lib/otelcol'
+        image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
+        name: init-fs
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        volumeMounts:
+          - name: varlibotelcol
+            mountPath: /var/lib/otelcol
+    {{- else }}
+    initContainers: []
+    {{- end }}
+
+    resources:
+      {{- toYaml .Values.observability.ncclProfiles.values.resources | nindent 6 }}
+
+    useGOMEMLIMIT: {{ .Values.observability.ncclProfiles.values.useGoMemLimit | default true }}
+
+    {{- if .Values.observability.opentelemetry.metrics.enabled }}
+    command:
+      extraArgs:
+        - "--feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress"
+    {{- end }}
+
+    ports:
+      jaeger-compact:
+        enabled: false
+      jaeger-grpc:
+        enabled: false
+      jaeger-thrift:
+        enabled: false
+      metrics:
+        {{- if .Values.observability.opentelemetry.metrics.enabled }}
+        enabled: true
+        containerPort: 8889
+        servicePort: 8889
+        {{- else }}
+        enabled: false
+        {{- end }}
+      otlp:
+        enabled: false
+      otlp-http:
+        enabled: false
+      zipkin:
+        enabled: false
+
+    podMonitor:
+      {{- if .Values.observability.opentelemetry.metrics.enabled }}
+      enabled: true
+      metricsEndpoints:
+        - port: metrics
+          interval: {{ .Values.observability.opentelemetry.metrics.interval | default "30s" }}
+          scrapeTimeout: {{ .Values.observability.opentelemetry.metrics.scrapeTimeout | default "10s" }}
+          relabelings:
+            - sourceLabels: [ __meta_kubernetes_pod_name ]
+              targetLabel: pod
+            - sourceLabels: [ __meta_kubernetes_node_name ]
+              targetLabel: node
+            - replacement: otel-collector-nccl-profiles
+              targetLabel: collector
+      {{- else }}
+      enabled: false
+      {{- end }}
+
+    config: {}
+    configMap:
+      create: false
+      existingName: {{ .Values.observability.ncclProfiles.releaseName }}-agent
+  {{- end }}
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: terraform-opentelemetry-collector-nccl-profiles
+      optional: true
+      valuesKey: values.yaml
+
+    - kind: ConfigMap
+      name: opentelemetry-collector-nccl-profiles
+      optional: true
+      valuesKey: values.yaml
+
+{{- end -}}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -50,9 +50,16 @@ spec:
               compression: gzip
               encoding: proto
               metrics_endpoint: {{ .Values.observability.ncclProfiles.values.metricsEndpoint | default "http://vmsingle-metrics-victoria-metrics-k8s-stack:8429/opentelemetry/v1/metrics" }}
+              timeout: {{ .Values.observability.ncclProfiles.values.metricsExporterTimeout | default "15s" }}
               retry_on_failure:
-                initial_interval: 200ms
-              timeout: 5s
+                enabled: true
+                initial_interval: 1s
+                max_interval: 10s
+                max_elapsed_time: 5m
+              sending_queue:
+                enabled: true
+                queue_size: {{ .Values.observability.ncclProfiles.values.metricsExporterSendingQueueSize | default 2000 }}
+                num_consumers: {{ .Values.observability.ncclProfiles.values.metricsExporterNumConsumers | default 4 }}
 
           receivers:
             filelog/nccl_metrics:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -209,7 +209,7 @@ spec:
     image:
       pullPolicy: IfNotPresent
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
-      tag: {{ .Values.observability.ncclProfiles.values.nebiusO11yAgentVersion | default "2.0.3" }}
+      tag: {{ .Values.observability.ncclProfiles.values.nebiusO11yAgentVersion | default "2.0.10" }}
 
     {{- if eq (.Values.observability.ncclProfiles.values.mode | default "shared") "shared" }}
     mode: deployment

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -37,6 +37,7 @@ spec:
   {{- if .Values.observability.ncclProfiles.configMapOverrideValues }}
     {{- toYaml .Values.observability.ncclProfiles.configMapOverrideValues | nindent 4 }}
   {{- else }}
+  {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
     resources:
     - apiVersion: v1
       kind: ConfigMap
@@ -60,6 +61,9 @@ spec:
                 enabled: true
                 queue_size: {{ .Values.observability.ncclProfiles.values.metricsExporterSendingQueueSize | default 2000 }}
                 num_consumers: {{ .Values.observability.ncclProfiles.values.metricsExporterNumConsumers | default 4 }}
+                {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+                storage: file_storage
+                {{- end }}
 
           receivers:
             filelog/nccl_metrics:
@@ -104,6 +108,12 @@ spec:
           connectors:
             ncclmetrics:
 
+          processors:
+            batch:
+              timeout: {{ $batch.timeout | default "5s" }}
+              send_batch_size: {{ $batch.sendBatchSize | default 2000 }}
+              send_batch_max_size: {{ $batch.sendBatchMaxSize | default 5000 }}
+
           service:
             {{- if .Values.observability.opentelemetry.metrics.enabled }}
             telemetry:
@@ -130,6 +140,8 @@ spec:
               metrics/nccl_metrics:
                 receivers:
                   - ncclmetrics
+                processors:
+                  - batch
                 exporters:
                   - otlphttp/victoriametrics
 
@@ -273,10 +285,6 @@ spec:
       - name: varlibotelcol
         mountPath: /var/lib/otelcol
       {{- end }}
-
-    extraEnvs:
-      - name: GOMAXPROCS
-        value: "1"
 
     securityContext:
       runAsGroup: 0

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -47,7 +47,7 @@ spec:
       data:
         relay: |
           exporters:
-            otlphttp/victoriametrics:
+            otlp_http/victoriametrics:
               compression: gzip
               encoding: proto
               metrics_endpoint: {{ .Values.observability.ncclProfiles.values.metricsEndpoint | default "http://vmsingle-metrics-victoria-metrics-k8s-stack:8429/opentelemetry/v1/metrics" }}
@@ -143,7 +143,7 @@ spec:
                 processors:
                   - batch
                 exporters:
-                  - otlphttp/victoriametrics
+                  - otlp_http/victoriametrics
 
           extensions:
             {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}

--- a/helm/soperator-fluxcd/tests/component_enabled_test.yaml
+++ b/helm/soperator-fluxcd/tests/component_enabled_test.yaml
@@ -5,6 +5,34 @@ excludeTemplates:
   - templates/helmrepository.yaml
   - templates/notifier.yaml
 tests:
+  - it: should render nccl profiles config when ncclProfiles.enabled=true
+    set:
+      observability.enabled: true
+      observability.vmStack.enabled: true
+      observability.ncclProfiles.enabled: true
+    templates:
+      - templates/opentelemetry-collector-nccl-profiles.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles-cm
+    asserts:
+      - exists:
+          path: 'spec.values.resources[0].data.relay'
+
+  - it: should render nccl profiles collector when ncclProfiles.enabled=true
+    set:
+      observability.enabled: true
+      observability.vmStack.enabled: true
+      observability.ncclProfiles.enabled: true
+    templates:
+      - templates/opentelemetry-collector-nccl-profiles.yaml
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles
+    asserts:
+      - exists:
+          path: 'spec.values.podMonitor'
+
   - it: should render jail logs component when jailLogs.enabled=true
     set:
       observability.enabled: true

--- a/helm/soperator-fluxcd/tests/values_override_test.yaml
+++ b/helm/soperator-fluxcd/tests/values_override_test.yaml
@@ -185,7 +185,140 @@ tests:
           value:
             cpu: 100m
             memory: 128Mi
+
 ---
+
+suite: test values override default values opentelemetry-collector-nccl-profiles
+templates:
+  - templates/opentelemetry-collector-nccl-profiles.yaml
+tests:
+  - it: should use override values for opentelemetry collector chart when provided
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.ncclProfiles.overrideValues:
+        customConfig: true
+        image:
+          repository: example.test/custom-agent
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles
+    asserts:
+      - equal:
+          path: spec.values.customConfig
+          value: true
+      - equal:
+          path: spec.values.image.repository
+          value: example.test/custom-agent
+      - notExists:
+          path: spec.values.clusterRole
+
+  - it: should use default values for opentelemetry collector chart when override values not provided
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.ncclProfiles.overrideValues: null
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles
+    asserts:
+      - exists:
+          path: spec.values.clusterRole
+      - equal:
+          path: spec.values.image.repository
+          value: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
+      - equal:
+          path: spec.values.configMap.existingName
+          value: opentelemetry-collector-nccl-profiles-agent
+
+  - it: should propagate nccl profiles values to opentelemetry collector chart
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.ncclProfiles.values.dumpDir: /custom/nccl
+      observability.ncclProfiles.values.enableFileStorage: false
+      observability.ncclProfiles.values.resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles
+    asserts:
+      - equal:
+          path: spec.values.extraVolumes[0].hostPath.path
+          value: /custom/nccl
+      - equal:
+          path: spec.values.initContainers
+          value: []
+      - equal:
+          path: spec.values.resources.requests
+          value:
+            cpu: 250m
+            memory: 256Mi
+      - equal:
+          path: spec.values.resources.limits
+          value:
+            memory: 512Mi
+
+  - it: should use custom values when provided
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.ncclProfiles.values.enableFileStorage: true
+      observability.ncclProfiles.values.metricsEndpoint: http://example.test:8429/custom
+      observability.ncclProfiles.values.deleteAfterRead.enabled: true
+      observability.ncclProfiles.values.deleteAfterRead.minAge: 30m
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles-cm
+    asserts:
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'file_storage'
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'metrics_endpoint: http://example\.test:8429/custom'
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'delete_after_read: true'
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'delete_after_read_min_age: 30m'
+
+  - it: should not include file_storage in relay config when disabled
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.ncclProfiles.values.enableFileStorage: false
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles-cm
+    asserts:
+      - notMatchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'file_storage'
+
+  - it: should not use delete_after_read in relay config when disabled
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.ncclProfiles.values.deleteAfterRead.enabled: false
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles-cm
+    asserts:
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'delete_after_read: false'
+      - notMatchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'delete_after_read_min_age'
+
+---
+
 suite: test values override default values nodesets
 templates:
   - templates/nodesets.yaml

--- a/helm/soperator-fluxcd/tests/values_override_test.yaml
+++ b/helm/soperator-fluxcd/tests/values_override_test.yaml
@@ -265,11 +265,46 @@ tests:
       - exists:
           path: spec.values.clusterRole
       - equal:
+          path: spec.values.mode
+          value: deployment
+      - equal:
+          path: spec.values.replicaCount
+          value: 1
+      - equal:
+          path: spec.values.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+          value: system
+      - notExists:
+          path: spec.values.tolerations
+      - equal:
           path: spec.values.image.repository
           value: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
       - equal:
           path: spec.values.configMap.existingName
           value: opentelemetry-collector-nccl-profiles-agent
+
+  - it: should use daemonset mode on worker nodes for node-local storage
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.ncclProfiles.values.mode: nodeLocal
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles
+    asserts:
+      - equal:
+          path: spec.values.mode
+          value: daemonset
+      - notExists:
+          path: spec.values.replicaCount
+      - equal:
+          path: spec.values.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+          value: worker
+      - contains:
+          path: spec.values.tolerations
+          content:
+            effect: NoSchedule
+            key: nvidia.com/gpu
+            operator: Exists
 
   - it: should propagate nccl profiles values to opentelemetry collector chart
     set:

--- a/helm/soperator-fluxcd/tests/values_override_test.yaml
+++ b/helm/soperator-fluxcd/tests/values_override_test.yaml
@@ -192,11 +192,34 @@ suite: test values override default values opentelemetry-collector-nccl-profiles
 templates:
   - templates/opentelemetry-collector-nccl-profiles.yaml
 tests:
-  - it: should use override values for opentelemetry collector chart when provided
+  - it: should use override values for nccl profiles configmap chart when provided
     set:
       observability.enabled: true
       observability.ncclProfiles.enabled: true
-      observability.ncclProfiles.overrideValues:
+      observability.ncclProfiles.configMapOverrideValues:
+        resources:
+          - apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: custom-nccl-profiles-agent
+            data:
+              relay: "custom: relay"
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles-cm
+    asserts:
+      - equal:
+          path: spec.values.resources[0].metadata.name
+          value: custom-nccl-profiles-agent
+      - equal:
+          path: spec.values.resources[0].data.relay
+          value: "custom: relay"
+
+  - it: should use collector override values for opentelemetry collector chart when provided
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.ncclProfiles.collectorOverrideValues:
         customConfig: true
         image:
           repository: example.test/custom-agent
@@ -213,11 +236,28 @@ tests:
       - notExists:
           path: spec.values.clusterRole
 
+  - it: should use legacy overrideValues for opentelemetry collector chart when provided
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.ncclProfiles.collectorOverrideValues:
+        legacyConfig: true
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles
+    asserts:
+      - equal:
+          path: spec.values.legacyConfig
+          value: true
+      - notExists:
+          path: spec.values.clusterRole
+
   - it: should use default values for opentelemetry collector chart when override values not provided
     set:
       observability.enabled: true
       observability.ncclProfiles.enabled: true
-      observability.ncclProfiles.overrideValues: null
+      observability.ncclProfiles.configMapOverrideValues: null
+      observability.ncclProfiles.collectorOverrideValues: null
     documentSelector:
       path: metadata.name
       value: RELEASE-NAME-otelcol-nccl-profiles

--- a/helm/soperator-fluxcd/tests/values_override_test.yaml
+++ b/helm/soperator-fluxcd/tests/values_override_test.yaml
@@ -344,6 +344,9 @@ tests:
       observability.ncclProfiles.enabled: true
       observability.ncclProfiles.values.enableFileStorage: true
       observability.ncclProfiles.values.metricsEndpoint: http://example.test:8429/custom
+      observability.ncclProfiles.values.metricsExporterTimeout: 25s
+      observability.ncclProfiles.values.metricsExporterSendingQueueSize: 4321
+      observability.ncclProfiles.values.metricsExporterNumConsumers: 7
       observability.ncclProfiles.values.deleteAfterRead.enabled: true
       observability.ncclProfiles.values.deleteAfterRead.minAge: 30m
     documentSelector:
@@ -356,6 +359,15 @@ tests:
       - matchRegex:
           path: spec.values.resources[0].data.relay
           pattern: 'metrics_endpoint: http://example\.test:8429/custom'
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'timeout: 25s'
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'queue_size: 4321'
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'num_consumers: 7'
       - matchRegex:
           path: spec.values.resources[0].data.relay
           pattern: 'delete_after_read: true'

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -388,6 +388,46 @@ observability:
           cpu: 100m
     driftDetection:
       mode: warn
+  ncclProfiles:
+    enabled: true
+    interval: 5m
+    timeout: 5m
+    version:
+      bedag: 2.0.0
+      opentelemetryCollector: 0.149.*
+    install:
+      crds: Skip
+      remediation:
+        retries: 3
+    upgrade:
+      crds: Skip
+      remediation:
+        retries: 3
+        remediateLastFailure: true
+    driftDetection:
+      mode: warn
+    releaseName: opentelemetry-collector-nccl-profiles
+    values:
+      resources:
+        requests:
+          memory: 200Mi
+          cpu: 500m
+        limits:
+          memory: 1Gi
+      nebiusO11yAgentVersion: 2.0.3
+      useGoMemLimit: true
+      metricsEndpoint: http://vmsingle-metrics-victoria-metrics-k8s-stack:8429/opentelemetry/v1/metrics
+      dumpDir: /mnt/jail/opt/soperator-outputs/nccl_profiles
+      pollInterval: 30s
+      exportLabels:
+        slurmJobId: slurm_job_id
+        slurmStepId: slurm_step_id
+        hostnamePid: hostname_pid
+      enableFileStorage: true
+      deleteAfterRead:
+        enabled: false
+        minAge: 15m
+
 securityProfilesOperator:
   enabled: true
   interval: 5m

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -432,7 +432,7 @@ observability:
         hostnamePid: hostname_pid
       enableFileStorage: true
       deleteAfterRead:
-        enabled: false
+        enabled: true
         minAge: 15m
 securityProfilesOperator:
   enabled: true

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -410,6 +410,8 @@ observability:
     configMapOverrideValues: null
     collectorOverrideValues: null
     values:
+      # or nodeLocal
+      mode: shared
       resources:
         requests:
           memory: 200Mi
@@ -429,7 +431,6 @@ observability:
       deleteAfterRead:
         enabled: false
         minAge: 15m
-
 securityProfilesOperator:
   enabled: true
   interval: 5m

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -421,6 +421,9 @@ observability:
       nebiusO11yAgentVersion: 2.0.3
       useGoMemLimit: true
       metricsEndpoint: http://vmsingle-metrics-victoria-metrics-k8s-stack:8429/opentelemetry/v1/metrics
+      metricsExporterTimeout: 15s
+      metricsExporterSendingQueueSize: 2000
+      metricsExporterNumConsumers: 4
       dumpDir: /mnt/jail/opt/soperator-outputs/nccl_profiles
       pollInterval: 30s
       exportLabels:

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -407,6 +407,8 @@ observability:
     driftDetection:
       mode: warn
     releaseName: opentelemetry-collector-nccl-profiles
+    configMapOverrideValues: null
+    collectorOverrideValues: null
     values:
       resources:
         requests:

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -418,7 +418,7 @@ observability:
           cpu: 500m
         limits:
           memory: 1Gi
-      nebiusO11yAgentVersion: 2.0.3
+      nebiusO11yAgentVersion: 2.0.5
       useGoMemLimit: true
       metricsEndpoint: http://vmsingle-metrics-victoria-metrics-k8s-stack:8429/opentelemetry/v1/metrics
       metricsExporterTimeout: 15s

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -418,7 +418,7 @@ observability:
           cpu: 500m
         limits:
           memory: 1Gi
-      nebiusO11yAgentVersion: 2.0.5
+      nebiusO11yAgentVersion: 2.0.10
       useGoMemLimit: true
       metricsEndpoint: http://vmsingle-metrics-victoria-metrics-k8s-stack:8429/opentelemetry/v1/metrics
       metricsExporterTimeout: 15s

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -389,7 +389,7 @@ observability:
     driftDetection:
       mode: warn
   ncclProfiles:
-    enabled: true
+    enabled: false
     interval: 5m
     timeout: 5m
     version:


### PR DESCRIPTION
## Problem
NCCL profiles collected via NCCL Inspector should be transformed into usable metrics and delivered into local Grafana.

## Solution
Install OpenTelemetry collector to convert NCCL profiles into metrics with Nebius O11y agent.

## Testing
Tested on a dev cluster.

## Release Notes
Feature: Added conversion pipeline for delivering NCCL profiles as metrics into local Grafana.