### PR TITLE
SCHED-1648: Better support for Block topology

### DIFF
--- a/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
+++ b/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
@@ -21,6 +21,10 @@ spec:
   slurmConfig:
     {{- toYaml .Values.slurmConfig | nindent 4 }}
   {{- end }}
+  {{- if .Values.topology }}
+  topology:
+    {{- toYaml .Values.topology | nindent 4 }}
+  {{- end }}
   {{- if .Values.customSlurmConfig }}
   customSlurmConfig: |
 {{- .Values.customSlurmConfig | nindent 4 }}

--- a/helm/slurm-cluster/tests/topology_test.yaml
+++ b/helm/slurm-cluster/tests/topology_test.yaml
@@ -1,0 +1,21 @@
+suite: test topology configuration
+templates:
+  - templates/slurm-cluster-cr.yaml
+tests:
+  - it: should not render topology by default
+    asserts:
+      - isKind:
+          of: SlurmCluster
+      - notExists:
+          path: spec.topology
+
+  - it: should render topology when provided
+    set:
+      topology:
+        blockSize: 18
+    asserts:
+      - isKind:
+          of: SlurmCluster
+      - equal:
+          path: spec.topology.blockSize
+          value: 18

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -150,6 +150,11 @@ slurmConfig:
   messageTimeout: 60
   topologyPlugin: "topology/tree"
   topologyParam: "SwitchAsNodeRank"
+# Topology contains topology-related parameters for Slurm.
+# Example for topology/block plugin:
+# topology:
+#   blockSize: 18
+topology: null
 customSlurmConfig: ""
 customCgroupConfig: ""
 mpiConfig:

--- a/images/worker/worker_init.py
+++ b/images/worker/worker_init.py
@@ -13,20 +13,22 @@ Environment Variables (wait-controller):
 Environment Variables (wait-topology):
     K8S_NODE_NAME: Kubernetes node name (required, from Downward API)
     TOPOLOGY_CONFIGMAP_PATH: Path to mounted ConfigMap (default: /tmp/slurm/topology-node-labels)
-    TOPOLOGY_PLUGIN: Slurm topology plugin override (default: read from slurm.conf)
     TOPOLOGY_WAIT_TIMEOUT: Max wait time in seconds (default: 180)
     TOPOLOGY_POLL_INTERVAL: Poll interval in seconds (default: 5)
+    SLURM_TOPOLOGY_PLUGIN: Slurm topology plugin override (default: read from slurm.conf)
 """
 
 import argparse
 import json
+import logging
 import os
 import re
 import shutil
 import subprocess
 import sys
 import time
-import logging
+from pathlib import Path
+from typing import Any
 
 # Configure logging
 logging.basicConfig(
@@ -34,35 +36,54 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 # Constants
-SLURM_CONFIG_LINK_SOURCE = "/mnt/jail/etc/slurm"
-SLURM_CONFIG_LINK_TARGET = "/etc/slurm"
-SLURM_CONF_PATH = "/etc/slurm/slurm.conf"
-TOPOLOGY_PLUGIN_TREE = "topology/tree"
-TOPOLOGY_PLUGIN_BLOCK = "topology/block"
+SLURM_CONFIG_LINK_SOURCE: Path = Path("/mnt/jail/etc/slurm")
+SLURM_CONFIG_LINK_TARGET: Path = Path("/etc/slurm")
+SLURM_CONFIG_PATH: Path = Path("/etc/slurm/slurm.conf")
+SLURM_TOPOLOGY_CONFIG_PATH: Path = Path("/etc/slurm/topology.conf")
+
+TOPOLOGY_PLUGIN_TREE: str = "topology/tree"
+TOPOLOGY_PLUGIN_BLOCK: str = "topology/block"
 
 
-# ============================================================
-# Controller readiness functions
-# ============================================================
+# region Common env functions
+
+
+def get_from_env_required(name: str) -> str:
+    """Get a value from environment variable."""
+    value: str | None = os.environ.get(name)
+
+    if value is None:
+        logger.error("Environment variable %s must be set", name)
+        sys.exit(1)
+
+    return str(value)
+
+
+# endregion Common env functions
+
+# region Controller readiness functions
 
 
 def create_slurm_config_symlink() -> None:
     """Create symlink to Slurm configs from jail mount."""
+    source: Path = Path(SLURM_CONFIG_LINK_SOURCE)
+    target: Path = Path(SLURM_CONFIG_LINK_TARGET)
+
     logger.info(
         "Creating symlink to slurm configs: %s -> %s",
-        SLURM_CONFIG_LINK_TARGET,
-        SLURM_CONFIG_LINK_SOURCE,
+        target,
+        source,
     )
-    if os.path.islink(SLURM_CONFIG_LINK_TARGET) or os.path.isfile(
-        SLURM_CONFIG_LINK_TARGET
-    ):
-        os.unlink(SLURM_CONFIG_LINK_TARGET)
-    elif os.path.isdir(SLURM_CONFIG_LINK_TARGET):
-        shutil.rmtree(SLURM_CONFIG_LINK_TARGET)
-    os.symlink(SLURM_CONFIG_LINK_SOURCE, SLURM_CONFIG_LINK_TARGET)
+
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+    elif target.is_dir():
+        shutil.rmtree(target)
+
+    target.symlink_to(source)
 
 
 def get_controller_max_attempts() -> int:
@@ -75,32 +96,23 @@ def get_controller_poll_interval() -> int:
     return int(os.environ.get("CONTROLLER_POLL_INTERVAL", "5"))
 
 
-def get_hostname() -> str:
-    """Get the hostname of the current node."""
-    return os.environ.get("HOSTNAME")
-
-
 def get_node_addr() -> str:
-    """Construct the NodeAddr for scontrol update based on environment variables."""
-    pod_name = os.environ.get("K8S_POD_NAME")
+    pod_name: str = get_from_env_required("K8S_POD_NAME")
     logger.info("Using K8S_POD_NAME=%s for NodeAddr construction", pod_name)
-    service_name = os.environ.get("K8S_SERVICE_NAME")
+
+    service_name: str = get_from_env_required("K8S_SERVICE_NAME")
     logger.info("Using K8S_SERVICE_NAME=%s for NodeAddr construction", service_name)
-    pod_namespace = os.environ.get("K8S_POD_NAMESPACE")
+
+    pod_namespace: str = get_from_env_required("K8S_POD_NAMESPACE")
     logger.info("Using K8S_POD_NAMESPACE=%s for NodeAddr construction", pod_namespace)
-    if not pod_name or not service_name or not pod_namespace:
-        logger.error(
-            "Environment variables K8S_POD_NAME, K8S_SERVICE_NAME, and K8S_POD_NAMESPACE must be set"
-        )
-        sys.exit(1)
-    node_addr = f"nodeaddr={pod_name}.{service_name}.{pod_namespace}.svc"
-    return node_addr
+
+    return f"nodeaddr={pod_name}.{service_name}.{pod_namespace}.svc"
 
 
 def wait_for_controller() -> None:
     """Wait for slurmctld to be ready by polling scontrol ping."""
-    max_attempts = get_controller_max_attempts()
-    poll_interval = get_controller_poll_interval()
+    max_attempts: int = get_controller_max_attempts()
+    poll_interval: int = get_controller_poll_interval()
 
     logger.info("Waiting for Slurm controller to be ready...")
     logger.info("Max attempts: %d, Poll interval: %ds", max_attempts, poll_interval)
@@ -116,7 +128,7 @@ def wait_for_controller() -> None:
         )
 
         try:
-            result = subprocess.run(
+            result: subprocess.CompletedProcess[str] = subprocess.run(
                 ["scontrol", "ping", "--json"],
                 capture_output=True,
                 text=True,
@@ -124,8 +136,8 @@ def wait_for_controller() -> None:
             )
             if result.returncode == 0:
                 try:
-                    data = json.loads(result.stdout)
-                    pings = data.get("pings", [])
+                    data: Any = json.loads(result.stdout)
+                    pings: list[dict[str, Any]] = data.get("pings", [])
                     if pings and all(
                         p.get("responding") is True and p.get("pinged") == "UP"
                         for p in pings
@@ -147,7 +159,7 @@ def wait_for_controller() -> None:
                         result.stdout.strip(),
                     )
             else:
-                output = (result.stdout + result.stderr).strip()
+                output: str = (result.stdout + result.stderr).strip()
                 logger.warning("scontrol ping failed with output:\n%s", output)
         except subprocess.TimeoutExpired:
             logger.warning("scontrol ping timed out")
@@ -161,45 +173,48 @@ def wait_for_controller() -> None:
     sys.exit(1)
 
 
-# ============================================================
-# Topology functions
-# ============================================================
+# endregion Controller readiness functions
+
+# region Topology functions
 
 
 def get_node_name() -> str:
     """Get the Kubernetes node name from environment variable."""
-    node_name = os.environ["K8S_NODE_NAME"]
-    return node_name
+    return os.environ["K8S_NODE_NAME"]
 
 
-def get_topology_path() -> str:
+def get_topology_path() -> Path:
     """Get the path to the topology ConfigMap mount."""
-    return os.environ.get("TOPOLOGY_CONFIGMAP_PATH", "/tmp/slurm/topology-node-labels")
+    return Path(
+        os.environ.get("TOPOLOGY_CONFIGMAP_PATH", "/tmp/slurm/topology-node-labels")
+    )
 
 
 def get_topology_wait_timeout() -> int:
     """Get the maximum wait timeout in seconds."""
-    timeout = os.environ.get("TOPOLOGY_WAIT_TIMEOUT", "180")
-    return int(timeout)
+    return int(os.environ.get("TOPOLOGY_WAIT_TIMEOUT", "180"))
 
 
 def get_topology_poll_interval() -> int:
     """Get the poll interval in seconds."""
-    interval = os.environ.get("TOPOLOGY_POLL_INTERVAL", "5")
-    return int(interval)
+    return int(os.environ.get("TOPOLOGY_POLL_INTERVAL", "5"))
 
 
-def get_topology_plugin(slurm_conf_path: str = SLURM_CONF_PATH) -> str:
+def get_topology_plugin(slurm_conf_path: Path = SLURM_CONFIG_PATH) -> str:
     """Get the configured Slurm topology plugin."""
     topology_plugin = os.environ.get("TOPOLOGY_PLUGIN", "").strip()
     if topology_plugin:
         return topology_plugin.lower()
 
+    slurm_conf_path: Path = Path(slurm_conf_path)
     try:
-        with open(slurm_conf_path, "r") as f:
+        with slurm_conf_path.open("r") as f:
+            pattern: re.Pattern[str] = re.compile(
+                r"^TopologyPlugin\s*=\s*(\S+)", re.IGNORECASE
+            )
             for line in f:
-                line = line.split("#", 1)[0].strip()
-                match = re.match(r"^TopologyPlugin\s*=\s*(\S+)", line, re.IGNORECASE)
+                line: str = line.split("#", 1)[0].strip()
+                match: re.Match[str] | None = re.match(pattern, line)
                 if match:
                     return match.group(1).lower()
     except (IOError, OSError) as e:
@@ -208,28 +223,30 @@ def get_topology_plugin(slurm_conf_path: str = SLURM_CONF_PATH) -> str:
     return TOPOLOGY_PLUGIN_TREE
 
 
-def topology_conf_contains_hostname(topology_conf_path: str, hostname: str) -> bool:
+def topology_conf_contains_hostname(topology_conf_path: Path, hostname: str) -> bool:
     """Check whether topology.conf contains the given hostname in a nodes list."""
-    if not os.path.isfile(topology_conf_path):
+    topology_conf_path: Path = Path(topology_conf_path)
+    if not topology_conf_path.is_file():
         return False
 
     try:
-        with open(topology_conf_path, "r") as f:
-            content = f.read()
+        content: str = topology_conf_path.read_text()
     except (IOError, OSError) as e:
         logger.warning("Failed to read topology config %s: %s", topology_conf_path, e)
         return False
 
     # Match hostname as a full token separated by key/value, comma or whitespace boundaries.
-    pattern = rf"(^|[=,\s]){re.escape(hostname)}($|[,\s])"
-    return re.search(pattern, content, flags=re.MULTILINE) is not None
+    pattern: re.Pattern[str] = re.compile(
+        rf"(^|[=,\s]){re.escape(hostname)}($|[,\s])", re.MULTILINE
+    )
+    return re.search(pattern, content) is not None
 
 
 def wait_for_hostname_in_topology_conf(
     hostname: str,
     wait_timeout: int,
     poll_interval: int,
-    topology_conf_path: str = "/etc/slurm/topology.conf",
+    topology_conf_path: Path = SLURM_TOPOLOGY_CONFIG_PATH,
 ) -> None:
     """Wait until topology.conf contains hostname, otherwise exit on timeout."""
     logger.info(
@@ -239,9 +256,9 @@ def wait_for_hostname_in_topology_conf(
         wait_timeout,
         poll_interval,
     )
-    start_time = time.time()
+    start_time: float = time.monotonic()
     while True:
-        elapsed = time.time() - start_time
+        elapsed: float = time.monotonic() - start_time
         if elapsed >= wait_timeout:
             logger.error(
                 "Hostname %s not found in %s after %ds",
@@ -264,22 +281,21 @@ def wait_for_hostname_in_topology_conf(
         time.sleep(poll_interval)
 
 
-def read_topology_for_node(topology_path: str, node_name: str) -> str:
+def read_topology_for_node(topology_path: Path, node_name: str) -> str:
     """
     Read topology data for the given node from the ConfigMap.
 
     ConfigMap is mounted as a directory where each key is a file.
     Returns the topology string or "" if not found.
     """
-    node_file = os.path.join(topology_path, node_name)
+    node_file: Path = Path(topology_path) / node_name
 
-    if not os.path.isfile(node_file):
+    if not node_file.is_file():
         return ""
 
     try:
-        with open(node_file, "r") as f:
-            topology = f.read().strip()
-            return topology if topology else ""
+        topology: str = node_file.read_text().strip()
+        return topology if topology else ""
     except (IOError, OSError) as e:
         logger.warning("Failed to read topology file %s: %s", node_file, e)
         return ""
@@ -319,15 +335,17 @@ def format_slurm_topology(
     if not topology:
         return ""
 
-    topology = topology.strip()
-    topology_plugin = (topology_plugin or TOPOLOGY_PLUGIN_TREE).strip().lower()
-    block_topology = topology_plugin == TOPOLOGY_PLUGIN_BLOCK
+    topology: str = topology.strip()
+    topology_plugin: str = (topology_plugin or TOPOLOGY_PLUGIN_TREE).strip().lower()
+    block_topology: bool = topology_plugin == TOPOLOGY_PLUGIN_BLOCK
 
     if topology.startswith("{"):
         try:
-            parts = json.loads(topology)
+            parts: dict[str, str] = json.loads(topology)
+
             if block_topology:
                 return _format_block_topology(parts)
+
             return _format_tier_topology(parts)
         except json.JSONDecodeError:
             logger.warning("Failed to parse topology as JSON: %s", topology)
@@ -336,18 +354,23 @@ def format_slurm_topology(
     if ":" in topology and "=" not in topology:
         if block_topology:
             return f"topology={topology}"
-        colon_parts = topology.split(":")
+
+        colon_parts: list[str] = topology.split(":")
+
         # "name:leaf" -> add root: "topology=name:root:leaf"
         # "name:sw1:sw2:sw3" -> already has intermediates, keep as-is
         if len(colon_parts) == 2:
             return f"topology={colon_parts[0]}:root:{colon_parts[1]}"
+
         return f"topology={topology}"
 
     # If in format "tier-0=switch1,tier-1=rack1", build switch hierarchy
     if "=" in topology:
-        parts = _parse_key_value_topology(topology)
+        parts: dict[str, str] = _parse_key_value_topology(topology)
+
         if block_topology:
             return _format_block_topology(parts)
+
         return _format_tier_topology(parts)
 
     if block_topology:
@@ -356,18 +379,20 @@ def format_slurm_topology(
     return f"topology=default:root:{topology}"
 
 
-def _parse_key_value_topology(topology: str) -> dict:
+def _parse_key_value_topology(topology: str) -> dict[str, str]:
     """Parse comma-separated topology key/value pairs."""
-    parts = {}
+    parts: dict[str, str] = {}
+
     for item in topology.split(","):
-        item = item.strip()
+        item: str = item.strip()
         if "=" in item:
             key, value = item.split("=", 1)
             parts[key.strip()] = value.strip()
+
     return parts
 
 
-def _format_block_topology(parts: dict) -> str:
+def _format_block_topology(parts: dict[str, str]) -> str:
     """
     Format tier-based topology for topology/block.
 
