### PR TITLE
SCHED-1666 Make acceptance tests for dev clusters

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -376,8 +376,6 @@ jobs:
 
       - name: Acceptance Tests
         timeout-minutes: 90
-        env:
-          E2E_REPORT_DIR: e2e-reports/acceptance
         run: |
           bin/e2e acceptance
 

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -193,11 +193,11 @@ jobs:
           go-version-file: "go.mod"
           cache: false
 
-      # cmd/e2e is the only Go binary not built by any image build, so it is
-      # the only one that can break unnoticed on a merge to main.
-      - name: go build ./cmd/e2e
+      # These Go binaries are not built by any image build, so they can break
+      # unnoticed on a merge to main without an explicit build check.
+      - name: go build e2e commands
         shell: bash
-        run: go build -o /dev/null ./cmd/e2e
+        run: go build ./cmd/e2e ./cmd/acceptance
 
   build-soperator-images:
     needs:

--- a/cmd/acceptance/main.go
+++ b/cmd/acceptance/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"nebius.ai/slurm-operator/internal/e2e/acceptance"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := acceptance.Run(ctx, os.Args[1:]); err != nil {
+		log.Fatalf("acceptance: %v", err)
+	}
+}

--- a/internal/e2e/acceptance.go
+++ b/internal/e2e/acceptance.go
@@ -3,30 +3,44 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os/exec"
+	"strings"
 
 	"nebius.ai/slurm-operator/internal/e2e/acceptance"
-	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
 )
 
