### PR TITLE
SCHED-1764: Bind-mount libdummy not only on login nodes but also on CPU-only workers in GPU clusters

### DIFF
--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -69,7 +69,7 @@ pushd "${jaildir}"
         fi
     done <<< "$submounts"
 
-    if [ -n "$worker" ] && [ "$SLURM_CLUSTER_TYPE" = "gpu" ]; then
+    if [ -n "$worker" ] && [ "$NODESET_GPU_ENABLED" = "true" ]; then
         echo "Run nvidia-container-cli to propagate NVIDIA drivers, CUDA, NVML and other GPU-related stuff to the jail"
 
         # Disable ldconfig to prevent race between the workers.
@@ -117,7 +117,7 @@ pushd "${jaildir}"
     fi
 
     echo "Bind-mount slurm client"
-    /opt/bin/slurm/bind_slurm_common.sh -j ${jaildir}
+    /opt/bin/slurm/bind_slurm_common.sh -j "${jaildir}"
 
     echo "Bind-mount slurm chroot plugin from container to the jail"
     mkdir -p usr/lib/slurm
@@ -159,21 +159,8 @@ pushd "${jaildir}"
     echo 'Creating Soperator output directory'
     mkdir -m 777 -p opt/soperator-outputs
 
-    if [ -n "$worker" ]; then
-        echo "Bind-mount slurmd spool directory from the host because it should be propagated to the jail"
-        mount --bind /var/spool/slurmd var/spool/slurmd/
-    fi
-
-    if [ -n "$worker" ]; then
-         # slurmd package tree https://gist.github.com/asteny/9eb5089a10a793834d12a5b2449cc2b9
-         echo "Bind-mount slurmd binaries from container to the jail"
-         touch usr/sbin/slurmd usr/sbin/slurmstepd
-         mount --bind /usr/sbin/slurmd usr/sbin/slurmd
-         mount --bind /usr/sbin/slurmstepd usr/sbin/slurmstepd
-    fi
-
-    # For login node with cluster type GPU
-    if [ -z "$worker" ] && [ "$SLURM_CLUSTER_TYPE" = "gpu" ]; then
+    # For login nodes in GPU clusters and CPU workers in GPU clusters
+    if { [ -z "$worker" ] && [ "$SLURM_CLUSTER_TYPE" = "gpu" ]; } || { [ -n "$worker" ] && [ "$SLURM_CLUSTER_TYPE" = "gpu" ] && [ "$NODESET_GPU_ENABLED" != "true" ]; }; then
         while [ ! -f "etc/gpu_libs_installed.flag" ]; do
             echo "Waiting for GPU libs to be propagated to the jail from a worker node"
             sleep 10
@@ -186,6 +173,13 @@ pushd "${jaildir}"
 
     # For worker node only
     if [ -n "$worker" ]; then
+        echo "Bind-mount slurmd spool directory from the host because it should be propagated to the jail"
+        mount --bind /var/spool/slurmd var/spool/slurmd/
+        # slurmd package tree https://gist.github.com/asteny/9eb5089a10a793834d12a5b2449cc2b9
+        echo "Bind-mount slurmd binaries from container to the jail"
+        touch usr/sbin/slurmd usr/sbin/slurmstepd
+        mount --bind /usr/sbin/slurmd usr/sbin/slurmd
+        mount --bind /usr/sbin/slurmstepd usr/sbin/slurmstepd
         echo "Update linker cache inside the jail"
         echo "  libnvidia-ml.so.1 exists before ldconfig: $(test -e usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.1 && echo 'yes' || echo 'NO')"
         echo "  libnvidia-ml versioned file size before ldconfig: $(stat -c%s usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.*.* 2>/dev/null || echo 'NOT FOUND')"

--- a/images/worker/slurmd.dockerfile
+++ b/images/worker/slurmd.dockerfile
@@ -32,6 +32,15 @@ RUN arch=$(uname -m) && \
     echo "LD_LIBRARY_PATH=/usr/mpi/gcc/openmpi-${OPENMPI_VERSION}/lib:/lib/${alt_arch}-linux-gnu:/usr/lib/${alt_arch}-linux-gnu:/usr/local/cuda/targets/${alt_arch}-linux/lib" >> /etc/environment
 ENV PATH=${PATH}:/usr/mpi/gcc/openmpi-${OPENMPI_VERSION}/bin
 
