### PR TITLE
SCHED-298: add custom helm chart for kruise

### DIFF
--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -4,8 +4,8 @@ helmRepository:
     url: oci://cr.eu-north1.nebius.cloud/soperator
     type: oci
   kruise:
-    url: https://openkruise.github.io/charts/
-    type: default
+    url: oci://cr.eu-north1.nebius.cloud/soperator
+    type: oci
   certManager:
     url: https://charts.jetstack.io
     type: default
@@ -515,7 +515,7 @@ soperator:
     enabled: true
     interval: 5m
     timeout: 5m
-    version: 1.8.0
+    version: 1.8.3-custom
     releaseName: soperator-kruise
     install:
       crds: CreateReplace
@@ -535,7 +535,6 @@ soperator:
           repository: cr.eu-north1.nebius.cloud/soperator/kruise-manager
         resources:
           limits:
-            cpu: 1000m
             memory: 2Gi
           requests:
             cpu: 1000m


### PR DESCRIPTION
## Problem
During tests Kruise couldn't schedule new worker pods for last 300 nodes (at ~2.5k nodes)

changed kruise-controller-manager args, added (link):

        - --rest-config-qps=100
        - --rest-config-burst=200

Current helm chart doesn’t support adding extra args through values (ref)

We need to fork it, make our changes, send PR to upstream

And use post-render in fluxcd to patch it in the meantime


## Testing
e2e

## Release Notes
add custom helm chart for kruise
