### PR TITLE
NOTIC: Move jail sentinel file out of the root directory

### DIFF
--- a/images/jail/populate_jail_entrypoint.sh
+++ b/images/jail/populate_jail_entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -eox
 
-SENTINEL="/mnt/jail/.populated"
+SENTINEL="/mnt/jail/etc/soperator-jail-populated"
 
 while ! mountpoint -q /mnt/jail; do
     echo "Waiting until /mnt/jail is mounted"
@@ -51,14 +51,23 @@ if [ "${OVERWRITE:-}" = "1" ]; then
     echo "Content overwriting is turned on, repopulating jail directory"
     populate_jail_rootfs
 elif [ -f "$SENTINEL" ]; then
+    echo "Jail directory is already populated (sentinel exists), removing empty libs and exiting"
     remove_empty_lib_mount_targets
-    echo "Jail directory is already populated (sentinel exists), exiting"
+    exit 0
+elif [ -f "/mnt/jail/.populated" ]; then
+    # Migration: jail was populated by an older version that created sentinel file in another location.
+    # Write it now so sconfigcontroller can proceed, and avoid unnecessary re-population.
+    # Also, delete the old sentinel file.
+    echo "Jail looks already populated (legacy, old sentinel), removing empty libs, migrating sentinel and exiting"
+    remove_empty_lib_mount_targets
+    date -Iseconds > "$SENTINEL"
+    rm -f "/mnt/jail/.populated"
     exit 0
 elif [ -d /mnt/jail/dev ] && [ -d /mnt/jail/usr ]; then
-    remove_empty_lib_mount_targets
     # Migration: jail was populated by an older version that didn't write the sentinel.
     # Write it now so sconfigcontroller can proceed, and avoid unnecessary re-population.
-    echo "Jail looks already populated (legacy, no sentinel), writing sentinel and exiting"
+    echo "Jail looks already populated (legacy, no sentinel), removing empty libs, writing sentinel and exiting"
+    remove_empty_lib_mount_targets
     date -Iseconds > "$SENTINEL"
     exit 0
 else

--- a/internal/render/sconfigcontroller/initcontainer.go
+++ b/internal/render/sconfigcontroller/initcontainer.go
@@ -63,10 +63,10 @@ func renderInitContainerSConfigController(
 		Args: []string{
 			`echo "Waiting for populate-jail to complete..."
 timeout=600; elapsed=0
-while [ ! -f /mnt/jail/.populated ] && [ $elapsed -lt $timeout ]; do
+while [ ! -f /mnt/jail/etc/soperator-jail-populated ] && [ $elapsed -lt $timeout ]; do
     sleep 5; elapsed=$((elapsed + 5))
 done
-if [ ! -f /mnt/jail/.populated ]; then
+if [ ! -f /mnt/jail/etc/soperator-jail-populated ]; then
     echo "ERROR: populate-jail did not complete within ${timeout}s"
     exit 1
 fi


### PR DESCRIPTION
## Problem
The sentinel file that marks the jail filesystem to be populated is now stored in the root directory.
1. It's better not to clog the root directory with such files
2. Users can remove the file, which will lead to full jail repopulation in the future, when we get rid of the old check that relies on the presence of /dev and /usr directories.

## Solution
Move the sentinel file to /etc, next to similar files gpu_libs_installed.flag and soperator-jail-version, and rename it to soperator-jail-populated.

## Testing
If cluster creation works then everything is fine

## Release Notes
--
