### PR TITLE
SCHED-1838: Rack support in dashboards

### DIFF
--- a/helm/soperator-dcgm-exporter/templates/servicemonitor.yaml
+++ b/helm/soperator-dcgm-exporter/templates/servicemonitor.yaml
@@ -13,13 +13,10 @@ spec:
     metricRelabelings:
     {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
     relabelings:
-    - action: replace
-      regex: nvidia-dcgm-exporter
-      replacement: dcgm-exporter
-      sourceLabels:
-      - __meta_kubernetes_pod_label_app
-      targetLabel: app_kubernetes_io_name
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
   jobLabel: app
+  attachMetadata:
+    node: true
   namespaceSelector:
     matchNames:
     - soperator

--- a/helm/soperator-dcgm-exporter/values.yaml
+++ b/helm/soperator-dcgm-exporter/values.yaml
@@ -34,6 +34,28 @@ serviceMonitor:
       regex: feature_node_kubernetes_io_.*|kubernetes_io_.*|nvidia_com_gpu.*
     - action: labeldrop
       regex: UUID|DCGM_FI_PROCESS_NAME|DCGM_FI_DEV_SERIAL|DCGM_FI_DEV_NAME|job|pci_bus_id|prometheus
+  relabelings:
+    - action: replace
+      regex: nvidia-dcgm-exporter
+      replacement: dcgm-exporter
+      sourceLabels:
+      - __meta_kubernetes_pod_label_app
+      targetLabel: app_kubernetes_io_name
+    - action: replace
+      regex: (.+)
+      sourceLabels:
+        - __meta_kubernetes_node_label_nebius_com_nvlink_instance_group
+      targetLabel: nvlink_instance_group
+    - action: replace
+      regex: (.+)
+      sourceLabels:
+        - __meta_kubernetes_node_label_slurm_nebius_ai_nodeset
+      targetLabel: slurm_nodeset
+    - action: replace
+      regex: (.+)
+      sourceLabels:
+        - __meta_kubernetes_node_label_slurm_nebius_ai_nodeset_name
+      targetLabel: slurm_nodeset_name
 
 serviceAccount:
   annotations: {}

--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -93,7 +93,7 @@ spec:
           - '--metric-allowlist=kube_node_info'
           - '--metric-allowlist=kube_customresource_.*'
           - '--metric-allowlist=kube_node_labels'
-          - '--metric-labels-allowlist=nodes=[nebius.com/driverful,nebius.com/gpu,nebius.com/node-group-id,slurm.nebius.ai/nodeset,slurm.nebius.ai/workload]'
+          - '--metric-labels-allowlist=nodes=[nebius.com/driverful,nebius.com/gpu,nebius.com/gpu-name,nebius.com/node-group-id,nebius.com/nvlink-instance-group,nebius.com/resource-preset,slurm.nebius.ai/nodeset,slurm.nebius.ai/nodeset-name,slurm.nebius.ai/workload]'
         rbac:
           extraRules:
             - apiGroups:

--- a/helm/soperator-monitoring-dashboards/dashboards/cluster_health.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/cluster_health.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 20,
+  "id": 22,
   "links": [
     {
       "asDropdown": false,
@@ -64,7 +64,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "text"
+                "color": "text",
+                "value": null
               }
             ]
           }
@@ -94,7 +95,7 @@
         "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -103,7 +104,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "group(\n    label_replace(\n        container_processes{\n            \n            image=~\".*slurm-operator:.*\",\n            container=\"manager\"\n        }\n    , \"version\", \"$1\", \"image\", \".*:(.+)\"\n    )\n) by(version)\n",
+          "expr": "group(\n    kube_customresource_slurmcluster_info{\n        cr_version!=\"\"\n    }\n) by(cr_version)\n",
           "instant": true,
           "legendFormat": "{{version}}",
           "range": false,
@@ -127,80 +128,12 @@
             "mode": "thresholds"
           },
           "mappings": [],
-          "noValue": "-",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "dateTimeFromNow"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 1
-      },
-      "id": 2,
-      "maxPerRow": 6,
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "value",
-        "wideLayout": false
-      },
-      "pluginVersion": "11.6.14",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "VictoriaMetrics"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(\n  tlast_change_over_time(\n    (\n      group(\n        label_replace(\n          container_processes{\n            \n            image=~\".*slurm-operator:.*\",\n            container=\"manager\"\n          },\n          \"version\",\n          \"$1\",\n          \"image\",\n          \".*:(.+)\"\n        )\n      ) by(version)\n    )[180d]\n  )\n    *\n  1000\n)\n  and on(version)\ngroup(\n  label_replace(\n    container_processes{\n      \n      image=~\".*slurm-operator:.*\",\n      container=\"manager\"\n    },\n    \"version\",\n    \"$1\",\n    \"image\",\n    \".*:(.+)\"\n  )\n) by(version)",
-          "instant": true,
-          "legendFormat": "{{version}}",
-          "range": false,
-          "refId": "A",
-          "useCustomValues": false,
-          "useDashValues": false
-        }
-      ],
-      "title": "Last Soperator upgrade",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "VictoriaMetrics"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-blue"
+                "color": "super-light-blue",
+                "value": null
               }
             ]
           }
@@ -209,8 +142,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
-        "x": 8,
+        "w": 8,
+        "x": 4,
         "y": 1
       },
       "id": 35,