+# Create dummy library for replacing GPU-specific libraries on CPU workers in GPU clusters
+RUN ALT_ARCH="$(uname -m)" && \
+    mkdir -p /usr/src/dummy && \
+    cd /usr/src/dummy && \
+    echo 'int main() { return 0; }' > dummy.c && \
+    gcc -shared -o libdummy.so dummy.c && \
+    mkdir -p "/lib/${ALT_ARCH}-linux-gnu" && \
+    cp libdummy.so "/lib/${ALT_ARCH}-linux-gnu/"
+
 # Install slurm сhroot plugin
 COPY images/common/chroot-plugin/chroot.c /usr/src/chroot-plugin/
 COPY images/common/scripts/install_chroot_plugin.sh /opt/bin/

--- a/internal/controller/clustercontroller/reconcile.go
+++ b/internal/controller/clustercontroller/reconcile.go
@@ -42,7 +42,6 @@ import (
 	"nebius.ai/slurm-operator/internal/logfield"
 	"nebius.ai/slurm-operator/internal/utils"
 	"nebius.ai/slurm-operator/internal/utils/resourcegetter"
-	"nebius.ai/slurm-operator/internal/utils/sliceutils"
 	"nebius.ai/slurm-operator/internal/values"
 )
 
@@ -236,24 +235,7 @@ func (r *SlurmClusterReconciler) reconcile(ctx context.Context, cluster *slurmv1
 		return ctrl.Result{}, fmt.Errorf("listing node sets: %w", err)
 	}
 
-	// Set cluster type to GPU if at least one NodeSet has GPU enabled
-	if sliceutils.IsEmptySeq(
-		sliceutils.FilterSeq(
-			sliceutils.MapSliceSeq(
-				nodeSets,
-				func(nodeSet slurmv1alpha1.NodeSet) bool {
-					return nodeSet.Spec.GPU.Enabled
-				},
-			),
-			func(b bool) bool {
-				return b
-			},
-		),
-	) {
-		clusterValues.ClusterType = consts.ClusterTypeCPU
-	} else {
-		clusterValues.ClusterType = consts.ClusterTypeGPU
-	}
+	clusterValues.ClusterType = values.BuildClusterTypeFromNodeSets(nodeSets)
 
 	// region Reconciliation
 	logger.Info("Starting reconciliation of Slurm Cluster")

--- a/internal/controller/nodesetcontroller/reconcile.go
+++ b/internal/controller/nodesetcontroller/reconcile.go
@@ -97,6 +97,13 @@ func (r *NodeSetReconciler) reconcile(ctx context.Context, nodeSet *slurmv1alpha
 		cluster.Spec.UseDefaultAppArmorProfile,
 	)
 
