### PR TITLE
respect power down nodes in sconfigcontroller

### DIFF
--- a/internal/controller/sconfigcontroller/jailedconfig_controller.go
+++ b/internal/controller/sconfigcontroller/jailedconfig_controller.go
@@ -681,8 +681,10 @@ func (r *JailedConfigReconciler) getNodesStartTime(ctx context.Context) (map[str
 
 		var skip bool
 		for _, state := range *node.State {
-			if state == v0041.V0041NodeStateNOTRESPONDING {
-				// Ignore NOT_RESPONDING nodes, since their start time doesn't change after reconfigure.
+			if state == v0041.V0041NodeStateNOTRESPONDING ||
+				state == v0041.V0041NodeStatePOWERINGDOWN ||
+				state == v0041.V0041NodeStatePOWEREDDOWN {
+				// Ignore NOT_RESPONDING, POWERING_DOWN and POWERED_DOWN nodes, since their start time doesn't change after reconfigure.
 				skip = true
 			}
 		}


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Sconfigcontroller doesn't respect nodes in POWER_DOWN and POWERING_DOWN states and treats them as regular running nodes. It leads to infinite reconfigure every N minutes.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Exclude nodes in POWER_DOWN and POWERING_DOWN states from sconfigcontroller polling.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Fix: exclude nodes in POWER_DOWN and POWERING_DOWN states from sconfigcontroller polling.
