### PR TITLE
Install NCCL Inspector and NCCL Inspector PreConf into images

### DIFF
--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -45,9 +45,9 @@ images:
   sansible: "cr.eu-north1.nebius.cloud/soperator/sansible:4.0.2-slurm25.11.5"
   activeCheckImageRepository: "cr.eu-north1.nebius.cloud#ml-containers/training_diag"
   activeCheckImageTags:
-    # Image training_diag from PR https://github.com/nebius/ml-containers/pull/88
-    "12.9.0": "12.9.0-ubuntu24.04-20260605082528"
-    "13.0.2": "13.0.2-ubuntu24.04-20260605082528"
+    # Image training_diag from PR https://github.com/nebius/ml-containers/pull/84
+    "12.9.0": "12.9.0-ubuntu24.04-20260610131231"
+    "13.0.2": "13.0.2-ubuntu24.04-20260610131231"
 # Optional override in Pyxis ("reg#repo:tag") format.
 activeCheckImage: ""
 checks:

--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -139,6 +139,10 @@ pushd "${jaildir}"
     touch usr/lib/slurm/spanknccldebug.so
     mount --bind "/${SLURM_LIB_PATH}/spanknccldebug.so" "usr/lib/slurm/spanknccldebug.so"
 
+    echo "Bind-mount NCCL Inspector PreConf SPANK plugin from container to the jail"
+    touch usr/lib/slurm/spank_nccl_inspector_preconf.so
+    mount --bind "/${SLURM_LIB_PATH}/spank_nccl_inspector_preconf.so" "usr/lib/slurm/spank_nccl_inspector_preconf.so"
+
     echo "Bind-mount /etc/enroot, /usr/share/enroot and /usr/lib/enroot"
     mkdir -p etc/enroot usr/share/enroot usr/lib/enroot
     mkdir -p /etc/enroot/mounts.d

--- a/images/common/scripts/install_spank_nccl_inspector_preconf.sh
+++ b/images/common/scripts/install_spank_nccl_inspector_preconf.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e # Exit immediately if any command returns a non-zero error code
+
+apt-get update
+apt-get -y install --reinstall spank-nccl-inspector-preconf
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/images/jail/jail.dockerfile
+++ b/images/jail/jail.dockerfile
@@ -2,8 +2,8 @@
 
 ARG CUDA_VERSION
 ARG SLURM_VERSION
-# https://github.com/nebius/ml-containers/pull/88
-FROM cr.eu-north1.nebius.cloud/ml-containers/slurm_training_diag:slurm${SLURM_VERSION}-cuda${CUDA_VERSION}-ubuntu24.04-20260605082538 AS jail
+# https://github.com/nebius/ml-containers/pull/84
+FROM cr.eu-north1.nebius.cloud/ml-containers/slurm_training_diag:slurm${SLURM_VERSION}-cuda${CUDA_VERSION}-ubuntu24.04-20260610131219 AS jail
 
 # Create directory for pivoting host's root
 RUN mkdir -m 555 /mnt/host

--- a/images/login/sshd.dockerfile
+++ b/images/login/sshd.dockerfile
@@ -36,12 +36,18 @@ RUN chmod +x /opt/bin/install_chroot_plugin.sh && \
     /opt/bin/install_chroot_plugin.sh && \
     rm /opt/bin/install_chroot_plugin.sh
 
-# Install NCCL debug plugin
+# Install NCCL Debug SPANK plugin
 COPY images/common/spank-nccl-debug/src /usr/src/soperator/spank/nccld-debug
 COPY images/common/scripts/install_nccld_debug_plugin.sh /opt/bin/
 RUN chmod +x /opt/bin/install_nccld_debug_plugin.sh && \
     /opt/bin/install_nccld_debug_plugin.sh && \
     rm /opt/bin/install_nccld_debug_plugin.sh
+
+# Install NCCL Inspector PreConf SPANK plugin
+COPY images/common/scripts/install_spank_nccl_inspector_preconf.sh /opt/bin/
+RUN chmod +x /opt/bin/install_spank_nccl_inspector_preconf.sh && \
+    /opt/bin/install_spank_nccl_inspector_preconf.sh && \
+    rm /opt/bin/install_spank_nccl_inspector_preconf.sh
 
 # Install enroot
 COPY images/common/scripts/install_enroot.sh /opt/bin/

--- a/images/sansible/sansible.dockerfile
+++ b/images/sansible/sansible.dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile-upstream:1.20.0
 
-# https://github.com/nebius/ml-containers/pull/88
-FROM cr.eu-north1.nebius.cloud/ml-containers/ansible_roles:noble-20260605082515 AS sansible
+# https://github.com/nebius/ml-containers/pull/84
+FROM cr.eu-north1.nebius.cloud/ml-containers/ansible_roles:noble-20260610131236 AS sansible
 
 # Install common packages
 RUN apt update && \