+const defaultAcceptanceReportDir = "e2e-reports/acceptance"
+
 func RunAcceptance(ctx context.Context, cfg Config) error {
-	state := &framework.ClusterState{
-		SlurmClusterName: cfg.SlurmClusterName,
-		WorkersByNodeSet: make(map[string][]framework.WorkerPodRef),
-	}
-	for _, nodeSet := range cfg.Profile.NodeSets {
-		state.ExpectedNodeSets = append(state.ExpectedNodeSets, framework.ExpectedNodeSet{
-			Name:   nodeSet.Name,
-			Size:   nodeSet.Size,
-			Preset: nodeSet.Preset,
-			HasGPU: parseGPUCount(nodeSet.Preset) > 0,
-		})
+	kubectlContext, err := currentKubectlContext(ctx)
+	if err != nil {
+		return err
 	}
 
-	runner := acceptance.NewRunner(state, cfg.RunUnstableTests)
-
-	if err := runner.Run(ctx); err != nil {
+	if err := acceptance.Run(ctx, acceptanceArgsForConfig(cfg, kubectlContext)); err != nil {
 		return fmt.Errorf("run acceptance suite: %w", err)
 	}
-
 	return nil
+}
+
+func acceptanceArgsForConfig(cfg Config, kubectlContext string) []string {
+	return []string{
+		"--kubectl-context", kubectlContext,
+		"--slurm-cluster-name", cfg.SlurmClusterName,
+		fmt.Sprintf("--run-unstable=%t", cfg.RunUnstableTests),
+		"--report-dir", defaultAcceptanceReportDir,
+	}
+}
+
+func currentKubectlContext(ctx context.Context) (string, error) {
+	output, err := exec.CommandContext(ctx, "kubectl", "config", "current-context").Output()
+	if err != nil {
+		return "", fmt.Errorf("get current kubectl context: %w", err)
+	}
+
+	kubectlContext := strings.TrimSpace(string(output))
+	if kubectlContext == "" {
+		return "", fmt.Errorf("current kubectl context is empty")
+	}
+	return kubectlContext, nil
 }

--- a/internal/e2e/acceptance/README.md
+++ b/internal/e2e/acceptance/README.md
@@ -1,0 +1,39 @@
+# Acceptance Tests On A Dev Cluster
+
+Use the standalone acceptance binary to run the acceptance suite against an
+existing dev Soperator cluster. 
+
+> !!! WARNING !!!
+> These tests mutate the target cluster. Run them only against a dev cluster
+> that is safe to change.
+> !!! WARNING !!!
+
+## Build
+
+From the repository root:
+
+```bash
+go build -o bin/acceptance ./cmd/acceptance
+```
+
+## Run
+
+Minimal manual run:
+
+```bash
+bin/acceptance --kubectl-context <dev-context>
+```
+
+All flags:
+
+- `--kubectl-context`: required. All local kubectl calls use this context.
+- `--slurm-cluster-name`: optional, defaults to `soperator`.
+- `--run-unstable`: optional, defaults to `false`; when false, scenarios tagged
+  `@unstable` are excluded.
+- `--report-dir`: optional. When set, the runner writes Cucumber and JUnit
+  reports into that directory.
+
+GPU scenarios are selected automatically. If no GPU workers are discovered,
+scenarios tagged `@gpu` are excluded.
+
+Note: The node replacement scenario uses the local `nebius` CLI to check instance removal.

--- a/internal/e2e/acceptance/features/cluster_creation.feature
+++ b/internal/e2e/acceptance/features/cluster_creation.feature
@@ -4,11 +4,10 @@ Feature: Cluster creation
     And all HelmReleases are Ready
     And all SlurmCluster CRs are available
     And all NodeSet CRs are ready
-    And configured nodesets match the live cluster
     And main and hidden partitions are present and sane
     And all Slurm nodes are healthy
     And all ActiveChecks completed successfully
     And login welcome output shows cluster information
     And main partition smoke job succeeds
     And hidden partition smoke job succeeds
-    And each configured nodeset accepts a targeted smoke job
+    And each discovered nodeset accepts a targeted smoke job

--- a/internal/e2e/acceptance/framework/exec.go
+++ b/internal/e2e/acceptance/framework/exec.go
@@ -16,15 +16,22 @@ type CommandScope interface {
 	RunWithDefaultRetry(ctx context.Context, command string) (string, error)
 }
 
+type ArgsScope interface {
+	Run(ctx context.Context, args ...string) (string, error)
+	RunWithRetry(ctx context.Context, attempts int, delay time.Duration, args ...string) (string, error)
+	RunWithDefaultRetry(ctx context.Context, args ...string) (string, error)
+}
+
 type Exec interface {
 	AvailableWorkers() []WorkerPodRef
 	AvailableGPUWorkers() []WorkerPodRef
+	Kubectl() ArgsScope
+	// Local returns a local process scope. Do not use it for kubectl commands;
+	// use Kubectl instead so the explicit Kubernetes context is applied.
+	Local() ArgsScope
 	Controller() CommandScope
 	Jail() CommandScope
 	Worker(worker string) CommandScope
-	Run(ctx context.Context, name string, args ...string) (string, error)
-	RunWithRetry(ctx context.Context, attempts int, delay time.Duration, name string, args ...string) (string, error)
-	RunWithDefaultRetry(ctx context.Context, name string, args ...string) (string, error)
 	WaitFor(ctx context.Context, description string, timeout, pollInterval time.Duration, condition func(context.Context) (bool, error)) error
 	Logf(format string, args ...any)
 }

--- a/internal/e2e/acceptance/framework/model.go
+++ b/internal/e2e/acceptance/framework/model.go
@@ -4,7 +4,7 @@ type WorkerPodRef struct {
 	Name string
 }
 
-type ExpectedNodeSet struct {
+type DiscoveredNodeSet struct {
 	Name   string
 	Size   int
 	Preset string
@@ -12,16 +12,16 @@ type ExpectedNodeSet struct {
 }
 
 type ClusterState struct {
-	SlurmClusterName string
-	Workers          []WorkerPodRef
-	GPUWorkers       []WorkerPodRef
-	WorkersByNodeSet map[string][]WorkerPodRef
-	ExpectedNodeSets []ExpectedNodeSet
+	SlurmClusterName   string
+	Workers            []WorkerPodRef
+	GPUWorkers         []WorkerPodRef
+	WorkersByNodeSet   map[string][]WorkerPodRef
+	DiscoveredNodeSets []DiscoveredNodeSet
 }
 
-func (s *ClusterState) ExpectedWorkerCount() int {
+func (s *ClusterState) DesiredWorkerCount() int {
 	total := 0
-	for _, nodeSet := range s.ExpectedNodeSets {
+	for _, nodeSet := range s.DiscoveredNodeSets {
 		total += nodeSet.Size
 	}
 	return total

--- a/internal/e2e/acceptance/options.go
+++ b/internal/e2e/acceptance/options.go
@@ -1,0 +1,71 @@
+package acceptance
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
+)
+
+const defaultSlurmClusterName = "soperator"
+
+type options struct {
+	KubectlContext   string
+	SlurmClusterName string
+	RunUnstableTests bool
+	ReportDir        string
+}
+
+func Run(ctx context.Context, args []string) error {
+	opts, err := parseOptions(args)
+	if errors.Is(err, flag.ErrHelp) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("parse acceptance args: %w", err)
+	}
+
+	state := &framework.ClusterState{
+		SlurmClusterName: opts.SlurmClusterName,
+		WorkersByNodeSet: make(map[string][]framework.WorkerPodRef),
+	}
+
+	runner := NewRunner(state, opts.RunUnstableTests, opts.KubectlContext, opts.ReportDir)
+	return runner.Run(ctx)
+}
+
+func parseOptions(args []string) (options, error) {
+	opts := options{
+		SlurmClusterName: defaultSlurmClusterName,
+	}
+
+	fs := flag.NewFlagSet("acceptance", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.StringVar(&opts.KubectlContext, "kubectl-context", "", "kubectl context to use for acceptance tests")
+	fs.StringVar(&opts.SlurmClusterName, "slurm-cluster-name", opts.SlurmClusterName, "SlurmCluster resource name")
+	fs.BoolVar(&opts.RunUnstableTests, "run-unstable", false, "run scenarios tagged @unstable")
+	fs.StringVar(&opts.ReportDir, "report-dir", "", "optional directory for Cucumber and JUnit reports")
+
+	if err := fs.Parse(args); err != nil {
+		return options{}, err
+	}
+	if fs.NArg() > 0 {
+		return options{}, fmt.Errorf("unexpected acceptance arguments: %s", strings.Join(fs.Args(), " "))
+	}
+
+	opts.KubectlContext = strings.TrimSpace(opts.KubectlContext)
+	if opts.KubectlContext == "" {
+		return options{}, fmt.Errorf("--kubectl-context is required")
+	}
+	opts.SlurmClusterName = strings.TrimSpace(opts.SlurmClusterName)
+	if opts.SlurmClusterName == "" {
+		return options{}, fmt.Errorf("--slurm-cluster-name must not be empty")
+	}
+	opts.ReportDir = strings.TrimSpace(opts.ReportDir)
+
+	return opts, nil
+}

--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cucumber/godog"
 	corev1 "k8s.io/api/core/v1"
 
+	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
 	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
 	"nebius.ai/slurm-operator/internal/e2e/acceptance/steps"
 )
@@ -33,9 +34,11 @@ const (
 type Runner struct {
 	state            *framework.ClusterState
 	runUnstableTests bool
+	kubectlContext   string
+	reportDir        string
 }
 
-func NewRunner(state *framework.ClusterState, runUnstableTests bool) *Runner {
+func NewRunner(state *framework.ClusterState, runUnstableTests bool, kubectlContext, reportDir string) *Runner {
 	if state == nil {
 		state = &framework.ClusterState{
 			WorkersByNodeSet: make(map[string][]framework.WorkerPodRef),
@@ -47,11 +50,13 @@ func NewRunner(state *framework.ClusterState, runUnstableTests bool) *Runner {
 	return &Runner{
 		state:            state,
 		runUnstableTests: runUnstableTests,
+		kubectlContext:   kubectlContext,
+		reportDir:        reportDir,
 	}
 }
 
 func (r *Runner) Run(ctx context.Context) error {
-	w := newWorld(r.state)
+	w := newWorld(r.state, r.kubectlContext)
 	if err := discoverCluster(ctx, w, r.state); err != nil {
 		return fmt.Errorf("discover cluster before suite: %w", err)
 	}
@@ -63,15 +68,9 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	tags := r.tagFilter()
 
-	format := "pretty"
-	if dir := os.Getenv("E2E_REPORT_DIR"); dir != "" {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return fmt.Errorf("create report dir %q: %w", dir, err)
-		}
-		format = fmt.Sprintf("pretty,cucumber:%s,junit:%s",
-			filepath.Join(dir, "acceptance.cucumber.json"),
-			filepath.Join(dir, "acceptance.junit.xml"),
-		)
+	format, err := reportFormat(r.reportDir)
+	if err != nil {
+		return err
 	}
 
 	suite := godog.TestSuite{
@@ -102,7 +101,7 @@ func (r *Runner) tagFilter() string {
 	var filters []string
 
 	if !r.runUnstableTests {
-		log.Printf("acceptance: RUN_UNSTABLE_TESTS=false, excluding @unstable scenarios")
+		log.Printf("acceptance: run-unstable=false, excluding @unstable scenarios")
 		filters = append(filters, "~@unstable")
 	}
 	if !r.state.HasGPUWorkers() {
@@ -114,7 +113,7 @@ func (r *Runner) tagFilter() string {
 }
 
 func discoverCluster(ctx context.Context, w *world, state *framework.ClusterState) error {
-	if _, err := w.RunWithDefaultRetry(ctx, "kubectl", "get", "pods", "-n", soperatorNamespace); err != nil {
+	if _, err := w.Kubectl().RunWithDefaultRetry(ctx, "get", "pods", "-n", soperatorNamespace); err != nil {
 		return err
 	}
 	if err := verifyPodReady(ctx, w, soperatorNamespace, state.SlurmClusterName+"-login-0"); err != nil {
@@ -129,6 +128,13 @@ func discoverCluster(ctx context.Context, w *world, state *framework.ClusterStat
 	if _, err := w.Jail().RunWithDefaultRetry(ctx, "true"); err != nil {
 		return fmt.Errorf("exec login jail sanity check: %w", err)
 	}
+
+	expectedNodeSets, err := discoverExpectedNodeSets(ctx, w, state.SlurmClusterName)
+	if err != nil {
+		return fmt.Errorf("discover expected NodeSets: %w", err)
+	}
+	state.ExpectedNodeSets = expectedNodeSets
+	log.Printf("acceptance: discovered expected nodesets: %s", expectedNodeSetSummary(state.ExpectedNodeSets))
 
 	workerOutput, err := w.Controller().RunWithDefaultRetry(ctx, `sinfo -hN -p main -o '%N'`)
 	if err != nil {
@@ -160,6 +166,56 @@ func discoverCluster(ctx context.Context, w *world, state *framework.ClusterStat
 	return nil
 }
 
+func reportFormat(reportDir string) (string, error) {
+	if reportDir == "" {
+		return "pretty", nil
+	}
+	if err := os.MkdirAll(reportDir, 0o755); err != nil {
+		return "", fmt.Errorf("create report dir %q: %w", reportDir, err)
+	}
+	return fmt.Sprintf("pretty,cucumber:%s,junit:%s",
+		filepath.Join(reportDir, "acceptance.cucumber.json"),
+		filepath.Join(reportDir, "acceptance.junit.xml"),
+	), nil
+}
+
+func discoverExpectedNodeSets(ctx context.Context, w *world, clusterName string) ([]framework.ExpectedNodeSet, error) {
+	output, err := w.Kubectl().RunWithDefaultRetry(ctx, "get", "nodesets", "-n", soperatorNamespace, "-o", "json")
+	if err != nil {
+		return nil, err
+	}
+
+	var nodeSets slurmv1alpha1.NodeSetList
+	if err := json.Unmarshal([]byte(output), &nodeSets); err != nil {
+		return nil, fmt.Errorf("decode NodeSet list: %w", err)
+	}
+
+	expected := expectedNodeSetsFromLiveList(nodeSets, clusterName)
+	if len(expected) == 0 {
+		return nil, fmt.Errorf("no NodeSets found in namespace %s for Slurm cluster %q", soperatorNamespace, clusterName)
+	}
+	return expected, nil
+}
+
+func expectedNodeSetsFromLiveList(nodeSets slurmv1alpha1.NodeSetList, clusterName string) []framework.ExpectedNodeSet {
+	expected := make([]framework.ExpectedNodeSet, 0, len(nodeSets.Items))
+	for _, nodeSet := range nodeSets.Items {
+		if nodeSet.Spec.ClusterName != "" && nodeSet.Spec.ClusterName != clusterName {
+			continue
+		}
+		expected = append(expected, framework.ExpectedNodeSet{
+			Name:   nodeSet.Name,
+			Size:   int(nodeSet.Spec.Replicas),
+			HasGPU: nodeSet.Spec.GPU.Enabled,
+		})
+	}
+
+	sort.Slice(expected, func(i, j int) bool {
+		return expected[i].Name < expected[j].Name
+	})
+	return expected
+}
+
 func featurePaths() []string {
 	return []string{
 		"features/cluster_creation.feature",
@@ -175,7 +231,7 @@ func featurePaths() []string {
 func (r *Runner) initializeScenario(sc *godog.ScenarioContext) {
 	registerTimingHooks(sc)
 
-	w := newWorld(r.state)
+	w := newWorld(r.state, r.kubectlContext)
 	slurm := framework.NewSlurmClient(w)
 
 	steps.NewClusterCreation(r.state, w).Register(sc)
@@ -238,10 +294,11 @@ func registerTimingHooks(sc *godog.ScenarioContext) {
 	})
 }
 
-func newWorld(state *framework.ClusterState) *world {
+func newWorld(state *framework.ClusterState, kubectlContext string) *world {
 	return &world{
-		logPrefix: "acceptance",
-		state:     state,
+		logPrefix:      "acceptance",
+		state:          state,
+		kubectlContext: kubectlContext,
 	}
 }
 
@@ -279,8 +336,23 @@ func workersByNodeSetSummary(workersByNodeSet map[string][]framework.WorkerPodRe
 	return strings.Join(parts, "; ")
 }
 
+func expectedNodeSetSummary(nodeSets []framework.ExpectedNodeSet) string {
+	if len(nodeSets) == 0 {
+		return "<none>"
+	}
+	parts := make([]string, 0, len(nodeSets))
+	for _, nodeSet := range nodeSets {
+		nodeType := "cpu"
+		if nodeSet.HasGPU {
+			nodeType = "gpu"
+		}
+		parts = append(parts, fmt.Sprintf("%s=%d/%s", nodeSet.Name, nodeSet.Size, nodeType))
+	}
+	return strings.Join(parts, ", ")
+}
+
 func verifyPodReady(ctx context.Context, w *world, namespace, name string) error {
-	output, err := w.RunWithDefaultRetry(ctx, "kubectl", "get", "pod", "-n", namespace, name, "-o", "json")
+	output, err := w.Kubectl().RunWithDefaultRetry(ctx, "get", "pod", "-n", namespace, name, "-o", "json")
 	if err != nil {
 		return err
 	}

--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -129,12 +129,12 @@ func discoverCluster(ctx context.Context, w *world, state *framework.ClusterStat
 		return fmt.Errorf("exec login jail sanity check: %w", err)
 	}
 
-	expectedNodeSets, err := discoverExpectedNodeSets(ctx, w, state.SlurmClusterName)
+	discoveredNodeSets, err := discoverNodeSets(ctx, w, state.SlurmClusterName)
 	if err != nil {
-		return fmt.Errorf("discover expected NodeSets: %w", err)
+		return fmt.Errorf("discover NodeSets: %w", err)
 	}
-	state.ExpectedNodeSets = expectedNodeSets
-	log.Printf("acceptance: discovered expected nodesets: %s", expectedNodeSetSummary(state.ExpectedNodeSets))
+	state.DiscoveredNodeSets = discoveredNodeSets
+	log.Printf("acceptance: discovered nodesets: %s", discoveredNodeSetSummary(state.DiscoveredNodeSets))
 
 	workerOutput, err := w.Controller().RunWithDefaultRetry(ctx, `sinfo -hN -p main -o '%N'`)
 	if err != nil {
@@ -159,6 +159,9 @@ func discoverCluster(ctx context.Context, w *world, state *framework.ClusterStat
 	}
 	state.Workers = workers
 	classifyWorkers(state)
+	if err := verifyDiscoveredWorkers(state); err != nil {
+		return err
+	}
 
 	log.Printf("acceptance: discovered workers: %s", workerNames(state.Workers))
 	log.Printf("acceptance: discovered GPU workers: %s", workerNames(state.GPUWorkers))
@@ -179,7 +182,7 @@ func reportFormat(reportDir string) (string, error) {
 	), nil
 }
 
-func discoverExpectedNodeSets(ctx context.Context, w *world, clusterName string) ([]framework.ExpectedNodeSet, error) {
+func discoverNodeSets(ctx context.Context, w *world, clusterName string) ([]framework.DiscoveredNodeSet, error) {
 	output, err := w.Kubectl().RunWithDefaultRetry(ctx, "get", "nodesets", "-n", soperatorNamespace, "-o", "json")
 	if err != nil {
 		return nil, err
@@ -190,30 +193,30 @@ func discoverExpectedNodeSets(ctx context.Context, w *world, clusterName string)
 		return nil, fmt.Errorf("decode NodeSet list: %w", err)
 	}
 
-	expected := expectedNodeSetsFromLiveList(nodeSets, clusterName)
-	if len(expected) == 0 {
+	discovered := discoveredNodeSetsFromLiveList(nodeSets, clusterName)
+	if len(discovered) == 0 {
 		return nil, fmt.Errorf("no NodeSets found in namespace %s for Slurm cluster %q", soperatorNamespace, clusterName)
 	}
-	return expected, nil
+	return discovered, nil
 }
 
-func expectedNodeSetsFromLiveList(nodeSets slurmv1alpha1.NodeSetList, clusterName string) []framework.ExpectedNodeSet {
-	expected := make([]framework.ExpectedNodeSet, 0, len(nodeSets.Items))
+func discoveredNodeSetsFromLiveList(nodeSets slurmv1alpha1.NodeSetList, clusterName string) []framework.DiscoveredNodeSet {
+	discovered := make([]framework.DiscoveredNodeSet, 0, len(nodeSets.Items))
 	for _, nodeSet := range nodeSets.Items {
 		if nodeSet.Spec.ClusterName != "" && nodeSet.Spec.ClusterName != clusterName {
 			continue
 		}
-		expected = append(expected, framework.ExpectedNodeSet{
+		discovered = append(discovered, framework.DiscoveredNodeSet{
 			Name:   nodeSet.Name,
 			Size:   int(nodeSet.Spec.Replicas),
 			HasGPU: nodeSet.Spec.GPU.Enabled,
 		})
 	}
 
-	sort.Slice(expected, func(i, j int) bool {
-		return expected[i].Name < expected[j].Name
+	sort.Slice(discovered, func(i, j int) bool {
+		return discovered[i].Name < discovered[j].Name
 	})
-	return expected
+	return discovered
 }
 
 func featurePaths() []string {
@@ -336,7 +339,7 @@ func workersByNodeSetSummary(workersByNodeSet map[string][]framework.WorkerPodRe
 	return strings.Join(parts, "; ")
 }
 
-func expectedNodeSetSummary(nodeSets []framework.ExpectedNodeSet) string {
+func discoveredNodeSetSummary(nodeSets []framework.DiscoveredNodeSet) string {
 	if len(nodeSets) == 0 {
 		return "<none>"
 	}
@@ -373,25 +376,25 @@ func verifyPodReady(ctx context.Context, w *world, namespace, name string) error
 }
 
 func classifyWorkers(state *framework.ClusterState) {
-	state.WorkersByNodeSet = make(map[string][]framework.WorkerPodRef, len(state.ExpectedNodeSets))
+	state.WorkersByNodeSet = make(map[string][]framework.WorkerPodRef, len(state.DiscoveredNodeSets))
 	state.GPUWorkers = nil
 
-	if len(state.ExpectedNodeSets) == 0 {
+	if len(state.DiscoveredNodeSets) == 0 {
 		return
 	}
 
-	expected := slices.Clone(state.ExpectedNodeSets)
-	sort.Slice(expected, func(i, j int) bool {
-		return len(expected[i].Name) > len(expected[j].Name)
+	discovered := slices.Clone(state.DiscoveredNodeSets)
+	sort.Slice(discovered, func(i, j int) bool {
+		return len(discovered[i].Name) > len(discovered[j].Name)
 	})
 
-	gpuByName := make(map[string]bool, len(expected))
-	for _, nodeSet := range expected {
+	gpuByName := make(map[string]bool, len(discovered))
+	for _, nodeSet := range discovered {
 		gpuByName[nodeSet.Name] = nodeSet.HasGPU
 	}
 
 	for _, worker := range state.Workers {
-		for _, nodeSet := range expected {
+		for _, nodeSet := range discovered {
 			prefix := nodeSet.Name + "-"
 			if !strings.HasPrefix(worker.Name, prefix) {
 				continue
@@ -403,4 +406,25 @@ func classifyWorkers(state *framework.ClusterState) {
 			break
 		}
 	}
+}
+
+func verifyDiscoveredWorkers(state *framework.ClusterState) error {
+	var problems []string
+	for _, nodeSet := range state.DiscoveredNodeSets {
+		liveWorkers := len(state.WorkersByNodeSet[nodeSet.Name])
+		if liveWorkers != nodeSet.Size {
+			problems = append(problems, fmt.Sprintf("NodeSet %s live workers in Slurm=%d desired=%d", nodeSet.Name, liveWorkers, nodeSet.Size))
+		}
+	}
+
+	desiredWorkers := state.DesiredWorkerCount()
+	if desiredWorkers > 0 && len(state.Workers) != desiredWorkers {
+		problems = append(problems, fmt.Sprintf("discovered workers=%d desired=%d", len(state.Workers), desiredWorkers))
+	}
+
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		return fmt.Errorf("%s", strings.Join(problems, "; "))
+	}
+	return nil
 }

--- a/internal/e2e/acceptance/runner_test.go
+++ b/internal/e2e/acceptance/runner_test.go
@@ -48,7 +48,7 @@ func TestParseOptionsRejectsExtraArgs(t *testing.T) {
 	assert.ErrorContains(t, err, "unexpected acceptance arguments")
 }
 
-func TestExpectedNodeSetsFromLiveList(t *testing.T) {
+func TestDiscoveredNodeSetsFromLiveList(t *testing.T) {
 	nodeSets := slurmv1alpha1.NodeSetList{
 		Items: []slurmv1alpha1.NodeSet{
 			{
@@ -77,16 +77,16 @@ func TestExpectedNodeSetsFromLiveList(t *testing.T) {
 		},
 	}
 
-	expected := expectedNodeSetsFromLiveList(nodeSets, "soperator")
-	require.Len(t, expected, 2)
+	discovered := discoveredNodeSetsFromLiveList(nodeSets, "soperator")
+	require.Len(t, discovered, 2)
 
-	assert.Equal(t, "worker-cpu", expected[0].Name)
-	assert.Equal(t, 3, expected[0].Size)
-	assert.False(t, expected[0].HasGPU)
+	assert.Equal(t, "worker-cpu", discovered[0].Name)
+	assert.Equal(t, 3, discovered[0].Size)
+	assert.False(t, discovered[0].HasGPU)
 
-	assert.Equal(t, "worker-gpu", expected[1].Name)
-	assert.Equal(t, 2, expected[1].Size)
-	assert.True(t, expected[1].HasGPU)
+	assert.Equal(t, "worker-gpu", discovered[1].Name)
+	assert.Equal(t, 2, discovered[1].Size)
+	assert.True(t, discovered[1].HasGPU)
 }
 
 func TestReportFormat(t *testing.T) {

--- a/internal/e2e/acceptance/runner_test.go
+++ b/internal/e2e/acceptance/runner_test.go
@@ -1,0 +1,105 @@
+package acceptance
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
+)
+
+func TestParseOptionsDefaults(t *testing.T) {
+	opts, err := parseOptions([]string{"--kubectl-context", "dev-context"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "dev-context", opts.KubectlContext)
+	assert.Equal(t, "soperator", opts.SlurmClusterName)
+	assert.False(t, opts.RunUnstableTests)
+	assert.Empty(t, opts.ReportDir)
+}
+
+func TestParseOptionsExplicitValues(t *testing.T) {
+	opts, err := parseOptions([]string{
+		"--kubectl-context", "dev-context",
+		"--slurm-cluster-name", "custom",
+		"--run-unstable=true",
+		"--report-dir", "reports",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "dev-context", opts.KubectlContext)
+	assert.Equal(t, "custom", opts.SlurmClusterName)
+	assert.True(t, opts.RunUnstableTests)
+	assert.Equal(t, "reports", opts.ReportDir)
+}
+
+func TestParseOptionsRequiresKubectlContext(t *testing.T) {
+	_, err := parseOptions(nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "--kubectl-context is required")
+}
+
+func TestParseOptionsRejectsExtraArgs(t *testing.T) {
+	_, err := parseOptions([]string{"--kubectl-context", "dev-context", "extra"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unexpected acceptance arguments")
+}
+
+func TestExpectedNodeSetsFromLiveList(t *testing.T) {
+	nodeSets := slurmv1alpha1.NodeSetList{
+		Items: []slurmv1alpha1.NodeSet{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "worker-gpu"},
+				Spec: slurmv1alpha1.NodeSetSpec{
+					ClusterName: "soperator",
+					Replicas:    2,
+					GPU:         slurmv1alpha1.GPUSpec{Enabled: true},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "worker-cpu"},
+				Spec: slurmv1alpha1.NodeSetSpec{
+					ClusterName: "soperator",
+					Replicas:    3,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "other-worker"},
+				Spec: slurmv1alpha1.NodeSetSpec{
+					ClusterName: "other",
+					Replicas:    4,
+					GPU:         slurmv1alpha1.GPUSpec{Enabled: true},
+				},
+			},
+		},
+	}
+
+	expected := expectedNodeSetsFromLiveList(nodeSets, "soperator")
+	require.Len(t, expected, 2)
+
+	assert.Equal(t, "worker-cpu", expected[0].Name)
+	assert.Equal(t, 3, expected[0].Size)
+	assert.False(t, expected[0].HasGPU)
+
+	assert.Equal(t, "worker-gpu", expected[1].Name)
+	assert.Equal(t, 2, expected[1].Size)
+	assert.True(t, expected[1].HasGPU)
+}
+
+func TestReportFormat(t *testing.T) {
+	format, err := reportFormat("")
+	require.NoError(t, err)
+	assert.Equal(t, "pretty", format)
+
+	dir := t.TempDir()
+	format, err = reportFormat(dir)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"pretty,cucumber:"+filepath.Join(dir, "acceptance.cucumber.json")+
+			",junit:"+filepath.Join(dir, "acceptance.junit.xml"),
+		format,
+	)
+}

--- a/internal/e2e/acceptance/scopes.go
+++ b/internal/e2e/acceptance/scopes.go
@@ -1,0 +1,70 @@
+package acceptance
+
+import (
+	"context"
+	"time"
+
+	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
+)
+
+type argsScope struct {
+	run func(context.Context, ...string) (string, error)
+}
+
+func (s argsScope) Run(ctx context.Context, args ...string) (string, error) {
+	return s.run(ctx, args...)
+}
+
+func (s argsScope) RunWithRetry(ctx context.Context, attempts int, delay time.Duration, args ...string) (string, error) {
+	return retry(ctx, attempts, delay, func(attemptCtx context.Context) (string, error) {
+		return s.Run(attemptCtx, args...)
+	})
+}
+
+func (s argsScope) RunWithDefaultRetry(ctx context.Context, args ...string) (string, error) {
+	return s.RunWithRetry(ctx, framework.DefaultRetryAttempts, framework.DefaultRetryDelay, args...)
+}
+
+type commandScope struct {
+	run func(context.Context, string) (string, error)
+}
+
+func (s commandScope) Run(ctx context.Context, command string) (string, error) {
+	return s.run(ctx, command)
+}
+
+func (s commandScope) RunWithRetry(ctx context.Context, command string, attempts int, delay time.Duration) (string, error) {
+	return retry(ctx, attempts, delay, func(attemptCtx context.Context) (string, error) {
+		return s.Run(attemptCtx, command)
+	})
+}
+
+func (s commandScope) RunWithDefaultRetry(ctx context.Context, command string) (string, error) {
+	return s.RunWithRetry(ctx, command, framework.DefaultRetryAttempts, framework.DefaultRetryDelay)
+}
+
+func retry(ctx context.Context, attempts int, delay time.Duration, run func(context.Context) (string, error)) (string, error) {
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var lastErr error
+	var out string
+	for attempt := 1; attempt <= attempts; attempt++ {
+		out, lastErr = run(ctx)
+		if lastErr == nil {
+			return out, nil
+		}
+		if attempt == attempts {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return out, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+
+	return out, lastErr
+}

--- a/internal/e2e/acceptance/steps/cluster_creation.go
+++ b/internal/e2e/acceptance/steps/cluster_creation.go
@@ -43,14 +43,13 @@ func (s *ClusterCreation) Register(sc *godog.ScenarioContext) {
 	sc.Step(`^all HelmReleases are Ready$`, s.checkHelmReleasesReady)
 	sc.Step(`^all SlurmCluster CRs are available$`, s.checkSlurmClustersReady)
 	sc.Step(`^all NodeSet CRs are ready$`, s.checkNodeSetsReady)
-	sc.Step(`^configured nodesets match the live cluster$`, s.checkExpectedNodeSets)
 	sc.Step(`^main and hidden partitions are present and sane$`, s.checkPartitions)
 	sc.Step(`^all Slurm nodes are healthy$`, s.checkSlurmNodeHealth)
 	sc.Step(`^all ActiveChecks completed successfully$`, s.checkActiveChecks)
 	sc.Step(`^login welcome output shows cluster information$`, s.checkWelcomeOutput)
 	sc.Step(`^main partition smoke job succeeds$`, s.checkMainSmokeJob)
 	sc.Step(`^hidden partition smoke job succeeds$`, s.checkHiddenSmokeJob)
-	sc.Step(`^each configured nodeset accepts a targeted smoke job$`, s.checkNodeSetSmokeJobs)
+	sc.Step(`^each discovered nodeset accepts a targeted smoke job$`, s.checkNodeSetSmokeJobs)
 }
 
 func (s *ClusterCreation) checkPodsReady(ctx context.Context) error {
@@ -182,51 +181,6 @@ func (s *ClusterCreation) checkNodeSetsReady(ctx context.Context) error {
 		if nodeSet.Status.Replicas != nodeSet.Spec.Replicas {
 			problems = append(problems, fmt.Sprintf("%s/%s ready=%d desired=%d", nodeSet.Namespace, nodeSet.Name, nodeSet.Status.Replicas, nodeSet.Spec.Replicas))
 		}
-	}
-
-	if len(problems) > 0 {
-		sort.Strings(problems)
-		return fmt.Errorf("%s", strings.Join(problems, "; "))
-	}
-	return nil
-}
-
-func (s *ClusterCreation) checkExpectedNodeSets(ctx context.Context) error {
-	if len(s.state.ExpectedNodeSets) == 0 {
-		s.exec.Logf("cluster creation: no expected nodesets configured, skipping nodeset/profile comparison")
-		return nil
-	}
-
-	var nodeSets slurmv1alpha1.NodeSetList
-	if err := kubectlJSON(ctx, s.exec, &nodeSets, "get", "nodesets", "-A", "-o", "json"); err != nil {
-		return fmt.Errorf("list NodeSets: %w", err)
-	}
-
-	actual := make(map[string]slurmv1alpha1.NodeSet, len(nodeSets.Items))
-	for _, nodeSet := range nodeSets.Items {
-		actual[nodeSet.Name] = nodeSet
-	}
-
-	var problems []string
-	for _, expected := range s.state.ExpectedNodeSets {
-		nodeSet, ok := actual[expected.Name]
-		if !ok {
-			problems = append(problems, fmt.Sprintf("NodeSet %s is missing", expected.Name))
-			continue
-		}
-		if int(nodeSet.Spec.Replicas) != expected.Size {
-			problems = append(problems, fmt.Sprintf("NodeSet %s desired=%d expected=%d", expected.Name, nodeSet.Spec.Replicas, expected.Size))
-		}
-
-		liveWorkers := len(s.state.WorkersByNodeSet[expected.Name])
-		if liveWorkers != expected.Size {
-			problems = append(problems, fmt.Sprintf("NodeSet %s live workers in Slurm=%d expected=%d", expected.Name, liveWorkers, expected.Size))
-		}
-	}
-
-	expectedWorkers := s.state.ExpectedWorkerCount()
-	if expectedWorkers > 0 && len(s.state.Workers) != expectedWorkers {
-		problems = append(problems, fmt.Sprintf("discovered workers=%d expected=%d", len(s.state.Workers), expectedWorkers))
 	}
 
 	if len(problems) > 0 {
@@ -407,13 +361,13 @@ func (s *ClusterCreation) checkHiddenSmokeJob(ctx context.Context) error {
 }
 
 func (s *ClusterCreation) checkNodeSetSmokeJobs(ctx context.Context) error {
-	if len(s.state.ExpectedNodeSets) == 0 {
-		s.exec.Logf("cluster creation: no expected nodesets configured, skipping per-nodeset smoke jobs")
+	if len(s.state.DiscoveredNodeSets) == 0 {
+		s.exec.Logf("cluster creation: no discovered nodesets configured, skipping per-nodeset smoke jobs")
 		return nil
 	}
 
 	var problems []string
-	for _, nodeSet := range s.state.ExpectedNodeSets {
+	for _, nodeSet := range s.state.DiscoveredNodeSets {
 		workers := slices.Clone(s.state.WorkersByNodeSet[nodeSet.Name])
 		if len(workers) == 0 {
 			problems = append(problems, fmt.Sprintf("%s has no discovered workers", nodeSet.Name))

--- a/internal/e2e/acceptance/steps/cluster_creation.go
+++ b/internal/e2e/acceptance/steps/cluster_creation.go
@@ -361,8 +361,8 @@ func (s *ClusterCreation) checkActiveChecks(ctx context.Context) error {
 }
 
 func (s *ClusterCreation) checkWelcomeOutput(ctx context.Context) error {
-	output, err := s.exec.RunWithDefaultRetry(ctx,
-		"kubectl", "exec", "-n", clusterCreationNamespace, s.state.SlurmClusterName+"-login-0", "--", "sh", "-lc",
+	output, err := s.exec.Kubectl().RunWithDefaultRetry(ctx,
+		"exec", "-n", clusterCreationNamespace, s.state.SlurmClusterName+"-login-0", "--", "sh", "-lc",
 		"/etc/update-motd.d/00-welcome && /etc/update-motd.d/20-slurm-stats")
 	if err != nil {
 		return fmt.Errorf("render welcome output: %w", err)
@@ -454,7 +454,7 @@ type helmReleaseStatusRef struct {
 }
 
 func kubectlJSON(ctx context.Context, exec framework.Exec, out any, args ...string) error {
-	output, err := exec.RunWithDefaultRetry(ctx, "kubectl", args...)
+	output, err := exec.Kubectl().RunWithDefaultRetry(ctx, args...)
 	if err != nil {
 		return err
 	}

--- a/internal/e2e/acceptance/steps/node_replacement.go
+++ b/internal/e2e/acceptance/steps/node_replacement.go
@@ -108,7 +108,7 @@ func (s *NodeReplacement) aMaintenanceEventIsTriggeredForThatNode(ctx context.Co
 	patch := fmt.Sprintf(
 		`{"status":{"conditions":[{"type":"NebiusMaintenanceScheduled","status":"True","reason":"AcceptanceTest","message":"Maintenance scheduled for node","lastTransitionTime":"%s"}]}}`,
 		time.Now().UTC().Format(time.RFC3339))
-	if _, err := s.exec.Run(ctx, "kubectl", "patch", "node", s.originalInstanceID,
+	if _, err := s.exec.Kubectl().Run(ctx, "patch", "node", s.originalInstanceID,
 		"--subresource=status", "--type=strategic", "-p", patch); err != nil {
 		return fmt.Errorf("patch maintenance condition: %w", err)
 	}
@@ -138,7 +138,7 @@ func (s *NodeReplacement) theTestJobIsCancelled(ctx context.Context) error {
 func (s *NodeReplacement) theOldInstanceIsRemoved(ctx context.Context) error {
 	originalInstanceID := s.originalInstanceID
 	return s.exec.WaitFor(ctx, "old instance removal", nodeReplacementRemoveTimeout, 30*time.Second, func(waitCtx context.Context) (bool, error) {
-		_, err := s.exec.Run(waitCtx, "nebius", "compute", "instance", "get", "--id", originalInstanceID, "--format", "json")
+		_, err := s.exec.Local().Run(waitCtx, "nebius", "compute", "instance", "get", "--id", originalInstanceID, "--format", "json")
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				return true, nil

--- a/internal/e2e/acceptance/world.go
+++ b/internal/e2e/acceptance/world.go
@@ -21,7 +21,8 @@ const (
 type world struct {
 	logPrefix string
 
-	state *framework.ClusterState
+	state          *framework.ClusterState
+	kubectlContext string
 }
 
 func (w *world) AvailableWorkers() []framework.WorkerPodRef {
@@ -36,20 +37,47 @@ func (w *world) Logf(format string, args ...any) {
 	w.logf(format, args...)
 }
 
+func (w *world) Kubectl() framework.ArgsScope {
+	return argsScope{
+		run: func(ctx context.Context, args ...string) (string, error) {
+			return w.Run(ctx, "kubectl", kubectlArgs(w.kubectlContext, args)...)
+		},
+	}
+}
+
+func (w *world) Local() framework.ArgsScope {
+	return argsScope{
+		run: func(ctx context.Context, args ...string) (string, error) {
+			if len(args) == 0 {
+				return "", fmt.Errorf("local command requires executable name")
+			}
+			return w.Run(ctx, args[0], args[1:]...)
+		},
+	}
+}
+
 func (w *world) Controller() framework.CommandScope {
-	return controllerScope{world: w}
+	return commandScope{
+		run: func(ctx context.Context, command string) (string, error) {
+			return w.Kubectl().Run(ctx, "exec", "-n", soperatorNamespace, w.state.SlurmClusterName+"-controller-0", "--", "bash", "-lc", command)
+		},
+	}
 }
 
 func (w *world) Jail() framework.CommandScope {
-	return jailScope{world: w}
+	return commandScope{
+		run: func(ctx context.Context, command string) (string, error) {
+			return w.Kubectl().Run(ctx, "exec", "-n", soperatorNamespace, w.state.SlurmClusterName+"-login-0", "--", "chroot", "/mnt/jail", "bash", "-lc", command)
+		},
+	}
 }
 
 func (w *world) Worker(worker string) framework.CommandScope {
-	return workerScope{world: w, worker: worker}
-}
-
-func (w *world) RunWithDefaultRetry(ctx context.Context, name string, args ...string) (string, error) {
-	return w.RunWithRetry(ctx, framework.DefaultRetryAttempts, framework.DefaultRetryDelay, name, args...)
+	return commandScope{
+		run: func(ctx context.Context, command string) (string, error) {
+			return w.Jail().Run(ctx, fmt.Sprintf("ssh %s %s", framework.ShellQuote(worker), framework.ShellQuote(command)))
+		},
+	}
 }
 
 func (w *world) Run(ctx context.Context, name string, args ...string) (string, error) {
@@ -80,81 +108,15 @@ func (w *world) Run(ctx context.Context, name string, args ...string) (string, e
 	return out, nil
 }
 
-func (w *world) RunWithRetry(ctx context.Context, attempts int, delay time.Duration, name string, args ...string) (string, error) {
-	if attempts < 1 {
-		attempts = 1
+func kubectlArgs(kubectlContext string, args []string) []string {
+	if kubectlContext == "" {
+		return append([]string(nil), args...)
 	}
 
-	var lastErr error
-	var out string
-	for attempt := 1; attempt <= attempts; attempt++ {
-		out, lastErr = w.Run(ctx, name, args...)
-		if lastErr == nil {
-			return out, nil
-		}
-		if attempt == attempts {
-			break
-		}
-
-		w.logf("retrying command after attempt %d/%d: %s %s: %v",
-			attempt, attempts, name, strings.Join(args, " "), lastErr)
-		select {
-		case <-ctx.Done():
-			return out, ctx.Err()
-		case <-time.After(delay):
-		}
-	}
-
-	return out, lastErr
-}
-
-type controllerScope struct {
-	world *world
-}
-
-func (s controllerScope) Run(ctx context.Context, command string) (string, error) {
-	return s.world.Run(ctx, "kubectl", "exec", "-n", soperatorNamespace, s.world.state.SlurmClusterName+"-controller-0", "--", "bash", "-lc", command)
-}
-
-func (s controllerScope) RunWithRetry(ctx context.Context, command string, attempts int, delay time.Duration) (string, error) {
-	return s.world.RunWithRetry(ctx, attempts, delay, "kubectl", "exec", "-n", soperatorNamespace, s.world.state.SlurmClusterName+"-controller-0", "--", "bash", "-lc", command)
-}
-
-func (s controllerScope) RunWithDefaultRetry(ctx context.Context, command string) (string, error) {
-	return s.RunWithRetry(ctx, command, framework.DefaultRetryAttempts, framework.DefaultRetryDelay)
-}
-
-type jailScope struct {
-	world *world
-}
-
-func (s jailScope) Run(ctx context.Context, command string) (string, error) {
-	return s.world.Run(ctx, "kubectl", "exec", "-n", soperatorNamespace, s.world.state.SlurmClusterName+"-login-0", "--", "chroot", "/mnt/jail", "bash", "-lc", command)
-}
-
-func (s jailScope) RunWithRetry(ctx context.Context, command string, attempts int, delay time.Duration) (string, error) {
-	return s.world.RunWithRetry(ctx, attempts, delay, "kubectl", "exec", "-n", soperatorNamespace, s.world.state.SlurmClusterName+"-login-0", "--", "chroot", "/mnt/jail", "bash", "-lc", command)
-}
-
-func (s jailScope) RunWithDefaultRetry(ctx context.Context, command string) (string, error) {
-	return s.RunWithRetry(ctx, command, framework.DefaultRetryAttempts, framework.DefaultRetryDelay)
-}
-
-type workerScope struct {
-	world  *world
-	worker string
-}
-
-func (s workerScope) Run(ctx context.Context, command string) (string, error) {
-	return s.world.Jail().Run(ctx, fmt.Sprintf("ssh %s %s", framework.ShellQuote(s.worker), framework.ShellQuote(command)))
-}
-
-func (s workerScope) RunWithRetry(ctx context.Context, command string, attempts int, delay time.Duration) (string, error) {
-	return s.world.Jail().RunWithRetry(ctx, fmt.Sprintf("ssh %s %s", framework.ShellQuote(s.worker), framework.ShellQuote(command)), attempts, delay)
-}
-
-func (s workerScope) RunWithDefaultRetry(ctx context.Context, command string) (string, error) {
-	return s.RunWithRetry(ctx, command, framework.DefaultRetryAttempts, framework.DefaultRetryDelay)
+	out := make([]string, 0, len(args)+2)
+	out = append(out, "--context", kubectlContext)
+	out = append(out, args...)
+	return out
 }
 
 func (w *world) WaitFor(ctx context.Context, description string, timeout, pollInterval time.Duration, condition func(context.Context) (bool, error)) error {

--- a/internal/e2e/acceptance/world_test.go
+++ b/internal/e2e/acceptance/world_test.go
@@ -1,0 +1,21 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKubectlArgsAddsContext(t *testing.T) {
+	assert.Equal(t,
+		[]string{"--context", "dev-context", "get", "pods"},
+		kubectlArgs("dev-context", []string{"get", "pods"}),
+	)
+}
+
+func TestKubectlArgsWithoutContext(t *testing.T) {
+	assert.Equal(t,
+		[]string{"get", "pods"},
+		kubectlArgs("", []string{"get", "pods"}),
+	)
+}

--- a/internal/e2e/acceptance_test.go
+++ b/internal/e2e/acceptance_test.go
@@ -1,0 +1,21 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAcceptanceArgsForConfig(t *testing.T) {
+	args := acceptanceArgsForConfig(Config{
+		RunUnstableTests: true,
+		SlurmClusterName: "custom",
+	}, "dev-context")
+
+	assert.Equal(t, []string{
+		"--kubectl-context", "dev-context",
+		"--slurm-cluster-name", "custom",
+		"--run-unstable=true",
+		"--report-dir", defaultAcceptanceReportDir,
+	}, args)
+}


### PR DESCRIPTION
## Problem

Acceptance tests were tightly coupled to the e2e flow, which made them impossible to run against an already existing dev cluster. Manual runs also needed a safer way to target a specific Kubernetes cluster instead of relying on whichever kubectl context happened to be active.

## Solution

Added a standalone acceptance runner for dev-cluster usage with explicit CLI configuration.

Also added documentation for building and running acceptance tests against a dev cluster.

## Testing

E2e passed + local test passed.

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
