### PR TITLE
adjust liveness probe for big clustes

### DIFF
--- a/helm/slurm-cluster/tests/probes_test.yaml
+++ b/helm/slurm-cluster/tests/probes_test.yaml
@@ -7,13 +7,14 @@ tests:
       clusterName: test-cluster
     asserts:
       - equal:
-          path: spec.slurmNodes.controller.slurmctld.livenessProbe.exec.command
-          value:
-            - scontrol
-            - ping
+          path: spec.slurmNodes.controller.slurmctld.livenessProbe.httpGet.path
+          value: /livez
+      - equal:
+          path: spec.slurmNodes.controller.slurmctld.livenessProbe.httpGet.port
+          value: 6817
       - equal:
           path: spec.slurmNodes.controller.slurmctld.livenessProbe.initialDelaySeconds
-          value: 25
+          value: 10
 
   - it: should merge partial readiness probe overrides for login sshd
     set:

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -389,15 +389,14 @@ slurmNodes:
       command: []
       args: []
       livenessProbe:
-        exec:
-          command:
-            - scontrol
-            - ping
-        initialDelaySeconds: 25
-        timeoutSeconds: 1
-        periodSeconds: 10
+        httpGet:
+          path: /livez
+          port: 6817
+        initialDelaySeconds: 10
+        timeoutSeconds: 10
+        periodSeconds: 60
         successThreshold: 1
-        failureThreshold: 3
+        failureThreshold: 5
       port: 6817
       resources:
         cpu: "1000m"


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
`scontrol ping` is not scalable option for liveness probe for controller

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Use native `/livez` http endpoint instead

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Fix: use `/livez` http probe instead of `scontrol ping` for slurmctld liveness
