### PR TITLE
SCHED-301 Scale metric collection for KSM

### DIFF
--- a/docs/metrics-pipeline.md
+++ b/docs/metrics-pipeline.md
@@ -104,7 +104,8 @@ Key Metrics:
   - 8081 - Telemetry endpoint (self-monitoring)
 - Metrics: Pod state metrics (filtered subset)
 - Deployment: Single replica deployment in `monitoring-system` namespace
-- Configuration: `--resources=pods` with metric allowlist filtering
+- Configuration: pod/node collectors with metric allowlist filtering
+- Scrape size: VMServiceScrape allows up to `150554432` bytes for the main `http` endpoint to support large clusters
 
 Connection Example:
 ```bash

--- a/docs/metrics-pipeline.md
+++ b/docs/metrics-pipeline.md
@@ -105,7 +105,7 @@ Key Metrics:
 - Metrics: Pod state metrics (filtered subset)
 - Deployment: Single replica deployment in `monitoring-system` namespace
 - Configuration: pod/node collectors with metric allowlist filtering
-- Scrape size: VMServiceScrape allows up to `150554432` bytes for the main `http` endpoint to support large clusters
+- Scrape size: inherits the global vmagent scrape size by default; `observability.vmStack.values.kubeStateMetrics.maxScrapeSize` can raise the main `http` endpoint limit for large clusters
 
 Connection Example:
 ```bash

--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -210,7 +210,9 @@ spec:
           spec:
             endpoints:
               - honorLabels: true
-                max_scrape_size: {{ $kubeStateMetrics.maxScrapeSize | default "150554432" | quote }}
+                {{- if $kubeStateMetrics.maxScrapeSize }}
+                max_scrape_size: {{ $kubeStateMetrics.maxScrapeSize | quote }}
+                {{- end }}
                 metricRelabelConfigs:
                   - action: labeldrop
                     regex: (uid|container_id|image_id)

--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -38,6 +38,7 @@ spec:
   {{- if .Values.observability.vmStack.overrideValues }}
     {{- toYaml .Values.observability.vmStack.overrideValues | nindent 4 }}
   {{- else }}
+  {{- $kubeStateMetrics := .Values.observability.vmStack.values.kubeStateMetrics | default dict }}
       alertmanager:
         enabled: false
       crds:
@@ -209,6 +210,7 @@ spec:
           spec:
             endpoints:
               - honorLabels: true
+                max_scrape_size: {{ $kubeStateMetrics.maxScrapeSize | default "150554432" | quote }}
                 metricRelabelConfigs:
                   - action: labeldrop
                     regex: (uid|container_id|image_id)

--- a/helm/soperator-fluxcd/tests/kube_state_metrics_test.yaml
+++ b/helm/soperator-fluxcd/tests/kube_state_metrics_test.yaml
@@ -2,7 +2,7 @@ suite: test kube-state-metrics scrape config
 templates:
   - templates/vm-stack.yaml
 tests:
-  - it: should set larger scrape size only for kube-state-metrics http endpoint
+  - it: should not set kube-state-metrics scrape size by default
     asserts:
       - hasDocuments:
           count: 1
@@ -12,9 +12,8 @@ tests:
       - equal:
           path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[0].port
           value: http
-      - equal:
+      - notExists:
           path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[0].max_scrape_size
-          value: "150554432"
       - equal:
           path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[1].port
           value: metrics
@@ -23,10 +22,10 @@ tests:
 
   - it: should allow overriding kube-state-metrics scrape size
     set:
-      observability.vmStack.values.kubeStateMetrics.maxScrapeSize: "201326592"
+      observability.vmStack.values.kubeStateMetrics.maxScrapeSize: "150554432"
     asserts:
       - hasDocuments:
           count: 1
       - equal:
           path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[0].max_scrape_size
-          value: "201326592"
+          value: "150554432"

--- a/helm/soperator-fluxcd/tests/kube_state_metrics_test.yaml
+++ b/helm/soperator-fluxcd/tests/kube_state_metrics_test.yaml
@@ -1,0 +1,32 @@
+suite: test kube-state-metrics scrape config
+templates:
+  - templates/vm-stack.yaml
+tests:
+  - it: should set larger scrape size only for kube-state-metrics http endpoint
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.vmagent.spec.extraArgs["promscrape.maxScrapeSize"]
+          value: "33554432"
+      - equal:
+          path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[0].port
+          value: http
+      - equal:
+          path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[0].max_scrape_size
+          value: "150554432"
+      - equal:
+          path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[1].port
+          value: metrics
+      - notExists:
+          path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[1].max_scrape_size
+
+  - it: should allow overriding kube-state-metrics scrape size
+    set:
+      observability.vmStack.values.kubeStateMetrics.maxScrapeSize: "201326592"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[0].max_scrape_size
+          value: "201326592"

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -273,8 +273,6 @@ observability:
           enabled: true
           org_name: Main Org.
           org_role: Admin
-      kubeStateMetrics:
-        maxScrapeSize: "150554432"
       vmagent:
         spec:
           extraArgs:

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -273,6 +273,8 @@ observability:
           enabled: true
           org_name: Main Org.
           org_role: Admin
+      kubeStateMetrics:
+        maxScrapeSize: "150554432"
       vmagent:
         spec:
           extraArgs:


### PR DESCRIPTION
## Problem

On large clusters, `kube-state-metrics` can return a /metrics response larger than the default vmagent scrape size limit, causing scrape failures around ~1.1k nodes.

## Solution

Added a configurable `max_scrape_size` for the `kube-state-metrics` main `http` scrape endpoint. The chart default is not raised: by default, kube-state-metrics inherits the existing global vmagent `promscrape.maxScrapeSize`. Large-cluster deployments can set `observability.vmStack.values.kubeStateMetrics.maxScrapeSize` explicitly.

The global vmagent limit remains unchanged for other targets.

## Testing

Ran:

```
- helm template test-release helm/soperator-fluxcd
- helm unittest -f 'tests/kube_state_metrics_test.yaml' helm/soperator-fluxcd
- helm unittest helm/soperator-fluxcd
- helm lint helm/soperator-fluxcd
- git diff --check
```

## Release Notes


