### PR TITLE
SCHED-1814: Upgrade otel-collectors

### DIFF
--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -177,6 +177,7 @@ spec:
             - otlp
             {{- end }}
             processors:
+            - k8s_attributes
             - transform
             - memory_limiter
             - batch

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -195,7 +195,7 @@ spec:
     image:
       pullPolicy: IfNotPresent
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
-      tag: 0.2.267
+      tag: 2.0.10
     mode: deployment
     rollout:
       rollingUpdate:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -157,7 +157,12 @@ spec:
         {{- if .Values.observability.opentelemetry.metrics.enabled }}
         telemetry:
           metrics:
-            address: 0.0.0.0:8888
+            readers:
+              - pull:
+                  exporter:
+                    prometheus:
+                      host: 0.0.0.0
+                      port: 8888
         {{- end }}
         extensions:
         - health_check

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -57,7 +57,7 @@ spec:
         - list
     config:
       exporters:
-        otlphttp/victoriametrics:
+        otlp_http/victoriametrics:
           compression: gzip
           encoding: proto
           logs_endpoint: http://vm-logs-victoria-logs-single-server:9428/insert/opentelemetry/v1/logs
@@ -97,7 +97,7 @@ spec:
           timeout: {{ $batch.timeout | default "1s" }}
           send_batch_size: {{ $batch.sendBatchSize | default 2000 }}
           send_batch_max_size: {{ $batch.sendBatchMaxSize | default 5000 }}
-        k8sattributes:
+        k8s_attributes:
           extract:
             labels:
             - from: pod
@@ -172,7 +172,7 @@ spec:
         pipelines:
           logs/events:
             exporters:
-            - otlphttp/victoriametrics
+            - otlp_http/victoriametrics
             {{- if $hasPublicEndpoint }}
             - otlp
             {{- end }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -300,7 +300,12 @@ spec:
         {{- if .Values.observability.opentelemetry.metrics.enabled }}
         telemetry:
           metrics:
-            address: 0.0.0.0:8888
+            readers:
+              - pull:
+                  exporter:
+                    prometheus:
+                      host: 0.0.0.0
+                      port: 8888
         {{- end }}
         extensions:
         - health_check

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -366,7 +366,7 @@ spec:
     image:
       pullPolicy: IfNotPresent
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
-      tag: 0.2.267
+      tag: 2.0.10
     initContainers:
     - command:
       - sh

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -218,7 +218,7 @@ spec:
           timeout: {{ $batch.timeout | default "1s" }}
           send_batch_size: {{ $batch.sendBatchSize | default 2000 }}
           send_batch_max_size: {{ $batch.sendBatchMaxSize | default 5000 }}
-        k8sattributes:
+        k8s_attributes:
           pod_association:
           - sources:
             - from: resource_attribute
@@ -259,7 +259,7 @@ spec:
             - set(attributes["sp_resource_id"], "${env:CLUSTER_ID}")
             {{- end }}
       exporters:
-        otlphttp/victorialogs:
+        otlp_http/victorialogs:
           compression: gzip
           encoding: proto
           logs_endpoint: http://vm-logs-victoria-logs-single-server:9428/insert/opentelemetry/v1/logs
@@ -319,12 +319,12 @@ spec:
             - filelog
             - filelog/health_checker
             processors:
-            - k8sattributes
+            - k8s_attributes
             - transform
             - memory_limiter
             - batch
             exporters:
-            - otlphttp/victorialogs
+            - otlp_http/victorialogs
             {{- if $hasPublicEndpoint }}
             - otlp
             {{- end }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -409,7 +409,7 @@ spec:
     image:
       pullPolicy: IfNotPresent
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
-      tag: 0.2.267
+      tag: 2.0.10
     initContainers:
     - command:
       - sh

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -192,6 +192,7 @@ spec:
             - type: move
               from: attributes.app
               to: attributes["syslog.appname"]
+              output: move-logtype
             - id: parse-syslog
               type: syslog_parser
               protocol: rfc3164
@@ -202,7 +203,8 @@ spec:
               if: '"message" in attributes'
             - id: not-syslog
               type: noop
-            - type: move
+            - id: move-logtype
+              type: move
               from: attributes["logtype"]
               to: resource["app.kubernetes.io/name"]
         {{- end }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -319,7 +319,12 @@ spec:
         {{- if .Values.observability.opentelemetry.metrics.enabled }}
         telemetry:
           metrics:
-            address: 0.0.0.0:8888
+            readers:
+              - pull:
+                  exporter:
+                    prometheus:
+                      host: 0.0.0.0
+                      port: 8888
         {{- end }}
         extensions:
         - health_check

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -50,7 +50,7 @@ spec:
         - list
     config:
       exporters:
-        otlphttp/victoriametrics:
+        otlp_http/victoriametrics:
           compression: gzip
           encoding: proto
           logs_endpoint: http://vm-logs-victoria-logs-single-server:9428/insert/opentelemetry/v1/logs
@@ -92,7 +92,7 @@ spec:
           timeout: {{ $batch.timeout | default "1s" }}
           send_batch_size: {{ $batch.sendBatchSize | default 2000 }}
           send_batch_max_size: {{ $batch.sendBatchMaxSize | default 5000 }}
-        k8sattributes:
+        k8s_attributes:
           extract:
             labels:
             - from: pod
@@ -335,12 +335,12 @@ spec:
         pipelines:
           logs:
             exporters:
-            - otlphttp/victoriametrics
+            - otlp_http/victoriametrics
             {{- if $hasPublicEndpoint }}
             - otlp
             {{- end }}
             processors:
-            - k8sattributes
+            - k8s_attributes
             - transform
             - memory_limiter
             - batch

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -164,7 +164,7 @@ observability:
       interval: 30s
       scrapeTimeout: 10s
     logs:
-      version: 0.117.*
+      version: 0.149.*
       interval: 15m
       timeout: 15m
       install:
@@ -202,7 +202,7 @@ observability:
       driftDetection:
         mode: warn
     events:
-      version: 0.117.*
+      version: 0.149.*
       interval: 5m
       timeout: 5m
       install:


### PR DESCRIPTION
## Problem

1. [Upgrading the version](https://github.com/nebius/soperator/pull/2571) of the `nebius-o11y-agent` (`otel-collector`) is not enough for supporting new features as it deprecated `service.telemetry.metrics.address` field in [v0.123.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.123.0)
2. Upgraded version of the collector also requires upgraded version of the Helm chart to deploy it
3. Log collector agents fail with `expecting a sequence number (from 1 to max 255 digits) [col 3]`

## Solution

- Modify the config to support latest schema along with bumping the version
- Upgrade the Helm chart version
- Fix pipeline of the `opentelemetry-collector-logs` to fix the sequence number issue

## Misc

It seems like the `k8s_attributes` processor of `opentelemetry-collector-events` was missed to be added into the pipeline though it is present in the list of processors.

`otlphttp` and `k8sattributes` processor aliases were deprecated, so they're replaced with `otlp_http` and `k8s_attributes` accordingly.

## Release Notes
Updated: nebius-o11y-agent version to improve stability and support metrics collection on ARM workers.