--- a/images/slurm_check_job/slurm_check_job.dockerfile
+++ b/images/slurm_check_job/slurm_check_job.dockerfile
@@ -34,12 +34,18 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install NCCL debug plugin
+# Install NCCL Debug SPANK plugin
 COPY images/common/spank-nccl-debug/src /usr/src/soperator/spank/nccld-debug
 COPY images/common/scripts/install_nccld_debug_plugin.sh /opt/bin/
 RUN chmod +x /opt/bin/install_nccld_debug_plugin.sh && \
     /opt/bin/install_nccld_debug_plugin.sh && \
     rm /opt/bin/install_nccld_debug_plugin.sh
+
+# Install NCCL Inspector PreConf SPANK plugin
+COPY images/common/scripts/install_spank_nccl_inspector_preconf.sh /opt/bin/
+RUN chmod +x /opt/bin/install_spank_nccl_inspector_preconf.sh && \
+    /opt/bin/install_spank_nccl_inspector_preconf.sh && \
+    rm /opt/bin/install_spank_nccl_inspector_preconf.sh
 
 # Install kubectl
 RUN ARCH="$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')" && \
@@ -58,10 +64,13 @@ RUN ARCH="$(uname -m)" && \
     mkdir -p /usr/lib/slurm && \
     ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/chroot.so" /usr/lib/slurm/chroot.so && \
     ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/spank_pyxis.so" /usr/lib/slurm/spank_pyxis.so && \
-    ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/spanknccldebug.so" /usr/lib/slurm/spanknccldebug.so
+    ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/spanknccldebug.so" /usr/lib/slurm/spanknccldebug.so && \
+    ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/spank_nccl_inspector_preconf.so" /usr/lib/slurm/spank_nccl_inspector_preconf.so
 
-# Disable NCCL debug plugin by default for slurm jobs
+# Disable NCCL Debug SPANK plugin by default for Slurm jobs
 ENV SNCCLD_ENABLED="false"
+# Disable NCCL Inspector PreConf SPANK plugin by default for Slurm jobs
+ENV SNCCLIPRECON_ENABLED="false"
 
 # Delete users & home because they will be linked from jail
 RUN rm /etc/passwd* /etc/group* /etc/shadow* /etc/gshadow*

--- a/images/worker/slurmd.dockerfile
+++ b/images/worker/slurmd.dockerfile
@@ -55,12 +55,18 @@ RUN chmod +x /opt/bin/install_chroot_plugin.sh && \
     /opt/bin/install_chroot_plugin.sh && \
     rm /opt/bin/install_chroot_plugin.sh
 
-# Install NCCL debug plugin
+# Install NCCL Debug SPANK plugin
 COPY images/common/spank-nccl-debug/src /usr/src/soperator/spank/nccld-debug
 COPY images/common/scripts/install_nccld_debug_plugin.sh /opt/bin/
 RUN chmod +x /opt/bin/install_nccld_debug_plugin.sh && \
     /opt/bin/install_nccld_debug_plugin.sh && \
     rm /opt/bin/install_nccld_debug_plugin.sh
+
+# Install NCCL Inspector PreConf SPANK plugin
+COPY images/common/scripts/install_spank_nccl_inspector_preconf.sh /opt/bin/
+RUN chmod +x /opt/bin/install_spank_nccl_inspector_preconf.sh && \
+    /opt/bin/install_spank_nccl_inspector_preconf.sh && \
+    rm /opt/bin/install_spank_nccl_inspector_preconf.sh
 
 # Install enroot
 COPY images/common/scripts/install_enroot.sh /opt/bin/


### PR DESCRIPTION
## Problem

NCCL Inspector and NCCL Inspector PreConf plugins are needed to be installed for an easy use.

- NCCL Inspector is a NCCL plugin which could be used right away with every program using NCCL under the hood.
- NCCL Inspector PreConf is a SPANK plugin which brings simplicity into NCCL Inspector pre-configuration for every Slurm job. Despite it's being installed into images, it needs to be activated as a plugin in `plugstack.conf` (matter of future PRs)

### Tickets to cover

- [Establish a deployment process for NCCL Inspector plugin](https://nebius.atlassian.net/browse/SCHED-1344)
- [Establish a deployment process for NCCL Inspector pre-configuration plugin](https://nebius.atlassian.net/browse/SCHED-1455)

## Solution

This PR introduces installation of the mentioned plugins from base image root FS into the Jail under proper locations.

Along with images for Login and Worker, it provides installation of the plugin into Slurm Check Job image, and disables the NCCL Inspector PreConf plugin by default.

The change in base image versions also brings new versions of `libnccl2` and `libnccl-dev` packages for better performance and stability.

## Testing

Tested the presence of the mentioned plugins on a dev cluster.

## Release Notes

Feature: Updated the version of `libnccl2` and  `libnccl-dev` packages to improve performance and stability. Brings NCCL P2P metrics collection support for the NCCL Inspector.

Feature: Added NCCL Inspector profiler plugin for deep NCCL performance investigation.

Feature: Added NCCL Inspector PreConf SPANK plugin for simple pre-configuration of NCCL Inspector for all Slurm jobs.
