### PR TITLE
SCHED-1146: rebooter: reduce memory usage when checking pod eviction on large clusters

### DIFF
--- a/cmd/rebooter/main.go
+++ b/cmd/rebooter/main.go
@@ -114,7 +114,7 @@ func main() {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.StringVar(&logFormat, "log-format", "json", "Log format: plain or json")
 	flag.StringVar(&logLevel, "log-level", "debug", "Log level: debug, info, warn, error, dpanic, panic, fatal")
-	flag.DurationVar(&reconcileTimeout, "reconcile-timeout", 3*time.Minute, "The maximum duration allowed for a single reconcile if some error occurs")
+	flag.DurationVar(&reconcileTimeout, "reconcile-timeout", 1*time.Minute, "The maximum duration allowed for a single reconcile if some error occurs")
 	flag.DurationVar(&cacheSyncTimeout, "cache-sync-timeout", 2*time.Minute, "The maximum duration allowed for caching sync")
 	flag.Parse()
 
@@ -142,6 +142,11 @@ func main() {
 	tlsOpts := []func(*tls.Config){}
 	if !enableHTTP2 {
 		tlsOpts = append(tlsOpts, disableHTTP2)
+	}
+
+	nodeName := os.Getenv(consts.RebooterNodeNameEnv)
+	if nodeName == "" {
+		cli.Fail(setupLog, fmt.Errorf("%s environment variable is not set", consts.RebooterNodeNameEnv), "unable to determine rebooter node name")
 	}
 
 	webhookServer := webhook.NewServer(webhook.Options{
@@ -177,13 +182,7 @@ func main() {
 
 	rebooterParams := rebooter.RebooterParams{
 		ReconcileTimeout: reconcileTimeout,
-	}
-
-	// Rebooter is a daemonset and should only reconcile the node it is running on
-	rebooterParams.NodeName = os.Getenv(consts.RebooterNodeNameEnv)
-	if rebooterParams.NodeName == "" {
-		errorStr := fmt.Errorf("%s environment variable is not set", consts.RebooterMethodEnv)
-		cli.Fail(setupLog, errorStr, "unable to determine rebooter node name")
+		NodeName:         nodeName,
 	}
 
 	envEvictionMethod := os.Getenv(consts.RebooterMethodEnv)
@@ -196,11 +195,18 @@ func main() {
 	default:
 		rebooterParams.EvictionMethod = consts.RebooterEvict
 	}
+	nodePodsFetcher, err := rebooter.NewAPIServerNodePodsFetcher(mgr.GetConfig())
+	if err != nil {
+		cli.Fail(setupLog, err, "unable to create node pods fetcher")
+	}
+
 	if err = rebooter.NewRebooterReconciler(
 		mgr.GetClient(),
+		mgr.GetAPIReader(),
 		mgr.GetScheme(),
 		mgr.GetEventRecorderFor(rebooter.ControllerName),
 		rebooterParams,
+		nodePodsFetcher,
 	).SetupWithManager(mgr, maxConcurrency, cacheSyncTimeout, rebooterParams.NodeName); err != nil {
 		cli.Fail(setupLog, err, "unable to create controller", rebooter.ControllerName)
 	}

--- a/config/rbac/nodeconfigurator/role.yaml
+++ b/config/rbac/nodeconfigurator/role.yaml
@@ -8,14 +8,6 @@ rules:
   - ""
   resources:
   - nodes
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes/status
   verbs:
   - get
@@ -26,8 +18,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
+  - nodes/proxy
   verbs:
   - get
-  - list
-  - watch

--- a/helm/nodeconfigurator/templates/nodeconfigurator-rbac.yaml
+++ b/helm/nodeconfigurator/templates/nodeconfigurator-rbac.yaml
@@ -10,14 +10,6 @@ rules:
   - ""
   resources:
   - nodes
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes/status
   verbs:
   - get
@@ -28,9 +20,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
+  - nodes/proxy
   verbs:
   - get
-  - list
-  - watch
 {{- end }}

--- a/internal/rebooter/apiserver_node_proxy.go
+++ b/internal/rebooter/apiserver_node_proxy.go
@@ -1,0 +1,51 @@
+package rebooter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// NodePodsFetcher fetches the pods running on a specific node without going
+// through the controller-runtime informer cache.
+type NodePodsFetcher interface {
+	GetPodsOnNode(ctx context.Context, nodeName string) (*corev1.PodList, error)
+}
+
+// apiserverNodeProxy implements NodePodsFetcher via the API server's
+// nodes/proxy sub-resource. This avoids direct kubelet access entirely -
+// TLS and auth are handled by the API server using its own credentials,
+// independent of kubelet serving-cert configuration.
+type apiserverNodeProxy struct {
+	clientset kubernetes.Interface
+}
+
+func (p *apiserverNodeProxy) GetPodsOnNode(ctx context.Context, nodeName string) (*corev1.PodList, error) {
+	raw, err := p.clientset.CoreV1().RESTClient().Get().
+		Resource("nodes").
+		Name(nodeName).
+		SubResource("proxy").
+		Suffix("pods").
+		DoRaw(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("node proxy request failed for %s: %w", nodeName, err)
+	}
+	var podList corev1.PodList
+	if err := json.Unmarshal(raw, &podList); err != nil {
+		return nil, fmt.Errorf("decode proxy response for %s: %w", nodeName, err)
+	}
+	return &podList, nil
+}
+
+// NewAPIServerNodePodsFetcher creates a NodePodsFetcher that proxies through the API server.
+func NewAPIServerNodePodsFetcher(config *rest.Config) (NodePodsFetcher, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client: %w", err)
+	}
+	return &apiserverNodeProxy{clientset: clientset}, nil
+}

--- a/internal/rebooter/apiserver_node_proxy_test.go
+++ b/internal/rebooter/apiserver_node_proxy_test.go
@@ -1,0 +1,58 @@
+package rebooter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+func TestAPIServerNodeProxyGetPodsOnNode(t *testing.T) {
+	t.Helper()
+
+	expectedPath := "/api/v1/nodes/test-node/proxy/pods"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method %q", r.Method)
+		}
+		if r.URL.Path != expectedPath {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(&corev1.PodList{
+			Items: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod-a",
+						Namespace: "default",
+					},
+				},
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	fetcher, err := NewAPIServerNodePodsFetcher(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatalf("create fetcher: %v", err)
+	}
+
+	podList, err := fetcher.GetPodsOnNode(context.Background(), "test-node")
+	if err != nil {
+		t.Fatalf("get pods on node: %v", err)
+	}
+	if len(podList.Items) != 1 {
+		t.Fatalf("got %d pods, want 1", len(podList.Items))
+	}
+	if podList.Items[0].Name != "pod-a" {
+		t.Fatalf("got pod %q, want %q", podList.Items[0].Name, "pod-a")
+	}
+}

--- a/internal/rebooter/reconcile.go
+++ b/internal/rebooter/reconcile.go
@@ -11,24 +11,27 @@ import (
 	"github.com/mackerelio/go-osstat/uptime"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/controller/reconciler"
 	"nebius.ai/slurm-operator/internal/controllerconfig"
 )
 
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;
-//+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=core,resources=nodes/status,verbs=get;update;patch;watch;list
+//+kubebuilder:rbac:groups=core,resources=nodes/proxy,verbs=get
 
 var (
 	ControllerName = "rebooter"
@@ -42,23 +45,29 @@ type RebooterParams struct {
 
 type RebooterReconciler struct {
 	*reconciler.Reconciler
+	APIReader        client.Reader
 	reconcileTimeout time.Duration
 	nodeName         string
 	evictionMethod   consts.RebooterMethod
+	NodePodsFetcher  NodePodsFetcher
 }
 
 func NewRebooterReconciler(
-	client client.Client,
+	c client.Client,
+	apiReader client.Reader,
 	scheme *runtime.Scheme,
 	recorder record.EventRecorder,
 	rebooterParams RebooterParams,
+	nodePodsFetcher NodePodsFetcher,
 ) *RebooterReconciler {
-	r := reconciler.NewReconciler(client, scheme, recorder)
+	r := reconciler.NewReconciler(c, scheme, recorder)
 	return &RebooterReconciler{
 		Reconciler:       r,
+		APIReader:        apiReader,
 		reconcileTimeout: rebooterParams.ReconcileTimeout,
 		nodeName:         rebooterParams.NodeName,
 		evictionMethod:   rebooterParams.EvictionMethod,
+		NodePodsFetcher:  nodePodsFetcher,
 	}
 }
 
@@ -99,6 +108,10 @@ func (r *RebooterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	logger.V(1).Info("Starting handling node reboot")
 	if err := r.handleNodeReboot(ctx, node, nodeActions); err != nil {
+		if apierrors.IsConflict(err) {
+			logger.V(1).Info("Conflict during reboot handling, requeueing")
+			return ctrl.Result{Requeue: true}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -106,10 +119,11 @@ func (r *RebooterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{RequeueAfter: r.reconcileTimeout}, nil
 }
 
-// getNode returns the node with the given name.
+// getNode returns the node with the given name directly from the API server,
+// bypassing the informer cache.
 func (r *RebooterReconciler) getNode(ctx context.Context) (*corev1.Node, error) {
 	node := &corev1.Node{}
-	if err := r.Get(ctx, client.ObjectKey{Name: r.nodeName}, node); err != nil {
+	if err := r.APIReader.Get(ctx, client.ObjectKey{Name: r.nodeName}, node); err != nil {
 		return nil, fmt.Errorf("failed to get node %s: %w", r.nodeName, err)
 	}
 	return node, nil
@@ -179,6 +193,10 @@ func (r *RebooterReconciler) handleDrainError(ctx context.Context, err error) (c
 	if errors.As(err, &podErr) {
 		log.FromContext(ctx).V(1).Info("Reenqueueing reconciliation due to failed pod eviction")
 		return ctrl.Result{RequeueAfter: r.reconcileTimeout}, nil
+	}
+	if apierrors.IsConflict(err) {
+		log.FromContext(ctx).V(1).Info("Conflict during drain handling, requeueing")
+		return ctrl.Result{Requeue: true}, nil
 	}
 	return ctrl.Result{}, fmt.Errorf("failed to drain node: %w", err)
 }
@@ -325,7 +343,7 @@ func (r *RebooterReconciler) DrainNodeIfNeeded(ctx context.Context, node *corev1
 	}
 
 	logger.Info("Evicting pods from node")
-	if err := r.AreAllPodsEvicted(ctx, node.Name); err != nil {
+	if err := r.AreAllPodsEvicted(ctx, node); err != nil {
 		return err
 	}
 
@@ -343,8 +361,13 @@ func (r *RebooterReconciler) SetNodeUnschedulable(ctx context.Context, node *cor
 	logger := log.FromContext(ctx).WithName("SetNodeUnschedulable").WithValues("nodeName", node.Name).V(1)
 	logger.Info("Setting node schedulable status", "unschedulable", unschedulable)
 
-	node.Spec.Unschedulable = unschedulable
-	if err := r.Update(ctx, node); err != nil {
+	if err := r.patchNodeSpecWithRetry(ctx, node, func(currentNode *corev1.Node) (bool, error) {
+		if currentNode.Spec.Unschedulable == unschedulable {
+			return false, nil
+		}
+		currentNode.Spec.Unschedulable = unschedulable
+		return true, nil
+	}); err != nil {
 		return fmt.Errorf("failed to update node %s to  is %v: %w", node.Name, unschedulable, err)
 	}
 	return nil
@@ -363,35 +386,67 @@ func (r *RebooterReconciler) TaintNodeWithNoExecute(ctx context.Context, node *c
 		Effect: corev1.TaintEffectNoExecute,
 	}
 
-	if addTaint {
-		if r.IsNodeTaintedWithNoExecute(node) {
-			logger.Info("Node already has NoExecute taint", "node name", node.Name)
-			return nil
+	if err := r.patchNodeSpecWithRetry(ctx, node, func(currentNode *corev1.Node) (bool, error) {
+		if addTaint {
+			if r.IsNodeTaintedWithNoExecute(currentNode) {
+				logger.Info("Node already has NoExecute taint", "node name", currentNode.Name)
+				return false, nil
+			}
+			currentNode.Spec.Taints = append(currentNode.Spec.Taints, taint)
+			logger.Info("Adding NoExecute taint to node", "node name", currentNode.Name)
+			return true, nil
 		}
-		node.Spec.Taints = append(node.Spec.Taints, taint)
-		logger.Info("Adding NoExecute taint to node", "node name", node.Name)
-	} else {
-		newTaints := []corev1.Taint{}
-		for _, t := range node.Spec.Taints {
+
+		newTaints := make([]corev1.Taint, 0, len(currentNode.Spec.Taints))
+		for _, t := range currentNode.Spec.Taints {
 			if t.Key != taint.Key || t.Effect != taint.Effect {
 				newTaints = append(newTaints, t)
 			}
 		}
-		if len(newTaints) == len(node.Spec.Taints) {
-			logger.Info("Node does not have NoExecute taint", "node name", node.Name)
-			return nil
+		if len(newTaints) == len(currentNode.Spec.Taints) {
+			logger.Info("Node does not have NoExecute taint", "node name", currentNode.Name)
+			return false, nil
 		}
-		node.Spec.Taints = newTaints
-		logger.Info("Removing NoExecute taint from node", "node name", node.Name)
-	}
-
-	if err := r.Update(ctx, node); err != nil {
+		currentNode.Spec.Taints = newTaints
+		logger.Info("Removing NoExecute taint from node", "node name", currentNode.Name)
+		return true, nil
+	}); err != nil {
 		logger.Error(err, "Failed to update node with NoExecute taint modification", "node name", node.Name)
 		return err
 	}
 
 	logger.Info("Successfully modified NoExecute taint on node", "node name", node.Name)
 	return nil
+}
+
+func (r *RebooterReconciler) patchNodeSpecWithRetry(
+	ctx context.Context,
+	node *corev1.Node,
+	mutate func(*corev1.Node) (bool, error),
+) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		currentNode := &corev1.Node{}
+		if err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(node), currentNode); err != nil {
+			return fmt.Errorf("get latest node %s: %w", node.Name, err)
+		}
+
+		base := currentNode.DeepCopy()
+		changed, err := mutate(currentNode)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			*node = *currentNode
+			return nil
+		}
+
+		if err := r.Client.Patch(ctx, currentNode, client.MergeFrom(base)); err != nil {
+			return fmt.Errorf("patch object: %w", err)
+		}
+
+		*node = *currentNode
+		return nil
+	})
 }
 
 // IsNodeTaintedWithNoExecute check if the taint already exists
@@ -404,32 +459,31 @@ func (r *RebooterReconciler) IsNodeTaintedWithNoExecute(node *corev1.Node) bool 
 	return false
 }
 
-// AreAllPodsEvicted checks if all pods on the node with the given name are evicted.
-func (r *RebooterReconciler) AreAllPodsEvicted(ctx context.Context, nodeName string) error {
-	logger := log.FromContext(ctx).WithName("EvictPodsFromNode").WithValues("nodeName", nodeName).V(1)
-	logger.Info("Listing pods on node")
+// AreAllPodsEvicted checks if all pods on the node are evicted by querying
+// the API server's node proxy endpoint. This avoids loading full PodList
+// objects into the informer cache while staying on the API server's auth path.
+func (r *RebooterReconciler) AreAllPodsEvicted(ctx context.Context, node *corev1.Node) error {
+	logger := log.FromContext(ctx).WithName("AreAllPodsEvicted").WithValues("nodeName", node.Name).V(1)
 
-	podList := &corev1.PodList{}
-	if err := r.List(ctx, podList, client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
-		return fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
+	podList, err := r.NodePodsFetcher.GetPodsOnNode(ctx, node.Name)
+	if err != nil {
+		return fmt.Errorf("fetch pods on node %s: %w", node.Name, err)
 	}
 
-	for _, pod := range podList.Items {
-		if IsControlledByDaemonSet(pod) {
+	logger.Info("Checking pods via API server proxy", "count", len(podList.Items))
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if IsControlledByDaemonSet(*pod) {
 			continue
 		}
-
-		if HasTolerationForNoExecute(pod) {
+		if HasTolerationForNoExecute(*pod) {
 			continue
 		}
-
-		if HasTolerationForExists(pod) {
+		if HasTolerationForExists(*pod) {
 			continue
 		}
-
 		return &PodNotEvictableError{PodName: pod.Name}
 	}
-
 	return nil
 }
 
@@ -478,7 +532,7 @@ func (r *RebooterReconciler) setNodeCondition(
 	message consts.MessageConditionType,
 ) error {
 	if err := r.SetNodeConditionIfNotExists(ctx, node, conditionType, status, reason, message); err != nil {
-		return fmt.Errorf("failed to set node condition for node %s: %w", r.nodeName, err)
+		return fmt.Errorf("set node condition for node %s: %w", r.nodeName, err)
 	}
 	return nil
 }
@@ -511,8 +565,11 @@ func (r *RebooterReconciler) SetNodeConditionIfNotExists(
 	// In Kubernetes, the status is considered a "system-owned" object and cannot be
 	// modified using a regular Update call.
 	// Instead, changes to the status must be made using the Status().Update method.
-	for i, cond := range node.Status.Conditions {
-		if cond.Type == conditionType {
+	return r.patchNodeStatusWithRetry(ctx, node, func(currentNode *corev1.Node) (bool, error) {
+		for i, cond := range currentNode.Status.Conditions {
+			if cond.Type != conditionType {
+				continue
+			}
 
 			if cond.Status == status && cond.Reason == string(reason) {
 				logger.Info(fmt.Sprintf("Node already has condition %s set to %s", conditionType, status))
@@ -520,16 +577,14 @@ func (r *RebooterReconciler) SetNodeConditionIfNotExists(
 			}
 
 			logger.Info("Updating existing condition on node")
-			patch := client.MergeFrom(node.DeepCopy())
-			node.Status.Conditions[i] = newNodeCondition
-
-			return r.Status().Patch(ctx, node, patch)
+			currentNode.Status.Conditions[i] = newNodeCondition
+			return true, nil
 		}
-	}
 
-	logger.Info("Adding new condition to node")
-	node.Status.Conditions = append(node.Status.Conditions, newNodeCondition)
-	return r.UpdateStatus(ctx, node)
+		logger.Info("Adding new condition to node")
+		currentNode.Status.Conditions = append(currentNode.Status.Conditions, newNodeCondition)
+		return true, nil
+	})
 }
 
 // RebootNode reboots the node with the given name.
@@ -551,100 +606,35 @@ func (r *RebooterReconciler) RebootNode(ctx context.Context, node *corev1.Node) 
 }
 
 // SetupWithManager sets up the controller with the Manager.
+// No node informer is registered — this avoids a LIST+WATCH against the API server
+// at startup. Instead, one GenericEvent is sent on startCh to kick off the first
+// reconcile; subsequent cycles are driven by ctrl.Result{RequeueAfter: ...}.
 func (r *RebooterReconciler) SetupWithManager(
 	mgr ctrl.Manager, maxConcurrency int, cacheSyncTimeout time.Duration, nodeName string,
 ) error {
-	ctx := context.Background()
-
-	// Index pods by node name. This is used to list and evict pods from a specific node.
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1.Pod{}, "spec.nodeName", func(rawObj client.Object) []string {
-		pod := rawObj.(*corev1.Pod)
-		// Check if the pod.Spec.NodeName is the same as the nodeName.
-		// If it is, return the nodeName to index the pod by it.
-		if pod.Spec.NodeName == nodeName {
-			return []string{pod.Spec.NodeName}
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("failed to setup field indexer: %w", err)
-	}
-
-	// Index the nodes by name
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1.Node{}, "metadata.name", func(rawObj client.Object) []string {
-		node := rawObj.(*corev1.Node)
-		if node.Name == nodeName {
-			return []string{node.Name}
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("failed to setup node field indexer: %w", err)
+	startCh := make(chan event.GenericEvent, 1)
+	startCh <- event.GenericEvent{
+		Object: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Node{}, builder.WithPredicates(predicate.Funcs{
-			UpdateFunc: func(e event.UpdateEvent) bool {
-				// Rebooter is daemonset and should only reconcile the node it is running on
-				// so we compare the node name to the NODE_NAME environment variable
-				if e.ObjectNew.GetName() != nodeName {
-					return false
-				}
-				oldNode := e.ObjectOld.(*corev1.Node)
-				newNode := e.ObjectNew.(*corev1.Node)
-
-				// Extract the desired conditions from both old and new nodes
-				// and compare them to determine if reconciliation is needed
-				// based on the conditions changing
-				var oldDrainCondition, newDrainCondition, oldRebootCondition, newRebootCondition *corev1.NodeCondition
-				for i := range oldNode.Status.Conditions {
-					if oldNode.Status.Conditions[i].Type == consts.SlurmNodeDrain {
-						oldDrainCondition = &oldNode.Status.Conditions[i]
-					} else if oldNode.Status.Conditions[i].Type == consts.SlurmNodeReboot {
-						oldRebootCondition = &oldNode.Status.Conditions[i]
-					}
-				}
-				for i := range newNode.Status.Conditions {
-					if newNode.Status.Conditions[i].Type == consts.SlurmNodeDrain {
-						newDrainCondition = &newNode.Status.Conditions[i]
-					} else if newNode.Status.Conditions[i].Type == consts.SlurmNodeReboot {
-						newRebootCondition = &newNode.Status.Conditions[i]
-					}
-				}
-
-				// Trigger reconciliation if the Drain condition has changed
-				if oldDrainCondition == nil || newDrainCondition == nil || oldDrainCondition.Status != newDrainCondition.Status {
-					return true
-				}
-
-				// Trigger reconciliation if the Reboot condition has changed
-				if oldRebootCondition == nil || newRebootCondition == nil || oldRebootCondition.Status != newRebootCondition.Status {
-					return true
-				}
-
-				return false
-			},
-			CreateFunc: func(e event.CreateEvent) bool {
-				return e.Object.GetName() == nodeName
-			},
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				return false
-			},
-			GenericFunc: func(e event.GenericEvent) bool {
-				return e.Object.GetName() == nodeName
-			},
-		})).
+		Named(ControllerName).
+		WatchesRawSource(source.Channel(
+			startCh,
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []ctrl.Request {
+				return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}}
+			}),
+		)).
 		WithOptions(controllerconfig.ControllerOptions(maxConcurrency, cacheSyncTimeout)).
 		Complete(r)
 }
 
-// This workaround is needed because kube-apiserver expects up-to-date objects for the following update operations.
-// And this why we modify the object in-place.
+// Update writes the node spec to the API server. controller-runtime mutates the
+// object in-place with the server response (including the new resourceVersion),
+// so no extra Get is needed to keep subsequent updates consistent.
 func (r *RebooterReconciler) Update(ctx context.Context, node *corev1.Node, opts ...client.UpdateOption) error {
 	if err := r.Client.Update(ctx, node, opts...); err != nil {
 		return fmt.Errorf("failed to update object: %w", err)
-	}
-
-	if err := r.Get(ctx, client.ObjectKey{Name: node.GetName()}, node); err != nil {
-		return fmt.Errorf("failed to get updated node: %w", err)
 	}
 	return nil
 }
@@ -653,9 +643,35 @@ func (r *RebooterReconciler) UpdateStatus(ctx context.Context, node *corev1.Node
 	if err := r.Status().Update(ctx, node, opts...); err != nil {
 		return fmt.Errorf("failed to update object status: %w", err)
 	}
-
-	if err := r.Get(ctx, client.ObjectKey{Name: node.GetName()}, node); err != nil {
-		return fmt.Errorf("failed to get updated node: %w", err)
-	}
 	return nil
+}
+
+func (r *RebooterReconciler) patchNodeStatusWithRetry(
+	ctx context.Context,
+	node *corev1.Node,
+	mutate func(*corev1.Node) (bool, error),
+) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		currentNode := &corev1.Node{}
+		if err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(node), currentNode); err != nil {
+			return fmt.Errorf("get latest node %s: %w", node.Name, err)
+		}
+
+		base := currentNode.DeepCopy()
+		changed, err := mutate(currentNode)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			*node = *currentNode
+			return nil
+		}
+
+		if err := r.Status().Patch(ctx, currentNode, client.MergeFrom(base)); err != nil {
+			return fmt.Errorf("patch object status: %w", err)
+		}
+
+		*node = *currentNode
+		return nil
+	})
 }

--- a/internal/rebooter/reconcile_test.go
+++ b/internal/rebooter/reconcile_test.go
@@ -2,6 +2,7 @@ package rebooter_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,16 @@ import (
 	"nebius.ai/slurm-operator/internal/controller/reconciler"
 	. "nebius.ai/slurm-operator/internal/rebooter"
 )
+
+// mockNodePodsFetcher is a test double for NodePodsFetcher.
+type mockNodePodsFetcher struct {
+	podList *corev1.PodList
+	err     error
+}
+
+func (m *mockNodePodsFetcher) GetPodsOnNode(_ context.Context, _ string) (*corev1.PodList, error) {
+	return m.podList, m.err
+}
 
 func TestCheckNodeCondition(t *testing.T) {
 	scheme := runtime.NewScheme()
@@ -131,9 +142,8 @@ func TestSetNodeSchedulable(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := &RebooterReconciler{
-		Reconciler: &reconciler.Reconciler{
-			Client: fakeClient,
-		},
+		Reconciler: &reconciler.Reconciler{Client: fakeClient},
+		APIReader:  fakeClient,
 	}
 
 	ctx := context.TODO()
@@ -170,9 +180,8 @@ func TestSetNodeConditionIfNotExists(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := &RebooterReconciler{
-		Reconciler: &reconciler.Reconciler{
-			Client: fakeClient,
-		},
+		Reconciler: &reconciler.Reconciler{Client: fakeClient},
+		APIReader:  fakeClient,
 	}
 
 	ctx := context.TODO()
@@ -212,15 +221,67 @@ func TestSetNodeConditionIfNotExists(t *testing.T) {
 	}
 }
 
+func TestSetNodeConditionIfNotExistsRefreshesStaleNode(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &RebooterReconciler{
+		Reconciler: &reconciler.Reconciler{Client: fakeClient},
+		APIReader:  fakeClient,
+	}
+
+	ctx := context.TODO()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-status-stale",
+		},
+	}
+
+	err := fakeClient.Create(ctx, node)
+	if err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	liveNode := &corev1.Node{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: node.Name}, liveNode)
+	if err != nil {
+		t.Fatalf("failed to get live node: %v", err)
+	}
+
+	liveNode.Status.Conditions = append(liveNode.Status.Conditions, corev1.NodeCondition{
+		Type:   corev1.NodeReady,
+		Status: corev1.ConditionTrue,
+	})
+	err = fakeClient.Status().Update(ctx, liveNode)
+	if err != nil {
+		t.Fatalf("failed to update live node status: %v", err)
+	}
+
+	err = r.SetNodeConditionIfNotExists(ctx, node, consts.SlurmNodeDrain, corev1.ConditionTrue, consts.ReasonNodeDrained, consts.MessageDrained)
+	if err != nil {
+		t.Fatalf("SetNodeConditionIfNotExists returned an error for stale object: %v", err)
+	}
+
+	updatedNode := &corev1.Node{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: node.Name}, updatedNode)
+	if err != nil {
+		t.Fatalf("failed to get updated node: %v", err)
+	}
+
+	assert.Len(t, updatedNode.Status.Conditions, 2)
+	assert.Equal(t, corev1.NodeReady, updatedNode.Status.Conditions[0].Type)
+	assert.Equal(t, consts.SlurmNodeDrain, updatedNode.Status.Conditions[1].Type)
+}
+
 func TestTaintNodeWithNoExecute(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := &RebooterReconciler{
-		Reconciler: &reconciler.Reconciler{
-			Client: fakeClient,
-		},
+		Reconciler: &reconciler.Reconciler{Client: fakeClient},
+		APIReader:  fakeClient,
 	}
 
 	ctx := context.TODO()
@@ -268,6 +329,59 @@ func TestTaintNodeWithNoExecute(t *testing.T) {
 	if len(updatedNode.Spec.Taints) != 0 {
 		t.Errorf("node was not untainted")
 	}
+}
+
+func TestTaintNodeWithNoExecuteRefreshesStaleNode(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &RebooterReconciler{
+		Reconciler: &reconciler.Reconciler{Client: fakeClient},
+		APIReader:  fakeClient,
+	}
+
+	ctx := context.TODO()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node-stale",
+		},
+	}
+
+	err := fakeClient.Create(ctx, node)
+	if err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	// Make the local object stale by updating the live object through a different copy.
+	liveNode := &corev1.Node{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: node.Name}, liveNode)
+	if err != nil {
+		t.Fatalf("failed to get live node: %v", err)
+	}
+
+	liveNode.Spec.Unschedulable = true
+	err = fakeClient.Update(ctx, liveNode)
+	if err != nil {
+		t.Fatalf("failed to update live node: %v", err)
+	}
+
+	err = r.TaintNodeWithNoExecute(ctx, node, true)
+	if err != nil {
+		t.Fatalf("TaintNodeWithNoExecute returned an error for stale object: %v", err)
+	}
+
+	updatedNode := &corev1.Node{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: node.Name}, updatedNode)
+	if err != nil {
+		t.Fatalf("failed to get updated node: %v", err)
+	}
+
+	assert.True(t, updatedNode.Spec.Unschedulable)
+	if len(updatedNode.Spec.Taints) != 1 {
+		t.Fatalf("expected 1 taint, got %d", len(updatedNode.Spec.Taints))
+	}
+	assert.Equal(t, corev1.TaintEffectNoExecute, updatedNode.Spec.Taints[0].Effect)
 }
 
 func TestIsNodeTaintedWithNoExecute(t *testing.T) {
@@ -412,6 +526,83 @@ func TestHasTolerationForExists(t *testing.T) {
 			result := HasTolerationForExists(tt.pod)
 			if result != tt.expected {
 				t.Errorf("HasTolerationForExists() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAreAllPodsEvicted(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ctx := context.TODO()
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+
+	daemonSetPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "ds-pod",
+			OwnerReferences: []metav1.OwnerReference{{Kind: "DaemonSet", Name: "my-ds"}},
+		},
+	}
+	noExecutePod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-execute-pod"},
+		Spec:       corev1.PodSpec{Tolerations: []corev1.Toleration{{Effect: corev1.TaintEffectNoExecute}}},
+	}
+	existsPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "exists-pod"},
+		Spec:       corev1.PodSpec{Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}}},
+	}
+	blockingPod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "blocking-pod"}}
+
+	tests := []struct {
+		name        string
+		fetcher     NodePodsFetcher
+		wantErr     bool
+		wantErrType interface{}
+	}{
+		{
+			name:    "all pods exempt — eviction complete",
+			fetcher: &mockNodePodsFetcher{podList: &corev1.PodList{Items: []corev1.Pod{daemonSetPod, noExecutePod, existsPod}}},
+			wantErr: false,
+		},
+		{
+			name:    "empty pod list — eviction complete",
+			fetcher: &mockNodePodsFetcher{podList: &corev1.PodList{}},
+			wantErr: false,
+		},
+		{
+			name:        "one blocking pod — not yet evicted",
+			fetcher:     &mockNodePodsFetcher{podList: &corev1.PodList{Items: []corev1.Pod{daemonSetPod, blockingPod}}},
+			wantErr:     true,
+			wantErrType: &PodNotEvictableError{},
+		},
+		{
+			name:        "early return on first blocking pod",
+			fetcher:     &mockNodePodsFetcher{podList: &corev1.PodList{Items: []corev1.Pod{blockingPod, blockingPod}}},
+			wantErr:     true,
+			wantErrType: &PodNotEvictableError{},
+		},
+		{
+			name:    "proxy request fails",
+			fetcher: &mockNodePodsFetcher{err: fmt.Errorf("connection refused")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RebooterReconciler{
+				Reconciler:      &reconciler.Reconciler{Client: fakeClient},
+				NodePodsFetcher: tt.fetcher,
+			}
+			err := r.AreAllPodsEvicted(ctx, node)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantErrType != nil {
+					assert.ErrorAs(t, err, &tt.wantErrType)
+				}
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

On large clusters the rebooter's `AreAllPodsEvicted()` called `r.List()` against the controller-runtime informer cache, which loads and retains full `Pod` objects for every pod in the cluster regardless of the field selector - memory grows linearly with pod count.

## Solution

Query the Kubelet API through kube-apiserver instead of the informer cache.  The pod field indexer and pod watch are removed entirely, so the manager no longer caches pods at all. RBAC updated: `pods get/list/watch` → `nodes/proxy get`.

## Testing

Added regression coverage for stale node updates and verified the rebooter test package passes.

## Release Notes

Reduced rebooter memory usage on large clusters by replacing informer-cache pod listing with direct per-node Kubelet API queries.