@@ -230,7 +163,7 @@
         "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -239,7 +172,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(\n  cadvisor_version_info{}\n) by(container_id)",
+          "expr": "count(\n  cadvisor_version_info{}\n) by(iam_project_id)",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -267,7 +200,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "super-light-blue"
+                "color": "super-light-blue",
+                "value": null
               }
             ]
           }
@@ -297,7 +231,7 @@
         "textMode": "name",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -306,7 +240,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "group(\n    label_transform(\n        DCGM_FI_DEV_COUNT{\n            \n            modelName!=\"\",\n        },\n        \"modelName\", \"NVIDIA (.*)\", \"$1\"\n    )\n) by (modelName)",
+          "expr": "group(\n    kube_node_labels{label_nebius_com_gpu_name!=\"\"}\n) by (label_nebius_com_gpu_name)",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -323,7 +257,7 @@
         "type": "prometheus",
         "uid": "VictoriaMetrics"
       },
-      "description": "",
+      "description": "For GB platform only",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -334,7 +268,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "super-light-purple"
+                "color": "super-light-purple",
+                "value": null
               }
             ]
           }
@@ -347,7 +282,7 @@
         "x": 16,
         "y": 1
       },
-      "id": 9,
+      "id": 100,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -363,12 +298,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(\n  DCGM_FI_DEV_GPU_UTIL{\n    \n  }\n) by()",
+          "expr": "count(\n  count by (label_slurm_nebius_ai_nodeset_name) (\n    kube_node_labels{\n      label_nebius_com_gpu_name=~\"GB.*\",\n      label_slurm_nebius_ai_nodeset_name!=\"\"\n    }\n  )\n)",
           "instant": true,
           "range": false,
           "refId": "A",
@@ -376,7 +311,7 @@
           "useDashValues": false
         }
       ],
-      "title": "GPUs",
+      "title": "Racks",
       "type": "stat"
     },
     {
@@ -395,7 +330,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "super-light-purple"
+                "color": "super-light-purple",
+                "value": null
               }
             ]
           }
@@ -424,7 +360,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
@@ -441,12 +377,274 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 4
+      },
+      "id": 2,
+      "maxPerRow": 6,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": false
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(\n  tlast_change_over_time(\n    (\n      group(\n        kube_customresource_slurmcluster_info{\n          cr_version!=\"\"\n        }\n      ) by(cr_version)\n    )[180d]\n  )\n    *\n  1000\n)\nand on(cr_version)\ngroup(\n  kube_customresource_slurmcluster_info{\n    cr_version!=\"\"\n  }\n) by(cr_version)",
+          "instant": true,
+          "legendFormat": "{{version}}",
+          "range": false,
+          "refId": "A",
+          "useCustomValues": false,
+          "useDashValues": false
+        }
+      ],
+      "title": "Last Soperator upgrade",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 4,
+        "y": 4
+      },
+      "id": 101,
+      "maxPerRow": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(\n  cadvisor_version_info{}\n) by(mk8s_cluster_id)",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "useCustomValues": false,
+          "useDashValues": false
+        }
+      ],
+      "title": "mk8s ID",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 4
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(\n  DCGM_FI_DEV_GPU_UTIL{\n    \n  }\n) by()",
+          "instant": true,
+          "range": false,
+          "refId": "A",
+          "useCustomValues": true,
+          "useDashValues": false
+        }
+      ],
+      "title": "GPUs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "For GB platform only",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 4
+      },
+      "id": 102,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(\n  count by (label_nebius_com_nvlink_instance_group) (\n    kube_node_labels{\n      label_nebius_com_gpu_name=~\"GB.*\",\n      label_nebius_com_nvlink_instance_group!=\"\"\n    }\n  )\n)",
+          "instant": true,
+          "range": false,
+          "refId": "A",
+          "useCustomValues": true,
+          "useDashValues": false
+        }
+      ],
+      "title": "NVLink Groups",
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 7
       },
       "id": 11,
       "panels": [],
@@ -470,7 +668,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-orange"
+                "color": "light-orange",
+                "value": null
               }
             ]
           },
@@ -482,7 +681,7 @@
         "h": 3,
         "w": 4,
         "x": 0,
