### PR TITLE
SCHED-1610: scale Slurm connection limits and node counts dynamically

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -71,7 +71,7 @@ type SlurmClusterSpec struct {
 	// SlurmConfig represents the Slurm configuration in slurm.conf. Not all options are supported.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={defMemPerNode: 0, defCpuPerGPU: 4, completeWait: 5, epilog: "", prolog: "", taskProlog: "", maxJobCount: 20000, minJobAge: 28800, messageTimeout: 60}
+	// +kubebuilder:default={defMemPerNode: 0, defCpuPerGPU: 4, completeWait: 5, epilog: "", prolog: "", taskProlog: "", maxJobCount: 20000, minJobAge: 3600, messageTimeout: 60}
 	SlurmConfig SlurmConfig `json:"slurmConfig,omitempty"`
 
 	// Topology contains topology-related parameters for Slurm.
@@ -175,7 +175,7 @@ type SlurmConfig struct {
 	// Don't remove jobs from controller memory after some time
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=28800
+	// +kubebuilder:default=3600
 	MinJobAge *int32 `json:"minJobAge,omitempty"`
 	// MessageTimeout specifies the permitted time for a round-trip communication to complete in seconds.
 	// See https://slurm.schedmd.com/slurm.conf.html#OPT_MessageTimeout.

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -3760,7 +3760,7 @@ spec:
                   epilog: ""
                   maxJobCount: 20000
                   messageTimeout: 60
-                  minJobAge: 28800
+                  minJobAge: 3600
                   prolog: ""
                   taskProlog: ""
                 description: SlurmConfig represents the Slurm configuration in slurm.conf.
@@ -3801,7 +3801,7 @@ spec:
                     format: int32
                     type: integer
                   minJobAge:
-                    default: 28800
+                    default: 3600
                     description: Don't remove jobs from controller memory after some
                       time
                     format: int32

--- a/helm/slurm-cluster/tests/README.md
+++ b/helm/slurm-cluster/tests/README.md
@@ -43,7 +43,7 @@ These tests verify the following kubebuilder default values:
 - `taskProlog: ""`
 - `taskPluginParam: ""`
 - `maxJobCount: 20000`
-- `minJobAge: 28800`
+- `minJobAge: 3600`
 - `messageTimeout: 60`
 - `topologyPlugin: "topology/tree"`
 - `topologyParam: "SwitchAsNodeRank"`

--- a/helm/slurm-cluster/tests/default-values_test.yaml
+++ b/helm/slurm-cluster/tests/default-values_test.yaml
@@ -51,7 +51,7 @@ tests:
           value: 20000
       - equal:
           path: spec.slurmConfig.minJobAge
-          value: 28800
+          value: 3600
       - equal:
           path: spec.slurmConfig.messageTimeout
           value: 60

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -148,7 +148,7 @@ slurmConfig:
   epilog: /opt/slurm_scripts/epilog.sh
   taskPluginParam: ""
   maxJobCount: 20000
-  minJobAge: 28800
+  minJobAge: 3600
   messageTimeout: 60
   topologyPlugin: "topology/tree"
   topologyParam: "SwitchAsNodeRank"

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -30989,7 +30989,7 @@ spec:
                   epilog: ""
                   maxJobCount: 20000
                   messageTimeout: 60
-                  minJobAge: 28800
+                  minJobAge: 3600
                   prolog: ""
                   taskProlog: ""
                 description: SlurmConfig represents the Slurm configuration in slurm.conf.
@@ -31030,7 +31030,7 @@ spec:
                     format: int32
                     type: integer
                   minJobAge:
-                    default: 28800
+                    default: 3600
                     description: Don't remove jobs from controller memory after some
                       time
                     format: int32

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -30989,7 +30989,7 @@ spec:
                   epilog: ""
                   maxJobCount: 20000
                   messageTimeout: 60
-                  minJobAge: 28800
+                  minJobAge: 3600
                   prolog: ""
                   taskProlog: ""
                 description: SlurmConfig represents the Slurm configuration in slurm.conf.
@@ -31030,7 +31030,7 @@ spec:
                     format: int32
                     type: integer
                   minJobAge:
-                    default: 28800
+                    default: 3600
                     description: Don't remove jobs from controller memory after some
                       time
                     format: int32

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -3,6 +3,7 @@ package common
 import (
 	"cmp"
 	"fmt"
+	"math/bits"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -317,10 +318,12 @@ func generateSlurmConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
 	res.AddProperty("SlurmdTimeout", 180)
 	res.AddProperty("TCPTimeout", 15)
 	res.AddProperty("WaitTime", 0)
+	total := totalWorkerNodes(cluster)
+	connMax := max(int32(1024), nextPow2(total*2))
 	if cluster.HasEphemeralNodes() {
-		res.AddProperty("SlurmctldParameters", "conmgr_max_connections=1024,conmgr_threads=32,cloud_dns,idle_on_node_suspend")
+		res.AddProperty("SlurmctldParameters", fmt.Sprintf("conmgr_max_connections=%d,conmgr_threads=32,cloud_dns,idle_on_node_suspend", connMax))
 	} else {
-		res.AddProperty("SlurmctldParameters", "conmgr_max_connections=1024,conmgr_threads=32")
+		res.AddProperty("SlurmctldParameters", fmt.Sprintf("conmgr_max_connections=%d,conmgr_threads=32", connMax))
 	}
 
 	res.AddProperty("RebootProgram", "/opt/bin/slurm/reboot.sh")
@@ -356,8 +359,8 @@ func generateSlurmConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
 	res.AddComment("")
 	res.AddComment("COMPUTE NODES")
 	res.AddComment("We're using the \"dynamic nodes\" feature: https://slurm.schedmd.com/dynamic_nodes.html")
-	res.AddProperty("MaxNodeCount", "1024")
-	res.AddProperty("MaxArraySize", "1024")
+	res.AddProperty("MaxNodeCount", max(int32(1024), nextPow2(total*2)))
+	res.AddProperty("MaxArraySize", max(int32(1024), total*5))
 	res.AddProperty("JobRequeue", 1)
 	res.AddProperty("PreemptMode", "REQUEUE")
 	res.AddProperty("PreemptType", "preempt/partition_prio")
@@ -445,6 +448,22 @@ func buildSuspendExcNodes(cluster *values.SlurmCluster) string {
 	}
 
 	return strings.Join(staticNodeSets, ",")
+}
+
+func totalWorkerNodes(cluster *values.SlurmCluster) int32 {
+	var total int32
+	for _, ns := range cluster.NodeSets {
+		total += ns.Spec.Replicas
+	}
+	return total
+}
+
+// nextPow2 returns the smallest power of 2 >= n (minimum 1).
+func nextPow2(n int32) int32 {
+	if n <= 1 {
+		return 1
+	}
+	return 1 << bits.Len(uint(n-1))
 }
 
 // addSlurmConfigProperties adds properties from the given struct to the config file


### PR DESCRIPTION
## Problem

On large clusters (>512 workers), hardcoded values of 1024 for `conmgr_max_connections`, `MaxNodeCount`, and `MaxArraySize` become bottlenecks. `minJobAge` of 28800 s (8 h) also causes slurmctld to hold completed job records in memory far longer than necessary.

## Solution

- `conmgr_max_connections` and `MaxNodeCount` are now set to `max(1024, nextPow2(totalWorkers * 2))`, so they scale automatically with cluster size.
- `MaxArraySize` is set to `max(1024, totalWorkers * 5)` to cover typical job-array use.
- Default `minJobAge` reduced from 28800 to 3600 s.

## Why `minJobAge=3600` is safe for extensive checks

Two places call `scontrol show job`. Both stay safe with the new value:

**1. `helm/slurm-cluster/slurm_scripts/check_runner.py:465`** — runs only in `prolog`/`epilog` context. Job is active by definition, `minJobAge` cannot affect it.

**2. `helm/soperator-activechecks/scripts/run-extensive-check-on-reservations.sh:30`** — checks state of the previously submitted extensive-check Slurm job to decide noop vs delete-and-recreate.

Timing for #2:

- Cron schedule: `*/5 * * * *` (every 5 min) — `run-extensive-check-on-reservations.yaml:14`
- Slurm job time limit: `#SBATCH --time=01:00:00` (1 h max) — `extensive-check.sh:8`
- After completion, slurmctld retains the record for `minJobAge` = 1 h

Worst case: job ends at t=60min, next cron tick lands within 5 min, slurmctld purges at t=120min. **~55 min margin** between when cron sees the final state and when the record is purged.

If the record were ever purged before the next check (e.g. paused cron), `scontrol show job <purged-id>` exits 1 with empty stdout. The pipe `scontrol ... | jq ...` has no `pipefail`, so the pipeline exits 0 with an empty `slurmJobState`. The RUNNING/PENDING check fails, the script returns `delete_create`, and the job is recreated — same outcome as a normally-completed job. Graceful degradation, no breakage.

A separate task tracks removing the `scontrol show job` dependency entirely, which would let us drop `minJobAge` to the official Slurm default (300 s).

## Testing

Unit tests in `configmap_test.go` cover the new `nextPow2` helper and the dynamic limit logic.

## Release Notes

Fix: Slurm connection limits, node counts, and array size now scale with cluster size instead of being capped at 1024; default `minJobAge` reduced from 8 h to 1 h.