### PR TITLE
SCHED-1698: rate-limit NodeSet pod startup to protect slurmctld

### DIFF
--- a/api/v1alpha1/nodeset_types.go
+++ b/api/v1alpha1/nodeset_types.go
@@ -132,6 +132,18 @@ type NodeSetSpec struct {
 	// +kubebuilder:default="20%"
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 
+	// MaxConcurrentStartup caps the number of worker pods created in parallel
+	// during initial NodeSet scale-out (i.e. cluster creation or NodeSet growth).
+	// Value can be an absolute number (ex: 500) or a percentage of desired pods (ex: 10%).
+	// Maps to the underlying kruise AdvancedStatefulSet's scaleStrategy.maxUnavailable.
+	// Prevents overloading the Slurm controller with simultaneous slurmd registrations
+	// on large clusters.
+	// Defaults to 500.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=500
+	MaxConcurrentStartup *intstr.IntOrString `json:"maxConcurrentStartup,omitempty"`
+
 	// EphemeralNodes enables ephemeral node behavior for this NodeSet.
 	// When true, nodes will use dynamic topology injection instead of legacy topology.conf.
 	// Topology data is read from the topology-node-labels ConfigMap at runtime

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1034,6 +1034,11 @@ func (in *NodeSetSpec) DeepCopyInto(out *NodeSetSpec) {
 		*out = new(intstr.IntOrString)
 		**out = **in
 	}
+	if in.MaxConcurrentStartup != nil {
+		in, out := &in.MaxConcurrentStartup, &out.MaxConcurrentStartup
+		*out = new(intstr.IntOrString)
+		**out = **in
+	}
 	if in.EphemeralNodes != nil {
 		in, out := &in.EphemeralNodes, &out.EphemeralNodes
 		*out = new(bool)

--- a/config/crd/bases/slurm.nebius.ai_nodesets.yaml
+++ b/config/crd/bases/slurm.nebius.ai_nodesets.yaml
@@ -2562,6 +2562,20 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              maxConcurrentStartup:
+                anyOf:
+                - type: integer
+                - type: string
+                default: 500
+                description: |-
+                  MaxConcurrentStartup caps the number of worker pods created in parallel
+                  during initial NodeSet scale-out (i.e. cluster creation or NodeSet growth).
+                  Value can be an absolute number (ex: 500) or a percentage of desired pods (ex: 10%).
+                  Maps to the underlying kruise AdvancedStatefulSet's scaleStrategy.maxUnavailable.
+                  Prevents overloading the Slurm controller with simultaneous slurmd registrations
+                  on large clusters.
+                  Defaults to 500.
+                x-kubernetes-int-or-string: true
               maxUnavailable:
                 anyOf:
                 - type: integer

--- a/helm/nodesets/templates/nodeset.yaml
+++ b/helm/nodesets/templates/nodeset.yaml
@@ -27,6 +27,10 @@ spec:
   maxUnavailable: {{ . }}
   {{- end }}
 
+  {{- with .maxConcurrentStartup }}
+  maxConcurrentStartup: {{ . }}
+  {{- end }}
+
   {{- if .ephemeralNodes }}
   ephemeralNodes: {{ .ephemeralNodes }}
   {{- end }}

--- a/helm/nodesets/tests/node_config_test.yaml
+++ b/helm/nodesets/tests/node_config_test.yaml
@@ -249,6 +249,59 @@ tests:
           value: 2
         documentIndex: 1
 
+  - it: should configure maxConcurrentStartup when set and omit it when unset
+    set:
+      nodesets:
+        - name: gpu-workers
+          replicas: 3
+          maxConcurrentStartup: 250
+          slurmd:
+            image:
+              repository: "test/slurm"
+            resources:
+              cpu: "4"
+              memory: "8Gi"
+            volumes:
+              spool:
+                emptyDir: {}
+              jail:
+                emptyDir: {}
+              jailSubMounts: []
+          munge:
+            image:
+              repository: "test/munge"
+            resources:
+              cpu: "100m"
+              memory: "128Mi"
+        - name: cpu-workers
+          replicas: 5
+          slurmd:
+            image:
+              repository: "test/slurm"
+            resources:
+              cpu: "2"
+              memory: "4Gi"
+            volumes:
+              spool:
+                emptyDir: {}
+              jail:
+                emptyDir: {}
+              jailSubMounts: []
+          munge:
+            image:
+              repository: "test/munge"
+            resources:
+              cpu: "50m"
+              memory: "64Mi"
+    asserts:
+      - equal:
+          path: spec.maxConcurrentStartup
+          value: 250
+        documentIndex: 0
+      - notExists:
+          path: spec.maxConcurrentStartup
+        documentIndex: 1
+
   - it: should configure worker annotations correctly
     set:
       nodesets:

--- a/helm/nodesets/values.yaml
+++ b/helm/nodesets/values.yaml
@@ -49,6 +49,12 @@ nodesets:
     # Could be a count (number) or percent (string)
     # Optional, defaults to 20%
     maxUnavailable: 1
+    # Maximum number of worker pods that can be created in parallel during
+    # initial scale-out, to avoid overloading the Slurm controller with
+    # simultaneous slurmd registrations.
+    # Could be a count (number) or percent (string).
+    # Optional, defaults to 500
+    maxConcurrentStartup: 500
     # Enable ephemeral node behavior for this NodeSet.
     # When true, nodes will use dynamic topology injection instead of legacy topology.conf.
     # Topology data is read from the topology-node-labels ConfigMap at runtime.

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -17656,6 +17656,20 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              maxConcurrentStartup:
+                anyOf:
+                - type: integer
+                - type: string
+                default: 500
+                description: |-
+                  MaxConcurrentStartup caps the number of worker pods created in parallel
+                  during initial NodeSet scale-out (i.e. cluster creation or NodeSet growth).
+                  Value can be an absolute number (ex: 500) or a percentage of desired pods (ex: 10%).
+                  Maps to the underlying kruise AdvancedStatefulSet's scaleStrategy.maxUnavailable.
+                  Prevents overloading the Slurm controller with simultaneous slurmd registrations
+                  on large clusters.
+                  Defaults to 500.
+                x-kubernetes-int-or-string: true
               maxUnavailable:
                 anyOf:
                 - type: integer

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -17656,6 +17656,20 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              maxConcurrentStartup:
+                anyOf:
+                - type: integer
+                - type: string
+                default: 500
+                description: |-
+                  MaxConcurrentStartup caps the number of worker pods created in parallel
+                  during initial NodeSet scale-out (i.e. cluster creation or NodeSet growth).
+                  Value can be an absolute number (ex: 500) or a percentage of desired pods (ex: 10%).
+                  Maps to the underlying kruise AdvancedStatefulSet's scaleStrategy.maxUnavailable.
+                  Prevents overloading the Slurm controller with simultaneous slurmd registrations
+                  on large clusters.
+                  Defaults to 500.
+                x-kubernetes-int-or-string: true
               maxUnavailable:
                 anyOf:
                 - type: integer

--- a/internal/controller/reconciler/k8s_statefulset_advanced.go
+++ b/internal/controller/reconciler/k8s_statefulset_advanced.go
@@ -57,6 +57,7 @@ func (r *AdvancedStatefulSetReconciler) patch(existing, desired client.Object) (
 		}
 		dst.Spec.Replicas = src.Spec.Replicas
 		dst.Spec.UpdateStrategy = src.Spec.UpdateStrategy
+		dst.Spec.ScaleStrategy = src.Spec.ScaleStrategy
 		dst.Spec.Template.Spec = src.Spec.Template.Spec
 		dst.Spec.ReserveOrdinals = src.Spec.ReserveOrdinals
 		dst.Spec.PersistentVolumeClaimRetentionPolicy = src.Spec.PersistentVolumeClaimRetentionPolicy

--- a/internal/controller/reconciler/k8s_statefulset_test.go
+++ b/internal/controller/reconciler/k8s_statefulset_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
@@ -183,6 +184,48 @@ func TestAdvancedStatefulSetPatchCopiesPVCDeletionPolicy(t *testing.T) {
 		)
 	}
 }