-        "y": 5
+        "y": 8
       },
       "id": 5,
       "options": {
@@ -500,7 +699,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
@@ -535,7 +734,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -551,7 +751,7 @@
         "h": 3,
         "w": 4,
         "x": 4,
-        "y": 5
+        "y": 8
       },
       "id": 16,
       "options": {
@@ -569,7 +769,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -609,7 +809,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -621,7 +822,7 @@
         "h": 3,
         "w": 4,
         "x": 8,
-        "y": 5
+        "y": 8
       },
       "id": 13,
       "options": {
@@ -639,7 +840,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -676,7 +877,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           }
@@ -687,7 +889,7 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 5
+        "y": 8
       },
       "id": 26,
       "options": {
@@ -705,7 +907,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
@@ -738,7 +940,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -750,7 +953,7 @@
         "h": 3,
         "w": 4,
         "x": 16,
-        "y": 5
+        "y": 8
       },
       "id": 21,
       "options": {
@@ -768,7 +971,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
@@ -803,7 +1006,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -815,7 +1019,7 @@
         "h": 3,
         "w": 4,
         "x": 20,
-        "y": 5
+        "y": 8
       },
       "id": 29,
       "options": {
@@ -836,7 +1040,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -872,7 +1076,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-orange"
+                "color": "light-orange",
+                "value": null
               }
             ]
           },
@@ -884,7 +1089,7 @@
         "h": 3,
         "w": 4,
         "x": 0,
-        "y": 8
+        "y": 11
       },
       "id": 6,
       "options": {
@@ -902,7 +1107,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
@@ -937,7 +1142,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -953,7 +1159,7 @@
         "h": 3,
         "w": 4,
         "x": 4,
-        "y": 8
+        "y": 11
       },
       "id": 17,
       "options": {
@@ -971,7 +1177,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1010,7 +1216,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "super-light-purple"
+                "color": "super-light-purple",
+                "value": null
               }
             ]
           },
@@ -1022,7 +1229,7 @@
         "h": 3,
         "w": 4,
         "x": 8,
-        "y": 8
+        "y": 11
       },
       "id": 97,
       "options": {
@@ -1040,7 +1247,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
@@ -1073,7 +1280,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "light-orange",
@@ -1092,7 +1300,7 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 8
+        "y": 11
       },
       "id": 27,
       "options": {
@@ -1110,7 +1318,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
@@ -1144,7 +1352,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "light-orange",
@@ -1164,7 +1373,7 @@
         "h": 3,
         "w": 4,
         "x": 16,
-        "y": 8
+        "y": 11
       },
       "id": 23,
       "options": {
@@ -1185,7 +1394,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1224,7 +1433,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1236,7 +1446,7 @@
         "h": 3,
         "w": 4,
         "x": 20,
-        "y": 8
+        "y": 11
       },
       "id": 30,
       "options": {
@@ -1257,7 +1467,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1293,7 +1503,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "super-light-purple"
+                "color": "super-light-purple",
+                "value": null
               }
             ]
           },
@@ -1305,7 +1516,7 @@
         "h": 3,
         "w": 4,
         "x": 4,
-        "y": 11
+        "y": 14
       },
       "id": 98,
       "options": {
@@ -1323,7 +1534,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
@@ -1356,7 +1567,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "super-light-purple"
+                "color": "super-light-purple",
+                "value": null
               }
             ]
           }
@@ -1367,7 +1579,7 @@
         "h": 3,
         "w": 4,
         "x": 8,
-        "y": 11
+        "y": 14
       },
       "id": 96,
       "options": {
@@ -1385,7 +1597,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
@@ -1417,7 +1629,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1429,7 +1642,7 @@
         "h": 3,
         "w": 4,
         "x": 16,
-        "y": 11
+        "y": 14
       },
       "id": 22,
       "options": {
@@ -1450,7 +1663,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1477,7 +1690,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 17
       },
       "id": 12,
       "panels": [],
@@ -1536,7 +1749,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-orange"
+                "color": "light-orange",
+                "value": null
               }
             ]
           }
@@ -1547,7 +1761,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 15
+        "y": 18
       },
       "id": 8,
       "options": {
@@ -1563,7 +1777,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1632,7 +1846,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1644,7 +1859,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 15
+        "y": 18
       },
       "id": 24,
       "options": {
@@ -1660,7 +1875,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1732,7 +1947,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1799,7 +2015,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 22
+        "y": 25
       },
       "id": 15,
       "options": {
@@ -1815,7 +2031,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1915,7 +2131,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1927,7 +2144,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 22
+        "y": 25
       },
       "id": 78,
       "interval": "30s",