@@ -377,7 +402,9 @@ def _format_block_topology(parts: dict) -> str:
     if not parts or not isinstance(parts, dict):
         return ""
 
-    block_name = parts.get("tier-0") or parts.get("block") or parts.get("BlockName")
+    block_name: str | None = (
+        parts.get("tier-0") or parts.get("block") or parts.get("BlockName")
+    )
     if not block_name:
         logger.warning("Failed to find tier-0 block name in topology data: %s", parts)
         return ""
@@ -385,7 +412,7 @@ def _format_block_topology(parts: dict) -> str:
     return f"topology=default:{block_name}"
 
 
-def _format_tier_topology(parts: dict) -> str:
+def _format_tier_topology(parts: dict[str, str]) -> str:
     """
     Format tier-based topology from a dictionary.
 
@@ -409,11 +436,11 @@ def _format_tier_topology(parts: dict) -> str:
         return ""
 
     # Find all tier keys and their numbers
-    tier_keys = []
+    tier_keys: list[tuple[int, str]] = []
     for k in parts.keys():
         if k.startswith("tier-"):
             try:
-                tier_num = int(k.split("-")[1])
+                tier_num: int = int(k.split("-")[1])
                 tier_keys.append((tier_num, k))
             except (ValueError, IndexError):
                 continue
@@ -421,11 +448,11 @@ def _format_tier_topology(parts: dict) -> str:
     if tier_keys:
         # Sort descending: highest tier first (spine/root-side), lowest last (leaf)
         tier_keys.sort(key=lambda x: x[0], reverse=True)
-        switches = [parts[k] for _, k in tier_keys]
+        switches: list[str] = [parts[k] for _, k in tier_keys]
         return f"topology=default:root:{':'.join(switches)}"
 
     if parts:
-        first_value = next(iter(parts.values()))
+        first_value: str = next(iter(parts.values()))
         return f"topology=default:root:{first_value}"
 
     return ""
@@ -434,7 +461,7 @@ def _format_tier_topology(parts: dict) -> str:
 def apply_node_topology(hostname: str, topology: str) -> None:
     """Apply topology to a node via scontrol update."""
     try:
-        node_addr = get_node_addr()
+        node_addr: str = get_node_addr()
         cmd = [
             "scontrol",
             "update",
@@ -446,14 +473,14 @@ def apply_node_topology(hostname: str, topology: str) -> None:
             "comment=",
         ]
         logger.info("Running: %s", " ".join(cmd))
-        result = subprocess.run(
+        result: subprocess.CompletedProcess[str] = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
             timeout=30,
         )
         if result.returncode != 0:
-            output = (result.stdout + result.stderr).strip()
+            output: str = (result.stdout + result.stderr).strip()
             if "Invalid node name" in output:
                 logger.warning(
                     "scontrol update: node %s not yet registered (dynamic node first start), skipping: %s",
@@ -487,17 +514,14 @@ def wait_for_topology() -> None:
     immediately assigns the node to the generic 'unknown' topology unit defined
     in topology.conf.
     """
-    hostname = get_hostname()
-    if not hostname:
-        logger.error("HOSTNAME environment variable is not set")
-        sys.exit(1)
+    hostname: str = get_from_env_required("HOSTNAME")
 
-    wait_timeout = get_topology_wait_timeout()
-    poll_interval = get_topology_poll_interval()
-    topology_plugin = get_topology_plugin()
+    wait_timeout: int = get_topology_wait_timeout()
+    poll_interval: int = get_topology_poll_interval()
+    topology_plugin: str = get_topology_plugin()
 
     if not is_gpu_enabled():
-        topology = "topology=default:root:unknown"
+        topology: str = "topology=default:root:unknown"
         if topology_plugin == TOPOLOGY_PLUGIN_BLOCK:
             topology = "topology=default:unknown"
 
@@ -511,27 +535,30 @@ def wait_for_topology() -> None:
         apply_node_topology(hostname, topology)
         return
 
-    node_name = get_node_name()
-    topology_path = get_topology_path()
+    node_name: str = get_node_name()
+    topology_path: Path = get_topology_path()
 
     logger.info("Waiting for topology data for node: %s", node_name)
     logger.info("Topology ConfigMap path: %s", topology_path)
     logger.info("Timeout: %ds, Poll interval: %ds", wait_timeout, poll_interval)
 
-    start_time = time.time()
-    raw_topology = ""
+    start_time: float = time.monotonic()
+    raw_topology: str = ""
 
     while True:
-        elapsed = time.time() - start_time
+        elapsed: float = time.monotonic() - start_time
 
         if elapsed >= wait_timeout:
             logger.error(
                 "Topology for node %s not found after %ds", node_name, wait_timeout
             )
             try:
-                if os.path.isdir(topology_path):
-                    files = os.listdir(topology_path)
-                    node_files = [f for f in files if not f.startswith(".")]
+                if topology_path.is_dir():
+                    node_files: list[str] = [
+                        path.name
+                        for path in topology_path.iterdir()
+                        if not path.name.startswith(".")
+                    ]
                     logger.error("Available nodes in ConfigMap: %s", node_files)
                 else:
                     logger.error("Topology ConfigMap not mounted at %s", topology_path)
@@ -543,15 +570,14 @@ def wait_for_topology() -> None:
                 )
             sys.exit(1)
 
-        if not os.path.isdir(topology_path):
+        if not topology_path.is_dir():
             logger.info(
                 "Waiting for ConfigMap to be mounted... (%ds elapsed)", int(elapsed)
             )
             time.sleep(poll_interval)
             continue
 
-        raw_topology = read_topology_for_node(topology_path, node_name)
-
+        raw_topology: str = read_topology_for_node(topology_path, node_name)
         if raw_topology:
             logger.info("Found topology for node %s: %s", node_name, raw_topology)
             break
@@ -563,7 +589,7 @@ def wait_for_topology() -> None:
         )
         time.sleep(poll_interval)
 
-    topology = format_slurm_topology(raw_topology, topology_plugin)
+    topology: str = format_slurm_topology(raw_topology, topology_plugin)
     if not topology:
         logger.error("Failed to format topology from raw data: %s", raw_topology)
         sys.exit(1)
@@ -572,8 +598,11 @@ def wait_for_topology() -> None:
     apply_node_topology(hostname, topology)
 
 
+# endregion Topology functions
+
+
 def main():
-    parser = argparse.ArgumentParser(
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description="Worker initialization tasks for Slurm",
     )
     parser.add_argument(
@@ -584,10 +613,12 @@ def main():
         "If both are specified, wait-controller is always executed first.",
     )
 
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
 
     # Ensure wait-controller always runs first
-    commands = sorted(args.commands, key=lambda c: 0 if c == "wait-controller" else 1)
+    commands: list[str] = sorted(
+        args.commands, key=lambda c: 0 if c == "wait-controller" else 1
+    )
 
     for cmd in commands:
         if cmd == "wait-controller":

--- a/images/worker/worker_init.py
+++ b/images/worker/worker_init.py
@@ -202,7 +202,7 @@ def get_topology_poll_interval() -> int:
 
 def get_topology_plugin(slurm_conf_path: Path = SLURM_CONFIG_PATH) -> str:
     """Get the configured Slurm topology plugin."""
-    topology_plugin = os.environ.get("TOPOLOGY_PLUGIN", "").strip()
+    topology_plugin: str = os.environ.get("SLURM_TOPOLOGY_PLUGIN", "").strip()
     if topology_plugin:
         return topology_plugin.lower()
 

--- a/images/worker/worker_init.py
+++ b/images/worker/worker_init.py
@@ -13,6 +13,7 @@ Environment Variables (wait-controller):
 Environment Variables (wait-topology):
     K8S_NODE_NAME: Kubernetes node name (required, from Downward API)
     TOPOLOGY_CONFIGMAP_PATH: Path to mounted ConfigMap (default: /tmp/slurm/topology-node-labels)
