### PR TITLE
SCHED-1213: Move active-check GetJobsByID to /slurmdb/v0.0.41/job/{id}

### DIFF
--- a/internal/controller/soperatorchecks/activecheck_jobs_controller.go
+++ b/internal/controller/soperatorchecks/activecheck_jobs_controller.go
@@ -260,11 +260,23 @@ func (r *ActiveCheckJobReconciler) Reconcile(
 
 		requeue := false
 		latestHandledFinalStateTime := lastHandledFinalStateTime
+		var notFoundInAccountingIDs []string
 		for _, slurmJobID := range ids {
-			slurmJobs, err := slurmAPIClient.GetJobsByID(ctx, slurmJobID)
+			slurmJobs, err := slurmAPIClient.GetJobsByIDFromAccounting(ctx, slurmJobID)
 			if err != nil {
 				logger.Error(err, "failed to get slurm job status")
 				return ctrl.Result{}, err
+			}
+
+			// slurmdbd may not yet have a record for a just-submitted job; the propagation
+			// from slurmctld is asynchronous. Treat an empty result as "not visible yet" and
+			// requeue, otherwise the loop would silently mark the run Complete with no jobs seen.
+			// Accumulate the IDs and log once after the loop so a misconfigured/down slurmdbd
+			// surfaces in logs instead of degrading silently into an infinite requeue.
+			if len(slurmJobs) == 0 {
+				notFoundInAccountingIDs = append(notFoundInAccountingIDs, slurmJobID)
+				requeue = true
+				continue
 			}
 
 			for _, slurmJob := range slurmJobs {
@@ -314,6 +326,14 @@ func (r *ActiveCheckJobReconciler) Reconcile(
 					latestHandledFinalStateTime = slurmJob.EndTime.Unix()
 				}
 			}
+		}
+
+		if len(notFoundInAccountingIDs) > 0 {
+			logger.Info("Slurm jobs not found in accounting, will retry",
+				"count", len(notFoundInAccountingIDs),
+				"job_ids", notFoundInAccountingIDs,
+				"total", len(ids),
+			)
 		}
 
 		if latestHandledFinalStateTime > lastHandledFinalStateTime {

--- a/internal/controller/soperatorchecks/activecheck_jobs_controller_test.go
+++ b/internal/controller/soperatorchecks/activecheck_jobs_controller_test.go
@@ -104,7 +104,7 @@ func TestActiveCheckJobReconciler_Reconcile_DoesNotFinalizeUntilAllSlurmJobsFini
 	reconcileRound := 1
 
 	mockClient.EXPECT().
-		GetJobsByID(mock.Anything, firstSlurmJobID).
+		GetJobsByIDFromAccounting(mock.Anything, firstSlurmJobID).
 		RunAndReturn(func(context.Context, string) ([]slurmapi.Job, error) {
 			return []slurmapi.Job{{
 				ID:         101,
@@ -117,7 +117,7 @@ func TestActiveCheckJobReconciler_Reconcile_DoesNotFinalizeUntilAllSlurmJobsFini
 		Twice()
 
 	mockClient.EXPECT().
-		GetJobsByID(mock.Anything, nextSlurmJobID).
+		GetJobsByIDFromAccounting(mock.Anything, nextSlurmJobID).
 		RunAndReturn(func(context.Context, string) ([]slurmapi.Job, error) {
 			if reconcileRound == 1 {
 				return []slurmapi.Job{{
@@ -312,7 +312,7 @@ func TestActiveCheckJobReconciler_Reconcile_SlurmJobAggregatesTerminalResultsInS
 	errorEndTime := metav1.NewTime(submitTime.Add(4 * time.Minute))
 
 	mockClient := slurmapifake.NewMockClient(t)
-	mockClient.EXPECT().GetJobsByID(mock.Anything, "101").Return([]slurmapi.Job{{
+	mockClient.EXPECT().GetJobsByIDFromAccounting(mock.Anything, "101").Return([]slurmapi.Job{{
 		ID:          101,
 		Name:        activeCheck.Name,
 		State:       string(api.V0041JobInfoJobStateFAILED),
@@ -320,21 +320,21 @@ func TestActiveCheckJobReconciler_Reconcile_SlurmJobAggregatesTerminalResultsInS
 		SubmitTime:  &submitTime,
 		EndTime:     &failedEndTime,
 	}}, nil).Once()
-	mockClient.EXPECT().GetJobsByID(mock.Anything, "102").Return([]slurmapi.Job{{
+	mockClient.EXPECT().GetJobsByIDFromAccounting(mock.Anything, "102").Return([]slurmapi.Job{{
 		ID:         102,
 		Name:       activeCheck.Name,
 		State:      string(api.V0041JobInfoJobStateCANCELLED),
 		SubmitTime: &submitTime,
 		EndTime:    &cancelledEndTime,
 	}}, nil).Once()
-	mockClient.EXPECT().GetJobsByID(mock.Anything, "103").Return([]slurmapi.Job{{
+	mockClient.EXPECT().GetJobsByIDFromAccounting(mock.Anything, "103").Return([]slurmapi.Job{{
 		ID:         103,
 		Name:       activeCheck.Name,
 		State:      string(api.V0041JobInfoJobStateCOMPLETED),
 		SubmitTime: &submitTime,
 		EndTime:    &completedEndTime,
 	}}, nil).Once()
-	mockClient.EXPECT().GetJobsByID(mock.Anything, "104").Return([]slurmapi.Job{{
+	mockClient.EXPECT().GetJobsByIDFromAccounting(mock.Anything, "104").Return([]slurmapi.Job{{
 		ID:          104,
 		Name:        activeCheck.Name,
 		State:       string(api.V0041JobInfoJobStateTIMEOUT),
@@ -388,7 +388,7 @@ func TestActiveCheckJobReconciler_Reconcile_SlurmJobAccumulatesTerminalResultsAc
 	reconcileRound := 1
 
 	mockClient.EXPECT().
-		GetJobsByID(mock.Anything, "101").
+		GetJobsByIDFromAccounting(mock.Anything, "101").
 		RunAndReturn(func(context.Context, string) ([]slurmapi.Job, error) {
 			return []slurmapi.Job{{
 				ID:          101,
@@ -402,7 +402,7 @@ func TestActiveCheckJobReconciler_Reconcile_SlurmJobAccumulatesTerminalResultsAc
 		Twice()
 
 	mockClient.EXPECT().
-		GetJobsByID(mock.Anything, "102").
+		GetJobsByIDFromAccounting(mock.Anything, "102").
 		RunAndReturn(func(context.Context, string) ([]slurmapi.Job, error) {
 			if reconcileRound == 1 {
 				return []slurmapi.Job{{
@@ -470,7 +470,7 @@ func TestActiveCheckJobReconciler_Reconcile_FailedSlurmJobWithoutReactionsOnlyUp
 	failedEndTime := metav1.NewTime(submitTime.Add(1 * time.Minute))
 
 	mockClient := slurmapifake.NewMockClient(t)
-	mockClient.EXPECT().GetJobsByID(mock.Anything, "101").Return([]slurmapi.Job{{
+	mockClient.EXPECT().GetJobsByIDFromAccounting(mock.Anything, "101").Return([]slurmapi.Job{{
 		ID:          101,
 		Name:        activeCheck.Name,
 		State:       string(api.V0041JobInfoJobStateFAILED),
@@ -495,6 +495,40 @@ func TestActiveCheckJobReconciler_Reconcile_FailedSlurmJobWithoutReactionsOnlyUp
 	}}, updatedCheck.Status.SlurmJobsStatus.LastRunFailJobsAndReasons)
 }
 
+// Slurmdbd lags slurmctld by some interval after sbatch — the just-submitted job ID may not yet
+// resolve on `/slurmdb/.../job/{id}`. The reconciler must requeue in that case rather than treat
+// "no rows" as success and finalize the run as Complete.
+func TestActiveCheckJobReconciler_Reconcile_SlurmJobNotYetVisibleInAccountingRequeues(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newActiveCheckJobTestScheme(t)
+
+	activeCheck, cronJob, k8sJob, pod := newActiveCheckJobTestObjects("gpu-check", "gpu-check-123", "slurmJob")
+	k8sJob.Annotations["slurm-job-id"] = "101"
+
+	mockClient := slurmapifake.NewMockClient(t)
+	mockClient.EXPECT().GetJobsByIDFromAccounting(mock.Anything, "101").Return([]slurmapi.Job{}, nil).Once()
+
+	reconciler, fakeClient := newActiveCheckJobTestReconciler(t, scheme, activeCheck, cronJob, k8sJob, pod, mockClient)
+
+	result, err := reconciler.Reconcile(ctx, newActiveCheckJobRequest(k8sJob))
+	require.NoError(t, err)
+	assert.True(t, result.Requeue)
+
+	updatedCheck := &slurmv1alpha1.ActiveCheck{}
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(activeCheck), updatedCheck))
+	assert.Equal(t, consts.ActiveCheckSlurmRunStatusInProgress, updatedCheck.Status.SlurmJobsStatus.LastRunStatus)
+	assert.Empty(t, updatedCheck.Status.SlurmJobsStatus.LastRunFailJobsAndReasons)
+	assert.Empty(t, updatedCheck.Status.SlurmJobsStatus.LastRunErrorJobsAndReasons)
+	assert.Empty(t, updatedCheck.Status.SlurmJobsStatus.LastRunCancelledJobs)
+
+	updatedJob := &batchv1.Job{}
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(k8sJob), updatedJob))
+	assert.Empty(t, updatedJob.Annotations[K8sAnnotationSoperatorChecksFinalStateTime],
+		"watermark must not advance until the job is observed in slurmdbd")
+}
+
 func TestActiveCheckJobReconciler_Reconcile_FailedSlurmJobExecutesCommentReaction(t *testing.T) {
 	t.Parallel()
 
@@ -513,7 +547,7 @@ func TestActiveCheckJobReconciler_Reconcile_FailedSlurmJobExecutesCommentReactio
 	failedEndTime := metav1.NewTime(submitTime.Add(1 * time.Minute))
 
 	mockClient := slurmapifake.NewMockClient(t)
-	mockClient.EXPECT().GetJobsByID(mock.Anything, "101").Return([]slurmapi.Job{{
+	mockClient.EXPECT().GetJobsByIDFromAccounting(mock.Anything, "101").Return([]slurmapi.Job{{
 		ID:          101,
 		Name:        activeCheck.Name,
 		State:       string(api.V0041JobInfoJobStateFAILED),

--- a/internal/slurmapi/client.go
+++ b/internal/slurmapi/client.go
@@ -239,13 +239,24 @@ func (c *client) GetNode(ctx context.Context, nodeName string) (Node, error) {
 	return node, nil
 }
 
-func (c *client) GetJobsByID(ctx context.Context, jobID string) ([]Job, error) {
-	getJobResp, err := c.SlurmV0041GetJobWithResponse(ctx, jobID, &api.SlurmV0041GetJobParams{})
+// GetJobsByIDFromAccounting looks up a single Slurm job through slurmdbd's
+// `/slurmdb/v0.0.41/job/{id}`. Going to slurmdbd here, instead of slurmctld, keeps active-check
+// polling off the scheduler's hot path — on busy clusters this single call site dominates
+// slurmctld's REQUEST_JOB_INFO_SINGLE counter. Slurmdbd has all the fields the active-check
+// reconciler reads (state, end_time, name, nodes, state_reason).
+//
+// An empty `Jobs` slice with no error means slurmdbd has no record for the ID. That happens in
+// two situations callers must distinguish themselves: (a) the job was just submitted and the
+// slurmctld→slurmdbd propagation hasn't completed yet — the right behavior is requeue/retry;
+// (b) the job has been purged by slurmdbd's `PurgeJobAfter` (default 12 months) — retries will
+// loop forever. Bound retries by elapsed time since submit if a caller can hit case (b).
+func (c *client) GetJobsByIDFromAccounting(ctx context.Context, jobID string) ([]Job, error) {
+	getJobResp, err := c.SlurmdbV0041GetJobWithResponse(ctx, jobID)
 	if err != nil {
 		return nil, fmt.Errorf("get job %s: %w", jobID, err)
 	}
 	if getJobResp.JSON200 == nil {
-		return nil, fmt.Errorf("json200 field is nil for job ID %s", jobID)
+		return nil, fmt.Errorf("get job %s: status=%d %s", jobID, getJobResp.StatusCode(), summarizeSlurmRESTBody(getJobResp.Body))
 	}
 	if getJobResp.JSON200.Errors != nil && len(*getJobResp.JSON200.Errors) != 0 {
 		return nil, fmt.Errorf("get job %s responded with errors: %v", jobID, *getJobResp.JSON200.Errors)
@@ -253,9 +264,9 @@ func (c *client) GetJobsByID(ctx context.Context, jobID string) ([]Job, error) {
 
 	jobs := make([]Job, 0, len(getJobResp.JSON200.Jobs))
 	for _, j := range getJobResp.JSON200.Jobs {
-		job, err := JobFromAPI(j)
+		job, err := JobFromAccountingAPI(j)
 		if err != nil {
-			return nil, fmt.Errorf("convert job from api response: %w", err)
+			return nil, fmt.Errorf("convert job from accounting api response: %w", err)
 		}
 
 		jobs = append(jobs, job)

--- a/internal/slurmapi/fake/mock_client.go
+++ b/internal/slurmapi/fake/mock_client.go
@@ -84,12 +84,12 @@ func (_c *MockClient_GetDiag_Call) RunAndReturn(run func(context.Context) (*v004
 	return _c
 }
 
-// GetJobsByID provides a mock function with given fields: ctx, jobID
-func (_m *MockClient) GetJobsByID(ctx context.Context, jobID string) ([]slurmapi.Job, error) {
+// GetJobsByIDFromAccounting provides a mock function with given fields: ctx, jobID
+func (_m *MockClient) GetJobsByIDFromAccounting(ctx context.Context, jobID string) ([]slurmapi.Job, error) {
 	ret := _m.Called(ctx, jobID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetJobsByID")
+		panic("no return value specified for GetJobsByIDFromAccounting")
 	}
 
 	var r0 []slurmapi.Job
@@ -114,31 +114,31 @@ func (_m *MockClient) GetJobsByID(ctx context.Context, jobID string) ([]slurmapi
 	return r0, r1
 }
 
-// MockClient_GetJobsByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetJobsByID'
-type MockClient_GetJobsByID_Call struct {
+// MockClient_GetJobsByIDFromAccounting_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetJobsByIDFromAccounting'
+type MockClient_GetJobsByIDFromAccounting_Call struct {
 	*mock.Call
 }
 
-// GetJobsByID is a helper method to define mock.On call
+// GetJobsByIDFromAccounting is a helper method to define mock.On call
 //   - ctx context.Context
 //   - jobID string
-func (_e *MockClient_Expecter) GetJobsByID(ctx interface{}, jobID interface{}) *MockClient_GetJobsByID_Call {
-	return &MockClient_GetJobsByID_Call{Call: _e.mock.On("GetJobsByID", ctx, jobID)}
+func (_e *MockClient_Expecter) GetJobsByIDFromAccounting(ctx interface{}, jobID interface{}) *MockClient_GetJobsByIDFromAccounting_Call {
+	return &MockClient_GetJobsByIDFromAccounting_Call{Call: _e.mock.On("GetJobsByIDFromAccounting", ctx, jobID)}
 }
 
-func (_c *MockClient_GetJobsByID_Call) Run(run func(ctx context.Context, jobID string)) *MockClient_GetJobsByID_Call {
+func (_c *MockClient_GetJobsByIDFromAccounting_Call) Run(run func(ctx context.Context, jobID string)) *MockClient_GetJobsByIDFromAccounting_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
 
-func (_c *MockClient_GetJobsByID_Call) Return(_a0 []slurmapi.Job, _a1 error) *MockClient_GetJobsByID_Call {
+func (_c *MockClient_GetJobsByIDFromAccounting_Call) Return(_a0 []slurmapi.Job, _a1 error) *MockClient_GetJobsByIDFromAccounting_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockClient_GetJobsByID_Call) RunAndReturn(run func(context.Context, string) ([]slurmapi.Job, error)) *MockClient_GetJobsByID_Call {
+func (_c *MockClient_GetJobsByIDFromAccounting_Call) RunAndReturn(run func(context.Context, string) ([]slurmapi.Job, error)) *MockClient_GetJobsByIDFromAccounting_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/slurmapi/interface.go
+++ b/internal/slurmapi/interface.go
@@ -10,7 +10,7 @@ type Client interface {
 	api.ClientWithResponsesInterface
 	ListNodes(ctx context.Context) ([]Node, error)
 	GetNode(ctx context.Context, nodeName string) (Node, error)
-	GetJobsByID(ctx context.Context, jobID string) ([]Job, error)
+	GetJobsByIDFromAccounting(ctx context.Context, jobID string) ([]Job, error)
 	ListJobs(ctx context.Context) ([]Job, error)
 	ListJobsWithParams(ctx context.Context, params ListJobsParams) ([]Job, error)
 	GetDiag(ctx context.Context) (*api.V0041OpenapiDiagResp, error)


### PR DESCRIPTION
## Problem

Active-check single-job polling slammed slurmctld with REQUEST_JOB_INFO_SINGLE traffic (~736k calls / ~17 min cumulative scheduler time on b300) even though the data needed lives in slurmdbd.

## Solution

Repointed the active-check `GetJobsByID` lookup at slurmdbd's `/slurmdb/v0.0.41/job/{id}` (renamed to `GetJobsByIDFromAccounting`) and added an empty-result requeue to handle slurmctld→slurmdbd propagation lag.

## Testing

`go test ./internal/slurmapi/... ./internal/controller/soperatorchecks/...` is green 
e2e and mually

## Release Notes

Improvement: active-check job-status polling moves off slurmctld onto slurmdbd, eliminating its dominant contribution to `REQUEST_JOB_INFO_SINGLE` on busy clusters; no CRD/config change.