@@ -1944,7 +2161,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
@@ -2012,7 +2229,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2079,7 +2297,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 29
+        "y": 32
       },
       "id": 99,
       "options": {
@@ -2095,7 +2313,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.14",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -2149,7 +2367,303 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 39
+      },
+      "id": 103,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "description": "Proportion of GPUs with at least 10% utilization to total for selected racks",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "light-orange",
+                "mode": "shades"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "light-orange",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 40
+          },
+          "id": 104,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "VictoriaMetrics"
+              },
+              "editorMode": "code",
+              "expr": "(\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n      slurm_nodeset_name=~\"$rack\"\n    }\n      >=\n    10\n  ) by(cluster)\n    /\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n      slurm_nodeset_name=~\"$rack\"\n    }\n  ) by(cluster)\n)\n  *\n100",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useCustomValues": true,
+              "useDashValues": false
+            }
+          ],
+          "title": "Rack Utilization",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "description": "Only for GPUs with at least 10% utilization for selected racks",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "green",
+                "mode": "fixed"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 50,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "watt"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "max"
+                },
+                "properties": [
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "min"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "avg"
+                },
+                "properties": [
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "dash": [10, 10],
+                      "fill": "dash"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "super-light-green",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "min"
+                },
+                "properties": [
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 40
+          },
+          "id": 105,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "VictoriaMetrics"
+              },
+              "editorMode": "code",
+              "expr": "max(\n  DCGM_FI_DEV_POWER_USAGE{\n      slurm_nodeset_name=~\"$rack\"\n    }\n    and on(exported_pod,gpu)\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n      slurm_nodeset_name=~\"$rack\"\n    }\n      >=\n    10\n  ) by(exported_pod,gpu)\n)",
+              "hide": false,
+              "legendFormat": "max",
+              "range": true,
+              "refId": "C",
+              "useCustomValues": true,
+              "useDashValues": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "VictoriaMetrics"
+              },
+              "editorMode": "code",
+              "expr": "avg(\n  DCGM_FI_DEV_POWER_USAGE{\n    slurm_nodeset_name=~\"$rack\"\n  }\n    and on(exported_pod,gpu)\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n      slurm_nodeset_name=~\"$rack\"\n    }\n      >=\n    10\n  ) by(exported_pod,gpu)\n)",
+              "hide": false,
+              "legendFormat": "avg",
+              "range": true,
+              "refId": "B",
+              "useCustomValues": true,
+              "useDashValues": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "VictoriaMetrics"
+              },
+              "editorMode": "code",
+              "expr": "min(\n  DCGM_FI_DEV_POWER_USAGE{\n    slurm_nodeset_name=~\"$rack\"\n  }\n    and on(exported_pod,gpu)\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n      slurm_nodeset_name=~\"$rack\"\n    }\n      >=\n    10\n  ) by(exported_pod,gpu)\n)",
+              "hide": false,
+              "legendFormat": "min",
+              "range": true,
+              "refId": "A",
+              "useCustomValues": true,
+              "useDashValues": false
+            }
+          ],
+          "title": "Cluster Power usage",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Racks",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
       },
       "id": 79,
       "panels": [
@@ -2203,7 +2717,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2325,7 +2840,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 48
           },
           "id": 82,
           "options": {
@@ -2341,7 +2856,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -2457,7 +2972,6 @@
                 "mode": "palette-classic"
               },
               "custom": {
-                "axisPlacement": "auto",
                 "fillOpacity": 70,
                 "hideFrom": {
                   "legend": false,
@@ -2499,7 +3013,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2511,7 +3026,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 48
           },
           "id": 83,
           "options": {
@@ -2530,7 +3045,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -2616,7 +3131,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2675,7 +3191,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 141
           },
           "id": 31,
           "options": {
@@ -2691,7 +3207,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -2791,7 +3307,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2850,7 +3367,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 141
           },
           "id": 73,
           "options": {
@@ -2866,7 +3383,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -2939,7 +3456,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3097,7 +3615,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 52
+            "y": 148
           },
           "id": 84,
           "options": {
@@ -3113,7 +3631,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -3298,7 +3816,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 41
       },
       "id": 80,
       "panels": [
@@ -3328,7 +3846,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -3450,7 +3969,8 @@
                       "mode": "absolute",
                       "steps": [
                         {
-                          "color": "green"
+                          "color": "green",
+                          "value": null
                         },
                         {
                           "color": "#EAB839",
@@ -3503,7 +4023,8 @@
                       "mode": "absolute",
                       "steps": [
                         {
-                          "color": "red"
+                          "color": "red",
+                          "value": null
                         },
                         {
                           "color": "orange",
@@ -3566,7 +4087,8 @@
                       "mode": "absolute",
                       "steps": [
                         {
-                          "color": "light-blue"
+                          "color": "light-blue",
+                          "value": null
                         }
                       ]
                     }
@@ -3579,7 +4101,7 @@
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 167
+            "y": 49
           },
           "id": 92,
           "options": {
@@ -3595,7 +4117,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -3850,7 +4372,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3866,7 +4389,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 179
+            "y": 61
           },
           "id": 19,
           "options": {
@@ -3882,7 +4405,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -3953,7 +4476,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4016,7 +4540,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 179
+            "y": 61
           },
           "id": 10,
           "options": {
@@ -4032,7 +4556,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -4131,7 +4655,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4194,7 +4719,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 186
+            "y": 68
           },
           "id": 74,
           "options": {
@@ -4210,7 +4735,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -4288,7 +4813,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4303,7 +4829,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 186
+            "y": 68
           },
           "id": 77,
           "options": {
@@ -4321,7 +4847,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "editorMode": "code",
@@ -4352,7 +4878,6 @@
                 "mode": "palette-classic-by-name"
               },
               "custom": {
-                "axisPlacement": "auto",
                 "fillOpacity": 70,
                 "hideFrom": {
                   "legend": false,
@@ -4382,7 +4907,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4394,7 +4920,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 193
+            "y": 75
           },
           "id": 72,
           "options": {
@@ -4413,7 +4939,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -4452,7 +4978,6 @@
                 "mode": "palette-classic-by-name"
               },
               "custom": {
-                "axisPlacement": "auto",
                 "fillOpacity": 75,
                 "hideFrom": {
                   "legend": false,
@@ -4579,7 +5104,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4594,7 +5120,7 @@
             "h": 22,
             "w": 12,
             "x": 12,
-            "y": 194
+            "y": 76
           },
           "id": 90,
           "options": {
@@ -4614,7 +5140,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -4684,7 +5210,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4700,7 +5227,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 200
+            "y": 82
           },
           "id": 87,
           "options": {
@@ -4716,7 +5243,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -4786,7 +5313,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4802,7 +5330,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 208
+            "y": 90
           },
           "id": 88,
           "options": {
@@ -4818,7 +5346,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -4864,7 +5392,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -5061,7 +5590,7 @@
             "h": 12,
             "w": 24,
             "x": 0,
-            "y": 216
+            "y": 98
           },
           "id": 91,
           "options": {
@@ -5077,7 +5606,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -5300,7 +5829,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 42
       },
       "id": 93,
       "panels": [
@@ -5353,7 +5882,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5369,7 +5899,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 168
+            "y": 50
           },
           "id": 85,
           "options": {
@@ -5385,7 +5915,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -5455,7 +5985,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5471,7 +6002,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 168
+            "y": 50
           },
           "id": 86,
           "options": {
@@ -5487,7 +6018,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -5558,7 +6089,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5570,7 +6102,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 176
+            "y": 58
           },
           "id": 94,
           "options": {
@@ -5586,7 +6118,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "datasource": {
@@ -5658,7 +6190,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -5700,7 +6233,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 176
+            "y": 58
           },
           "id": 75,
           "options": {
@@ -5716,7 +6249,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.6.14",
+          "pluginVersion": "11.5.1",
           "targets": [
             {
               "editorMode": "code",
@@ -5793,7 +6326,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 184
+            "y": 66
           },
           "id": 95,
           "options": {
@@ -5836,22 +6369,43 @@
     }
   ],
   "preload": false,
-  "schemaVersion": 41,
+  "schemaVersion": 40,
   "tags": ["nebius", "soperator", "overview", "cluster"],
   "templating": {
     "list": [
       {
-        "allValue": ".*",
         "allowCustomValue": false,
         "current": {
           "text": ["All"],
+          "value": ["$__all"]
+        },
+        "definition": "label_values(kube_node_labels{label_nebius_com_gpu_name=~\"GB.*\"},label_slurm_nebius_ai_nodeset_name)",
+        "description": "For GB platforms",
+        "includeAll": true,
+        "label": "Rack",
+        "multi": true,
+        "name": "rack",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kube_node_labels{label_nebius_com_gpu_name=~\"GB.*\"},label_slurm_nebius_ai_nodeset_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
           "value": ["$__all"]
         },
         "datasource": {
           "type": "prometheus",
           "uid": "VictoriaMetrics"
         },
-        "definition": "label_values(slurm_node_info, node_name)",
+        "definition": "label_values(slurm_node_info{node_name=~\"$rack-.*\"}, node_name)",
         "description": "",
         "includeAll": true,
         "label": "Worker Node",
@@ -5860,7 +6414,7 @@
         "options": [],
         "query": {
           "qryType": 5,
-          "query": "label_values(slurm_node_info, node_name)",
+          "query": "label_values(slurm_node_info{node_name=~\"$rack-.*\"}, node_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -5872,7 +6426,7 @@
         "allValue": ".*",
         "allowCustomValue": false,
         "current": {
-          "text": ["All"],
+          "text": "All",
           "value": ["$__all"]
         },
         "datasource": {

--- a/helm/soperator-monitoring-dashboards/dashboards/workers_overview.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/workers_overview.json
@@ -42,7 +42,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 100,
+  "id": 23,
   "links": [
     {
       "asDropdown": false,
@@ -72,9 +72,9 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "VictoriaMetrics"
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
       },
       "gridPos": {
         "h": 5,
@@ -92,7 +92,7 @@
         "content": "* You can select multiple workers from the Drop Down above\n* Stats in all panels will be based on selected workers\n",
         "mode": "markdown"
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "title": "Usage Guide",
       "type": "text"
     },
@@ -153,7 +153,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -236,7 +236,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -320,7 +320,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -408,7 +408,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -494,7 +494,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -578,7 +578,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -662,7 +662,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -739,7 +739,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -816,7 +816,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -849,9 +849,9 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "VictoriaMetrics"
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -869,7 +869,7 @@
         "content": "* It shows the compute instance that a particular worker was scheduled on at any time\n* Worker that were moved to a different node will have more than one row for placement on each node\n* Workers that are added later (as scale up) would show with partial lines",
         "mode": "markdown"
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "title": "Usage Guide",
       "type": "text"
     },
@@ -1079,11 +1079,12 @@
         "rowHeight": 0.9,
         "showValue": "never",
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1242,11 +1243,12 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1427,11 +1429,12 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1621,11 +1624,12 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1671,117 +1675,6 @@
         }
       ],
       "title": "GPU Temperature",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "VictoriaMetrics"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "shades"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "tflops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 23
-      },
-      "id": 406,
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull"],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.4.0",
-      "targets": [
-        {
-          "datasource": {
-            "uid": "VictoriaMetrics"
-          },
-          "editorMode": "code",
-          "expr": "sum(DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{exported_pod=~\"$worker\"} * 1979)",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "FP8",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "uid": "VictoriaMetrics"
-          },
-          "editorMode": "code",
-          "expr": "sum(DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{exported_pod=~\"$worker\"} * 989.7)",
-          "format": "time_series",
-          "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "FP16/BF16",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "GPU Theoretical FLOPS",
       "type": "timeseries"
     },
     {
@@ -1908,11 +1801,12 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -1954,6 +1848,268 @@
         }
       ],
       "title": "CPU Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "shades"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "tflops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 23
+      },
+      "id": 406,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "sum(DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{exported_pod=~\"$worker\"} * 1979)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "FP8",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "sum(DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{exported_pod=~\"$worker\"} * 989.7)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "FP16/BF16",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "GPU Theoretical FLOPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/Rx.*/"
+            },
+            "properties": [
+              {
+                "id": "custom.transform",
+                "value": "negative-Y"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "shades"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/Tx.*/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-red",
+                  "mode": "shades"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 23
+      },
+      "id": 362,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$ip\"}[$__interval]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Tx {{pod}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate(node_infiniband_port_data_received_bytes_total{instance=~\"$ip\"}[$__interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Rx {{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Infiniband Throughput",
       "type": "timeseries"
     },
     {
@@ -2076,7 +2232,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 23
+        "y": 30
       },
       "id": 361,
       "interval": "2m",
@@ -2088,11 +2244,12 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
@@ -2141,6 +2298,19 @@
       "type": "timeseries"
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 339,
+      "panels": [],
+      "title": "GPU Stats per Worker",
+      "type": "row"
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "VictoriaMetrics"
@@ -2148,7 +2318,316 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "purple",
+            "mode": "shades"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 38
+      },
+      "id": 340,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "avg by (exported_pod) (DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "GPU Avg Utilization per Worker",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "shades"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 38
+      },
+      "id": 341,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "avg by (exported_pod) (DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}/(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}+DCGM_FI_DEV_FB_FREE{exported_pod=~\"$worker\"}))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "GPU Avg Mem Usage per Worker",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-yellow",
+            "mode": "shades"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 38
+      },
+      "id": 39,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "avg by (exported_pod) (DCGM_FI_DEV_MEM_COPY_UTIL{exported_pod=~\"$worker\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "GPU Avg Mem Copy Utilization per Worker",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-green",
+            "mode": "shades"
           },
           "custom": {
             "axisBorderShow": false,
@@ -2177,7 +2656,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -2188,61 +2667,22 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
+                "color": "green"
               }
             ]
           },
-          "unit": "Bps"
+          "unit": "watt"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "/Rx.*/"
-            },
-            "properties": [
-              {
-                "id": "custom.transform",
-                "value": "negative-Y"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "shades"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "/Tx.*/"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "light-red",
-                  "mode": "shades"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 7,
         "w": 8,
-        "x": 16,
-        "y": 23
+        "x": 0,
+        "y": 45
       },
-      "id": 362,
+      "id": 24,
+      "interval": "2m",
       "options": {
         "legend": {
           "calcs": ["lastNotNull"],
@@ -2262,31 +2702,228 @@
             "uid": "VictoriaMetrics"
           },
           "editorMode": "code",
-          "expr": "sum (rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$ip\"}[$__interval]))",
+          "expr": "sum by (exported_pod) (DCGM_FI_DEV_POWER_USAGE{exported_pod=~\"$worker\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "Tx {{pod}}",
+          "intervalFactor": 1,
+          "legendFormat": "__auto",
           "range": true,
           "refId": "B"
+        }
+      ],
+      "title": "GPU Total Power Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-red",
+            "mode": "shades"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "celsius"
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 45
+      },
+      "id": 344,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
         {
           "datasource": {
             "uid": "VictoriaMetrics"
           },
           "editorMode": "code",
-          "expr": "sum (rate(node_infiniband_port_data_received_bytes_total{instance=~\"$ip\"}[$__interval]))",
+          "expr": "avg by (exported_pod) (DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"})",
           "format": "time_series",
           "hide": false,
