### PR TITLE
SCHED-1779: Basic IMDS sidecar for VMagent

### DIFF
--- a/docs/metrics-pipeline.md
+++ b/docs/metrics-pipeline.md
@@ -163,7 +163,7 @@ curl "http://localhost:8429/api/v1/query?query=up"
 
 #### Remote Write to Nebius Cloud
 - Endpoint: `https://write.monitoring.{region}.nebius.cloud/projects/{projectId}/buckets/soperator/prometheus`
-- Authentication: Bearer token from `/mnt/cloud-metadata/tsa-token`
+- Authentication: Bearer token from `/mnt/imds/tsa-token`, populated and refreshed by the vmagent IMDS token sidecar
 - When: Enabled with `publicEndpointEnabled: true`
 
 ### Visualization

--- a/helm/soperator-fluxcd/files/tsa-token-refresher.sh
+++ b/helm/soperator-fluxcd/files/tsa-token-refresher.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -eu
+
+: "${TSA_TOKEN_PATH:=/mnt/imds/tsa-token}"
+: "${TSA_TOKEN_EXPIRY_PATH:=${TSA_TOKEN_PATH}.expires_at}"
+: "${IMDS_BASE_URL:=http://169.254.169.254}"
+: "${TSA_TOKEN_REFRESH_SAFETY_MARGIN_SECONDS:=900}"
+
+mkdir -p "$(dirname "${TSA_TOKEN_PATH}")" "$(dirname "${TSA_TOKEN_EXPIRY_PATH}")"
+
+json_string_field() {
+  field="$1"
+  sed -n "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n 1
+}
+
+timestamp_to_epoch() {
+  timestamp="$1"
+  case "${timestamp}" in
+    *.*Z) timestamp="${timestamp%%.*}Z" ;;
+  esac
+  if date -u -d "${timestamp}" +%s >/tmp/tsa-token-date 2>/dev/null; then
+    cat /tmp/tsa-token-date
+    return 0
+  fi
+  date -u -D "%Y-%m-%dT%H:%M:%SZ" -d "${timestamp}" +%s
+}
+
+fetch_and_save_token() {
+  response="$(curl -fsSL -H "Metadata: true" "${IMDS_BASE_URL}/v1/iam/tsa/token")"
+  access_token="$(printf '%s\n' "${response}" | json_string_field "access_token")"
+  expires_at="$(printf '%s\n' "${response}" | json_string_field "expires_at")"
+
+  if [ -z "${access_token}" ] || [ -z "${expires_at}" ]; then
+    echo "IMDS TSA token response did not include access_token or expires_at" >&2
+    return 1
+  fi
+
+  token_tmp="${TSA_TOKEN_PATH}.tmp"
+  expiry_tmp="${TSA_TOKEN_EXPIRY_PATH}.tmp"
+  printf '%s' "${access_token}" > "${token_tmp}"
+  printf '%s\n' "${expires_at}" > "${expiry_tmp}"
+  chmod 0444 "${token_tmp}" "${expiry_tmp}"
+  mv "${token_tmp}" "${TSA_TOKEN_PATH}"
+  mv "${expiry_tmp}" "${TSA_TOKEN_EXPIRY_PATH}"
+
+  echo "refreshed tsa-token, expires at ${expires_at}"
+}
+
+seconds_until_refresh() {
+  expires_epoch="$(timestamp_to_epoch "$(cat "${TSA_TOKEN_EXPIRY_PATH}")")"
+  now_epoch="$(date -u +%s)"
+  sleep_seconds=$((expires_epoch - now_epoch - TSA_TOKEN_REFRESH_SAFETY_MARGIN_SECONDS))
+
+  if [ "${sleep_seconds}" -lt 1 ]; then
+    echo 1
+    return 0
+  fi
+
+  echo "${sleep_seconds}"
+}
+
+while true; do
+  fetch_and_save_token
+  sleep "$(seconds_until_refresh)"
+done

