### PR TITLE
SCHED-1714: Collapse NodeSet replicas into Slurm hostlist ranges

### DIFF
--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -103,11 +103,15 @@ func AddNodeSetsToSlurmConfig(res *renderutils.PropertiesConfig, cluster *values
 	}
 }
 
-// AddNodesToSlurmConfig adds all node names to the slurm config
+// AddNodesToSlurmConfig adds all node names to the slurm config.
+//
+// All replicas in a NodeSet share an identical body, so we emit one line per
+// NodeSet using Slurm hostlist range syntax. This keeps the ConfigMap well
+// under the Kubernetes 1 MiB object size limit on large clusters.
 //
 // Example output:
-// NodeName=gb200-0-0 State=CLOUD NodeHostname=gb200-0-0 NodeAddr=gb200-0-0.gb200-0.soperator.svc RealMemory=1612639 Features=platform-gb200,gb200-rack-0 Gres=gpu:nvidia-b200:4 NodeCPUs=128 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=2
-// NodeName=gb200-0-1 State=CLOUD NodeHostname=gb200-0-1 NodeAddr=gb200-0-1.gb200-0.soperator.svc RealMemory=1612639 Features=platform-gb200,gb200-rack-0 Gres=gpu:nvidia-b200:4 NodeCPUs=128 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=2
+// NodeName=gb200-0-0 State=CLOUD NodeAddr=gb200-0-0.gb200-0.soperator.svc RealMemory=1612639 Feature=platform-gb200,gb200-rack-0 Gres=gpu:nvidia-b200:4 NodeCPUs=128 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=2
+// NodeName=gb200-1-[0-17] State=CLOUD NodeAddr=gb200-1-[0-17].gb200-1.soperator.svc RealMemory=1612639 Feature=platform-gb200,gb200-rack-1 Gres=gpu:nvidia-b200:4 NodeCPUs=128 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=2
 func AddNodesToSlurmConfig(res *renderutils.PropertiesConfig, cluster *values.SlurmCluster) {
 	res.AddComment("Nodes section")
 
@@ -125,59 +129,60 @@ func AddNodesToSlurmConfig(res *renderutils.PropertiesConfig, cluster *values.Sl
 			continue
 		}
 
-		for i := int32(0); i < nodeSet.Spec.Replicas; i++ {
-			nodeName := fmt.Sprintf("%s-%d", nodeSet.Name, i)
-
-			nodeAddr := fmt.Sprintf(
-				"%s.%s",
-				nodeName,
-				naming.BuildNodeSetUmbrellaServiceFQDN(nodeSet.Namespace, cluster.Name),
-			)
-			realMemory := strconv.FormatInt(
-				RenderRealMemorySlurmd(corev1.ResourceRequirements{Requests: nodeSet.Spec.Slurmd.Resources}),
-				10,
-			)
-
-			var nodeConfigParts []string
-			nodeConfigParts = append(nodeConfigParts,
-				fmt.Sprintf("NodeHostname=%s", nodeName),
-				fmt.Sprintf("NodeAddr=%s", nodeAddr),
-				fmt.Sprintf("RealMemory=%s", realMemory),
-			)
-			if nodeSet.Spec.Slurmd.Port != 0 {
-				nodeConfigParts = append(nodeConfigParts, fmt.Sprintf("Port=%d", nodeSet.Spec.Slurmd.Port))
-			}
-			nodeConfig := strings.Join(nodeConfigParts, " ")
-
-			if len(nodeSet.Spec.NodeConfig.Features) > 0 {
-				features := strings.Join(nodeSet.Spec.NodeConfig.Features, ",")
-				nodeConfig = fmt.Sprintf("%s %s%s", nodeConfig, nodeFeatureKey, features)
-			}
-
-			// Remove feature and state overrides
-			staticConfig := strings.Join(
-				slices.Filter(
-					nil,
-					strings.Split(nodeSet.Spec.NodeConfig.Static, " "),
-					func(s string) bool {
-						return !strings.HasPrefix(s, nodeFeatureKey) &&
-							!strings.HasPrefix(s, stateKey)
-					},
-				),
-				" ",
-			)
-
-			if len(nodeConfig) > 0 {
-				nodeConfig = fmt.Sprintf("%s %s", nodeConfig, staticConfig)
-			}
-
-			// Create static nodes with state CLOUD.
-			// Otherwise, nodes will disappear from the Slurm state every time the corresponding K8s pods don't run.
-			res.AddProperty(
-				"NodeName",
-				fmt.Sprintf("%s State=CLOUD %s", nodeName, nodeConfig),
-			)
+		var nodeRange string
+		if nodeSet.Spec.Replicas == 1 {
+			nodeRange = fmt.Sprintf("%s-0", nodeSet.Name)
+		} else {
+			nodeRange = fmt.Sprintf("%s-[0-%d]", nodeSet.Name, nodeSet.Spec.Replicas-1)
 		}
+
+		nodeAddr := fmt.Sprintf(
+			"%s.%s",
+			nodeRange,
+			naming.BuildNodeSetUmbrellaServiceFQDN(nodeSet.Namespace, cluster.Name),
+		)
+		realMemory := strconv.FormatInt(
+			RenderRealMemorySlurmd(corev1.ResourceRequirements{Requests: nodeSet.Spec.Slurmd.Resources}),
+			10,
+		)
+
+		var nodeConfigParts []string
+		nodeConfigParts = append(nodeConfigParts,
+			fmt.Sprintf("NodeAddr=%s", nodeAddr),
+			fmt.Sprintf("RealMemory=%s", realMemory),
+		)
+		if nodeSet.Spec.Slurmd.Port != 0 {
+			nodeConfigParts = append(nodeConfigParts, fmt.Sprintf("Port=%d", nodeSet.Spec.Slurmd.Port))
+		}
+		nodeConfig := strings.Join(nodeConfigParts, " ")
+
+		if len(nodeSet.Spec.NodeConfig.Features) > 0 {
+			features := strings.Join(nodeSet.Spec.NodeConfig.Features, ",")
+			nodeConfig = fmt.Sprintf("%s %s%s", nodeConfig, nodeFeatureKey, features)
+		}
+
+		staticConfig := strings.Join(
+			slices.Filter(
+				nil,
+				strings.Split(nodeSet.Spec.NodeConfig.Static, " "),
+				func(s string) bool {
+					return !strings.HasPrefix(s, nodeFeatureKey) &&
+						!strings.HasPrefix(s, stateKey)
+				},
+			),
+			" ",
+		)
+
+		if len(nodeConfig) > 0 {
+			nodeConfig = fmt.Sprintf("%s %s", nodeConfig, staticConfig)
+		}
+
+		// State=CLOUD keeps nodes registered in Slurm even when the
+		// corresponding K8s pods are not running.
+		res.AddProperty(
+			"NodeName",
+			fmt.Sprintf("%s State=CLOUD %s", nodeRange, nodeConfig),
+		)
 	}
 }
 