+
+func TestAdvancedStatefulSetPatchCopiesScaleStrategy(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing *kruisev1b1.StatefulSetScaleStrategy
+		desired  *kruisev1b1.StatefulSetScaleStrategy
+	}{
+		{
+			name:     "absolute MaxUnavailable is propagated",
+			existing: &kruisev1b1.StatefulSetScaleStrategy{MaxUnavailable: ptrIntOrString(intstr.FromInt32(100))},
+			desired:  &kruisev1b1.StatefulSetScaleStrategy{MaxUnavailable: ptrIntOrString(intstr.FromInt32(500))},
+		},
+		{
+			name:     "percentage MaxUnavailable is propagated",
+			existing: &kruisev1b1.StatefulSetScaleStrategy{MaxUnavailable: ptrIntOrString(intstr.FromString("5%"))},
+			desired:  &kruisev1b1.StatefulSetScaleStrategy{MaxUnavailable: ptrIntOrString(intstr.FromString("25%"))},
+		},
+		{
+			name:     "newly set ScaleStrategy is populated",
+			existing: nil,
+			desired:  &kruisev1b1.StatefulSetScaleStrategy{MaxUnavailable: ptrIntOrString(intstr.FromInt32(500))},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := &kruisev1b1.StatefulSet{Spec: kruisev1b1.StatefulSetSpec{ScaleStrategy: tt.existing}}
+			desired := &kruisev1b1.StatefulSet{Spec: kruisev1b1.StatefulSetSpec{ScaleStrategy: tt.desired}}
+
+			r := &AdvancedStatefulSetReconciler{}
+			if _, err := r.patch(existing, desired); err != nil {
+				t.Fatalf("patch returned error: %v", err)
+			}
+
+			if !equality.Semantic.DeepEqual(existing.Spec.ScaleStrategy, tt.desired) {
+				t.Fatalf("expected ScaleStrategy=%+v, got %+v", tt.desired, existing.Spec.ScaleStrategy)
+			}
+		})
+	}
+}
+
+func ptrIntOrString(v intstr.IntOrString) *intstr.IntOrString { return &v }
 
 func TestStatefulSetPatchCopiesPVCDeletionPolicy(t *testing.T) {
 	existing := &appsv1.StatefulSet{

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -159,6 +159,9 @@ func RenderNodeSetStatefulSet(
 			ServiceName:         nodeSet.ServiceUmbrella.Name,
 			Replicas:            replicas,
 			ReserveOrdinals:     reserveOrdinals,
+			ScaleStrategy: &kruisev1b1.StatefulSetScaleStrategy{
+				MaxUnavailable: &nodeSet.StatefulSet.MaxConcurrentStartup,
+			},
 			UpdateStrategy: kruisev1b1.StatefulSetUpdateStrategy{
 				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: &kruisev1b1.RollingUpdateStatefulSetStrategy{

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -413,6 +414,90 @@ func TestRenderNodeSetStatefulSet_PersistentVolumeClaimRetentionPolicy(t *testin
 			if assert.NotNil(t, result.Spec.PersistentVolumeClaimRetentionPolicy) {
 				assert.Equal(t, tt.expectedWhenDeleted, result.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
 				assert.Equal(t, tt.expectedWhenScaled, result.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
+			}
+		})
+	}
+}
+
+func TestRenderNodeSetStatefulSet_ScaleStrategy(t *testing.T) {
+	makeNodeSet := func(maxConcurrentStartup, maxUnavailable intstr.IntOrString) *values.SlurmNodeSet {
+		return &values.SlurmNodeSet{
+			Name: "test-nodeset",
+			ParentalCluster: client.ObjectKey{
+				Namespace: "test-namespace",
+				Name:      "test-cluster",
+			},
+			ContainerSlurmd: values.Container{
+				NodeContainer: slurmv1.NodeContainer{
+					Image:           "test-image",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Resources: corev1.ResourceList{
+						corev1.ResourceMemory:           resource.MustParse("1Gi"),
+						corev1.ResourceCPU:              resource.MustParse("100m"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+			ContainerMunge: values.Container{
+				NodeContainer: slurmv1.NodeContainer{Image: "munge-image"},
+			},
+			VolumeSpool: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/spool"}},
+			VolumeJail:  corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/jail"}},
+			StatefulSet: values.StatefulSet{
+				Replicas:             1,
+				MaxUnavailable:       maxUnavailable,
+				MaxConcurrentStartup: maxConcurrentStartup,
+			},
+			SupervisorDConfigMapName: "supervisord-config",
+			SSHDConfigMapName:        "sshd-config",
+			GPU:                      &slurmv1alpha1.GPUSpec{Enabled: false},
+		}
+	}
+
+	tests := []struct {
+		name                       string
+		maxConcurrentStartup       intstr.IntOrString
+		maxUnavailable             intstr.IntOrString
+		expectedMaxConcurrentStart intstr.IntOrString
+		expectedMaxUnavailable     intstr.IntOrString
+	}{
+		{
+			name:                       "absolute MaxConcurrentStartup is propagated to ScaleStrategy",
+			maxConcurrentStartup:       intstr.FromInt32(500),
+			maxUnavailable:             intstr.FromString("20%"),
+			expectedMaxConcurrentStart: intstr.FromInt32(500),
+			expectedMaxUnavailable:     intstr.FromString("20%"),
+		},
+		{
+			name:                       "percentage MaxConcurrentStartup is propagated to ScaleStrategy",
+			maxConcurrentStartup:       intstr.FromString("10%"),
+			maxUnavailable:             intstr.FromInt32(1),
+			expectedMaxConcurrentStart: intstr.FromString("10%"),
+			expectedMaxUnavailable:     intstr.FromInt32(1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := worker.RenderNodeSetStatefulSet(
+				"test-cluster",
+				makeNodeSet(tt.maxConcurrentStartup, tt.maxUnavailable),
+				&slurmv1.Secrets{},
+				consts.CGroupV2,
+				false,
+			)
+			assert.NoError(t, err)
+
+			if assert.NotNil(t, result.Spec.ScaleStrategy) &&
+				assert.NotNil(t, result.Spec.ScaleStrategy.MaxUnavailable) {
+				assert.Equal(t, tt.expectedMaxConcurrentStart, *result.Spec.ScaleStrategy.MaxUnavailable,
+					"ScaleStrategy.MaxUnavailable should mirror StatefulSet.MaxConcurrentStartup")
+			}
+
+			if assert.NotNil(t, result.Spec.UpdateStrategy.RollingUpdate) &&
+				assert.NotNil(t, result.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable) {
+				assert.Equal(t, tt.expectedMaxUnavailable, *result.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable,
+					"UpdateStrategy.RollingUpdate.MaxUnavailable governs the update path and must not be affected")
 			}
 		})
 	}

--- a/internal/values/slurm_controller.go
+++ b/internal/values/slurm_controller.go
@@ -42,6 +42,7 @@ func buildSlurmControllerFrom(clusterName string, maintenance *consts.Maintenanc
 		naming.BuildStatefulSetName(consts.ComponentTypeController),
 		consts.SingleReplicas,
 		nil,
+		nil,
 	)
 
 	daemonSet := buildDaemonSetFrom(

--- a/internal/values/slurm_nodeset.go
+++ b/internal/values/slurm_nodeset.go
@@ -119,6 +119,7 @@ func BuildSlurmNodeSetFrom(
 			naming.BuildNodeSetStatefulSetName(nodeSet.Name),
 			nsSpec.Replicas,
 			nsSpec.MaxUnavailable,
+			nsSpec.MaxConcurrentStartup,
 		),
 		Service:         buildServiceFrom(naming.BuildNodeSetServiceName(clusterName, nodeSet.Name)),
 		ServiceUmbrella: buildServiceFrom(naming.BuildServiceName(consts.ComponentTypeNodeSet, clusterName)),

--- a/internal/values/types.go
+++ b/internal/values/types.go
@@ -64,9 +64,10 @@ func buildServiceFrom(
 // region StatefulSet
 
 type StatefulSet struct {
-	Name           string
-	Replicas       int32
-	MaxUnavailable intstr.IntOrString
+	Name                 string
+	Replicas             int32
+	MaxUnavailable       intstr.IntOrString
+	MaxConcurrentStartup intstr.IntOrString
 }
 
 func buildStatefulSetFrom(
@@ -84,6 +85,7 @@ func buildStatefulSetWithMaxUnavailableFrom(
 	name string,
 	size int32,
 	maxUnavailable *intstr.IntOrString,
+	maxConcurrentStartup *intstr.IntOrString,
 ) StatefulSet {
 	result := StatefulSet{
 		Name:     name,
@@ -92,6 +94,10 @@ func buildStatefulSetWithMaxUnavailableFrom(
 
 	if maxUnavailable != nil {
 		result.MaxUnavailable = *maxUnavailable
+	}
+
+	if maxConcurrentStartup != nil {
+		result.MaxConcurrentStartup = *maxConcurrentStartup
 	}
 
 	return result


### PR DESCRIPTION
## Problem

On large NodeSet scale-outs (cluster creation, or growing a NodeSet by hundreds/thousands of nodes), the Kruise AdvancedStatefulSet creates all missing worker pods at once. Their slurmds register with `slurmctld` simultaneously, overwhelming the controller and causing slow startup or RPC failures.

## Solution

- Add `MaxConcurrentStartup` field to `NodeSetSpec` (`intstr.IntOrString`, default `500`).
- Map it to the underlying ASTS `scaleStrategy.maxUnavailable`, which caps how many pods Kruise creates in parallel during scale-out.
- Keep `UpdateStrategy.RollingUpdate.MaxUnavailable` (the update path) untouched.
- Plumb through values, Helm chart, CRDs (`soperator-crds`, `soperator`, `config/crd`).

## Testing

- Unit test in `internal/render/worker/statefulset_test.go` checks both absolute and percentage values propagate to `ScaleStrategy` without affecting `UpdateStrategy`.
- Helm chart test in `helm/nodesets/tests/node_config_test.yaml` verifies the field is rendered when set and omitted when unset.
- E2E run: https://github.com/nebius/soperator/actions/runs/26107473961

## Release Notes

Feature: NodeSet now exposes `maxConcurrentStartup` (default 500) to cap parallel worker pod creation during scale-out, preventing slurmctld overload on large clusters.