+	nodeSets, err := resourcegetter.ListNodeSetsByClusterRef(ctx, r.Client, client.ObjectKeyFromObject(cluster))
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("Failed to list %s", slurmv1alpha1.KindNodeSet))
+		return ctrl.Result{}, fmt.Errorf("listing node sets: %w", err)
+	}
+	clusterType := values.BuildClusterTypeFromNodeSets(nodeSets)
+
 	// region Ephemeral nodes power state
 	if nodeSetValues.EphemeralNodes != nil && *nodeSetValues.EphemeralNodes {
 		activeNodes, err := r.reconcileNodeSetPowerState(ctx, nodeSet)
@@ -108,7 +115,7 @@ func (r *NodeSetReconciler) reconcile(ctx context.Context, nodeSet *slurmv1alpha
 	}
 	// endregion Ephemeral nodes power state
 
-	if err = r.executeReconciliation(ctx, nodeSet, &nodeSetValues, cluster); err != nil {
+	if err = r.executeReconciliation(ctx, nodeSet, &nodeSetValues, cluster, clusterType); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -245,6 +252,7 @@ func (r NodeSetReconciler) executeReconciliation(
 	nodeSet *slurmv1alpha1.NodeSet,
 	nodeSetValues *values.SlurmNodeSet,
 	cluster *slurmv1.SlurmCluster,
+	clusterType consts.ClusterType,
 ) error {
 	steps := []utils.MultiStepExecutionStep{
 		{
@@ -360,6 +368,7 @@ func (r NodeSetReconciler) executeReconciliation(
 					nodeSetValues,
 					&secrets,
 					cluster.Spec.CgroupVersion,
+					clusterType,
 					topologyPluginEnabled,
 				)
 				if err != nil {

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -10,7 +10,6 @@ import (
 	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
 	"nebius.ai/slurm-operator/internal/check"
 	"nebius.ai/slurm-operator/internal/naming"
-	"nebius.ai/slurm-operator/internal/utils"
 	"nebius.ai/slurm-operator/internal/utils/sliceutils"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
@@ -134,6 +133,7 @@ func renderContainerNodeSetSlurmd(
 	nodeSet *values.SlurmNodeSet,
 	topologyEnabled bool,
 	cgroupVersion string,
+	clusterType consts.ClusterType,
 ) (corev1.Container, error) {
 	volumeMounts := []corev1.VolumeMount{
 		common.RenderVolumeMountSpool(consts.ComponentTypeWorker, consts.SlurmdName),
@@ -224,7 +224,8 @@ func renderContainerNodeSetSlurmd(
 		Env: append(
 			renderNodeSetSlurmdEnv(
 				cgroupVersion,
-				utils.Ternary(nodeSet.GPU.Enabled, consts.ClusterTypeGPU, consts.ClusterTypeCPU),
+				clusterType,
+				nodeSet.GPU.Enabled,
 				nodeSet.GPU.Nvidia.GDRCopyEnabled,
 				nodeSet.NodeExtra,
 			),
@@ -268,6 +269,7 @@ func renderVolumeMountSupervisordConfigMap() corev1.VolumeMount {
 func renderNodeSetSlurmdEnv(
 	cgroupVersion string,
 	clusterType consts.ClusterType,
+	nodeSetGPUEnabled bool,
 	enableGDRCopy bool,
 	slurmNodeExtra string,
 ) []corev1.EnvVar {
@@ -284,6 +286,10 @@ func renderNodeSetSlurmdEnv(
 		{
 			Name:  "SLURM_CLUSTER_TYPE",
 			Value: clusterType.String(),
+		},
+		{
+			Name:  "NODESET_GPU_ENABLED",
+			Value: strconv.FormatBool(nodeSetGPUEnabled),
 		},
 	}
 

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -29,6 +29,7 @@ func RenderNodeSetStatefulSet(
 	nodeSet *values.SlurmNodeSet,
 	secrets *slurmv1.Secrets,
 	cgroupVersion string,
+	clusterType consts.ClusterType,
 	topologyPluginEnabled bool,
 ) (kruisev1b1.StatefulSet, error) {
 	labels := common.RenderLabels(consts.ComponentTypeNodeSet, nodeSet.ParentalCluster.Name)
@@ -72,7 +73,7 @@ func RenderNodeSetStatefulSet(
 		)
 	}
 
-	slurmdContainer, err := renderContainerNodeSetSlurmd(nodeSet, topologyPluginEnabled, cgroupVersion)
+	slurmdContainer, err := renderContainerNodeSetSlurmd(nodeSet, topologyPluginEnabled, cgroupVersion, clusterType)
 	if err != nil {
 		return kruisev1b1.StatefulSet{}, fmt.Errorf("rendering slurmd container: %w", err)
 	}

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -17,6 +17,19 @@ import (
 	"nebius.ai/slurm-operator/internal/values"
 )
 
+func assertEnvValue(t *testing.T, envs []corev1.EnvVar, name, expectedValue string) {
+	t.Helper()
+
+	for _, env := range envs {
+		if env.Name == name {
+			assert.Equal(t, expectedValue, env.Value)
+			return
+		}
+	}
+
+	t.Fatalf("env var %s not found", name)
+}
+
 func Test_RenderContainerWorkerInit(t *testing.T) {
 	container := &values.Container{
 		NodeContainer: slurmv1.NodeContainer{
@@ -140,6 +153,92 @@ func Test_RenderContainerWorkerInit_K8SServiceName(t *testing.T) {
 	}
 }
 
+func TestRenderNodeSetStatefulSet_SlurmdGPUEnv(t *testing.T) {
+	tests := []struct {
+		name                   string
+		clusterType            consts.ClusterType
+		nodeSetGPUEnabled      bool
+		expectedClusterType    string
+		expectedNodeSetGPUFlag string
+	}{
+		{
+			name:                   "gpu cluster with gpu nodeset",
+			clusterType:            consts.ClusterTypeGPU,
+			nodeSetGPUEnabled:      true,
+			expectedClusterType:    "gpu",
+			expectedNodeSetGPUFlag: "true",
+		},
+		{
+			name:                   "gpu cluster with cpu nodeset",
+			clusterType:            consts.ClusterTypeGPU,
+			nodeSetGPUEnabled:      false,
+			expectedClusterType:    "gpu",
+			expectedNodeSetGPUFlag: "false",
+		},
+		{
+			name:                   "cpu cluster with cpu nodeset",
+			clusterType:            consts.ClusterTypeCPU,
+			nodeSetGPUEnabled:      false,
+			expectedClusterType:    "cpu",
+			expectedNodeSetGPUFlag: "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeSet := &values.SlurmNodeSet{
+				Name: "test-nodeset",
+				ParentalCluster: client.ObjectKey{
+					Namespace: "test-namespace",
+					Name:      "test-cluster",
+				},
+				ContainerSlurmd: values.Container{
+					NodeContainer: slurmv1.NodeContainer{
+						Image:           "test-image",
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Resources: corev1.ResourceList{
+							corev1.ResourceMemory:           resource.MustParse("1Gi"),
+							corev1.ResourceCPU:              resource.MustParse("100m"),
+							corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+						},
+					},
+				},
+				ContainerMunge: values.Container{
+					NodeContainer: slurmv1.NodeContainer{
+						Image: "munge-image",
+					},
+				},
+				VolumeSpool: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/spool"},
+				},
+				VolumeJail: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/jail"},
+				},
+				StatefulSet: values.StatefulSet{
+					Replicas: 1,
+				},
+				ServiceUmbrella:          values.Service{Name: "test-umbrella"},
+				SupervisorDConfigMapName: "supervisord-config",
+				SSHDConfigMapName:        "sshd-config",
+				GPU:                      &slurmv1alpha1.GPUSpec{Enabled: tt.nodeSetGPUEnabled},
+			}
+
+			result, err := worker.RenderNodeSetStatefulSet(
+				"test-cluster",
+				nodeSet,
+				&slurmv1.Secrets{},
+				consts.CGroupV2,
+				tt.clusterType,
+				false,
+			)
+			assert.NoError(t, err)
+
+			assertEnvValue(t, result.Spec.Template.Spec.Containers[0].Env, "SLURM_CLUSTER_TYPE", tt.expectedClusterType)
+			assertEnvValue(t, result.Spec.Template.Spec.Containers[0].Env, "NODESET_GPU_ENABLED", tt.expectedNodeSetGPUFlag)
+		})
+	}
+}
+
 func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 	createNodeSet := func(ephemeralNodes *bool, waitTimeout int32) *values.SlurmNodeSet {
 		return &values.SlurmNodeSet{
@@ -237,6 +336,7 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 				nodeSet,
 				&slurmv1.Secrets{},
 				consts.CGroupV2,
+				consts.ClusterTypeGPU,
 				tt.topologyPluginEnabled,
 			)
 			assert.NoError(t, err)
@@ -375,6 +475,7 @@ func TestRenderNodeSetStatefulSet_PersistentVolumeClaimRetentionPolicy(t *testin
 				tt.nodeSet,
 				&slurmv1.Secrets{},
 				consts.CGroupV2,
+				consts.ClusterTypeGPU,
 				false,
 			)
 			assert.NoError(t, err)
@@ -477,7 +578,7 @@ func TestRenderNodeSetStatefulSet_EphemeralNodesReserveOrdinals(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			nodeSet := createNodeSetWithActiveNodes(tt.ephemeralNodes, tt.activeNodes)
 
-			result, err := worker.RenderNodeSetStatefulSet("test-cluster", nodeSet, &slurmv1.Secrets{}, consts.CGroupV2, false)
+			result, err := worker.RenderNodeSetStatefulSet("test-cluster", nodeSet, &slurmv1.Secrets{}, consts.CGroupV2, consts.ClusterTypeGPU, false)
 			assert.NoError(t, err)
 
 			// Verify replicas

--- a/internal/values/slurm_cluster.go
+++ b/internal/values/slurm_cluster.go
@@ -99,6 +99,16 @@ func BuildSlurmClusterFrom(ctx context.Context, cluster *slurmv1.SlurmCluster) (
 	return res, nil
 }
 
+func BuildClusterTypeFromNodeSets(nodeSets []slurmav1alpha1.NodeSet) consts.ClusterType {
+	for _, nodeSet := range nodeSets {
+		if nodeSet.Spec.GPU.Enabled {
+			return consts.ClusterTypeGPU
+		}
+	}
+
+	return consts.ClusterTypeCPU
+}
+
 // HasEphemeralNodes returns true if any NodeSet in the cluster has ephemeral nodes enabled
 func (c *SlurmCluster) HasEphemeralNodes() bool {
 	for _, ns := range c.NodeSets {


### PR DESCRIPTION
## Problem

CPU-only workers in GPU clusters did not get the dummy GPU library setup, so jail preparation could fail or behave differently from login nodes.

## Solution

Pass cluster type into NodeSet rendering, add `NODESET_GPU_ENABLED`, and update jail setup so CPU-only workers in GPU clusters bind-mount dummy GPU libraries. Also add `libdummy.so` to the worker image.

## Testing

Added/updated unit tests for worker StatefulSet environment rendering. Local test run was not completed in this session.

## Release Notes

Fix: CPU-only workers in GPU clusters now get the expected dummy GPU library setup during jail preparation. No breaking changes.