### PR TITLE
SCHED-1522 Fix Slurm config readers

### DIFF
--- a/images/slurm_check_job/slurm_check_job_entrypoint.sh
+++ b/images/slurm_check_job/slurm_check_job_entrypoint.sh
@@ -39,10 +39,11 @@ export HOME=~soperatorchecks
 
 # Auto-detect GPU requirement from the sbatch script's #SBATCH directives.
 # If the script requests GPU resources but the cluster has no GPU workers,
-# skip the check. Missing slurm.conf is fail-open (surface the real problem).
+# skip the check. Missing Slurm base config is fail-open (surface the real problem).
 if grep -qE '#SBATCH\s+.*(--gpus-per-node|--gpus\b|--gres=gpu|-G\s)' /opt/bin/sbatch.sh; then
-    if [[ -f /etc/slurm/slurm.conf ]] && ! grep -q '^[^#]*Gres=gpu' /etc/slurm/slurm.conf; then
-        SKIP_REASON="script requires GPU but no GPU nodes in slurm.conf"
+    SLURM_BASE_CONFIG="/etc/slurm/slurm_base.conf.noedit"
+    if [[ -f "$SLURM_BASE_CONFIG" ]] && ! grep -q '^[^#]*Gres=gpu' "$SLURM_BASE_CONFIG"; then
+        SKIP_REASON="script requires GPU but no GPU nodes in slurm_base.conf.noedit"
         echo "$SKIP_REASON — marking check '$ACTIVE_CHECK_NAME' as Skipped"
 
         K8S_JOB_NAME=$(kubectl get pod "$K8S_POD_NAME" -n "$K8S_POD_NAMESPACE" \

--- a/images/worker/worker_init.py
+++ b/images/worker/worker_init.py
@@ -15,7 +15,7 @@ Environment Variables (wait-topology):
     TOPOLOGY_CONFIGMAP_PATH: Path to mounted ConfigMap (default: /tmp/slurm/topology-node-labels)
     TOPOLOGY_WAIT_TIMEOUT: Max wait time in seconds (default: 180)
     TOPOLOGY_POLL_INTERVAL: Poll interval in seconds (default: 5)
-    SLURM_TOPOLOGY_PLUGIN: Slurm topology plugin override (default: read from slurm.conf)
+    SLURM_TOPOLOGY_PLUGIN: Optional override; unset reads slurm_base.conf.noedit.
 """
 
 import argparse
@@ -41,7 +41,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 # Constants
 SLURM_CONFIG_LINK_SOURCE: Path = Path("/mnt/jail/etc/slurm")
 SLURM_CONFIG_LINK_TARGET: Path = Path("/etc/slurm")
-SLURM_CONFIG_PATH: Path = Path("/etc/slurm/slurm.conf")
+SLURM_CONFIG_PATH: Path = Path("/etc/slurm/slurm_base.conf.noedit")
 SLURM_TOPOLOGY_CONFIG_PATH: Path = Path("/etc/slurm/topology.conf")
 
 TOPOLOGY_PLUGIN_TREE: str = "topology/tree"
@@ -200,15 +200,15 @@ def get_topology_poll_interval() -> int:
     return int(os.environ.get("TOPOLOGY_POLL_INTERVAL", "5"))
 
 
-def get_topology_plugin(slurm_conf_path: Path = SLURM_CONFIG_PATH) -> str:
+def get_topology_plugin(slurm_config_path: Path = SLURM_CONFIG_PATH) -> str:
     """Get the configured Slurm topology plugin."""
     topology_plugin: str = os.environ.get("SLURM_TOPOLOGY_PLUGIN", "").strip()
     if topology_plugin:
         return topology_plugin.lower()
 
-    slurm_conf_path: Path = Path(slurm_conf_path)
+    slurm_config_path: Path = Path(slurm_config_path)
     try:
-        with slurm_conf_path.open("r") as f:
+        with slurm_config_path.open("r") as f:
             pattern: re.Pattern[str] = re.compile(
                 r"^TopologyPlugin\s*=\s*(\S+)", re.IGNORECASE
             )
@@ -218,7 +218,7 @@ def get_topology_plugin(slurm_conf_path: Path = SLURM_CONFIG_PATH) -> str:
                 if match:
                     return match.group(1).lower()
     except (IOError, OSError) as e:
-        logger.info("Failed to read topology plugin from %s: %s", slurm_conf_path, e)
+        logger.info("Failed to read topology plugin from %s: %s", slurm_config_path, e)
 
     return TOPOLOGY_PLUGIN_TREE
 

--- a/images/worker/worker_init_test.py
+++ b/images/worker/worker_init_test.py
@@ -375,28 +375,28 @@ class TestGetEnvironmentVariables(unittest.TestCase):
             os.environ,
             {"SLURM_TOPOLOGY_PLUGIN": worker_init.TOPOLOGY_PLUGIN_BLOCK},
         ):
-            result = worker_init.get_topology_plugin("/missing/slurm.conf")
+            result = worker_init.get_topology_plugin("/missing/slurm_base.conf.noedit")
         self.assertEqual(result, worker_init.TOPOLOGY_PLUGIN_BLOCK)
 
-    def test_get_topology_plugin_from_slurm_conf(self):
-        """Topology plugin is read from slurm.conf when env is not set."""
+    def test_get_topology_plugin_from_slurm_base_config(self):
+        """Topology plugin is read from slurm_base.conf.noedit when env is not set."""
         with tempfile.TemporaryDirectory() as temp_dir:
-            slurm_conf = os.path.join(temp_dir, "slurm.conf")
-            with open(slurm_conf, "w") as f:
+            slurm_base_config = os.path.join(temp_dir, "slurm_base.conf.noedit")
+            with open(slurm_base_config, "w") as f:
                 f.write("# comment\nTopologyPlugin = topology/block # inline\n")
 
             env = os.environ.copy()
             env.pop("SLURM_TOPOLOGY_PLUGIN", None)
             with mock.patch.dict(os.environ, env, clear=True):
-                result = worker_init.get_topology_plugin(slurm_conf)
+                result = worker_init.get_topology_plugin(slurm_base_config)
         self.assertEqual(result, worker_init.TOPOLOGY_PLUGIN_BLOCK)
 
     def test_get_topology_plugin_defaults_to_tree(self):
-        """Missing slurm.conf defaults to topology/tree."""
+        """Missing slurm_base.conf.noedit defaults to topology/tree."""
         env = os.environ.copy()
         env.pop("SLURM_TOPOLOGY_PLUGIN", None)
         with mock.patch.dict(os.environ, env, clear=True):
-            result = worker_init.get_topology_plugin("/missing/slurm.conf")
+            result = worker_init.get_topology_plugin("/missing/slurm_base.conf.noedit")
         self.assertEqual(result, worker_init.TOPOLOGY_PLUGIN_TREE)
 
     def test_get_controller_max_attempts_default(self):

--- a/internal/controller/soperatorchecks/activecheck_skipped_test.go
+++ b/internal/controller/soperatorchecks/activecheck_skipped_test.go
@@ -45,7 +45,7 @@ func TestActiveCheckJobReconciler_SkippedAnnotation(t *testing.T) {
 		activeCheckName = "cuda-samples"
 		jobName         = "cuda-samples-12345"
 		podName         = "cuda-samples-12345-abcde"
-		skipReason      = "no GPU nodes in slurm.conf"
+		skipReason      = "no GPU nodes in slurm_base.conf.noedit"
 	)
 
 	activeCheck := &slurmv1alpha1.ActiveCheck{
@@ -157,7 +157,7 @@ func TestActiveCheckJobReconciler_SkippedAnnotation_Idempotent(t *testing.T) {
 			Name:      jobName,
 			Namespace: ns,
 			Annotations: map[string]string{
-				consts.ActiveCheckSkippedReasonAnnotation:  "no GPU nodes in slurm.conf",
+				consts.ActiveCheckSkippedReasonAnnotation:  "no GPU nodes in slurm_base.conf.noedit",
 				K8sAnnotationSoperatorChecksFinalStateTime: preExistingFinalTime,
 			},
 			Labels: map[string]string{


### PR DESCRIPTION
## Problem
After Slurm config files were renamed/split, a couple of code paths still checked `/etc/slurm/slurm.conf`. This made the GPU active check and worker topology plugin fallback rely on stale config paths, so their logic could be incorrect in clusters using the new config layout.

## Solution
Updated the remaining stale readers to use `slurm_base.conf.noedit` instead of `slurm.conf`.

Specifically:
- GPU active check now detects GPU node configuration from `/etc/slurm/slurm_base.conf.noedit`.
- Worker topology plugin fallback now reads from `slurm_base.conf.noedit`.
- Tests and skipped-check messages were updated to match the new config name.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