--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -391,6 +391,31 @@ spec:
         spec:
           {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
           {{- $hasVmagentSpec := .Values.observability.vmStack.values.vmagent.spec }}
+          {{- $tsaTokenSidecar := .Values.observability.vmStack.tsaTokenSidecar | default dict }}
+          {{- $tsaTokenSidecarEnabled := true }}
+          {{- if hasKey $tsaTokenSidecar "enabled" }}
+          {{- $tsaTokenSidecarEnabled = $tsaTokenSidecar.enabled }}
+          {{- end }}
+          {{- $tsaTokenImage := $tsaTokenSidecar.image | default dict }}
+          {{- $tsaTokenImageRepository := required "observability.vmStack.tsaTokenSidecar.image.repository is required" $tsaTokenImage.repository }}
+          {{- $tsaTokenImageTag := required "observability.vmStack.tsaTokenSidecar.image.tag is required" $tsaTokenImage.tag }}
+          {{- $tsaTokenImagePullPolicy := required "observability.vmStack.tsaTokenSidecar.image.pullPolicy is required" $tsaTokenImage.pullPolicy }}
+          {{- $tsaTokenMountPath := required "observability.vmStack.tsaTokenSidecar.tokenMountPath is required" $tsaTokenSidecar.tokenMountPath }}
+          {{- $tsaTokenFilePath := required "observability.vmStack.tsaTokenSidecar.tokenFilePath is required" $tsaTokenSidecar.tokenFilePath }}
+          {{- $hasHostNetwork := and $hasVmagentSpec (hasKey $hasVmagentSpec "hostNetwork") }}
+          {{- $hasDnsPolicy := and $hasVmagentSpec (hasKey $hasVmagentSpec "dnsPolicy") }}
+
+          {{- if and $hasPublicEndpoint $tsaTokenSidecarEnabled }}
+          hostNetwork: true
+          dnsPolicy: {{ default "ClusterFirstWithHostNet" $hasVmagentSpec.dnsPolicy }}
+          {{- else }}
+          {{- if $hasHostNetwork }}
+          hostNetwork: {{ $hasVmagentSpec.hostNetwork }}
+          {{- end }}
+          {{- if $hasDnsPolicy }}
+          dnsPolicy: {{ $hasVmagentSpec.dnsPolicy }}
+          {{- end }}
+          {{- end }}
 
           {{- $hasExternalLabels := and $hasVmagentSpec $hasVmagentSpec.externalLabels }}
           {{- if and $hasExternalLabels (gt (len $hasExternalLabels) 0) }}
@@ -432,12 +457,53 @@ spec:
           {{- toYaml $hasVmagentSpec.remoteWrite | nindent 12 }}
           {{- end }}
 
+          {{- $hasContainers := and $hasVmagentSpec $hasVmagentSpec.containers }}
+          {{- $containersNotEmpty := and $hasContainers (gt (len $hasVmagentSpec.containers) 0) }}
+          {{- if or (and $hasPublicEndpoint $tsaTokenSidecarEnabled) $containersNotEmpty }}
+          containers:
+          {{- if and $hasPublicEndpoint $tsaTokenSidecarEnabled }}
+            - name: tsa-token-refresher
+              image: {{ printf "%s:%s" $tsaTokenImageRepository $tsaTokenImageTag | quote }}
+              imagePullPolicy: {{ $tsaTokenImagePullPolicy | quote }}
+              command:
+                - /bin/sh
+                - -ec
+                - |
+{{ .Files.Get "files/tsa-token-refresher.sh" | indent 18 }}
+              env:
+                - name: TSA_TOKEN_PATH
+                  value: {{ $tsaTokenFilePath | quote }}
+                {{- with $tsaTokenSidecar.expiryFilePath }}
+                - name: TSA_TOKEN_EXPIRY_PATH
+                  value: {{ . | quote }}
+                {{- end }}
+                {{- with $tsaTokenSidecar.imdsBaseUrl }}
+                - name: IMDS_BASE_URL
+                  value: {{ . | quote }}
+                {{- end }}
+                {{- with $tsaTokenSidecar.refreshSafetyMarginSeconds }}
+                - name: TSA_TOKEN_REFRESH_SAFETY_MARGIN_SECONDS
+                  value: {{ . | quote }}
+                {{- end }}
+              volumeMounts:
+                - name: cloud-metadata
+                  mountPath: {{ $tsaTokenMountPath | quote }}
+              {{- with $tsaTokenSidecar.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          {{- end }}
+          {{- if $containersNotEmpty }}
+          {{- toYaml $hasVmagentSpec.containers | nindent 12 }}
+          {{- end }}
+          {{- end }}
+
           volumeMounts:
           {{- $hasVolumeMounts := and $hasVmagentSpec $hasVmagentSpec.volumeMounts }}
           {{- $volumeMountsNotEmpty := and $hasVolumeMounts (gt (len $hasVmagentSpec.volumeMounts) 0) }}
-          {{- if $hasPublicEndpoint }}
+          {{- if and $hasPublicEndpoint $tsaTokenSidecarEnabled }}
             - name: cloud-metadata
-              mountPath: /mnt/cloud-metadata
+              mountPath: {{ $tsaTokenMountPath | quote }}
               readOnly: true
           {{- if $volumeMountsNotEmpty }}
           {{- toYaml $hasVmagentSpec.volumeMounts | nindent 12 }}
@@ -449,11 +515,9 @@ spec:
           volumes:
           {{- $hasVolumes := and $hasVmagentSpec $hasVmagentSpec.volumes }}
           {{- $volumesNotEmpty := and $hasVolumes (gt (len $hasVmagentSpec.volumes) 0) }}
-          {{- if $hasPublicEndpoint }}
+          {{- if and $hasPublicEndpoint $tsaTokenSidecarEnabled }}
             - name: cloud-metadata
-              hostPath:
-                path: /mnt/cloud-metadata
-                type: Directory
+              emptyDir: {}
           {{- if $volumesNotEmpty }}
           {{- toYaml $hasVmagentSpec.volumes | nindent 12 }}
           {{- end }}
@@ -466,7 +530,9 @@ spec:
           {{- $extraArgsNotEmpty := and $hasExtraArgs (gt (len $hasVmagentSpec.extraArgs) 0) }}
           {{- if $hasPublicEndpoint }}
             remoteWrite.flushInterval: 2s
-            remoteWrite.bearerTokenFile: /mnt/cloud-metadata/tsa-token
+          {{- if $tsaTokenSidecarEnabled }}
+            remoteWrite.bearerTokenFile: {{ $tsaTokenFilePath | quote }}
+          {{- end }}
             remoteWrite.maxRowsPerBlock: "12000"
           {{- if $extraArgsNotEmpty }}
           {{- toYaml $hasVmagentSpec.extraArgs | nindent 12 }}

--- a/helm/soperator-fluxcd/tests/vmagent_test.yaml
+++ b/helm/soperator-fluxcd/tests/vmagent_test.yaml
@@ -82,6 +82,9 @@ tests:
                   - name: "cache-volume"
                     emptyDir:
                       sizeLimit: "1Gi"
+                containers:
+                  - name: "custom-sidecar"
+                    image: "example/custom-sidecar:v1"
     asserts:
       - hasDocuments:
           count: 1
@@ -102,10 +105,19 @@ tests:
           value: "token"
       - lengthEqual:
           path: spec.values.vmagent.spec.volumeMounts
-          count: 3  # 2 custom + 1 tsa-token
+          count: 3 # 2 custom + 1 tsa-token
       - lengthEqual:
           path: spec.values.vmagent.spec.volumes
-          count: 3   # 2 custom + 1 tsa-token
+          count: 3 # 2 custom + 1 tsa-token
+      - lengthEqual:
+          path: spec.values.vmagent.spec.containers
+          count: 2 # 1 tsa-token refresher + 1 custom
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].name
+          value: "tsa-token-refresher"
+      - equal:
+          path: spec.values.vmagent.spec.containers[1].name
+          value: "custom-sidecar"
 
   - it: should override default extraArgs correctly
     set:
@@ -118,10 +130,10 @@ tests:
             vmagent:
               spec:
                 extraArgs:
-                  "promscrape.dropOriginalLabels": "false"  # Override default
-                  "remoteWrite.rateLimit": "10"             # Override default
-                  "promscrape.maxScrapeSize": "67108864"    # Override default
-                  "custom.newArg": "newValue"               # Add new
+                  "promscrape.dropOriginalLabels": "false" # Override default
+                  "remoteWrite.rateLimit": "10" # Override default
+                  "promscrape.maxScrapeSize": "67108864" # Override default
+                  "custom.newArg": "newValue" # Add new
     asserts:
       - hasDocuments:
           count: 1
@@ -143,7 +155,7 @@ tests:
           value: "true"
       - equal:
           path: spec.values.vmagent.spec.extraArgs["remoteWrite.bearerTokenFile"]
-          value: "/mnt/cloud-metadata/tsa-token"
+          value: "/mnt/imds/tsa-token"
 
   - it: should handle special characters in projectId
     set:
@@ -172,7 +184,7 @@ tests:
           publicEndpointEnabled: true
           values:
             vmagent:
-              spec: {}  # Empty spec to test conditional blocks
+              spec: {} # Empty spec to test conditional blocks
     asserts:
       - hasDocuments:
           count: 1
@@ -188,6 +200,14 @@ tests:
       - exists:
           path: spec.values.vmagent.spec.volumes
       - exists:
+          path: spec.values.vmagent.spec.containers
+      - equal:
+          path: spec.values.vmagent.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.values.vmagent.spec.dnsPolicy
+          value: "ClusterFirstWithHostNet"
+      - exists:
           path: spec.values.vmagent.spec.resources
       # Should not have these sections when not provided
       - notExists:
@@ -197,9 +217,9 @@ tests:
     set:
       observability:
         enabled: true
+        publicEndpointEnabled: false
         vmStack:
           enabled: true
-          publicEndpointEnabled: false
           values:
             vmagent:
               spec:
@@ -295,7 +315,7 @@ tests:
       # Should have both default and custom remoteWrite entries
       - lengthEqual:
           path: spec.values.vmagent.spec.remoteWrite
-          count: 3  # 1 default + 2 custom
+          count: 3 # 1 default + 2 custom
       # Check default endpoint (should be first)
       - equal:
           path: spec.values.vmagent.spec.remoteWrite[0].url
@@ -346,14 +366,14 @@ tests:
       # Should have both default and custom volumeMounts
       - lengthEqual:
           path: spec.values.vmagent.spec.volumeMounts
-          count: 3  # 1 default tsa-token + 2 custom
+          count: 3 # 1 default tsa-token + 2 custom
       # Check default tsa-token mount
       - equal:
           path: spec.values.vmagent.spec.volumeMounts[0].name
           value: "cloud-metadata"
       - equal:
           path: spec.values.vmagent.spec.volumeMounts[0].mountPath
-          value: "/mnt/cloud-metadata"
+          value: "/mnt/imds"
       - equal:
           path: spec.values.vmagent.spec.volumeMounts[0].readOnly
           value: true
@@ -373,17 +393,15 @@ tests:
       # Should have both default and custom volumes
       - lengthEqual:
           path: spec.values.vmagent.spec.volumes
-          count: 3  # 1 default tsa-token + 2 custom
+          count: 3 # 1 default tsa-token + 2 custom
       # Check default tsa-token volume
       - equal:
           path: spec.values.vmagent.spec.volumes[0].name
           value: "cloud-metadata"
-      - equal:
-          path: spec.values.vmagent.spec.volumes[0].hostPath.path
-          value: "/mnt/cloud-metadata"
-      - equal:
-          path: spec.values.vmagent.spec.volumes[0].hostPath.type
-          value: "Directory"
+      - exists:
+          path: spec.values.vmagent.spec.volumes[0].emptyDir
+      - notExists:
+          path: spec.values.vmagent.spec.volumes[0].hostPath
       # Check custom volumes
       - equal:
           path: spec.values.vmagent.spec.volumes[1].name
@@ -418,23 +436,143 @@ tests:
       # Should still have defaults when custom arrays are empty
       - lengthEqual:
           path: spec.values.vmagent.spec.remoteWrite
-          count: 1  # Only default
+          count: 1 # Only default
       - equal:
           path: spec.values.vmagent.spec.remoteWrite[0].url
           value: "https://write.monitoring.eu-north1.nebius.cloud/projects/default-project-id/buckets/soperator/prometheus"
       # Should have default volumeMounts and volumes
       - lengthEqual:
           path: spec.values.vmagent.spec.volumeMounts
-          count: 1  # Only default tsa-token
+          count: 1 # Only default tsa-token
       - equal:
           path: spec.values.vmagent.spec.volumeMounts[0].name
           value: "cloud-metadata"
       - lengthEqual:
           path: spec.values.vmagent.spec.volumes
-          count: 1  # Only default tsa-token
+          count: 1 # Only default tsa-token
       - equal:
           path: spec.values.vmagent.spec.volumes[0].name
           value: "cloud-metadata"
+      - exists:
+          path: spec.values.vmagent.spec.containers[0]
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].name
+          value: "tsa-token-refresher"
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].image
+          value: "cr.eu-north1.nebius.cloud/soperator-proxy-docker-io/alpine/curl:8.19.0"
+      - lengthEqual:
+          path: spec.values.vmagent.spec.containers[0].env
+          count: 1
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].env[0].name
+          value: "TSA_TOKEN_PATH"
       # Should not have extraEnv when empty
       - notExists:
           path: spec.values.vmagent.spec.extraEnv