--- a/internal/render/common/configmap_test.go
+++ b/internal/render/common/configmap_test.go
@@ -585,7 +585,7 @@ func TestAddNodesToSlurmConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: "NodeName=nodeA-0 State=CLOUD NodeHostname=nodeA-0 NodeAddr=nodeA-0.slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=2048 Feature=a,b Gres=gpu:nvidia-a100:4 NodeCPUs=64 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=1",
+			expected: "NodeName=nodeA-0 State=CLOUD NodeAddr=nodeA-0.slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=2048 Feature=a,b Gres=gpu:nvidia-a100:4 NodeCPUs=64 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=1",
 		},
 		{
 			name: "Single nodeset with multiple replicas",
@@ -614,9 +614,7 @@ func TestAddNodesToSlurmConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: "NodeName=nodeB-0 State=CLOUD NodeHostname=nodeB-0 NodeAddr=nodeB-0.slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=4096 Gres=gpu:nvidia-a100:8 NodeCPUs=128 Boards=1 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
-				"NodeName=nodeB-1 State=CLOUD NodeHostname=nodeB-1 NodeAddr=nodeB-1.slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=4096 Gres=gpu:nvidia-a100:8 NodeCPUs=128 Boards=1 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
-				"NodeName=nodeB-2 State=CLOUD NodeHostname=nodeB-2 NodeAddr=nodeB-2.slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=4096 Gres=gpu:nvidia-a100:8 NodeCPUs=128 Boards=1 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1",
+			expected: "NodeName=nodeB-[0-2] State=CLOUD NodeAddr=nodeB-[0-2].slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=4096 Gres=gpu:nvidia-a100:8 NodeCPUs=128 Boards=1 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1",
 		},
 		{
 			name: "Multiple nodesets with varying replicas",
@@ -662,9 +660,8 @@ func TestAddNodesToSlurmConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: "NodeName=nodeC-0 State=CLOUD NodeHostname=nodeC-0 NodeAddr=nodeC-0.slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=8192 Gres=gpu:nvidia-a100:16 NodeCPUs=256 Boards=2 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
-				"NodeName=nodeC-1 State=CLOUD NodeHostname=nodeC-1 NodeAddr=nodeC-1.slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=8192 Gres=gpu:nvidia-a100:16 NodeCPUs=256 Boards=2 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
-				"NodeName=nodeD-0 State=CLOUD NodeHostname=nodeD-0 NodeAddr=nodeD-0.slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=16384 Gres=gpu:nvidia-a100:32 NodeCPUs=512 Boards=4 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1",
+			expected: "NodeName=nodeC-[0-1] State=CLOUD NodeAddr=nodeC-[0-1].slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=8192 Gres=gpu:nvidia-a100:16 NodeCPUs=256 Boards=2 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1\n" +
+				"NodeName=nodeD-0 State=CLOUD NodeAddr=nodeD-0.slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=16384 Gres=gpu:nvidia-a100:32 NodeCPUs=512 Boards=4 SocketsPerBoard=4 CoresPerSocket=32 ThreadsPerCode=1",
 		},
 		{
 			name: "Nodeset with zero replicas",


### PR DESCRIPTION
## Problem

`slurm.conf` is rendered into a ConfigMap, which Kubernetes caps at 1 MiB. On large clusters we emit one `NodeName=` line per replica, and the file grows past the limit, blocking reconcile.

## Solution

- Emit a single `NodeName=<set>-[0-N]` line per NodeSet using Slurm hostlist range syntax, since all replicas in a NodeSet share an identical body.
- Drop the redundant `NodeHostname=` field — Slurm derives it from `NodeName` when omitted.
- Single-replica NodeSets still render as `<set>-0` (no brackets) so existing parsing stays the same.

## Testing

- Updated unit tests in `internal/render/common/configmap_test.go` to cover single-replica, multi-replica, and mixed-NodeSet cases.
- Tested on 2 test clusters

## Release Notes

Fix: shrink rendered `slurm.conf` so large clusters stay under the 1 MiB ConfigMap limit.