### PR TITLE
NOTASK: upgrade cert-manager to 1.20

### DIFF
--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -47,7 +47,7 @@ certManager:
   enabled: true
   interval: 5m
   timeout: 5m
-  version: v1.19.*
+  version: v1.20.*
   namespace: cert-manager-system
   releaseName: cert-manager
   values: null


### PR DESCRIPTION
https://cert-manager.io/docs/releases/

since Jun 24, 2026 cert-manager v 1.19 is not supported anymore.

No special upgrade steps are required to upgrade from cert-manager v1.19 to v1.20.
https://cert-manager.io/docs/releases/upgrading/upgrading-1.19-1.20