### PR TITLE
SCHED-962: Set finite default SuspendTime for Slurm power-save

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -189,11 +189,12 @@ type SlurmConfig struct {
 	// +kubebuilder:default="SwitchAsNodeRank"
 	TopologyParam string `json:"topologyParam,omitempty"`
 	// SuspendTime is the idle time in seconds after which ephemeral (CLOUD) nodes become eligible
-	// for automatic power down. A negative value (the default, -1) disables automatic power down.
-	// Automatic power up is unaffected by this setting.
+	// for automatic power down. The default is a large finite value so Slurm power-save remains
+	// enabled; with INFINITE/-1 and no partition-level finite SuspendTime, Slurm disables
+	// power-save and scontrol power down cannot trigger SuspendProgram.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=-1
+	// +kubebuilder:default=1000000000
 	SuspendTime *int32 `json:"suspendTime,omitempty"`
 }
 

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -3805,11 +3805,12 @@ spec:
                       starts. Default value is no prolog
                     type: string
                   suspendTime:
-                    default: -1
+                    default: 1000000000
                     description: |-
                       SuspendTime is the idle time in seconds after which ephemeral (CLOUD) nodes become eligible
-                      for automatic power down. A negative value (the default, -1) disables automatic power down.
-                      Automatic power up is unaffected by this setting.
+                      for automatic power down. The default is a large finite value so Slurm power-save remains
+                      enabled; with INFINITE/-1 and no partition-level finite SuspendTime, Slurm disables
+                      power-save and scontrol power down cannot trigger SuspendProgram.
                     format: int32
                     type: integer
                   taskPluginParam:

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -30656,11 +30656,12 @@ spec:
                       starts. Default value is no prolog
                     type: string
                   suspendTime:
-                    default: -1
+                    default: 1000000000
                     description: |-
                       SuspendTime is the idle time in seconds after which ephemeral (CLOUD) nodes become eligible
-                      for automatic power down. A negative value (the default, -1) disables automatic power down.
-                      Automatic power up is unaffected by this setting.
+                      for automatic power down. The default is a large finite value so Slurm power-save remains
+                      enabled; with INFINITE/-1 and no partition-level finite SuspendTime, Slurm disables
+                      power-save and scontrol power down cannot trigger SuspendProgram.
                     format: int32
                     type: integer
                   taskPluginParam:

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -30656,11 +30656,12 @@ spec:
                       starts. Default value is no prolog
                     type: string
                   suspendTime:
-                    default: -1
+                    default: 1000000000
                     description: |-
                       SuspendTime is the idle time in seconds after which ephemeral (CLOUD) nodes become eligible
-                      for automatic power down. A negative value (the default, -1) disables automatic power down.
-                      Automatic power up is unaffected by this setting.
+                      for automatic power down. The default is a large finite value so Slurm power-save remains
+                      enabled; with INFINITE/-1 and no partition-level finite SuspendTime, Slurm disables
+                      power-save and scontrol power down cannot trigger SuspendProgram.
                     format: int32
                     type: integer
                   taskPluginParam:

--- a/internal/render/common/configmap_test.go
+++ b/internal/render/common/configmap_test.go
@@ -344,6 +344,19 @@ func TestRenderSlurmConfigMapAndTopology(t *testing.T) {
 	}
 }
 
+func TestRenderSlurmConfigMapWithLargeSuspendTime(t *testing.T) {
+	result := RenderConfigMapSlurmConfigs(&values.SlurmCluster{
+		SlurmConfig: slurmv1.SlurmConfig{
+			SuspendTime: ptr.To[int32](1000000000),
+		},
+	})
+
+	slurmConfig := result.Data[consts.ConfigMapKeySlurmConfig]
+	assert.Contains(t, slurmConfig, "SuspendTime=1000000000")
+	assert.NotContains(t, slurmConfig, "SuspendTime=-1")
+	assert.NotContains(t, slurmConfig, "SuspendTime=INFINITE")
+}
+
 func TestRenderPlugstack(t *testing.T) {
 	t.Run("Pyxis no options", func(t *testing.T) {
 		result := generateSpankConfig(&values.SlurmCluster{


### PR DESCRIPTION
## Problem
`SuspendTime=-1` maps to Slurm `INFINITE`, which disables power-save when partitions do not define their own finite `SuspendTime`. As a result, `scontrol power down <node>` cannot trigger `SuspendProgram` for ephemeral nodes.

## Solution
Changed the default `SuspendTime` to `1000000000`, a large finite value that keeps Slurm power-save enabled while effectively avoiding automatic idle power down in normal operation. Updated the CRD documentation and added a render test for this value.

## Testing
Manually on the live cluster
Ran:

```bash
go test ./internal/render/common
```

## Release Notes
Changed the default Slurm `SuspendTime` to a large finite value so ephemeral node power-save commands can trigger `SuspendProgram` reliably. No migration is required; users can still override `spec.slurmConfig.suspendTime` explicitly.