+    TOPOLOGY_PLUGIN: Slurm topology plugin override (default: read from slurm.conf)
     TOPOLOGY_WAIT_TIMEOUT: Max wait time in seconds (default: 180)
     TOPOLOGY_POLL_INTERVAL: Poll interval in seconds (default: 5)
 """
@@ -38,6 +39,9 @@ logger = logging.getLogger(__name__)
 # Constants
 SLURM_CONFIG_LINK_SOURCE = "/mnt/jail/etc/slurm"
 SLURM_CONFIG_LINK_TARGET = "/etc/slurm"
+SLURM_CONF_PATH = "/etc/slurm/slurm.conf"
+TOPOLOGY_PLUGIN_TREE = "topology/tree"
+TOPOLOGY_PLUGIN_BLOCK = "topology/block"
 
 
 # ============================================================
@@ -52,7 +56,12 @@ def create_slurm_config_symlink() -> None:
         SLURM_CONFIG_LINK_TARGET,
         SLURM_CONFIG_LINK_SOURCE,
     )
-    shutil.rmtree(SLURM_CONFIG_LINK_TARGET)
+    if os.path.islink(SLURM_CONFIG_LINK_TARGET) or os.path.isfile(
+        SLURM_CONFIG_LINK_TARGET
+    ):
+        os.unlink(SLURM_CONFIG_LINK_TARGET)
+    elif os.path.isdir(SLURM_CONFIG_LINK_TARGET):
+        shutil.rmtree(SLURM_CONFIG_LINK_TARGET)
     os.symlink(SLURM_CONFIG_LINK_SOURCE, SLURM_CONFIG_LINK_TARGET)
 
 
@@ -72,17 +81,19 @@ def get_hostname() -> str:
 
 
 def get_node_addr() -> str:
-    """Construct the NodeAddr for scontrol update based on environment variables.""" 
+    """Construct the NodeAddr for scontrol update based on environment variables."""
     pod_name = os.environ.get("K8S_POD_NAME")
     logger.info("Using K8S_POD_NAME=%s for NodeAddr construction", pod_name)
-    service_name = os.environ.get("K8S_SERVICE_NAME") 
+    service_name = os.environ.get("K8S_SERVICE_NAME")
     logger.info("Using K8S_SERVICE_NAME=%s for NodeAddr construction", service_name)
-    pod_namespace = os.environ.get("K8S_POD_NAMESPACE") 
+    pod_namespace = os.environ.get("K8S_POD_NAMESPACE")
     logger.info("Using K8S_POD_NAMESPACE=%s for NodeAddr construction", pod_namespace)
-    if not pod_name or not service_name or not pod_namespace: 
-        logger.error( "Environment variables K8S_POD_NAME, K8S_SERVICE_NAME, and K8S_POD_NAMESPACE must be set" ) 
-        sys.exit(1) 
-    node_addr = f"nodeaddr={pod_name}.{service_name}.{pod_namespace}.svc" 
+    if not pod_name or not service_name or not pod_namespace:
+        logger.error(
+            "Environment variables K8S_POD_NAME, K8S_SERVICE_NAME, and K8S_POD_NAMESPACE must be set"
+        )
+        sys.exit(1)
+    node_addr = f"nodeaddr={pod_name}.{service_name}.{pod_namespace}.svc"
     return node_addr
 
 
@@ -146,9 +157,7 @@ def wait_for_controller() -> None:
 
         time.sleep(poll_interval)
 
-    logger.error(
-        "Controller did not become ready after %d attempts", max_attempts
-    )
+    logger.error("Controller did not become ready after %d attempts", max_attempts)
     sys.exit(1)
 
 
@@ -180,6 +189,25 @@ def get_topology_poll_interval() -> int:
     return int(interval)
 
 
+def get_topology_plugin(slurm_conf_path: str = SLURM_CONF_PATH) -> str:
+    """Get the configured Slurm topology plugin."""
+    topology_plugin = os.environ.get("TOPOLOGY_PLUGIN", "").strip()
+    if topology_plugin:
+        return topology_plugin.lower()
+
+    try:
+        with open(slurm_conf_path, "r") as f:
+            for line in f:
+                line = line.split("#", 1)[0].strip()
+                match = re.match(r"^TopologyPlugin\s*=\s*(\S+)", line, re.IGNORECASE)
+                if match:
+                    return match.group(1).lower()
+    except (IOError, OSError) as e:
+        logger.info("Failed to read topology plugin from %s: %s", slurm_conf_path, e)
+
+    return TOPOLOGY_PLUGIN_TREE
+
+
 def topology_conf_contains_hostname(topology_conf_path: str, hostname: str) -> bool:
     """Check whether topology.conf contains the given hostname in a nodes list."""
     if not os.path.isfile(topology_conf_path):
@@ -198,7 +226,10 @@ def topology_conf_contains_hostname(topology_conf_path: str, hostname: str) -> b
 
 
 def wait_for_hostname_in_topology_conf(
-    hostname: str, wait_timeout: int, poll_interval: int, topology_conf_path: str = "/etc/slurm/topology.conf"
+    hostname: str,
+    wait_timeout: int,
+    poll_interval: int,
+    topology_conf_path: str = "/etc/slurm/topology.conf",
 ) -> None:
     """Wait until topology.conf contains hostname, otherwise exit on timeout."""
     logger.info(
@@ -253,17 +284,26 @@ def read_topology_for_node(topology_path: str, node_name: str) -> str:
         logger.warning("Failed to read topology file %s: %s", node_file, e)
         return ""
 
-def format_slurm_topology(topology: str) -> str:
+
+def format_slurm_topology(
+    topology: str, topology_plugin: str = TOPOLOGY_PLUGIN_TREE
+) -> str:
     """
     Format topology string for Slurm --conf option.
 
-    Input formats:
+    Input formats for topology/tree:
       - JSON: '{"tier-1":"switch1","tier-2":"rack1"}' -> "topology=default:root:rack1:switch1"
         (builds full switch hierarchy: highest tier first, leaf last)
       - "default:switch1" -> "topology=default:root:switch1"
       - "default:sw_root:s1:s2" -> "topology=default:sw_root:s1:s2" (intermediate switches already present)
       - "tier-0=block1,tier-1=rack1" -> "topology=default:root:rack1:block1"
       - "switch1" -> "topology=default:root:switch1"
+
+    Input formats for topology/block:
+      - JSON: '{"tier-0":"block1","tier-1":"rack1"}' -> "topology=default:block1"
+      - "tier-0=block1,tier-1=rack1" -> "topology=default:block1"
+      - "default:block1" -> "topology=default:block1"
+      - "block1" -> "topology=default:block1"
 
     Slurm dynamic topology format: topology=<name>:<switch_near_root>:...<leaf_switch>
     Tiers are sorted descending so that the highest tier (closest to root/spine) comes
@@ -280,16 +320,22 @@ def format_slurm_topology(topology: str) -> str:
         return ""
 
     topology = topology.strip()
+    topology_plugin = (topology_plugin or TOPOLOGY_PLUGIN_TREE).strip().lower()
+    block_topology = topology_plugin == TOPOLOGY_PLUGIN_BLOCK
 
     if topology.startswith("{"):
         try:
             parts = json.loads(topology)
+            if block_topology:
+                return _format_block_topology(parts)
             return _format_tier_topology(parts)
         except json.JSONDecodeError:
             logger.warning("Failed to parse topology as JSON: %s", topology)
 
     # If already in format "name:switch" or "name:sw1:sw2:sw3", use as-is
     if ":" in topology and "=" not in topology:
+        if block_topology:
+            return f"topology={topology}"
         colon_parts = topology.split(":")
         # "name:leaf" -> add root: "topology=name:root:leaf"
         # "name:sw1:sw2:sw3" -> already has intermediates, keep as-is
@@ -299,15 +345,44 @@ def format_slurm_topology(topology: str) -> str:
 
     # If in format "tier-0=switch1,tier-1=rack1", build switch hierarchy
     if "=" in topology:
-        parts = {}
-        for item in topology.split(","):
-            item = item.strip()
-            if "=" in item:
-                key, value = item.split("=", 1)
-                parts[key.strip()] = value.strip()
+        parts = _parse_key_value_topology(topology)
+        if block_topology:
+            return _format_block_topology(parts)
         return _format_tier_topology(parts)
 
+    if block_topology:
+        return f"topology=default:{topology}"
+
     return f"topology=default:root:{topology}"
+
+
+def _parse_key_value_topology(topology: str) -> dict:
+    """Parse comma-separated topology key/value pairs."""
+    parts = {}
+    for item in topology.split(","):
+        item = item.strip()
+        if "=" in item:
+            key, value = item.split("=", 1)
+            parts[key.strip()] = value.strip()
+    return parts
+
+
+def _format_block_topology(parts: dict) -> str:
+    """
+    Format tier-based topology for topology/block.
+
+    For block topology the dynamic topology unit is the block name, so the
+    node must join tier-0 directly instead of a tree path through higher tiers.
+    """
+    if not parts or not isinstance(parts, dict):
+        return ""
+
+    block_name = parts.get("tier-0") or parts.get("block") or parts.get("BlockName")
+    if not block_name:
+        logger.warning("Failed to find tier-0 block name in topology data: %s", parts)
+        return ""
+
+    return f"topology=default:{block_name}"
 
 
 def _format_tier_topology(parts: dict) -> str:
@@ -355,14 +430,20 @@ def _format_tier_topology(parts: dict) -> str:
 
     return ""
 
+
 def apply_node_topology(hostname: str, topology: str) -> None:
     """Apply topology to a node via scontrol update."""
     try:
         node_addr = get_node_addr()
         cmd = [
-            "scontrol", "update",
-            f"nodename={hostname}", f"{node_addr}", f"{topology}",
-            "state=UNDRAIN", "reason=", "comment=",
+            "scontrol",
+            "update",
+            f"nodename={hostname}",
+            f"{node_addr}",
+            f"{topology}",
+            "state=UNDRAIN",
+            "reason=",
+            "comment=",
         ]
         logger.info("Running: %s", " ".join(cmd))
         result = subprocess.run(
@@ -380,7 +461,9 @@ def apply_node_topology(hostname: str, topology: str) -> None:
                     output,
                 )
                 return
-            logger.error("scontrol update failed (rc=%d): %s", result.returncode, output)
+            logger.error(
+                "scontrol update failed (rc=%d): %s", result.returncode, output
+            )
             sys.exit(1)
 
         logger.info("Topology applied successfully for worker %s", hostname)
@@ -391,6 +474,7 @@ def apply_node_topology(hostname: str, topology: str) -> None:
         logger.error("scontrol command not found")
         sys.exit(1)
 
+
 def is_gpu_enabled() -> bool:
     """Return True if NODESET_GPU_ENABLED is set to 'true'."""
     return os.environ.get("NODESET_GPU_ENABLED", "") == "true"
@@ -400,7 +484,8 @@ def wait_for_topology() -> None:
     """Wait for topology data to become available for this node, then apply it via scontrol.
 
     For non-GPU nodes (NODESET_GPU_ENABLED != 'true'), skips ConfigMap lookup and
-    immediately assigns the node to the generic 'unknown' switch defined in topology.conf.
+    immediately assigns the node to the generic 'unknown' topology unit defined
+    in topology.conf.
     """
     hostname = get_hostname()
     if not hostname:
@@ -409,13 +494,21 @@ def wait_for_topology() -> None:
 
     wait_timeout = get_topology_wait_timeout()
     poll_interval = get_topology_poll_interval()
+    topology_plugin = get_topology_plugin()
 
     if not is_gpu_enabled():
+        topology = "topology=default:root:unknown"
+        if topology_plugin == TOPOLOGY_PLUGIN_BLOCK:
+            topology = "topology=default:unknown"
+
         logger.info(
             "NODESET_GPU_ENABLED is not set to 'true', "
-            "assigning node %s to default:root:unknown topology", hostname
+            "assigning node %s to %s topology",
+            hostname,
+            topology,
         )
-        apply_node_topology(hostname, "topology=default:root:unknown")
+        wait_for_hostname_in_topology_conf(hostname, wait_timeout, poll_interval)
+        apply_node_topology(hostname, topology)
         return
 
     node_name = get_node_name()
@@ -470,7 +563,7 @@ def wait_for_topology() -> None:
         )
         time.sleep(poll_interval)
 
-    topology = format_slurm_topology(raw_topology)
+    topology = format_slurm_topology(raw_topology, topology_plugin)
     if not topology:
         logger.error("Failed to format topology from raw data: %s", raw_topology)
         sys.exit(1)

--- a/images/worker/worker_init.py
+++ b/images/worker/worker_init.py
@@ -235,11 +235,143 @@ def topology_conf_contains_hostname(topology_conf_path: Path, hostname: str) -> 
         logger.warning("Failed to read topology config %s: %s", topology_conf_path, e)
         return False
 
