### PR TITLE
Fix populate_jail_entrypoint for NFS

### DIFF
--- a/images/jail/populate_jail_entrypoint.sh
+++ b/images/jail/populate_jail_entrypoint.sh
@@ -14,7 +14,8 @@ populate_jail_rootfs() {
     restic --repo /jail_restic --insecure-no-password restore latest --target /mnt/jail \
       --overwrite always --delete \
       --no-cache --no-extra-verify --option local.connections=64 \
-      --json
+      --json \
+      --exclude-xattr system.nfs4_acl
 
     echo "Set permissions for jail directory"
     chmod 755 /mnt/jail # Permissions 755 are only allowed permissions for OpenSSH ChrootDirectory feature


### PR DESCRIPTION
**Problem**
`populate_jail_entrypoint.sh` failed when NFS from Soperator's `nfs-server`chart  was used for `/mnt/jail`.

This part
```bash
restic --repo /jail_restic --insecure-no-password restore latest --target /mnt/jail \
      --overwrite always --delete \
      --no-cache --no-extra-verify --option local.connections=64 \
      --json
```

produced errors like:
```
xattr.LRemove /target/path/file.txt system.nfs4_acl: invalid argument
```

Seems that NFS adds extra attrs at write, while `restic` expects a full match of attrs with the snapshot.

**Solution**

Find a similar issue on Google, added `--exclude-xattr system.nfs4_acl` as suggested there.

https://forum.restic.net/t/restoring-to-truenas-using-nfs/9580/4

**Testing**

I built a custom `populate_jail_entrypoint` image [dockerhub](https://hub.docker.com/repository/docker/minotru/populate_jail/tags/4.0.0-slurm25.11.3-rcbd62644-cuda12.9.0-restic-fix-2026-05-09/sha256:c4a9da0e7bd7ecff6ac6e4604cc73c6b7a8d90c054eb5fc0ca7d37bcb40c56fc) and tested it with `oci://cr.eu-north1.nebius.cloud/soperator-unstable/helm-slurm-cluster --version 4.0.0-rcbd62644`

## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
