### PR TITLE
SCHED-1420: Retry flaky kubectl cp when collecting jail files

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -507,8 +507,10 @@ jobs:
           if [[ -n "$SCONFIG_POD" ]]; then
             echo "Copying jail files from $SCONFIG_POD"
             kubectl exec -n soperator "$SCONFIG_POD" -- find /mnt/jail -maxdepth 4 -not -path '*/proc/*' > ./jail/tree.txt 2>&1 || true
-            kubectl cp "soperator/$SCONFIG_POD:/mnt/jail/etc/slurm/" ./jail/etc/slurm
-            kubectl cp "soperator/$SCONFIG_POD:/mnt/jail/opt/soperator-outputs" ./jail/opt/soperator-outputs
+            .github/workflows/scripts/retry.sh \
+              kubectl cp "soperator/$SCONFIG_POD:/mnt/jail/etc/slurm/" ./jail/etc/slurm
+            .github/workflows/scripts/retry.sh \
+              kubectl cp "soperator/$SCONFIG_POD:/mnt/jail/opt/soperator-outputs" ./jail/opt/soperator-outputs
           else
             echo "No running sconfigcontroller pod found, skipping jail files collection"
           fi

--- a/.github/workflows/scripts/retry.sh
+++ b/.github/workflows/scripts/retry.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e          # Exit on error
+set -u          # Exit on undefined variable
+set -o pipefail # Exit on pipe failure
+
+# Generic retry wrapper for flaky commands used in CI workflow steps.
+#
+# Usage:
+#   retry.sh <cmd> [args...]
+#
+# Env overrides:
+#   RETRY_MAX      total attempts           (default: 3)
+#   RETRY_BACKOFF  base seconds, linear     (default: 5)
+#                  waits RETRY_BACKOFF*attempt between tries
+
+: "${RETRY_MAX:=3}"
+: "${RETRY_BACKOFF:=5}"
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: retry.sh <cmd> [args...]" >&2
+  exit 2
+fi
+
+attempt=1
+while : ; do
+  rc=0
+  out=$("$@" 2>&1) || rc=$?
+  if (( rc == 0 )); then
+    printf '%s' "$out"
+    exit 0
+  fi
+  echo "Retry attempt ${attempt}/${RETRY_MAX} failed (exit ${rc}): $*" >&2
+  printf '%s\n' "$out" >&2
+  if (( attempt >= RETRY_MAX )); then
+    exit "$rc"
+  fi
+  sleep $(( RETRY_BACKOFF * attempt ))
+  attempt=$(( attempt + 1 ))
+done


### PR DESCRIPTION
## Problem

The e2e teardown step that copies jail files out of the `sconfigcontroller` pod occasionally fails on a transient `kubectl cp` error, which aborts the rest of teardown and loses artifacts we want to keep.

## Solution

- Add `.github/workflows/scripts/retry.sh`, a small generic retry wrapper (3 attempts, linear backoff, configurable via `RETRY_MAX` / `RETRY_BACKOFF`).
- Wrap both `kubectl cp` calls in `e2e_test.yml` with it so transient failures get retried instead of killing the job.

## Testing

Script checked locally against a failing and a succeeding command. CI run on this branch will exercise the wrapped `kubectl cp` path.

## Release Notes

None