### PR TITLE
SCHED-1562: Add @skip tag hook to acceptance runner

### DIFF
--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -184,6 +184,20 @@ func (r *Runner) initializeScenario(sc *godog.ScenarioContext) {
 	steps.NewDockerContainers(w, slurm).Register(sc)
 	steps.NewEnrootContainers(w, slurm).Register(sc)
 	steps.NewTopology(r.state, w).Register(sc)
+
+	registerSkipHook(sc)
+}
+
+func registerSkipHook(sc *godog.ScenarioContext) {
+	sc.Before(func(ctx context.Context, scenario *godog.Scenario) (context.Context, error) {
+		for _, t := range scenario.Tags {
+			if t.Name == "@skip" {
+				log.Printf("acceptance: scenario %q has @skip, marking as skipped", scenario.Name)
+				return ctx, godog.ErrSkip
+			}
+		}
+		return ctx, nil
+	})
 }
 
 func registerTimingHooks(sc *godog.ScenarioContext) {


### PR DESCRIPTION
## Problem

The acceptance runner has no way to mark a Godog scenario as skipped. If we want to disable a flaky scenario without deleting it, we have to comment it out or move it to another file.

## Solution

- Add a `Before` hook in `internal/e2e/acceptance/runner.go` that returns `godog.ErrSkip` when a scenario has the `@skip` tag, so Godog reports it as skipped instead of running it.

## Testing

Compile-only; the hook is exercised by tagging a scenario with `@skip` in feature files.

## Release Notes

None