-          "instant": false,
           "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "Rx {{pod}}",
+          "intervalFactor": 1,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "GPU Avg Temperature per Worker",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-red",
+            "mode": "shades"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 0,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/No Error.*/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 45
+      },
+      "id": 338,
+      "interval": "2m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "sum by (err_msg, exported_pod) (rate(DCGM_FI_DEV_XID_ERRORS{exported_pod=~\"$worker\"}))",
+          "instant": false,
+          "legendFormat": "{{exported_pod}}: {{err_msg}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Infiniband Throughput",
+      "title": "XID errors",
       "type": "timeseries"
     },
     {
@@ -2295,635 +2932,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
-      },
-      "id": 339,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "VictoriaMetrics"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "purple",
-                "mode": "shades"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 20,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "smooth",
-                "lineWidth": 1,
-                "pointSize": 3,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "fieldMinMax": false,
-              "mappings": [],
-              "max": 100,
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 0,
-            "y": 101
-          },
-          "id": 340,
-          "interval": "2m",
-          "options": {
-            "legend": {
-              "calcs": ["lastNotNull"],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.4.0",
-          "targets": [
-            {
-              "datasource": {
-                "uid": "VictoriaMetrics"
-              },
-              "editorMode": "code",
-              "expr": "avg by (exported_pod) (DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "GPU Avg Utilization per Worker",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "VictoriaMetrics"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "blue",
-                "mode": "shades"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 20,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "smooth",
-                "lineWidth": 1,
-                "pointSize": 3,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "links": [],
-              "mappings": [],
-              "max": 1,
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 8,
-            "y": 101
-          },
-          "id": 341,
-          "interval": "2m",
-          "options": {
-            "legend": {
-              "calcs": ["lastNotNull"],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.4.0",
-          "targets": [
-            {
-              "datasource": {
-                "uid": "VictoriaMetrics"
-              },
-              "editorMode": "code",
-              "expr": "avg by (exported_pod) (DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}/(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}+DCGM_FI_DEV_FB_FREE{exported_pod=~\"$worker\"}))",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "GPU Avg Mem Usage per Worker",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "VictoriaMetrics"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "light-yellow",
-                "mode": "shades"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 20,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "smooth",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "max": 100,
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 16,
-            "y": 101
-          },
-          "id": 39,
-          "interval": "2m",
-          "options": {
-            "legend": {
-              "calcs": ["lastNotNull"],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.4.0",
-          "targets": [
-            {
-              "datasource": {
-                "uid": "VictoriaMetrics"
-              },
-              "editorMode": "code",
-              "expr": "avg by (exported_pod) (DCGM_FI_DEV_MEM_COPY_UTIL{exported_pod=~\"$worker\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "GPU Avg Mem Copy Utilization per Worker",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "VictoriaMetrics"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "light-green",
-                "mode": "shades"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 20,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "smooth",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "watt"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 0,
-            "y": 164
-          },
-          "id": 24,
-          "interval": "2m",
-          "options": {
-            "legend": {
-              "calcs": ["lastNotNull"],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.4.0",
-          "targets": [
-            {
-              "datasource": {
-                "uid": "VictoriaMetrics"
-              },
-              "editorMode": "code",
-              "expr": "sum by (exported_pod) (DCGM_FI_DEV_POWER_USAGE{exported_pod=~\"$worker\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "GPU Total Power Usage",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "VictoriaMetrics"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "light-red",
-                "mode": "shades"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 20,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "smooth",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 8,
-            "y": 164
-          },
-          "id": 344,
-          "interval": "2m",
-          "options": {
-            "legend": {
-              "calcs": ["lastNotNull"],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.4.0",
-          "targets": [
-            {
-              "datasource": {
-                "uid": "VictoriaMetrics"
-              },
-              "editorMode": "code",
-              "expr": "avg by (exported_pod) (DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"})",
-              "format": "time_series",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "GPU Avg Temperature per Worker",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "VictoriaMetrics"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "light-red",
-                "mode": "shades"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "smooth",
-                "lineWidth": 1,
-                "pointSize": 0,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byRegexp",
-                  "options": "/No Error.*/"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "green",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 16,
-            "y": 164
-          },
-          "id": 338,
-          "interval": "2m",
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.4.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "VictoriaMetrics"
-              },
-              "editorMode": "code",
-              "expr": "sum by (err_msg, exported_pod) (rate(DCGM_FI_DEV_XID_ERRORS{exported_pod=~\"$worker\"}))",
-              "instant": false,
-              "legendFormat": "{{exported_pod}}: {{err_msg}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "XID errors",
-          "type": "timeseries"
-        }
-      ],
-      "title": "GPU Stats per Worker",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "VictoriaMetrics"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 31
+        "y": 52
       },
       "id": 19,
       "panels": [
@@ -2990,7 +2999,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 102
+            "y": 172
           },
           "id": 347,
           "interval": "2m",
@@ -3087,7 +3096,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 102
+            "y": 172
           },
           "id": 354,
           "interval": "2m",
@@ -3205,7 +3214,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 109
+            "y": 179
           },
           "id": 38,
           "interval": "2m",
@@ -3319,7 +3328,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 109
+            "y": 179
           },
           "id": 351,
           "interval": "2m",
@@ -3422,7 +3431,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 109
+            "y": 179
           },
           "id": 352,
           "interval": "2m",
@@ -3460,15 +3469,6 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "VictoriaMetrics"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "CPU, RAM, File System",
       "type": "row"
     },
@@ -3478,7 +3478,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 53
       },
       "id": 335,
       "panels": [
@@ -3577,7 +3577,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 103
+            "y": 173
           },
           "id": 37,
           "interval": "2m",
@@ -3726,7 +3726,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 103
+            "y": 173
           },
           "id": 41,
           "interval": "2m",
@@ -3858,7 +3858,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 103
+            "y": 173
           },
           "id": 348,
           "interval": "2m",
@@ -3970,7 +3970,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 110
+            "y": 180
           },
           "id": 35,
           "interval": "2m",
@@ -4070,7 +4070,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 110
+            "y": 180
           },
           "id": 355,
           "interval": "2m",