+
+  - it: should render configurable tsa-token IMDS sidecar when publicEndpointEnabled is true
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        vmStack:
+          enabled: true
+          tsaTokenSidecar:
+            image:
+              repository: "example.com/metadata-token"
+              tag: "v2"
+              pullPolicy: Always
+            imdsBaseUrl: "http://metadata.test.internal"
+            tokenMountPath: "/var/run/cloud-metadata"
+            tokenFilePath: "/var/run/cloud-metadata/tsa-token"
+            expiryFilePath: "/var/run/cloud-metadata/tsa-token.expires_at"
+            refreshSafetyMarginSeconds: 1200
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.vmagent.spec.extraArgs["remoteWrite.bearerTokenFile"]
+          value: "/var/run/cloud-metadata/tsa-token"
+      - equal:
+          path: spec.values.vmagent.spec.volumeMounts[0].mountPath
+          value: "/var/run/cloud-metadata"
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].image
+          value: "example.com/metadata-token:v2"
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].imagePullPolicy
+          value: "Always"
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].env[0].value
+          value: "/var/run/cloud-metadata/tsa-token"
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].env[1].value
+          value: "/var/run/cloud-metadata/tsa-token.expires_at"
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].env[2].value
+          value: "http://metadata.test.internal"
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].env[3].value
+          value: "1200"
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].env[3].name
+          value: "TSA_TOKEN_REFRESH_SAFETY_MARGIN_SECONDS"
+      - lengthEqual:
+          path: spec.values.vmagent.spec.containers[0].env
+          count: 4
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].volumeMounts[0].mountPath
+          value: "/var/run/cloud-metadata"
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].resources.requests.cpu
+          value: "10m"
+      - equal:
+          path: spec.values.vmagent.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.values.vmagent.spec.dnsPolicy
+          value: "ClusterFirstWithHostNet"
+
+  - it: should not render tsa-token sidecar when publicEndpointEnabled is false
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: false
+        vmStack:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.values.vmagent.spec.containers
+      - notExists:
+          path: spec.values.vmagent.spec.hostNetwork
+
+  - it: should not set bearer token file when tsa-token sidecar is disabled
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        vmStack:
+          enabled: true
+          tsaTokenSidecar:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.values.vmagent.spec.containers
+      - notExists:
+          path: spec.values.vmagent.spec.volumeMounts[0]
+      - notExists:
+          path: spec.values.vmagent.spec.volumes[0]
+      - notExists:
+          path: spec.values.vmagent.spec.extraArgs["remoteWrite.bearerTokenFile"]
+      - equal:
+          path: spec.values.vmagent.spec.extraArgs["remoteWrite.flushInterval"]
+          value: "2s"

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -261,6 +261,15 @@ observability:
       remediation:
         retries: 3
         remediateLastFailure: true
+    tsaTokenSidecar:
+      enabled: true
+      image:
+        repository: cr.eu-north1.nebius.cloud/soperator-proxy-docker-io/alpine/curl
+        tag: "8.19.0"
+        pullPolicy: IfNotPresent
+      tokenMountPath: /mnt/imds
+      tokenFilePath: /mnt/imds/tsa-token
+      resources: {}
     values:
       dashboardNamespaces:
         - soperator


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

Cloud metadata mount is being deprecated in favor of IMDS API.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
This adds the most basic support for fetching `tsa-token` from IMDS API. 

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
Tested using a dedicated dev cluster, waited for at least one token expiry and refresh.

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
