### PR TITLE
SCHED-292: Restore eu-north logging endpoint default

### DIFF
--- a/docs/logs-pipeline.md
+++ b/docs/logs-pipeline.md
@@ -40,8 +40,8 @@ Logs are delivered to both local VictoriaLogs and Nebius Cloud Logging (when `pu
 - Local: VictoriaLogs at port 9428 for direct API queries
 - Cloud: Nebius Cloud Logging via OTLP/gRPC with bearer token authentication
 
-The public logging endpoint is derived from `observability.region` by default. For example, `region: eu-west1`
-uses `dns:///write.logging.eu-west1.nebius.cloud.:443`. Set
+The public logging endpoint defaults to `dns:///write.logging.eu-north1.nebius.cloud.:443` by design.
+`observability.region` does not change the log write region. Set
 `observability.opentelemetry.publicEndpoint` only when an explicit endpoint override is needed.
 
 ## Components
@@ -157,8 +157,8 @@ observability:
   logsProjectId: "your-nebius-project-id"
   region: "eu-north1"
   opentelemetry:
-    # Optional. Defaults to dns:///write.logging.<region>.nebius.cloud.:443
-    publicEndpoint: ""
+    # Optional. Defaults to dns:///write.logging.eu-north1.nebius.cloud.:443
+    publicEndpoint: "dns:///write.logging.eu-north1.nebius.cloud.:443"
     batch:
       timeout: 1s
       sendBatchSize: 2000

--- a/helm/soperator-fluxcd/templates/_helpers.tpl
+++ b/helm/soperator-fluxcd/templates/_helpers.tpl
@@ -62,17 +62,3 @@ Validate observability.publicEndpointTokenKind is one of: secret, hostPath
   {{- fail (printf "observability.publicEndpointTokenKind must be one of: secret, hostPath (got %q)" $kind) -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Default public logging endpoint derived from observability.region.
-*/}}
-{{- define "soperator-fluxcd.defaultLoggingEndpoint" -}}
-{{- printf "dns:///write.logging.%s.nebius.cloud.:443" (.Values.observability.region | default "eu-north1") -}}
-{{- end -}}
-
-{{/*
-Public logging endpoint. Explicit observability.opentelemetry.publicEndpoint overrides the regional default.
-*/}}
-{{- define "soperator-fluxcd.loggingEndpoint" -}}
-{{- .Values.observability.opentelemetry.publicEndpoint | default (include "soperator-fluxcd.defaultLoggingEndpoint" .) -}}
-{{- end -}}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -66,7 +66,7 @@ spec:
           timeout: 5s
         {{- if $hasPublicEndpoint }}
         otlp:
-          endpoint: {{ include "soperator-fluxcd.loggingEndpoint" . }}
+          endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
           balancer_name: round_robin
           compression: snappy
           retry_on_failure:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -268,7 +268,7 @@ spec:
           timeout: 5s
         {{- if $hasPublicEndpoint }}
         otlp:
-          endpoint: {{ include "soperator-fluxcd.loggingEndpoint" . }}
+          endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
           balancer_name: round_robin
           compression: snappy
           retry_on_failure:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -59,7 +59,7 @@ spec:
           timeout: 5s
         {{- if $hasPublicEndpoint }}
         otlp:
-          endpoint: {{ include "soperator-fluxcd.loggingEndpoint" . }}
+          endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
           balancer_name: round_robin
           compression: snappy
           retry_on_failure:

--- a/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
+++ b/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
@@ -2,7 +2,7 @@ suite: test opentelemetry collector logs config
 templates:
   - templates/opentelemetry-collector-logs.yaml
 tests:
-  - it: should derive public endpoint from observability region and render default batch settings
+  - it: should use eu-north public endpoint regardless of observability region and render default batch settings
     set:
       observability.region: eu-west1
     asserts:
@@ -10,7 +10,7 @@ tests:
           count: 1
       - equal:
           path: spec.values.config.exporters.otlp.endpoint
-          value: dns:///write.logging.eu-west1.nebius.cloud.:443
+          value: dns:///write.logging.eu-north1.nebius.cloud.:443
       - equal:
           path: spec.values.config.processors.batch.timeout
           value: 1s
@@ -74,7 +74,7 @@ suite: test opentelemetry collector jail logs config
 templates:
   - templates/opentelemetry-collector-jail-logs.yaml
 tests:
-  - it: should derive public endpoint from observability region and render default batch settings
+  - it: should use eu-north public endpoint regardless of observability region and render default batch settings
     set:
       observability.region: me-west1
     asserts:
@@ -82,7 +82,7 @@ tests:
           count: 1
       - equal:
           path: spec.values.config.exporters.otlp.endpoint
-          value: dns:///write.logging.me-west1.nebius.cloud.:443
+          value: dns:///write.logging.eu-north1.nebius.cloud.:443
       - equal:
           path: spec.values.config.processors.batch.timeout
           value: 1s

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -152,7 +152,7 @@ observability:
   region: eu-north1
   opentelemetry:
     enabled: true
-    publicEndpoint: ""
+    publicEndpoint: dns:///write.logging.eu-north1.nebius.cloud.:443
     namespace: logs-system
     extraHeaders: {}
     batch:


### PR DESCRIPTION
## Problem

Log export endpoint selection was changed to derive from observability.region, but log writes are expected to go to eu-north by design. This could route logs to a regional endpoint unintentionally when Terraform sets the cluster region.

## Solution

Restored the default OpenTelemetry log export endpoint to `dns:///write.logging.eu-north1.nebius.cloud.:443` and removed the regional endpoint derivation. Kept OpenTelemetry batch settings configurable.

## Testing

```
helm unittest -f 'tests/opentelemetry_collector_config_test.yaml' helm/soperator-fluxcd
helm unittest helm/soperator-fluxcd
helm lint helm/soperator-fluxcd
helm template test-release helm/soperator-fluxcd --set observability.region=eu-west1
git diff --check
```

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
