### PR TITLE
SCHED-1562: Skip hanging Docker NCCL acceptance scenario via @skip tag

### DIFF
--- a/internal/e2e/acceptance/features/docker_containers.feature
+++ b/internal/e2e/acceptance/features/docker_containers.feature
@@ -1,4 +1,6 @@
 Feature: Docker containers
+  # Skipped: Docker NCCL job hangs even after the prepull-image fix (SCHED-1562); needs deeper triage.
+  @skip
   @gpu
   Scenario: A long-running Docker NCCL job uses local storage and cleans up containers
     Given a long-running Docker NCCL job is submitted on two GPU workers

--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -185,6 +185,20 @@ func (r *Runner) initializeScenario(sc *godog.ScenarioContext) {
 	steps.NewDockerContainers(w, slurm).Register(sc)
 	steps.NewEnrootContainers(w, slurm).Register(sc)
 	steps.NewTopology(r.state, w).Register(sc)
+
+	registerSkipHook(sc)
+}
+
+func registerSkipHook(sc *godog.ScenarioContext) {
+	sc.Before(func(ctx context.Context, scenario *godog.Scenario) (context.Context, error) {
+		for _, t := range scenario.Tags {
+			if t.Name == "@skip" {
+				log.Printf("acceptance: scenario %q has @skip, marking as skipped", scenario.Name)
+				return ctx, godog.ErrSkip
+			}
+		}
+		return ctx, nil
+	})
 }
 
 func registerTimingHooks(sc *godog.ScenarioContext) {


### PR DESCRIPTION
## Problem

The Docker NCCL acceptance scenario in `docker_containers.feature` still hangs even after the prepull-image fix from #2487/#2490. We need to keep CI green while triage continues, and `godog` does not have a built-in way to skip a scenario without removing it.

## Solution

- Add a `Before` hook in `internal/e2e/acceptance/runner.go` that returns `godog.ErrSkip` for any scenario tagged `@skip`, so tagged scenarios are reported as skipped rather than executed.
- Tag the long-running Docker NCCL scenario with `@skip` and a comment pointing back to SCHED-1562.

## Testing

Mechanism is a thin wrapper around `godog.ErrSkip`; no unit tests added. Will verify on the next e2e run that the Docker scenario shows up as skipped instead of timing out.

## Release Notes

None