### PR TITLE
SCHED-1562: Source e2e container-job image from prepull ActiveCheck

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -166,8 +166,6 @@ jobs:
       PROFILE_ENV_VAR: ${{ inputs.profile_env_var || vars.PROFILE_ENV_VAR }}
       E2E_PROFILE: ${{ vars[inputs.profile_env_var || vars.PROFILE_ENV_VAR] }}
       RUN_UNSTABLE_TESTS: ${{ inputs.run_unstable_tests || 'false' }}
-      E2E_DOCKER_IMAGE: "cr.eu-north1.nebius.cloud/soperator/active_checks:12.9.0-ubuntu24.04-nccl_tests2.16.4-3935b93"
-      E2E_ENROOT_IMAGE: "docker://cr.eu-north1.nebius.cloud#soperator/active_checks:12.9.0-ubuntu24.04-nccl_tests2.16.4-3935b93"
 
     steps:
       - name: Checkout repository

--- a/internal/e2e/acceptance/steps/docker_containers.go
+++ b/internal/e2e/acceptance/steps/docker_containers.go
@@ -71,7 +71,7 @@ func (s *DockerContainers) aLongRunningDockerNCCLJobIsSubmittedOnTwoGPUWorkers(c
 	s.workers = workers
 	s.connectionWorker = s.workers[0]
 
-	image, err := framework.RequiredEnv("E2E_DOCKER_IMAGE")
+	image, err := PrepullContainerImageDocker(ctx, s.exec)
 	if err != nil {
 		return err
 	}

--- a/internal/e2e/acceptance/steps/enroot_containers.go
+++ b/internal/e2e/acceptance/steps/enroot_containers.go
@@ -337,7 +337,7 @@ func (s *EnrootContainers) submitEnrootJob(ctx context.Context, containerName, j
 		s.connectionWorker = s.workers[0]
 	}
 
-	image, err := framework.RequiredEnv("E2E_ENROOT_IMAGE")
+	image, err := PrepullContainerImageEnroot(ctx, s.exec)
 	if err != nil {
 		return err
 	}

--- a/internal/e2e/acceptance/steps/prepull_container_image.go
+++ b/internal/e2e/acceptance/steps/prepull_container_image.go
@@ -1,0 +1,67 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
+	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
+)
+
+const prepullActiveCheckName = "prepull-container-image"
+
+var containerImageRegex = regexp.MustCompile(`--container-image=(\S+)`)
+
+// PrepullContainerImagePyxis returns the Pyxis-format image declared in the
+// prepull-container-image ActiveCheck's sbatch script
+// (e.g. "cr.eu-north1.nebius.cloud#ml-containers/training_diag:<tag>").
+func PrepullContainerImagePyxis(ctx context.Context, exec framework.Exec) (string, error) {
+	var checks slurmv1alpha1.ActiveCheckList
+	if err := kubectlJSON(ctx, exec, &checks, "get", "activechecks", "-A", "-o", "json"); err != nil {
+		return "", fmt.Errorf("list ActiveChecks: %w", err)
+	}
+	for _, c := range checks.Items {
+		if c.Name != prepullActiveCheckName {
+			continue
+		}
+		script := ""
+		if c.Spec.SlurmJobSpec.SbatchScript != nil {
+			script = *c.Spec.SlurmJobSpec.SbatchScript
+		}
+		if script == "" {
+			return "", fmt.Errorf("ActiveCheck %s has empty sbatchScript", prepullActiveCheckName)
+		}
+		m := containerImageRegex.FindStringSubmatch(script)
+		if len(m) < 2 {
+			return "", fmt.Errorf("ActiveCheck %s sbatchScript has no --container-image= argument", prepullActiveCheckName)
+		}
+		image := strings.TrimPrefix(strings.TrimSpace(m[1]), "docker://")
+		if image == "" {
+			return "", fmt.Errorf("ActiveCheck %s --container-image= is empty", prepullActiveCheckName)
+		}
+		return image, nil
+	}
+	return "", fmt.Errorf("ActiveCheck %s not found", prepullActiveCheckName)
+}
+
+// PrepullContainerImageDocker returns the same image in plain Docker URL form
+// ("reg/repo:tag"), which is what `docker run` accepts.
+func PrepullContainerImageDocker(ctx context.Context, exec framework.Exec) (string, error) {
+	pyxis, err := PrepullContainerImagePyxis(ctx, exec)
+	if err != nil {
+		return "", err
+	}
+	return strings.Replace(pyxis, "#", "/", 1), nil
+}
+
+// PrepullContainerImageEnroot returns the image with the `docker://` Pyxis prefix
+// expected by `srun --container-image=`.
+func PrepullContainerImageEnroot(ctx context.Context, exec framework.Exec) (string, error) {
+	pyxis, err := PrepullContainerImagePyxis(ctx, exec)
+	if err != nil {
+		return "", err
+	}
+	return "docker://" + pyxis, nil
+}


### PR DESCRIPTION
## Problem

The docker and enroot container e2e tests pulled their image from hardcoded `E2E_DOCKER_IMAGE` / `E2E_ENROOT_IMAGE` env vars in `e2e_test.yml`. The cluster itself prepulls a different image via the `prepull-container-image` ActiveCheck, so the two could drift apart whenever the ActiveCheck image was bumped without also touching the workflow. When that happened, the test workers had to pull a fresh image on the spot, which was slow and flaky.

## Solution

- Add `PrepullContainerImagePyxis/Docker/Enroot` helpers in `internal/e2e/acceptance/steps/prepull_container_image.go` that read the `prepull-container-image` ActiveCheck and extract the `--container-image=` argument from its sbatch script.
- `docker_containers.go` and `enroot_containers.go` now call those helpers instead of `framework.RequiredEnv`.
- Drop the two `E2E_*_IMAGE` env vars from `.github/workflows/e2e_test.yml`.

## Testing

https://github.com/nebius/soperator/actions/workflows/e2e_test.yml?query=branch%3ASCHED-1562%2Ffix-docker-containers-test

## Release Notes

None