### PR TITLE
SCHED-1865: kill leftover terraform processes after e2e apply

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -367,6 +367,25 @@ jobs:
 
           bin/e2e apply
 
+      - name: Kill leftover Terraform processes
+        if: always()
+        shell: bash
+        run: |
+          # A timed-out Terraform Apply can leave terraform running: the
+          # runner's process-tree kill misses reparented orphans. The survivor
+          # keeps creating resources concurrently with Terraform Destroy and
+          # leaks them (SCHED-1865). Kill everything terraform-related before
+          # any further terraform interaction.
+          for name in e2e terraform; do
+            pids=$(pgrep -x "$name" || true)
+            if [ -n "$pids" ]; then
+              echo "Killing leftover '$name' processes: $pids"
+              pkill -9 -x "$name" || true
+            fi
+          done
+          # provider plugin comm names are truncated, match by full cmdline
+          pkill -9 -f terraform-provider || true
+
       - name: K8s Cluster Info and NodeGroups
         if: always()
         shell: bash


### PR DESCRIPTION
## Problem

When `Terraform Apply` hits its 90-minute step timeout, the runner's process-tree kill can miss the `terraform` process (orphan reparented under `bin/e2e`). The survivor keeps applying concurrently with `Terraform Destroy` (the S3 state backend has no locking) and creates resources the destroy plan never sees. In run [27283799817](https://github.com/nebius/soperator/actions/runs/27283799817) this leaked the backups SA and bucket, which now fail every `SB_KCS_B200` run with `AlreadyExists` ([SCHED-1865](https://nebius.atlassian.net/browse/SCHED-1865)).

## Solution

- Add a `Kill leftover Terraform processes` step with `if: always()` right after `Terraform Apply`: SIGKILL leftover `e2e`/`terraform` processes by exact name and `terraform-provider*` plugins by cmdline.
- SIGKILL instead of SIGINT: graceful stop makes terraform wait for in-flight operations, which is the window that produces the leak. Destroy refreshes state right after, so a lost state write is harmless.

## Testing

- [x] e2e-test run: https://github.com/nebius/soperator/actions/runs/27356042613

## Release Notes

None


[SCHED-1865]: https://nebius.atlassian.net/browse/SCHED-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