### PR TITLE
Revert "SCHED-1650 Use nebius-o11y-agent 2.0.10 (arm images)"

### DIFF
--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -195,7 +195,7 @@ spec:
     image:
       pullPolicy: IfNotPresent
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
-      tag: 2.0.10
+      tag: 0.2.267
     mode: deployment
     rollout:
       rollingUpdate:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -366,7 +366,7 @@ spec:
     image:
       pullPolicy: IfNotPresent
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
-      tag: 2.0.10
+      tag: 0.2.267
     initContainers:
     - command:
       - sh

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -409,7 +409,7 @@ spec:
     image:
       pullPolicy: IfNotPresent
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
-      tag: 2.0.10
+      tag: 0.2.267
     initContainers:
     - command:
       - sh


### PR DESCRIPTION
## What

Reverts commit `d6f4325b` ("SCHED-1650 Use nebius-o11y-agent 2.0.10 (arm images)", PR #2571), restoring the `nebius-o11y-agent` image tag from `2.0.10` back to the last known-good `0.2.267` in all three otel-collector templates (`opentelemetry-collector-{events,logs,jail-logs}.yaml`).

## Why

`nebius-o11y-agent:2.0.10` crash-loops on startup on the B200 (amd64) e2e profile: the collector process exits before binding its health-check port `:13133`, so liveness/readiness probes get `connection refused` → CrashLoopBackOff across all three collectors → flux `helm install --wait` times out (`context deadline exceeded`) → the `opentelemetry-collector-*` HelmReleases never become Ready → e2e acceptance fails immediately on the "all HelmReleases are Ready" check.

This has broken every B200 e2e run since the bump merged on 2026-06-02 (tracked in SCHED-1824, 4 reproductions so far). The previous tag `0.2.267` does not exhibit the crash.

The exact in-process crash reason isn't recoverable from e2e artifacts — the crashing pods are the o11y log shippers, and `logs-system` isn't in the `kubectl cluster-info dump` namespace list — so this restores the working version rather than blocking CI while the `2.0.x` regression is chased.

## Tradeoff

This drops the ARM image goal that SCHED-1650 was after. Re-adopting `2.0.x` should be a separate change, after confirming the image actually starts on amd64 GPU nodes (and ideally after adding `logs-system` to the e2e cluster-info dump + `kubectl logs --previous` capture, so a future crash is debuggable).

## Evidence

- e2e run [26883855591](https://github.com/nebius/soperator/actions/runs/26883855591) (2026-06-03, `main`, profile `SB_KCS_B200`)
- `Helm install failed for release logs-system/opentelemetry-collector-events with chart opentelemetry-collector@0.117.3: context deadline exceeded`
- All `opentelemetry-collector-*` pods in `logs-system` in CrashLoopBackOff; probes `connection refused` on `:13133`

See SCHED-1824.
