### PR TITLE
NOTIC: Support command execution in soperator_instance_login.sh utility

### DIFF
--- a/ansible/roles/soperator-scripts/files/fs_usage.sh
+++ b/ansible/roles/soperator-scripts/files/fs_usage.sh
@@ -6,9 +6,9 @@ usage() {
     echo "Get Soperator filesystem usage." >&2
     echo "" >&2
     echo "usage: ${0} [-s] [-l] [-h]" >&2
-    echo "  -s - only show shared filesystems"
-    echo "  -l - only show local filesystems"
-    echo "  -m - only show in-memory filesystems"
+    echo "  -s - only show shared filesystems" >&2
+    echo "  -l - only show local filesystems" >&2
+    echo "  -m - only show in-memory filesystems" >&2
     exit 1
 }
 

--- a/ansible/roles/soperator-scripts/files/soperator_instance_login.sh
+++ b/ansible/roles/soperator-scripts/files/soperator_instance_login.sh
@@ -3,18 +3,26 @@
 set -e # Exit immediately if any command returns a non-zero error code
 
 usage() {
-    echo "Run an interactive login shell on the instance associated with a specific worker node." >&2
+    echo "Run an interactive login shell or execute a command on the instance associated with a specific worker node." >&2
     echo "" >&2
-    echo "usage: ${0} [-w worker_name] [-i instance_id] [-h]" >&2
-    echo "       (either -w or -i must be set)"
+    echo "usage: ${0} [-w worker_name] [-i instance_id] [-c command] [-h]" >&2
+    echo "       (either -w or -i must be set)" >&2
+    echo "" >&2
+    echo "examples:" >&2
+    echo "  - get a shell on the instance under worker-0:" >&2
+    echo "      ${0} -w worker-0" >&2
+    echo "  - collect RDMA stats from 128 workers:" >&2
+    echo "    scontrol show hostnames worker-[0-127] \\" >&2
+    echo "      | parallel -j 20 --linebuffer \"${0} -w {} -c 'hostname; rdma stat -j' > /tmp/{}-rdma-stat.out\"" >&2
     exit 1
 }
 
-while getopts w:i:h flag
+while getopts w:i:c:h flag
 do
     case "${flag}" in
         w) worker_name=${OPTARG};;
         i) instance_id=${OPTARG};;
+        c) cmd=${OPTARG};;
         h) usage;;
         *) usage;;
     esac
@@ -32,4 +40,8 @@ if [ -z "$worker_name" ] && [ -n "$instance_id" ]; then
     fi
 fi
 
-ssh -t "${worker_name}" sudo chroot /run/nvidia/driver nsenter -t 1 -m -u -i -n systemd-run --pty /bin/bash -l
+if [ -z "$cmd" ]; then
+    ssh -t "${worker_name}" sudo chroot /run/nvidia/driver nsenter -t 1 -m -u -i -n systemd-run --pty /bin/bash -l
+else
+    ssh "${worker_name}" "sudo chroot /run/nvidia/driver nsenter -t 1 -m -u -i -n bash -c $(printf %q "$cmd")"
+fi

--- a/ansible/roles/soperator-scripts/files/worker_nvidia_bug_report.sh
+++ b/ansible/roles/soperator-scripts/files/worker_nvidia_bug_report.sh
@@ -6,7 +6,7 @@ usage() {
     echo "Get NVIDIA bug report from a worker node." >&2
     echo "" >&2
     echo "usage: ${0} [-w worker_name] [-i instance_id] [-h]" >&2
-    echo "       (either -w or -i must be set)"
+    echo "       (either -w or -i must be set)" >&2
     exit 1
 }
 


### PR DESCRIPTION
## Problem
Now, it's pretty easy to execute a specific command on a list of worker nodes:
```
scontrol show hostnames worker-[0-128] | parallel 'ssh {} hostname'
```
However, if you need to execute something on instances under these worker nodes, it's not so simple.
Soperator provides the utility script `soperator_instance_login.sh` for opening a login shell on an instance under a specific worker, but it can't be used for executing commands in a non-interactive mode.

## Solution
Support command execution in `soperator_instance_login.sh`, so the following works:
```
scontrol show hostnames worker-[0-128] | parallel 'soperator_instance_login.sh -w {} -c hostname'
```

## Testing
Tested on a dev cluster.

## Release Notes
`soperator_instance_login.sh` utility can now accept a bash command that will be executed on the K8s node.