-    # Match hostname as a full token separated by key/value, comma or whitespace boundaries.
-    pattern: re.Pattern[str] = re.compile(
-        rf"(^|[=,\s]){re.escape(hostname)}($|[,\s])", re.MULTILINE
+    return any(
+        nodes == "ALL" or _slurm_hostlist_contains(nodes, hostname)
+        for nodes in _topology_nodes_values(content)
     )
-    return re.search(pattern, content) is not None
+
+
+def _topology_nodes_values(content: str) -> list[str]:
+    """Extract Nodes= values from topology.conf content."""
+    values: list[str] = []
+    pattern: re.Pattern[str] = re.compile(r"(?:^|\s)Nodes=(\S+)")
+
+    for raw_line in content.splitlines():
+        line: str = raw_line.split("#", 1)[0].strip()
+        match: re.Match[str] | None = pattern.search(line)
+        if match:
+            values.append(match.group(1))
+
+    return values
+
+
+def _slurm_hostlist_contains(hostlist: str, hostname: str) -> bool:
+    """Return True when a Slurm hostlist expression contains hostname."""
+    return any(
+        _slurm_hostlist_token_contains(token, hostname)
+        for token in _split_slurm_hostlist(hostlist)
+    )
+
+
+def _split_slurm_hostlist(hostlist: str) -> list[str]:
+    """Split a Slurm hostlist on commas, ignoring commas inside brackets."""
+    tokens: list[str] = []
+    start: int = 0
+    bracket_depth: int = 0
+
+    for index, char in enumerate(hostlist):
+        if char == "[":
+            bracket_depth += 1
+        elif char == "]" and bracket_depth > 0:
+            bracket_depth -= 1
+        elif char == "," and bracket_depth == 0:
+            token: str = hostlist[start:index].strip()
+            if token:
+                tokens.append(token)
+            start = index + 1
+
+    token: str = hostlist[start:].strip()
+    if token:
+        tokens.append(token)
+
+    return tokens
+
+
+def _slurm_hostlist_token_contains(token: str, hostname: str) -> bool:
+    """Return True when one Slurm hostlist token contains hostname."""
+    bracket_start: int = token.find("[")
+    if bracket_start == -1:
+        return token == hostname
+
+    bracket_end: int = token.find("]", bracket_start)
+    if bracket_end == -1:
+        return token == hostname
+
+    prefix: str = token[:bracket_start]
+    suffix: str = token[bracket_end + 1 :]
+    if not hostname.startswith(prefix):
+        return False
+
+    remainder: str = hostname[len(prefix) :]
+    return any(
+        _slurm_hostlist_range_contains(part.strip(), suffix, remainder)
+        for part in token[bracket_start + 1 : bracket_end].split(",")
+        if part.strip()
+    )
+
+
+def _slurm_hostlist_range_contains(part: str, suffix: str, remainder: str) -> bool:
+    """Return True when one bracket item can match the hostname remainder."""
+    if "-" in part:
+        start_value, end_value = part.split("-", 1)
+    else:
+        start_value = end_value = part
+
+    if start_value.isdigit() and end_value.isdigit():
+        return _slurm_numeric_range_contains(
+            start_value,
+            end_value,
+            suffix,
+            remainder,
+        )
+
+    return remainder.startswith(part) and _slurm_hostlist_token_contains(
+        suffix,
+        remainder[len(part) :],
+    )
+
+
+def _slurm_numeric_range_contains(
+    start_value: str,
+    end_value: str,
+    suffix: str,
+    remainder: str,
+) -> bool:
+    """Return True when a numeric hostlist range can match hostname remainder."""
+    start: int = int(start_value)
+    end: int = int(end_value)
+    if start > end:
+        return False
+
+    padded_width: int = 0
+    if start_value.startswith("0") or end_value.startswith("0"):
+        padded_width = max(len(start_value), len(end_value))
+
+    if padded_width > 0:
+        candidate: str = remainder[:padded_width]
+        if len(candidate) != padded_width or not candidate.isdigit():
+            return False
+        return start <= int(candidate) <= end and _slurm_hostlist_token_contains(
+            suffix, remainder[padded_width:]
+        )
+
+    digit_count: int = 0
+    for char in remainder:
+        if not char.isdigit():
+            break
+        digit_count += 1
+
+    for length in range(1, digit_count + 1):
+        candidate = remainder[:length]
+        if len(candidate) > 1 and candidate.startswith("0"):
+            continue
+        if start <= int(candidate) <= end and _slurm_hostlist_token_contains(
+            suffix,
+            remainder[length:],
+        ):
+            return True
+
+    return False
 
 
 def wait_for_hostname_in_topology_conf(

--- a/images/worker/worker_init_test.py
+++ b/images/worker/worker_init_test.py
@@ -70,9 +70,7 @@ class TestFormatSlurmTopology(unittest.TestCase):
 
     def test_tier_format_with_spaces(self):
         """Tier format with spaces is handled correctly."""
-        result = worker_init.format_slurm_topology(
-            "tier-1 = leaf01 , tier-2 = spine01"
-        )
+        result = worker_init.format_slurm_topology("tier-1 = leaf01 , tier-2 = spine01")
         self.assertEqual(result, "topology=default:root:spine01:leaf01")
 
     def test_tier_format_unordered(self):
@@ -89,7 +87,10 @@ class TestFormatSlurmTopology(unittest.TestCase):
             '{"tier-1":"4dcbe855beb5ce19f484ba1a8960929d","tier-2":"5df641bb92d51e0dd5d97037fc7e2971"}'
         )
         # tier-2 (spine) first, tier-1 (leaf) last
-        self.assertEqual(result, "topology=default:root:5df641bb92d51e0dd5d97037fc7e2971:4dcbe855beb5ce19f484ba1a8960929d")
+        self.assertEqual(
+            result,
+            "topology=default:root:5df641bb92d51e0dd5d97037fc7e2971:4dcbe855beb5ce19f484ba1a8960929d",
+        )
 
     def test_json_format_single_tier(self):
         """JSON format with single tier is parsed correctly."""
@@ -119,6 +120,46 @@ class TestFormatSlurmTopology(unittest.TestCase):
         # tier-1 (rack/leaf-switch) first, tier-0 (NVL domain) last
         self.assertEqual(result, "topology=default:root:leaf01:nvl0")
 
+    def test_json_format_block_topology_uses_tier_zero(self):
+        """JSON format in block mode uses tier-0 as the block name."""
+        result = worker_init.format_slurm_topology(
+            '{"tier-0":"block1","tier-1":"leaf01","tier-2":"spine01"}',
+            worker_init.TOPOLOGY_PLUGIN_BLOCK,
+        )
+        self.assertEqual(result, "topology=default:block1")
+
+    def test_tier_format_block_topology_uses_tier_zero(self):
+        """Key/value format in block mode uses tier-0 as the block name."""
+        result = worker_init.format_slurm_topology(
+            "tier-0=block1,tier-1=leaf01,tier-2=spine01",
+            worker_init.TOPOLOGY_PLUGIN_BLOCK,
+        )
+        self.assertEqual(result, "topology=default:block1")
+
+    def test_named_block_topology_preserves_topology_name(self):
+        """Block topology with an explicit topology name is preserved."""
+        result = worker_init.format_slurm_topology(
+            "default:block1",
+            worker_init.TOPOLOGY_PLUGIN_BLOCK,
+        )
+        self.assertEqual(result, "topology=default:block1")
+
+    def test_simple_block_topology_name(self):
+        """Simple block name gets the default topology name."""
+        result = worker_init.format_slurm_topology(
+            "block1",
+            worker_init.TOPOLOGY_PLUGIN_BLOCK,
+        )
+        self.assertEqual(result, "topology=default:block1")
+
+    def test_block_topology_requires_tier_zero_for_structured_data(self):
+        """Structured block data without tier-0 is rejected."""
+        result = worker_init.format_slurm_topology(
+            '{"tier-1":"leaf01"}',
+            worker_init.TOPOLOGY_PLUGIN_BLOCK,
+        )
+        self.assertEqual(result, "")
+
 
 class TestFormatTierTopology(unittest.TestCase):
     """Tests for _format_tier_topology internal function."""
@@ -140,72 +181,64 @@ class TestFormatTierTopology(unittest.TestCase):
 
     def test_two_tiers_builds_hierarchy(self):
         """Two tiers builds full hierarchy: spine first, leaf last."""
-        result = worker_init._format_tier_topology({
-            "tier-1": "leaf01",
-            "tier-2": "spine01"
-        })
+        result = worker_init._format_tier_topology(
+            {"tier-1": "leaf01", "tier-2": "spine01"}
+        )
         self.assertEqual(result, "topology=default:root:spine01:leaf01")
 
     def test_tier_zero_included_as_leaf(self):
         """tier-0 is included as the innermost switch (leaf/block domain)."""
-        result = worker_init._format_tier_topology({
-            "tier-0": "nvl0",
-            "tier-1": "leaf01",
-            "tier-2": "spine01"
-        })
+        result = worker_init._format_tier_topology(
+            {"tier-0": "nvl0", "tier-1": "leaf01", "tier-2": "spine01"}
+        )
         self.assertEqual(result, "topology=default:root:spine01:leaf01:nvl0")
 
     def test_three_tiers_builds_hierarchy(self):
         """Three tiers builds full path from fabric to leaf."""
-        result = worker_init._format_tier_topology({
-            "tier-1": "leaf01",
-            "tier-2": "spine01",
-            "tier-3": "fabric01"
-        })
+        result = worker_init._format_tier_topology(
+            {"tier-1": "leaf01", "tier-2": "spine01", "tier-3": "fabric01"}
+        )
         self.assertEqual(result, "topology=default:root:fabric01:spine01:leaf01")
 
     def test_unordered_tier_keys(self):
         """Tier keys in any order produce the same sorted hierarchy."""
-        result = worker_init._format_tier_topology({
-            "tier-3": "fabric01",
-            "tier-1": "leaf01",
-            "tier-2": "spine01"
-        })
+        result = worker_init._format_tier_topology(
+            {"tier-3": "fabric01", "tier-1": "leaf01", "tier-2": "spine01"}
+        )
         self.assertEqual(result, "topology=default:root:fabric01:spine01:leaf01")
 
     def test_non_tier_keys_ignored(self):
         """Non-tier keys are ignored, tier keys used."""
-        result = worker_init._format_tier_topology({
-            "other": "value",
-            "tier-1": "leaf01",
-            "name": "test"
-        })
+        result = worker_init._format_tier_topology(
+            {"other": "value", "tier-1": "leaf01", "name": "test"}
+        )
         self.assertEqual(result, "topology=default:root:leaf01")
 
     def test_only_non_tier_keys_uses_first_value(self):
         """Only non-tier keys uses first value as fallback."""
-        result = worker_init._format_tier_topology({
-            "switch": "sw1",
-            "rack": "r1"
-        })
+        result = worker_init._format_tier_topology({"switch": "sw1", "rack": "r1"})
         self.assertEqual(result, "topology=default:root:sw1")
 
     def test_invalid_tier_format_ignored(self):
         """Invalid tier format keys are ignored."""
-        result = worker_init._format_tier_topology({
-            "tier-abc": "invalid",
-            "tier-1": "leaf01"
-        })
+        result = worker_init._format_tier_topology(
+            {"tier-abc": "invalid", "tier-1": "leaf01"}
+        )
         self.assertEqual(result, "topology=default:root:leaf01")
 
     def test_tier_with_hash_value(self):
         """Tier with hash value (real ConfigMap data) builds full hierarchy."""
-        result = worker_init._format_tier_topology({
-            "tier-1": "4dcbe855beb5ce19f484ba1a8960929d",
-            "tier-2": "5df641bb92d51e0dd5d97037fc7e2971"
-        })
+        result = worker_init._format_tier_topology(
+            {
+                "tier-1": "4dcbe855beb5ce19f484ba1a8960929d",
+                "tier-2": "5df641bb92d51e0dd5d97037fc7e2971",
+            }
+        )
         # tier-2 (spine) first, tier-1 (leaf) last
-        self.assertEqual(result, "topology=default:root:5df641bb92d51e0dd5d97037fc7e2971:4dcbe855beb5ce19f484ba1a8960929d")
+        self.assertEqual(
+            result,
+            "topology=default:root:5df641bb92d51e0dd5d97037fc7e2971:4dcbe855beb5ce19f484ba1a8960929d",
+        )
 
 
 class TestReadTopologyForNode(unittest.TestCase):
@@ -218,6 +251,7 @@ class TestReadTopologyForNode(unittest.TestCase):
     def tearDown(self):
         """Clean up temporary directory."""
         import shutil
+
         shutil.rmtree(self.temp_dir)
 
     def test_read_existing_node(self):
@@ -334,6 +368,36 @@ class TestGetEnvironmentVariables(unittest.TestCase):
             result = worker_init.get_topology_poll_interval()
         self.assertEqual(result, 10)
 
+    def test_get_topology_plugin_env_override(self):
+        """Topology plugin can be supplied by environment variable."""
+        with mock.patch.dict(
+            os.environ,
+            {"TOPOLOGY_PLUGIN": worker_init.TOPOLOGY_PLUGIN_BLOCK},
+        ):
+            result = worker_init.get_topology_plugin("/missing/slurm.conf")
+        self.assertEqual(result, worker_init.TOPOLOGY_PLUGIN_BLOCK)
+
+    def test_get_topology_plugin_from_slurm_conf(self):
+        """Topology plugin is read from slurm.conf when env is not set."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            slurm_conf = os.path.join(temp_dir, "slurm.conf")
+            with open(slurm_conf, "w") as f:
+                f.write("# comment\nTopologyPlugin = topology/block # inline\n")
+
+            env = os.environ.copy()
+            env.pop("TOPOLOGY_PLUGIN", None)
+            with mock.patch.dict(os.environ, env, clear=True):
+                result = worker_init.get_topology_plugin(slurm_conf)
+        self.assertEqual(result, worker_init.TOPOLOGY_PLUGIN_BLOCK)
+
+    def test_get_topology_plugin_defaults_to_tree(self):
+        """Missing slurm.conf defaults to topology/tree."""
+        env = os.environ.copy()
+        env.pop("TOPOLOGY_PLUGIN", None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = worker_init.get_topology_plugin("/missing/slurm.conf")
+        self.assertEqual(result, worker_init.TOPOLOGY_PLUGIN_TREE)
+
     def test_get_controller_max_attempts_default(self):
         """Get controller max attempts returns default when not set."""
         env = os.environ.copy()
@@ -376,12 +440,14 @@ class TestCreateSlurmConfigSymlink(unittest.TestCase):
     def tearDown(self):
         """Clean up temporary directories."""
         import shutil
+
         shutil.rmtree(self.temp_dir)
 
     def test_create_symlink_no_existing_target(self):
         """Creates symlink when target does not exist."""
-        with mock.patch.object(worker_init, "SLURM_CONFIG_LINK_SOURCE", self.source), \
-             mock.patch.object(worker_init, "SLURM_CONFIG_LINK_TARGET", self.target):
+        with mock.patch.object(
+            worker_init, "SLURM_CONFIG_LINK_SOURCE", self.source
+        ), mock.patch.object(worker_init, "SLURM_CONFIG_LINK_TARGET", self.target):
             worker_init.create_slurm_config_symlink()
 
         self.assertTrue(os.path.islink(self.target))
@@ -391,8 +457,9 @@ class TestCreateSlurmConfigSymlink(unittest.TestCase):
         """Replaces existing symlink at target."""
         os.symlink("/some/old/path", self.target)
 
-        with mock.patch.object(worker_init, "SLURM_CONFIG_LINK_SOURCE", self.source), \
-             mock.patch.object(worker_init, "SLURM_CONFIG_LINK_TARGET", self.target):
+        with mock.patch.object(
+            worker_init, "SLURM_CONFIG_LINK_SOURCE", self.source
+        ), mock.patch.object(worker_init, "SLURM_CONFIG_LINK_TARGET", self.target):
             worker_init.create_slurm_config_symlink()
 
         self.assertTrue(os.path.islink(self.target))
@@ -405,8 +472,9 @@ class TestCreateSlurmConfigSymlink(unittest.TestCase):
         with open(os.path.join(self.target, "test.conf"), "w") as f:
             f.write("test")
 
-        with mock.patch.object(worker_init, "SLURM_CONFIG_LINK_SOURCE", self.source), \
-             mock.patch.object(worker_init, "SLURM_CONFIG_LINK_TARGET", self.target):
+        with mock.patch.object(
+            worker_init, "SLURM_CONFIG_LINK_SOURCE", self.source
+        ), mock.patch.object(worker_init, "SLURM_CONFIG_LINK_TARGET", self.target):
             worker_init.create_slurm_config_symlink()
 
         self.assertTrue(os.path.islink(self.target))
@@ -416,23 +484,48 @@ class TestCreateSlurmConfigSymlink(unittest.TestCase):
 class TestWaitForController(unittest.TestCase):
     """Tests for wait_for_controller function."""
 
-    _PING_UP_JSON = json.dumps({
-        "pings": [{"hostname": "controller-0", "pinged": "UP", "responding": True, "mode": "primary"}],
-        "errors": [], "warnings": [],
-    })
+    _PING_UP_JSON = json.dumps(
+        {
+            "pings": [
+                {
+                    "hostname": "controller-0",
+                    "pinged": "UP",
+                    "responding": True,
+                    "mode": "primary",
+                }
+            ],
+            "errors": [],
+            "warnings": [],
+        }
+    )
 
-    _PING_DOWN_JSON = json.dumps({
-        "pings": [{"hostname": "controller-0", "pinged": "DOWN", "responding": False, "mode": "primary"}],
-        "errors": [], "warnings": [],
-    })
+    _PING_DOWN_JSON = json.dumps(
+        {
+            "pings": [
+                {
+                    "hostname": "controller-0",
+                    "pinged": "DOWN",
+                    "responding": False,
+                    "mode": "primary",
+                }
+            ],
+            "errors": [],
+            "warnings": [],
+        }
+    )
 
     @mock.patch("worker_init.create_slurm_config_symlink")
     @mock.patch("subprocess.run")
     def test_controller_ready_immediately(self, mock_run, mock_symlink):
         """Controller is ready on first attempt."""
-        mock_run.return_value = mock.Mock(returncode=0, stdout=self._PING_UP_JSON, stderr="")
+        mock_run.return_value = mock.Mock(
+            returncode=0, stdout=self._PING_UP_JSON, stderr=""
+        )
 
-        with mock.patch.dict(os.environ, {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"}):
+        with mock.patch.dict(
+            os.environ,
+            {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"},
+        ):
             worker_init.wait_for_controller()
 
         mock_symlink.assert_called_once()
@@ -449,7 +542,10 @@ class TestWaitForController(unittest.TestCase):
             mock.Mock(returncode=0, stdout=self._PING_UP_JSON, stderr=""),
         ]
 
-        with mock.patch.dict(os.environ, {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "1"}):
+        with mock.patch.dict(
+            os.environ,
+            {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "1"},
+        ):
             worker_init.wait_for_controller()
 
         self.assertEqual(mock_run.call_count, 3)
@@ -458,14 +554,19 @@ class TestWaitForController(unittest.TestCase):
     @mock.patch("worker_init.create_slurm_config_symlink")
     @mock.patch("subprocess.run")
     @mock.patch("time.sleep")
-    def test_controller_not_responding_retries(self, mock_sleep, mock_run, mock_symlink):
+    def test_controller_not_responding_retries(
+        self, mock_sleep, mock_run, mock_symlink
+    ):
         """Controller returns JSON but responding=false, retries until ready."""
         mock_run.side_effect = [
             mock.Mock(returncode=0, stdout=self._PING_DOWN_JSON, stderr=""),
             mock.Mock(returncode=0, stdout=self._PING_UP_JSON, stderr=""),
         ]
 
-        with mock.patch.dict(os.environ, {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"}):
+        with mock.patch.dict(
+            os.environ,
+            {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"},
+        ):
             worker_init.wait_for_controller()
 
         self.assertEqual(mock_run.call_count, 2)
@@ -480,7 +581,10 @@ class TestWaitForController(unittest.TestCase):
             mock.Mock(returncode=0, stdout=self._PING_UP_JSON, stderr=""),
         ]
 
-        with mock.patch.dict(os.environ, {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"}):
+        with mock.patch.dict(
+            os.environ,
+            {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"},
+        ):
             worker_init.wait_for_controller()
 
         self.assertEqual(mock_run.call_count, 2)
@@ -490,9 +594,14 @@ class TestWaitForController(unittest.TestCase):
     @mock.patch("time.sleep")
     def test_controller_timeout(self, mock_sleep, mock_run, mock_symlink):
         """Controller does not become ready within max attempts."""
-        mock_run.return_value = mock.Mock(returncode=1, stdout="", stderr="connection refused")
+        mock_run.return_value = mock.Mock(
+            returncode=1, stdout="", stderr="connection refused"
+        )
 
-        with mock.patch.dict(os.environ, {"CONTROLLER_MAX_ATTEMPTS": "3", "CONTROLLER_POLL_INTERVAL": "0"}):
+        with mock.patch.dict(
+            os.environ,
+            {"CONTROLLER_MAX_ATTEMPTS": "3", "CONTROLLER_POLL_INTERVAL": "0"},
+        ):
             with self.assertRaises(SystemExit) as ctx:
                 worker_init.wait_for_controller()
             self.assertEqual(ctx.exception.code, 1)
@@ -505,7 +614,10 @@ class TestWaitForController(unittest.TestCase):
         """scontrol command not found exits immediately."""
         mock_run.side_effect = FileNotFoundError("scontrol not found")
 
-        with mock.patch.dict(os.environ, {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"}):
+        with mock.patch.dict(
+            os.environ,
+            {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"},
+        ):
             with self.assertRaises(SystemExit) as ctx:
                 worker_init.wait_for_controller()
             self.assertEqual(ctx.exception.code, 1)
@@ -516,12 +628,16 @@ class TestWaitForController(unittest.TestCase):
     def test_controller_ping_timeout(self, mock_sleep, mock_run, mock_symlink):
         """scontrol ping times out but retries."""
         import subprocess
+
         mock_run.side_effect = [
             subprocess.TimeoutExpired(cmd="scontrol", timeout=30),
             mock.Mock(returncode=0, stdout=self._PING_UP_JSON, stderr=""),
         ]
 
-        with mock.patch.dict(os.environ, {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"}):
+        with mock.patch.dict(
+            os.environ,
+            {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"},
+        ):
             worker_init.wait_for_controller()
 
         self.assertEqual(mock_run.call_count, 2)
@@ -529,28 +645,39 @@ class TestWaitForController(unittest.TestCase):
     @mock.patch("worker_init.create_slurm_config_symlink")
     @mock.patch("subprocess.run")
     @mock.patch("time.sleep")
-    def test_controller_multiple_pings_all_must_be_up(self, mock_sleep, mock_run, mock_symlink):
+    def test_controller_multiple_pings_all_must_be_up(
+        self, mock_sleep, mock_run, mock_symlink
+    ):
         """All controllers in pings array must be UP and responding."""
-        partial_json = json.dumps({
-            "pings": [
-                {"hostname": "ctrl-0", "pinged": "UP", "responding": True},
-                {"hostname": "ctrl-1", "pinged": "DOWN", "responding": False},
-            ],
-            "errors": [], "warnings": [],
-        })
-        all_up_json = json.dumps({
-            "pings": [
-                {"hostname": "ctrl-0", "pinged": "UP", "responding": True},
-                {"hostname": "ctrl-1", "pinged": "UP", "responding": True},
-            ],
-            "errors": [], "warnings": [],
-        })
+        partial_json = json.dumps(
+            {
+                "pings": [
+                    {"hostname": "ctrl-0", "pinged": "UP", "responding": True},
+                    {"hostname": "ctrl-1", "pinged": "DOWN", "responding": False},
+                ],
+                "errors": [],
+                "warnings": [],
+            }
+        )
+        all_up_json = json.dumps(
+            {
+                "pings": [
+                    {"hostname": "ctrl-0", "pinged": "UP", "responding": True},
+                    {"hostname": "ctrl-1", "pinged": "UP", "responding": True},
+                ],
+                "errors": [],
+                "warnings": [],
+            }
+        )
         mock_run.side_effect = [
             mock.Mock(returncode=0, stdout=partial_json, stderr=""),
             mock.Mock(returncode=0, stdout=all_up_json, stderr=""),
         ]
 
-        with mock.patch.dict(os.environ, {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"}):
+        with mock.patch.dict(
+            os.environ,
+            {"CONTROLLER_MAX_ATTEMPTS": "5", "CONTROLLER_POLL_INTERVAL": "0"},
+        ):
             worker_init.wait_for_controller()
 
         self.assertEqual(mock_run.call_count, 2)
@@ -589,9 +716,15 @@ class TestWaitForTopologyNonGpu(unittest.TestCase):
     @mock.patch("worker_init.apply_node_topology")
     @mock.patch("worker_init.is_gpu_enabled", return_value=False)
     @mock.patch.dict(os.environ, {"HOSTNAME": "worker-0"})
-    def test_non_gpu_applies_unknown_topology(self, mock_gpu, mock_apply, mock_wait_hostname):
+    def test_non_gpu_applies_unknown_topology(
+        self, mock_gpu, mock_apply, mock_wait_hostname
+    ):
         """Non-GPU node immediately applies topology=default:root:unknown."""
-        worker_init.wait_for_topology()
+        with mock.patch(
+            "worker_init.get_topology_plugin",
+            return_value=worker_init.TOPOLOGY_PLUGIN_TREE,
+        ):
+            worker_init.wait_for_topology()
 
         mock_wait_hostname.assert_called_once_with("worker-0", 180, 5)
         mock_apply.assert_called_once_with("worker-0", "topology=default:root:unknown")
@@ -600,9 +733,31 @@ class TestWaitForTopologyNonGpu(unittest.TestCase):
     @mock.patch("worker_init.apply_node_topology")
     @mock.patch("worker_init.is_gpu_enabled", return_value=False)
     @mock.patch.dict(os.environ, {"HOSTNAME": "worker-0"})
-    def test_non_gpu_does_not_read_configmap(self, mock_gpu, mock_apply, mock_wait_hostname):
+    def test_non_gpu_applies_unknown_block_topology(
+        self, mock_gpu, mock_apply, mock_wait_hostname
+    ):
+        """Non-GPU node in block mode applies topology=default:unknown."""
+        with mock.patch(
+            "worker_init.get_topology_plugin",
+            return_value=worker_init.TOPOLOGY_PLUGIN_BLOCK,
+        ):
+            worker_init.wait_for_topology()
+
+        mock_wait_hostname.assert_called_once_with("worker-0", 180, 5)
+        mock_apply.assert_called_once_with("worker-0", "topology=default:unknown")
+
+    @mock.patch("worker_init.wait_for_hostname_in_topology_conf")
+    @mock.patch("worker_init.apply_node_topology")
+    @mock.patch("worker_init.is_gpu_enabled", return_value=False)
+    @mock.patch.dict(os.environ, {"HOSTNAME": "worker-0"})
+    def test_non_gpu_does_not_read_configmap(
+        self, mock_gpu, mock_apply, mock_wait_hostname
+    ):
         """Non-GPU node does not wait for ConfigMap at all."""
-        with mock.patch("worker_init.read_topology_for_node") as mock_read:
+        with mock.patch(
+            "worker_init.get_topology_plugin",
+            return_value=worker_init.TOPOLOGY_PLUGIN_TREE,
+        ), mock.patch("worker_init.read_topology_for_node") as mock_read:
             worker_init.wait_for_topology()
             mock_read.assert_not_called()
         mock_wait_hostname.assert_called_once_with("worker-0", 180, 5)
@@ -610,7 +765,9 @@ class TestWaitForTopologyNonGpu(unittest.TestCase):
     @mock.patch("worker_init.wait_for_hostname_in_topology_conf")
     @mock.patch("worker_init.apply_node_topology")
     @mock.patch("worker_init.is_gpu_enabled", return_value=False)
-    def test_non_gpu_exits_if_hostname_not_set(self, mock_gpu, mock_apply, mock_wait_hostname):
+    def test_non_gpu_exits_if_hostname_not_set(
+        self, mock_gpu, mock_apply, mock_wait_hostname
+    ):
         """Non-GPU node exits if HOSTNAME is not set."""
         env = os.environ.copy()
         env.pop("HOSTNAME", None)
@@ -640,7 +797,9 @@ def test_topology_conf_does_not_match_partial_hostname():
         with open(topology_conf, "w") as f:
             f.write("SwitchName=unknown Nodes=worker-10\n")
 
-        assert not worker_init.topology_conf_contains_hostname(topology_conf, "worker-1")
+        assert not worker_init.topology_conf_contains_hostname(
+            topology_conf, "worker-1"
+        )
 
 
 class TestTopologyIntegration(unittest.TestCase):
@@ -655,6 +814,7 @@ class TestTopologyIntegration(unittest.TestCase):
     def tearDown(self):
         """Clean up temporary directories."""
         import shutil
+
         shutil.rmtree(self.temp_dir)
 
     def test_full_flow_read_and_format(self):
@@ -689,6 +849,34 @@ class TestTopologyIntegration(unittest.TestCase):
 
         formatted = worker_init.format_slurm_topology(result)
         self.assertEqual(formatted, "topology=default:root:spine01:leaf01")
+
+    @mock.patch("worker_init.wait_for_hostname_in_topology_conf")
+    @mock.patch("worker_init.apply_node_topology")
+    def test_wait_for_topology_block_json_applies_tier_zero(
+        self, mock_apply, mock_wait_hostname
+    ):
+        """Block mode applies tier-0 as the dynamic topology unit."""
+        node_name = "gpu-node-003"
+        topology = '{"tier-0":"block1","tier-1":"leaf01","tier-2":"spine01"}'
+
+        node_file = os.path.join(self.configmap_dir, node_name)
+        with open(node_file, "w") as f:
+            f.write(topology)
+
+        env = {
+            "HOSTNAME": "worker-0",
+            "K8S_NODE_NAME": node_name,
+            "TOPOLOGY_CONFIGMAP_PATH": self.configmap_dir,
+            "NODESET_GPU_ENABLED": "true",
+        }
+        with mock.patch.dict(os.environ, env), mock.patch(
+            "worker_init.get_topology_plugin",
+            return_value=worker_init.TOPOLOGY_PLUGIN_BLOCK,
+        ):
+            worker_init.wait_for_topology()
+
+        mock_wait_hostname.assert_called_once_with("worker-0", 180, 5)
+        mock_apply.assert_called_once_with("worker-0", "topology=default:block1")
 
 
 class TestEdgeCases(unittest.TestCase):
@@ -747,7 +935,9 @@ class TestMainArgparse(unittest.TestCase):
     @mock.patch("worker_init.wait_for_controller")
     def test_main_both_commands(self, mock_controller, mock_topology):
         """Main runs both commands sequentially."""
-        with mock.patch("sys.argv", ["worker_init.py", "wait-controller", "wait-topology"]):
+        with mock.patch(
+            "sys.argv", ["worker_init.py", "wait-controller", "wait-topology"]
+        ):
             worker_init.main()
         mock_controller.assert_called_once()
         mock_topology.assert_called_once()

--- a/images/worker/worker_init_test.py
+++ b/images/worker/worker_init_test.py
@@ -11,6 +11,7 @@ import os
 import tempfile
 import unittest
 import unittest.mock as mock
+from pathlib import Path
 
 # Import the module under test
 import worker_init
@@ -326,13 +327,13 @@ class TestGetEnvironmentVariables(unittest.TestCase):
         env.pop("TOPOLOGY_CONFIGMAP_PATH", None)
         with mock.patch.dict(os.environ, env, clear=True):
             result = worker_init.get_topology_path()
-        self.assertEqual(result, "/tmp/slurm/topology-node-labels")
+        self.assertEqual(result, Path("/tmp/slurm/topology-node-labels"))
 
     def test_get_topology_path_custom(self):
         """Get topology path returns custom value when set."""
         with mock.patch.dict(os.environ, {"TOPOLOGY_CONFIGMAP_PATH": "/custom/path"}):
             result = worker_init.get_topology_path()
-        self.assertEqual(result, "/custom/path")
+        self.assertEqual(result, Path("/custom/path"))
 
     def test_get_topology_wait_timeout_default(self):
         """Get wait timeout returns default when not set."""

--- a/images/worker/worker_init_test.py
+++ b/images/worker/worker_init_test.py
@@ -373,7 +373,7 @@ class TestGetEnvironmentVariables(unittest.TestCase):
         """Topology plugin can be supplied by environment variable."""
         with mock.patch.dict(
             os.environ,
-            {"TOPOLOGY_PLUGIN": worker_init.TOPOLOGY_PLUGIN_BLOCK},
+            {"SLURM_TOPOLOGY_PLUGIN": worker_init.TOPOLOGY_PLUGIN_BLOCK},
         ):
             result = worker_init.get_topology_plugin("/missing/slurm.conf")
         self.assertEqual(result, worker_init.TOPOLOGY_PLUGIN_BLOCK)
@@ -386,7 +386,7 @@ class TestGetEnvironmentVariables(unittest.TestCase):
                 f.write("# comment\nTopologyPlugin = topology/block # inline\n")
 
             env = os.environ.copy()
-            env.pop("TOPOLOGY_PLUGIN", None)
+            env.pop("SLURM_TOPOLOGY_PLUGIN", None)
             with mock.patch.dict(os.environ, env, clear=True):
                 result = worker_init.get_topology_plugin(slurm_conf)
         self.assertEqual(result, worker_init.TOPOLOGY_PLUGIN_BLOCK)
@@ -394,7 +394,7 @@ class TestGetEnvironmentVariables(unittest.TestCase):
     def test_get_topology_plugin_defaults_to_tree(self):
         """Missing slurm.conf defaults to topology/tree."""
         env = os.environ.copy()
-        env.pop("TOPOLOGY_PLUGIN", None)
+        env.pop("SLURM_TOPOLOGY_PLUGIN", None)
         with mock.patch.dict(os.environ, env, clear=True):
             result = worker_init.get_topology_plugin("/missing/slurm.conf")
         self.assertEqual(result, worker_init.TOPOLOGY_PLUGIN_TREE)

--- a/images/worker/worker_init_test.py
+++ b/images/worker/worker_init_test.py
@@ -780,27 +780,123 @@ class TestWaitForTopologyNonGpu(unittest.TestCase):
         mock_apply.assert_not_called()
 
 
-def test_topology_conf_contains_hostname_exact_token():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        topology_conf = os.path.join(temp_dir, "topology.conf")
-        with open(topology_conf, "w") as f:
-            f.write(
-                "SwitchName=root Switches=unknown\n"
-                "SwitchName=unknown Nodes=worker-0,worker-1\n"
+class TestTopologyConfContainsHostname(unittest.TestCase):
+    """Tests for topology.conf hostname membership checks."""
+
+    def test_exact_token(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            topology_conf = Path(temp_dir) / "topology.conf"
+            with open(topology_conf, "w") as f:
+                f.write(
+                    "SwitchName=root Switches=unknown\n"
+                    "SwitchName=unknown Nodes=worker-0,worker-1\n"
+                )
+
+            self.assertTrue(
+                worker_init.topology_conf_contains_hostname(
+                    topology_conf,
+                    "worker-0",
+                )
             )
 
-        assert worker_init.topology_conf_contains_hostname(topology_conf, "worker-0")
+    def test_does_not_match_partial_hostname(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            topology_conf = Path(temp_dir) / "topology.conf"
+            with open(topology_conf, "w") as f:
+                f.write("SwitchName=unknown Nodes=worker-10\n")
 
+            self.assertFalse(
+                worker_init.topology_conf_contains_hostname(
+                    topology_conf,
+                    "worker-1",
+                )
+            )
 
-def test_topology_conf_does_not_match_partial_hostname():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        topology_conf = os.path.join(temp_dir, "topology.conf")
-        with open(topology_conf, "w") as f:
-            f.write("SwitchName=unknown Nodes=worker-10\n")
+    def test_contains_hostname_in_slurm_range(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            topology_conf = Path(temp_dir) / "topology.conf"
+            with open(topology_conf, "w") as f:
+                f.write("SwitchName=unknown Nodes=worker-[0-5]\n")
 
-        assert not worker_init.topology_conf_contains_hostname(
-            topology_conf, "worker-1"
-        )
+            self.assertTrue(
+                worker_init.topology_conf_contains_hostname(
+                    topology_conf,
+                    "worker-1",
+                )
+            )
+
+    def test_does_not_match_hostname_outside_slurm_range(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            topology_conf = Path(temp_dir) / "topology.conf"
+            with open(topology_conf, "w") as f:
+                f.write("SwitchName=unknown Nodes=worker-[10-15]\n")
+
+            self.assertFalse(
+                worker_init.topology_conf_contains_hostname(
+                    topology_conf,
+                    "worker-1",
+                )
+            )
+
+    def test_contains_hostname_in_merged_slurm_hostlist(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            topology_conf = Path(temp_dir) / "topology.conf"
+            with open(topology_conf, "w") as f:
+                f.write(
+                    "BlockName=block-a "
+                    "Nodes=worker-[0-2,4],worker-cpu-[0-1],workerkek1\n"
+                )
+
+            self.assertTrue(
+                worker_init.topology_conf_contains_hostname(
+                    topology_conf,
+                    "worker-cpu-1",
+                )
+            )
+            self.assertTrue(
+                worker_init.topology_conf_contains_hostname(
+                    topology_conf,
+                    "worker-4",
+                )
+            )
+            self.assertFalse(
+                worker_init.topology_conf_contains_hostname(
+                    topology_conf,
+                    "worker-3",
+                )
+            )
+            self.assertTrue(
+                worker_init.topology_conf_contains_hostname(
+                    topology_conf,
+                    "workerkek1",
+                )
+            )
+
+    def test_contains_hostname_in_zero_padded_slurm_range(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            topology_conf = Path(temp_dir) / "topology.conf"
+            with open(topology_conf, "w") as f:
+                f.write("SwitchName=leaf Nodes=gpu[099-101]\n")
+
+            self.assertTrue(
+                worker_init.topology_conf_contains_hostname(topology_conf, "gpu099")
+            )
+            self.assertFalse(
+                worker_init.topology_conf_contains_hostname(topology_conf, "gpu99")
+            )
+
+    def test_nodes_all_contains_hostname(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            topology_conf = Path(temp_dir) / "topology.conf"
+            with open(topology_conf, "w") as f:
+                f.write("SwitchName=root Nodes=ALL\n")
+
+            self.assertTrue(
+                worker_init.topology_conf_contains_hostname(
+                    topology_conf,
+                    "worker-1",
+                )
+            )
 
 
 class TestTopologyIntegration(unittest.TestCase):

--- a/internal/controller/nodesetcontroller/reconcile.go
+++ b/internal/controller/nodesetcontroller/reconcile.go
@@ -394,7 +394,8 @@ func (r NodeSetReconciler) executeReconciliation(
 					secrets.SshdKeysName = naming.BuildSecretSSHDKeysName(cluster.Name)
 				}
 
-				topologyPluginEnabled := cluster.Spec.SlurmConfig.TopologyPlugin != ""
+				topologyPlugin := cluster.Spec.SlurmConfig.TopologyPlugin
+				topologyPluginEnabled := topologyPlugin != ""
 
 				desired, err := worker.RenderNodeSetStatefulSet(
 					cluster.Name,
@@ -403,6 +404,7 @@ func (r NodeSetReconciler) executeReconciliation(
 					cluster.Spec.CgroupVersion,
 					clusterWithGPU,
 					topologyPluginEnabled,
+					topologyPlugin,
 				)
 				if err != nil {
 					stepLogger.Error(err, "Failed to render")

--- a/internal/controller/topologyconfcontroller/topology_blocks.go
+++ b/internal/controller/topologyconfcontroller/topology_blocks.go
@@ -3,9 +3,10 @@ package topologyconfcontroller
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	slurmpattern "nebius.ai/slurm-operator/internal/utils/slurm/pattern"
 )
 
 // TopologyBlocks represents a block topology.
@@ -40,7 +41,14 @@ func (b TopologyBlocks) RenderConfigLines() []string {
 		if len(workers) == 0 {
 			continue
 		}
-		lines = append(lines, fmt.Sprintf("BlockName=%s Nodes=%s", blockName, strings.Join(workers, ",")))
+		lines = append(
+			lines,
+			fmt.Sprintf(
+				"BlockName=%s Nodes=%s",
+				blockName,
+				slurmpattern.Merge(workers),
+			),
+		)
 	}
 
 	return lines

--- a/internal/controller/topologyconfcontroller/topology_blocks_test.go
+++ b/internal/controller/topologyconfcontroller/topology_blocks_test.go
@@ -17,28 +17,56 @@ func TestBuildTopologyBlocks_GroupsWorkersByTierZero(t *testing.T) {
 		"node2": {"tier-0": "block-a"},
 		"node3": {"tier-0": "block-b"},
 	}
-	gpuPodsByNode := map[string][]string{
-		"node1": {"pod1", "pod2"},
-		"node2": {"pod3"},
-		"node3": {"pod4"},
+
+	{
+		gpuPodsByNode := map[string][]string{
+			"node1": {"pod1", "pod2"},
+			"node2": {"pod3"},
+			"node3": {"pod4"},
+		}
+		allNodeNames := []string{"pod1", "pod2", "pod3", "pod4"}
+
+		blocks := tc.BuildTopologyBlocks(context.Background(), labelsByNode, gpuPodsByNode, allNodeNames)
+		lines := blocks.RenderConfigLines()
+
+		require.True(t, len(lines) != 0, "expected non-empty block lines")
+		result := parseBlockLines(t, lines)
+		require.Equal(t, map[string][]string{
+			"block-a": {"pod1", "pod2", "pod3"},
+			"block-b": {"pod4"},
+		}, result)
+
+		require.Equal(t, map[string][]string{
+			"node1": {"pod1", "pod2"},
+			"node2": {"pod3"},
+			"node3": {"pod4"},
+		}, gpuPodsByNode, "BuildTopologyBlocks must not mutate the input gpuPodsByNode map")
 	}
-	allNodeNames := []string{"pod1", "pod2", "pod3", "pod4"}
 
-	blocks := tc.BuildTopologyBlocks(context.Background(), labelsByNode, gpuPodsByNode, allNodeNames)
-	lines := blocks.RenderConfigLines()
+	{
+		gpuPodsByNode := map[string][]string{
+			"node1": {"pod-1", "pod-2"},
+			"node2": {"pod-3"},
+			"node3": {"pod-4"},
+		}
+		allNodeNames := []string{"pod-1", "pod-2", "pod-3", "pod-4"}
 
-	require.True(t, len(lines) != 0, "expected non-empty block lines")
-	result := parseBlockLines(t, lines)
-	require.Equal(t, map[string][]string{
-		"block-a": {"pod1", "pod2", "pod3"},
-		"block-b": {"pod4"},
-	}, result)
+		blocks := tc.BuildTopologyBlocks(context.Background(), labelsByNode, gpuPodsByNode, allNodeNames)
+		lines := blocks.RenderConfigLines()
 
-	require.Equal(t, map[string][]string{
-		"node1": {"pod1", "pod2"},
-		"node2": {"pod3"},
-		"node3": {"pod4"},
-	}, gpuPodsByNode, "BuildTopologyBlocks must not mutate the input gpuPodsByNode map")
+		require.True(t, len(lines) != 0, "expected non-empty block lines")
+		result := parseBlockLines(t, lines)
+		require.Equal(t, map[string][]string{
+			"block-a": {"pod-[1-3]"},
+			"block-b": {"pod-4"},
+		}, result)
+
+		require.Equal(t, map[string][]string{
+			"node1": {"pod-1", "pod-2"},
+			"node2": {"pod-3"},
+			"node3": {"pod-4"},
+		}, gpuPodsByNode, "BuildTopologyBlocks must not mutate the input gpuPodsByNode map")
+	}
 }
 
 func TestBuildTopologyBlocks_AssignsUnknownBlock(t *testing.T) {
@@ -60,6 +88,26 @@ func TestBuildTopologyBlocks_AssignsUnknownBlock(t *testing.T) {
 		"block-a": {"pod1"},
 		"unknown": {"pod2", "pod3"},
 	}, result)
+}
+
+func TestBuildTopologyBlocks_RenderMergesWorkerNodes(t *testing.T) {
+	labelsByNode := map[string]tc.NodeTopologyLabels{
+		"node1": {"tier-0": "block-a"},
+		"node2": {"tier-0": "block-a"},
+	}
+	podsByNode := map[string][]string{
+		"node1": {"worker-0", "worker-1", "worker-cpu-0"},
+		"node2": {"worker-2", "worker-cpu-1", "workerkek1"},
+	}
+
+	allNodeNames := []string{"worker-0", "worker-1", "worker-cpu-0", "worker-2", "worker-cpu-1", "workerkek1"}
+
+	blocks := tc.BuildTopologyBlocks(context.Background(), labelsByNode, podsByNode, allNodeNames)
+	lines := blocks.RenderConfigLines()
+
+	require.Equal(t, []string{
+		"BlockName=block-a Nodes=worker-[0-2],worker-cpu-[0-1],workerkek1",
+	}, lines)
 }
 
 func TestBuildTopologyBlocks_RenderEmpty(t *testing.T) {

--- a/internal/controller/topologyconfcontroller/topology_graph.go
+++ b/internal/controller/topologyconfcontroller/topology_graph.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	slurmpattern "nebius.ai/slurm-operator/internal/utils/slurm/pattern"
 )
 
 // TopologyGraph represents a network topology as a single tree with two types of vertices:
@@ -100,7 +102,7 @@ func (g TopologyGraph) RenderConfigLines() []string {
 		}
 		slices.Sort(children)
 		if hasGrandChildren {
-			lines = append(lines, fmt.Sprintf("SwitchName=%s Switches=%s", parent, strings.Join(children, ",")))
+			lines = append(lines, fmt.Sprintf("SwitchName=%s Switches=%s", parent, slurmpattern.Merge(children)))
 		} else {
 			lines = append(lines, fmt.Sprintf("SwitchName=%s Nodes=%s", parent, strings.Join(children, ",")))
 		}

--- a/internal/controller/topologyconfcontroller/topology_graph_test.go
+++ b/internal/controller/topologyconfcontroller/topology_graph_test.go
@@ -376,3 +376,27 @@ func TestRenderTopologyConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderTopologyConfig_MergesSwitches(t *testing.T) {
+	labelsByNode := map[string]tc.NodeTopologyLabels{
+		"node1": {"tier-1": "leaf-0", "tier-2": "spine-0"},
+		"node2": {"tier-1": "leaf-1", "tier-2": "spine-0"},
+		"node3": {"tier-1": "leaf-cpu-0", "tier-2": "spine-0"},
+		"node4": {"tier-1": "leaf-cpu-2", "tier-2": "spine-0"},
+		"node5": {"tier-1": "leafkek1", "tier-2": "spine-0"},
+	}
+	podsByNode := map[string][]string{
+		"node1": {"worker-a"},
+		"node2": {"worker-b"},
+		"node3": {"worker-c"},
+		"node4": {"worker-d"},
+		"node5": {"worker-e"},
+	}
+
+	allNodeNames := []string{"worker-a", "worker-b", "worker-c", "worker-d", "worker-e"}
+
+	graph := tc.BuildTopologyGraph(context.Background(), labelsByNode, podsByNode, allNodeNames)
+	lines := graph.RenderConfigLines()
+
+	require.Contains(t, lines, "SwitchName=spine-0 Switches=leaf-[0-1],leaf-cpu-[0,2],leafkek1")
+}

--- a/internal/controller/topologyconfcontroller/workertopology_controller.go
+++ b/internal/controller/topologyconfcontroller/workertopology_controller.go
@@ -393,7 +393,7 @@ func (r *WorkerTopologyReconciler) listPods(
 	return podList, nil
 }
 
-// BuildTopologyBlocks builds topology config.
+// BuildTopologyBlocks builds topology/block config.
 func (r *WorkerTopologyReconciler) BuildTopologyBlocks(
 	ctx context.Context,
 	blockSize *int,
@@ -410,13 +410,16 @@ func (r *WorkerTopologyReconciler) BuildTopologyBlocks(
 	if err != nil {
 		return "", fmt.Errorf("deserialize node block topology: %w", err)
 	}
+
 	blocks := BuildTopologyBlocks(ctx, labelsByNode, gpuPodsByNode, allNodeNames)
+
 	config := strings.Join(blocks.RenderConfigLines(), "\n") + "\n"
 	config = fmt.Sprintf("%sBlockSizes=%d\n", config, bs)
+
 	return config, nil
 }
 
-// BuildTopologyConfig builds topology config.
+// BuildTopologyConfig builds topology/tree config.
 func (r *WorkerTopologyReconciler) BuildTopologyConfig(
 	ctx context.Context,
 	topologyNodeLabelsCM *corev1.ConfigMap,

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -26,6 +26,7 @@ func RenderContainerWorkerInit(
 	container *values.Container,
 	topologyEnabled, gpuEnabled bool,
 	waitTimeoutSeconds int32,
+	topologyPlugin string,
 ) corev1.Container {
 	command := []string{
 		"python3",
@@ -114,6 +115,14 @@ func RenderContainerWorkerInit(
 				Value: "5",
 			},
 		)
+		if topologyPlugin != "" {
+			env = append(env,
+				corev1.EnvVar{
+					Name:  "TOPOLOGY_PLUGIN",
+					Value: topologyPlugin,
+				},
+			)
+		}
 	}
 
 	return corev1.Container{

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -118,7 +118,7 @@ func RenderContainerWorkerInit(
 		if topologyPlugin != "" {
 			env = append(env,
 				corev1.EnvVar{
-					Name:  "TOPOLOGY_PLUGIN",
+					Name:  "SLURM_TOPOLOGY_PLUGIN",
 					Value: topologyPlugin,
 				},
 			)

--- a/internal/render/worker/sssd_test.go
+++ b/internal/render/worker/sssd_test.go
@@ -69,7 +69,15 @@ func TestRenderNodeSetStatefulSet_SSSD(t *testing.T) {
 		CustomInitContainers:     []corev1.Container{},
 	}
 
-	result, err := worker.RenderNodeSetStatefulSet("test-cluster", nodeSet, &slurmv1.Secrets{}, consts.CGroupV2, false, false)
+	result, err := worker.RenderNodeSetStatefulSet(
+		"test-cluster",
+		nodeSet,
+		&slurmv1.Secrets{},
+		consts.CGroupV2,
+		false,
+		false,
+		"",
+	)
 	assert.NoError(t, err)
 
 	assert.Len(t, result.Spec.Template.Spec.InitContainers, 3)

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -31,6 +31,7 @@ func RenderNodeSetStatefulSet(
 	cgroupVersion string,
 	clusterWithGPU bool,
 	topologyPluginEnabled bool,
+	topologyPlugin string,
 ) (kruisev1b1.StatefulSet, error) {
 	labels := common.RenderLabels(consts.ComponentTypeNodeSet, nodeSet.ParentalCluster.Name)
 	labels[consts.LabelNodeSetKey] = nodeSet.Name
@@ -60,8 +61,12 @@ func RenderNodeSetStatefulSet(
 	}
 	initContainers = append(initContainers,
 		RenderContainerWorkerInit(
-			clusterName, &nodeSet.ContainerSlurmd, topologyPluginEnabled,
-			nodeSet.GPU.Enabled, topologyTimeOut,
+			clusterName,
+			&nodeSet.ContainerSlurmd,
+			topologyPluginEnabled,
+			nodeSet.GPU.Enabled,
+			topologyTimeOut,
+			topologyPlugin,
 		),
 	)
 

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -40,14 +40,22 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 	}
 
 	t.Run("with topology enabled", func(t *testing.T) {
-		result := worker.RenderContainerWorkerInit("test-cluster", container, true, true, 300)
+		result := worker.RenderContainerWorkerInit(
+			"test-cluster",
+			container,
+			true,
+			true,
+			300,
+			consts.SlurmTopologyBlock,
+		)
 
 		assert.Equal(t, consts.ContainerNameWorkerInit, result.Name)
 		assert.Equal(t, container.Image, result.Image)
 		assert.Equal(t, container.ImagePullPolicy, result.ImagePullPolicy)
 		assert.Equal(t, []string{"python3", "/opt/bin/slurm/worker_init.py", "wait-controller", "wait-topology"}, result.Command)
-		assert.Equal(t, 10, len(result.Env)) // 6 base + 1 NODESET_GPU_ENABLED + 3 topology
+		assert.Equal(t, 11, len(result.Env)) // 6 base + 1 NODESET_GPU_ENABLED + 4 topology
 		assert.Equal(t, 3, len(result.VolumeMounts))
+		assertEnvValue(t, result.Env, "TOPOLOGY_PLUGIN", consts.SlurmTopologyBlock)
 
 		expectedMounts := map[string]string{
 			consts.VolumeNameJail:               consts.VolumeMountPathJail,
@@ -63,7 +71,14 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 	})
 
 	t.Run("without topology", func(t *testing.T) {
-		result := worker.RenderContainerWorkerInit("test-cluster", container, false, false, 0)
+		result := worker.RenderContainerWorkerInit(
+			"test-cluster",
+			container,
+			false,
+			false,
+			0,
+			"",
+		)
 
 		assert.Equal(t, consts.ContainerNameWorkerInit, result.Name)
 		assert.Equal(t, container.Image, result.Image)
@@ -86,7 +101,12 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 
 		// Verify no topology env vars
 		for _, envVar := range result.Env {
-			assert.NotContains(t, []string{"TOPOLOGY_CONFIGMAP_PATH", "TOPOLOGY_WAIT_TIMEOUT", "TOPOLOGY_POLL_INTERVAL"}, envVar.Name,
+			assert.NotContains(t, []string{
+				"TOPOLOGY_CONFIGMAP_PATH",
+				"TOPOLOGY_PLUGIN",
+				"TOPOLOGY_WAIT_TIMEOUT",
+				"TOPOLOGY_POLL_INTERVAL",
+			}, envVar.Name,
 				"topology env var %s should not be present when topology is disabled", envVar.Name)
 		}
 	})
@@ -143,7 +163,14 @@ func Test_RenderContainerWorkerInit_K8SServiceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := worker.RenderContainerWorkerInit(tt.clusterName, container, false, tt.gpuEnabled, 0)
+			result := worker.RenderContainerWorkerInit(
+				tt.clusterName,
+				container,
+				false,
+				tt.gpuEnabled,
+				0,
+				"",
+			)
 
 			env, found := findEnv(result.Env, "K8S_SERVICE_NAME")
 			assert.True(t, found, "K8S_SERVICE_NAME env var must be present")
@@ -231,6 +258,7 @@ func TestRenderNodeSetStatefulSet_SlurmdGPUEnv(t *testing.T) {
 				consts.CGroupV2,
 				tt.clusterWithGPU,
 				false,
+				"",
 			)
 			assert.NoError(t, err)
 
@@ -339,6 +367,7 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 				consts.CGroupV2,
 				true,
 				tt.topologyPluginEnabled,
+				consts.SlurmTopologyBlock,
 			)
 			assert.NoError(t, err)
 
@@ -349,8 +378,10 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 
 			// Verify worker-init container has topology command when topology plugin is enabled
 			var hasWaitForTopology bool
+			var workerInitContainer *corev1.Container
 			for _, container := range result.Spec.Template.Spec.InitContainers {
 				if container.Name == consts.ContainerNameWorkerInit {
+					workerInitContainer = &container
 					for _, arg := range container.Command {
 						if arg == "wait-topology" {
 							hasWaitForTopology = true
@@ -362,6 +393,9 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 			}
 			assert.Equal(t, tt.expectWaitForTopology, hasWaitForTopology,
 				"wait-topology command presence mismatch")
+			if tt.expectWaitForTopology && assert.NotNil(t, workerInitContainer) {
+				assertEnvValue(t, workerInitContainer.Env, "TOPOLOGY_PLUGIN", consts.SlurmTopologyBlock)
+			}
 
 			// Verify topology-related volumes
 			var hasTopologyNodeLabelsVolume bool
@@ -510,6 +544,7 @@ func TestRenderNodeSetStatefulSet_PersistentVolumeClaimRetentionPolicy(t *testin
 				consts.CGroupV2,
 				true,
 				false,
+				"",
 			)
 			assert.NoError(t, err)
 			if assert.NotNil(t, result.Spec.PersistentVolumeClaimRetentionPolicy) {
@@ -587,6 +622,7 @@ func TestRenderNodeSetStatefulSet_ScaleStrategy(t *testing.T) {
 				consts.CGroupV2,
 				true,
 				false,
+				"",
 			)
 			assert.NoError(t, err)
 
@@ -696,7 +732,15 @@ func TestRenderNodeSetStatefulSet_EphemeralNodesReserveOrdinals(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			nodeSet := createNodeSetWithActiveNodes(tt.ephemeralNodes, tt.activeNodes)
 
-			result, err := worker.RenderNodeSetStatefulSet("test-cluster", nodeSet, &slurmv1.Secrets{}, consts.CGroupV2, true, false)
+			result, err := worker.RenderNodeSetStatefulSet(
+				"test-cluster",
+				nodeSet,
+				&slurmv1.Secrets{},
+				consts.CGroupV2,
+				true,
+				false,
+				"",
+			)
 			assert.NoError(t, err)
 
 			// Verify replicas

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -55,7 +55,7 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 		assert.Equal(t, []string{"python3", "/opt/bin/slurm/worker_init.py", "wait-controller", "wait-topology"}, result.Command)
 		assert.Equal(t, 11, len(result.Env)) // 6 base + 1 NODESET_GPU_ENABLED + 4 topology
 		assert.Equal(t, 3, len(result.VolumeMounts))
-		assertEnvValue(t, result.Env, "TOPOLOGY_PLUGIN", consts.SlurmTopologyBlock)
+		assertEnvValue(t, result.Env, "SLURM_TOPOLOGY_PLUGIN", consts.SlurmTopologyBlock)
 
 		expectedMounts := map[string]string{
 			consts.VolumeNameJail:               consts.VolumeMountPathJail,
@@ -103,9 +103,9 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 		for _, envVar := range result.Env {
 			assert.NotContains(t, []string{
 				"TOPOLOGY_CONFIGMAP_PATH",
-				"TOPOLOGY_PLUGIN",
 				"TOPOLOGY_WAIT_TIMEOUT",
 				"TOPOLOGY_POLL_INTERVAL",
+				"SLURM_TOPOLOGY_PLUGIN",
 			}, envVar.Name,
 				"topology env var %s should not be present when topology is disabled", envVar.Name)
 		}
@@ -394,7 +394,7 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 			assert.Equal(t, tt.expectWaitForTopology, hasWaitForTopology,
 				"wait-topology command presence mismatch")
 			if tt.expectWaitForTopology && assert.NotNil(t, workerInitContainer) {
-				assertEnvValue(t, workerInitContainer.Env, "TOPOLOGY_PLUGIN", consts.SlurmTopologyBlock)
+				assertEnvValue(t, workerInitContainer.Env, "SLURM_TOPOLOGY_PLUGIN", consts.SlurmTopologyBlock)
 			}
 
 			// Verify topology-related volumes

--- a/internal/utils/slurm/pattern/helpers.go
+++ b/internal/utils/slurm/pattern/helpers.go
@@ -1,0 +1,79 @@
+package pattern
+
+import (
+	"fmt"
+	"strings"
+)
+
+type suffixKey struct {
+	number int
+	width  int
+}
+type numericSuffix struct {
+	number int
+	width  int
+}
+
+type suffixGroup struct {
+	width   int
+	numbers []int
+}
+
+func renderSuffixGroup(prefix string, group suffixGroup) string {
+	if len(group.numbers) == 1 {
+		return prefix + formatPatternNumber(group.numbers[0], group.width)
+	}
+
+	ranges := make([]string, 0, len(group.numbers))
+	for i := 0; i < len(group.numbers); i++ {
+		start := group.numbers[i]
+		end := start
+		for i+1 < len(group.numbers) && group.numbers[i+1] == end+1 {
+			i++
+			end = group.numbers[i]
+		}
+
+		if start == end {
+			ranges = append(ranges, formatPatternNumber(start, group.width))
+			continue
+		}
+
+		ranges = append(
+			ranges,
+			formatPatternNumber(start, group.width)+"-"+formatPatternNumber(end, group.width),
+		)
+	}
+
+	return fmt.Sprintf("%s[%s]", prefix, strings.Join(ranges, ","))
+}
+
+func formatPatternNumber(number, width int) string {
+	return fmt.Sprintf("%0*d", width, number)
+}
+
+func hasLeadingZero(s string) bool {
+	return len(s) > 1 && s[0] == '0'
+}
+
+func dashedPrefix(s string) (string, bool) {
+	i := strings.LastIndex(s, "-")
+	if i == -1 || i == len(s)-1 {
+		return "", false
+	}
+
+	suffix := s[i+1:]
+	if !isDigits(suffix) {
+		return "", false
+	}
+
+	return s[:i+1], true
+}
+
+func isDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/utils/slurm/pattern/merge.go
+++ b/internal/utils/slurm/pattern/merge.go
@@ -1,0 +1,135 @@
+package pattern
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+)
+
+func Merge(entities []string) string {
+	if len(entities) == 0 {
+		return ""
+	}
+
+	entitiesByPrefix := make(map[string][]string)
+	var prefixes []string
+	passthrough := make(map[string]struct{})
+
+	for _, entity := range entities {
+		prefix, ok := dashedPrefix(entity)
+		if !ok {
+			passthrough[entity] = struct{}{}
+			continue
+		}
+
+		if _, ok := entitiesByPrefix[prefix]; !ok {
+			prefixes = append(prefixes, prefix)
+		}
+		entitiesByPrefix[prefix] = append(entitiesByPrefix[prefix], entity)
+	}
+
+	slices.Sort(prefixes)
+
+	parts := make([]string, 0, len(prefixes)+len(passthrough))
+	for _, prefix := range prefixes {
+		parts = append(parts, MergePrefixed(entitiesByPrefix[prefix], prefix))
+	}
+
+	passthroughEntities := make([]string, 0, len(passthrough))
+	for entity := range passthrough {
+		passthroughEntities = append(passthroughEntities, entity)
+	}
+	slices.Sort(passthroughEntities)
+	parts = append(parts, passthroughEntities...)
+
+	return strings.Join(parts, ",")
+}
+
+func MergePrefixed(entities []string, prefix string) string {
+	if len(entities) == 0 {
+		return ""
+	}
+
+	suffixesByWidth := make(map[int][]int)
+	seenSuffixes := make(map[suffixKey]struct{}, len(entities))
+	var numericSuffixes []numericSuffix
+	passthrough := make(map[string]struct{})
+	hasPaddedSuffix := false
+
+	for _, entity := range entities {
+		if !strings.HasPrefix(entity, prefix) {
+			passthrough[entity] = struct{}{}
+			continue
+		}
+
+		suffix := strings.TrimPrefix(entity, prefix)
+		if suffix == "" || !isDigits(suffix) {
+			passthrough[entity] = struct{}{}
+			continue
+		}
+
+		number, err := strconv.Atoi(suffix)
+		if err != nil {
+			passthrough[entity] = struct{}{}
+			continue
+		}
+
+		numericSuffixes = append(numericSuffixes, numericSuffix{
+			number: number,
+			width:  len(suffix),
+		})
+		hasPaddedSuffix = hasPaddedSuffix || hasLeadingZero(suffix)
+	}
+
+	for _, suffix := range numericSuffixes {
+		width := 0
+		if hasPaddedSuffix {
+			width = suffix.width
+		}
+
+		key := suffixKey{number: suffix.number, width: width}
+		if _, ok := seenSuffixes[key]; ok {
+			continue
+		}
+		seenSuffixes[key] = struct{}{}
+		suffixesByWidth[key.width] = append(suffixesByWidth[key.width], key.number)
+	}
+
+	groups := make([]suffixGroup, 0, len(suffixesByWidth))
+	for width, numbers := range suffixesByWidth {
+		slices.Sort(numbers)
+		groups = append(groups, suffixGroup{
+			width:   width,
+			numbers: numbers,
+		})
+	}
+	slices.SortFunc(groups, func(a, b suffixGroup) int {
+		if a.numbers[0] < b.numbers[0] {
+			return -1
+		}
+		if a.numbers[0] > b.numbers[0] {
+			return 1
+		}
+		if a.width < b.width {
+			return -1
+		}
+		if a.width > b.width {
+			return 1
+		}
+		return 0
+	})
+
+	parts := make([]string, 0, len(groups)+len(passthrough))
+	for _, group := range groups {
+		parts = append(parts, renderSuffixGroup(prefix, group))
+	}
+
+	passthroughEntities := make([]string, 0, len(passthrough))
+	for entity := range passthrough {
+		passthroughEntities = append(passthroughEntities, entity)
+	}
+	slices.Sort(passthroughEntities)
+	parts = append(parts, passthroughEntities...)
+
+	return strings.Join(parts, ",")
+}

--- a/internal/utils/slurm/pattern/merge_test.go
+++ b/internal/utils/slurm/pattern/merge_test.go
@@ -1,0 +1,114 @@
+package pattern_test
+
+import (
+	"fmt"
+	"testing"
+
+	slurmpattern "nebius.ai/slurm-operator/internal/utils/slurm/pattern"
+)
+
+func TestMerge(t *testing.T) {
+	entities := []string{
+		"worker-cpu-4",
+		"worker-cpu-1",
+		"worker-cpu-0",
+		"workerkek1",
+	}
+
+	for i := 15; i >= 0; i-- {
+		entities = append(entities, fmt.Sprintf("worker-%d", i))
+	}
+	for i := 7; i >= 0; i-- {
+		entities = append(entities, fmt.Sprintf("worker-rack1-%d", i))
+		entities = append(entities, fmt.Sprintf("worker-rack0-%d", i))
+	}
+
+	got := slurmpattern.Merge(entities)
+	want := "worker-[0-15],worker-cpu-[0-1,4],worker-rack0-[0-7],worker-rack1-[0-7],workerkek1"
+	if got != want {
+		t.Fatalf("Merge(%v) = %q, want %q", entities, got, want)
+	}
+}
+
+func TestMergePrefixed(t *testing.T) {
+	tests := []struct {
+		name     string
+		entities []string
+		prefix   string
+		want     string
+	}{
+		{
+			name: "merges sorted numeric ranges",
+			entities: []string{
+				"dev12",
+				"dev2",
+				"dev1",
+				"dev8",
+				"dev0",
+				"dev7",
+				"dev4",
+				"dev3",
+				"dev5",
+			},
+			prefix: "dev",
+			want:   "dev[0-5,7-8,12]",
+		},
+		{
+			name:     "deduplicates entities",
+			entities: []string{"dev2", "dev1", "dev2", "dev3"},
+			prefix:   "dev",
+			want:     "dev[1-3]",
+		},
+		{
+			name:     "keeps single entity unbracketed",
+			entities: []string{"dev12"},
+			prefix:   "dev",
+			want:     "dev12",
+		},
+		{
+			name:     "supports prefixes with separators",
+			entities: []string{"worker-3", "worker-1", "worker-2"},
+			prefix:   "worker-",
+			want:     "worker-[1-3]",
+		},
+		{
+			name:     "preserves zero padding",
+			entities: []string{"gpu004", "gpu001", "gpu002"},
+			prefix:   "gpu",
+			want:     "gpu[001-002,004]",
+		},
+		{
+			name:     "preserves zero padding across digit boundary",
+			entities: []string{"gpu100", "gpu099", "gpu101"},
+			prefix:   "gpu",
+			want:     "gpu[099-101]",
+		},
+		{
+			name:     "keeps mixed suffix widths separate",
+			entities: []string{"dev1", "dev002", "dev003"},
+			prefix:   "dev",
+			want:     "dev1,dev[002-003]",
+		},
+		{
+			name:     "keeps non matching entities",
+			entities: []string{"dev0", "other2", "devx", "dev2"},
+			prefix:   "dev",
+			want:     "dev[0,2],devx,other2",
+		},
+		{
+			name:     "empty input",
+			entities: nil,
+			prefix:   "dev",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := slurmpattern.MergePrefixed(tt.entities, tt.prefix)
+			if got != tt.want {
+				t.Fatalf("MergePrefixed(%v, %q) = %q, want %q", tt.entities, tt.prefix, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Existing `worker-init` init container dynamically registers worker topology as if the Slurm cluster is always has `TopologyPlugin=topology/tree` - it generates worker topology as this: `default:<tier0>:<tier1>:<tier2>:<worker>`. This doesn't work for block topology, as it expects workers to be part of only one block.

## Solution

Provide separate dynamic topology generation based on the topology plugin:
- For `topology/tree` - nothing changes
- For `topology/block` - generate `default:<tier0>:<worker>`
- Other topology plugins are not supported

### Additional changes

#### Support for pattern names in `topology.conf`

We used to generate a comma-separated list of nodes, which may hit the CM size limit on really big clusters. Now we use patterns which are length-efficient and easy-readable. Sorted order and possible gaps are managed automatically.

#### Support for `topology` section of SlurmCluster CR to be set by Helm

It was impossible to set e.g. `blockSize` via Helm.

## Release Notes

Feature: `TopologyPlugin=topology/block` is supported for dynamic worker topology setting.
Feature: `topology.conf` uses pattern names for nodes instead of comma-separated list.
Feature: `topology` section is possible to change via `slurm-cluster` Helm chart.
