### PR TITLE
SCHED-292 Tune otel log collector + make it better configurable

### DIFF
--- a/docs/logs-pipeline.md
+++ b/docs/logs-pipeline.md
@@ -40,6 +40,10 @@ Logs are delivered to both local VictoriaLogs and Nebius Cloud Logging (when `pu
 - Local: VictoriaLogs at port 9428 for direct API queries
 - Cloud: Nebius Cloud Logging via OTLP/gRPC with bearer token authentication
 
+The public logging endpoint is derived from `observability.region` by default. For example, `region: eu-west1`
+uses `dns:///write.logging.eu-west1.nebius.cloud.:443`. Set
+`observability.opentelemetry.publicEndpoint` only when an explicit endpoint override is needed.
+
 ## Components
 
 ### Log Collection
@@ -150,8 +154,15 @@ The logging system automatically extracts metadata from filenames and creates th
 observability:
   # Cloud delivery
   publicEndpointEnabled: true  # Enable/disable cloud export
-  projectId: "your-nebius-project-id"
+  logsProjectId: "your-nebius-project-id"
   region: "eu-north1"
+  opentelemetry:
+    # Optional. Defaults to dns:///write.logging.<region>.nebius.cloud.:443
+    publicEndpoint: ""
+    batch:
+      timeout: 1s
+      sendBatchSize: 2000
+      sendBatchMaxSize: 5000
   
   # Storage
   vmLogs:

--- a/helm/soperator-fluxcd/templates/_helpers.tpl
+++ b/helm/soperator-fluxcd/templates/_helpers.tpl
@@ -62,3 +62,17 @@ Validate observability.publicEndpointTokenKind is one of: secret, hostPath
   {{- fail (printf "observability.publicEndpointTokenKind must be one of: secret, hostPath (got %q)" $kind) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Default public logging endpoint derived from observability.region.
+*/}}
+{{- define "soperator-fluxcd.defaultLoggingEndpoint" -}}
+{{- printf "dns:///write.logging.%s.nebius.cloud.:443" (.Values.observability.region | default "eu-north1") -}}
+{{- end -}}
+
+{{/*
+Public logging endpoint. Explicit observability.opentelemetry.publicEndpoint overrides the regional default.
+*/}}
+{{- define "soperator-fluxcd.loggingEndpoint" -}}
+{{- .Values.observability.opentelemetry.publicEndpoint | default (include "soperator-fluxcd.defaultLoggingEndpoint" .) -}}
+{{- end -}}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -32,6 +32,7 @@ spec:
   targetNamespace: logs-system
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
+  {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
   {{- if .Values.observability.opentelemetry.events.overrideValues }}
     {{- toYaml .Values.observability.opentelemetry.events.overrideValues | nindent 4 }}
   {{- else }}
@@ -65,7 +66,7 @@ spec:
           timeout: 5s
         {{- if $hasPublicEndpoint }}
         otlp:
-          endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
+          endpoint: {{ include "soperator-fluxcd.loggingEndpoint" . }}
           balancer_name: round_robin
           compression: snappy
           retry_on_failure:
@@ -93,8 +94,9 @@ spec:
         {{- end }}
       processors:
         batch:
-          send_batch_max_size: 700
-          send_batch_size: 250
+          timeout: {{ $batch.timeout | default "1s" }}
+          send_batch_size: {{ $batch.sendBatchSize | default 2000 }}
+          send_batch_max_size: {{ $batch.sendBatchMaxSize | default 5000 }}
         k8sattributes:
           extract:
             labels:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -38,6 +38,7 @@ spec:
   targetNamespace: logs-system
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
+  {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}
     {{- toYaml .Values.observability.opentelemetry.logs.overrideValues | nindent 4 }}
   {{- else }}
@@ -214,8 +215,9 @@ spec:
         prometheus: null
       processors:
         batch:
-          send_batch_max_size: 700
-          send_batch_size: 250
+          timeout: {{ $batch.timeout | default "1s" }}
+          send_batch_size: {{ $batch.sendBatchSize | default 2000 }}
+          send_batch_max_size: {{ $batch.sendBatchMaxSize | default 5000 }}
         k8sattributes:
           pod_association:
           - sources:
@@ -266,7 +268,7 @@ spec:
           timeout: 5s
         {{- if $hasPublicEndpoint }}
         otlp:
-          endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
+          endpoint: {{ include "soperator-fluxcd.loggingEndpoint" . }}
           balancer_name: round_robin
           compression: snappy
           retry_on_failure:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -32,6 +32,7 @@ spec:
   targetNamespace: logs-system
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
+  {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}
     {{- toYaml .Values.observability.opentelemetry.logs.overrideValues | nindent 4 }}
   {{- else }}
@@ -58,7 +59,7 @@ spec:
           timeout: 5s
         {{- if $hasPublicEndpoint }}
         otlp:
-          endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
+          endpoint: {{ include "soperator-fluxcd.loggingEndpoint" . }}
           balancer_name: round_robin
           compression: snappy
           retry_on_failure:
@@ -88,8 +89,9 @@ spec:
         {{- end }}
       processors:
         batch:
-          send_batch_max_size: 700
-          send_batch_size: 250
+          timeout: {{ $batch.timeout | default "1s" }}
+          send_batch_size: {{ $batch.sendBatchSize | default 2000 }}
+          send_batch_max_size: {{ $batch.sendBatchMaxSize | default 5000 }}
         k8sattributes:
           extract:
             labels:

--- a/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
+++ b/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
@@ -1,0 +1,94 @@
+suite: test opentelemetry collector logs config
+templates:
+  - templates/opentelemetry-collector-logs.yaml
+tests:
+  - it: should derive public endpoint from observability region and render default batch settings
+    set:
+      observability.region: eu-west1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.config.exporters.otlp.endpoint
+          value: dns:///write.logging.eu-west1.nebius.cloud.:443
+      - equal:
+          path: spec.values.config.processors.batch.timeout
+          value: 1s
+      - equal:
+          path: spec.values.config.processors.batch.send_batch_size
+          value: 2000
+      - equal:
+          path: spec.values.config.processors.batch.send_batch_max_size
+          value: 5000
+
+  - it: should prefer explicit public endpoint override
+    set:
+      observability.region: eu-west1
+      observability.opentelemetry.publicEndpoint: dns:///write.logging.custom.nebius.cloud.:443
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.config.exporters.otlp.endpoint
+          value: dns:///write.logging.custom.nebius.cloud.:443
+
+  - it: should fall back to default batch settings when batch config is empty
+    set:
+      observability.opentelemetry.batch: null
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.config.processors.batch.timeout
+          value: 1s
+      - equal:
+          path: spec.values.config.processors.batch.send_batch_size
+          value: 2000
+      - equal:
+          path: spec.values.config.processors.batch.send_batch_max_size
+          value: 5000
+---
+suite: test opentelemetry collector events config
+templates:
+  - templates/opentelemetry-collector-events.yaml
+tests:
+  - it: should render configured batch settings
+    set:
+      observability.opentelemetry.batch.timeout: 2s
+      observability.opentelemetry.batch.sendBatchSize: 3000
+      observability.opentelemetry.batch.sendBatchMaxSize: 7000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.config.processors.batch.timeout
+          value: 2s
+      - equal:
+          path: spec.values.config.processors.batch.send_batch_size
+          value: 3000
+      - equal:
+          path: spec.values.config.processors.batch.send_batch_max_size
+          value: 7000
+---
+suite: test opentelemetry collector jail logs config
+templates:
+  - templates/opentelemetry-collector-jail-logs.yaml
+tests:
+  - it: should derive public endpoint from observability region and render default batch settings
+    set:
+      observability.region: me-west1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.config.exporters.otlp.endpoint
+          value: dns:///write.logging.me-west1.nebius.cloud.:443
+      - equal:
+          path: spec.values.config.processors.batch.timeout
+          value: 1s
+      - equal:
+          path: spec.values.config.processors.batch.send_batch_size
+          value: 2000
+      - equal:
+          path: spec.values.config.processors.batch.send_batch_max_size
+          value: 5000

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -152,9 +152,13 @@ observability:
   region: eu-north1
   opentelemetry:
     enabled: true
-    publicEndpoint: dns:///write.logging.eu-north1.nebius.cloud.:443
+    publicEndpoint: ""
     namespace: logs-system
     extraHeaders: {}
+    batch:
+      timeout: 1s
+      sendBatchSize: 2000
+      sendBatchMaxSize: 5000
     metrics:
       enabled: true
       interval: 30s


### PR DESCRIPTION
## Problem

Large Slurm clusters can generate too many small OpenTelemetry log export requests, increasing load on logging ingest/Envoy. Log public endpoint defaults were also hardcoded to eu-north1, so default log forwarding could ignore observability.region.

## Solution

Made OTel log batch `timeout`, `sendBatchSize`, and `sendBatchMaxSize` configurable and raised defaults to 1s / 2000 / 5000. Changed the default public logging endpoint to derive from observability.region, while preserving explicit `observability.opentelemetry.publicEndpoint` overrides.

## Testing

Ran:
```
- helm template test-release helm/soperator-fluxcd
- helm unittest -f 'tests/opentelemetry_collector_config_test.yaml' helm/soperator-fluxcd
- helm unittest helm/soperator-fluxcd
- helm lint helm/soperator-fluxcd
- git diff --check
```

## Release Notes