@@ -4170,7 +4170,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 110
+            "y": 180
           },
           "id": 353,
           "interval": "2m",
@@ -4217,25 +4217,48 @@
   "templating": {
     "list": [
       {
-        "allValue": "worker-.*",
+        "allowCustomValue": false,
         "current": {
-          "text": ["worker-0", "worker-1", "worker-2", "worker-3", "worker-4"],
-          "value": ["worker-0", "worker-1", "worker-2", "worker-3", "worker-4"]
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "definition": "label_values(kube_node_labels{label_nebius_com_gpu_name=~\"GB.*\"},label_slurm_nebius_ai_nodeset_name)",
+        "description": "For GB platforms",
+        "includeAll": true,
+        "label": "Rack",
+        "multi": true,
+        "name": "rack",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kube_node_labels{label_nebius_com_gpu_name=~\"GB.*\"},label_slurm_nebius_ai_nodeset_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": false,
+        "current": {
+          "text": ["worker-rack0-0"],
+          "value": ["worker-rack0-0"]
         },
         "datasource": {
           "type": "prometheus",
           "uid": "VictoriaMetrics"
         },
-        "definition": "label_values(kube_pod_info{pod=~\"^worker-.*\"},pod)",
+        "definition": "label_values(slurm_node_info{node_name=~\"$rack-.*\"}, node_name)",
         "description": "Select as many workers as you need to check their aggregate and separate stats in panels.",
-        "includeAll": false,
+        "includeAll": true,
         "label": "Workers",
         "multi": true,
         "name": "worker",
         "options": [],
         "query": {
-          "qryType": 1,
-          "query": "label_values(kube_pod_info{pod=~\"^worker-.*\"},pod)",
+          "qryType": 5,
+          "query": "label_values(slurm_node_info{node_name=~\"$rack-.*\"}, node_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -4246,7 +4269,7 @@
       {
         "current": {
           "text": "All",
-          "value": ["$__all"]
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus",
@@ -4272,7 +4295,7 @@
       {
         "current": {
           "text": "All",
-          "value": ["$__all"]
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus",
@@ -4316,6 +4339,6 @@
   "timezone": "browser",
   "title": "Workers Overview",
   "uid": "soperator_workers_overview",
-  "version": 1,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
## Release Notes
- Adds extra labels related to GB300 to metrics
- Adds filters for "Cluster Health & Overview" and "Worker Overview" dashboards for racks 
