### PR TITLE
SCHED-1931: fix worker-init scontrol topology update rejected

### DIFF
--- a/images/worker/worker_init.py
+++ b/images/worker/worker_init.py
@@ -200,6 +200,29 @@ def get_topology_poll_interval() -> int:
     return int(os.environ.get("TOPOLOGY_POLL_INTERVAL", "5"))
 
 
+def get_topology_fabric() -> str:
+    """Get the IB fabric / top-of-tree switch name for this node's NodeSet.
+
+    Must match the operator's per-fabric root switch (spec.topology.fabric), which the operator
+    renders as the parentless switch in topology.conf. Defaults to "root" for NodeSets without an
+    explicit fabric, matching the operator's default single-root tree.
+    """
+    fabric: str = os.environ.get("SLURM_TOPOLOGY_FABRIC", "").strip()
+    return fabric or "root"
+
+
+def unknown_switch_name(fabric: str) -> str:
+    """Return the catch-all switch/block name for nodes of the given fabric without IB labels.
+
+    Must match the operator's unknownSwitchName: the default fabric keeps the legacy "unknown"
+    name; named fabrics use "<fabric>.unknown".
+    """
+    fabric = (fabric or "root").strip()
+    if fabric == "root":
+        return "unknown"
+    return f"{fabric}.unknown"
+
+
 def get_topology_plugin(slurm_config_path: Path = SLURM_CONFIG_PATH) -> str:
     """Get the configured Slurm topology plugin."""
     topology_plugin: str = os.environ.get("SLURM_TOPOLOGY_PLUGIN", "").strip()
@@ -434,7 +457,7 @@ def read_topology_for_node(topology_path: Path, node_name: str) -> str:
 
 
 def format_slurm_topology(
-    topology: str, topology_plugin: str = TOPOLOGY_PLUGIN_TREE
+    topology: str, topology_plugin: str = TOPOLOGY_PLUGIN_TREE, fabric: str = "root"
 ) -> str:
     """
     Format topology string for Slurm --conf option.
@@ -470,6 +493,7 @@ def format_slurm_topology(
     topology: str = topology.strip()
     topology_plugin: str = (topology_plugin or TOPOLOGY_PLUGIN_TREE).strip().lower()
     block_topology: bool = topology_plugin == TOPOLOGY_PLUGIN_BLOCK
+    fabric: str = (fabric or "root").strip()
 
     if topology.startswith("{"):
         try:
@@ -478,7 +502,7 @@ def format_slurm_topology(
             if block_topology:
                 return _format_block_topology(parts)
 
-            return _format_tier_topology(parts)
+            return _format_tier_topology(parts, fabric)
         except json.JSONDecodeError:
             logger.warning("Failed to parse topology as JSON: %s", topology)
 
@@ -489,10 +513,10 @@ def format_slurm_topology(
 
         colon_parts: list[str] = topology.split(":")
 
-        # "name:leaf" -> add root: "topology=name:root:leaf"
+        # "name:leaf" -> add the fabric root: "topology=name:<fabric>:leaf"
         # "name:sw1:sw2:sw3" -> already has intermediates, keep as-is
         if len(colon_parts) == 2:
-            return f"topology={colon_parts[0]}:root:{colon_parts[1]}"
+            return f"topology={colon_parts[0]}:{fabric}:{colon_parts[1]}"
 
         return f"topology={topology}"
 
@@ -503,12 +527,12 @@ def format_slurm_topology(
         if block_topology:
             return _format_block_topology(parts)
 
-        return _format_tier_topology(parts)
+        return _format_tier_topology(parts, fabric)
 
     if block_topology:
         return f"topology=default:{topology}"
 
-    return f"topology=default:root:{topology}"
+    return f"topology=default:{fabric}:{topology}"
 
 
 def _parse_key_value_topology(topology: str) -> dict[str, str]:
@@ -544,12 +568,13 @@ def _format_block_topology(parts: dict[str, str]) -> str:
     return f"topology=default:{block_name}"
 
 
-def _format_tier_topology(parts: dict[str, str]) -> str:
+def _format_tier_topology(parts: dict[str, str], fabric: str = "root") -> str:
     """
     Format tier-based topology from a dictionary.
 
     Args:
         parts: Dictionary with tier keys like {"tier-1": "switch1", "tier-2": "rack1"}
+        fabric: IB fabric / top-of-tree switch name (the operator's per-fabric root).
 
     Returns:
         Formatted Slurm Topology string with the full switch hierarchy.
@@ -577,15 +602,17 @@ def _format_tier_topology(parts: dict[str, str]) -> str:
             except (ValueError, IndexError):
                 continue
 
+    fabric = (fabric or "root").strip()
+
     if tier_keys:
         # Sort descending: highest tier first (spine/root-side), lowest last (leaf)
         tier_keys.sort(key=lambda x: x[0], reverse=True)
         switches: list[str] = [parts[k] for _, k in tier_keys]
-        return f"topology=default:root:{':'.join(switches)}"
+        return f"topology=default:{fabric}:{':'.join(switches)}"
 
     if parts:
         first_value: str = next(iter(parts.values()))
-        return f"topology=default:root:{first_value}"
+        return f"topology=default:{fabric}:{first_value}"
 
     return ""
 
@@ -653,9 +680,12 @@ def wait_for_topology() -> None:
     topology_plugin: str = get_topology_plugin()
 
     if not is_gpu_enabled():
-        topology: str = "topology=default:root:unknown"
+        fabric: str = get_topology_fabric()
+        unknown: str = unknown_switch_name(fabric)
         if topology_plugin == TOPOLOGY_PLUGIN_BLOCK:
-            topology = "topology=default:unknown"
+            topology: str = f"topology=default:{unknown}"
+        else:
+            topology = f"topology=default:{fabric}:{unknown}"
 
         logger.info(
             "NODESET_GPU_ENABLED is not set to 'true', "
@@ -721,7 +751,9 @@ def wait_for_topology() -> None:
         )
         time.sleep(poll_interval)
 
-    topology: str = format_slurm_topology(raw_topology, topology_plugin)
+    topology: str = format_slurm_topology(
+        raw_topology, topology_plugin, get_topology_fabric()
+    )
     if not topology:
         logger.error("Failed to format topology from raw data: %s", raw_topology)
         sys.exit(1)

--- a/images/worker/worker_init_test.py
+++ b/images/worker/worker_init_test.py
@@ -137,6 +137,44 @@ class TestFormatSlurmTopology(unittest.TestCase):
         )
         self.assertEqual(result, "topology=default:block1")
 
+    def test_fabric_is_top_switch_for_tier_path(self):
+        """A configured fabric is used as the top-of-tree switch instead of "root"."""
+        result = worker_init.format_slurm_topology(
+            '{"tier-1":"leaf01","tier-2":"spine01"}',
+            worker_init.TOPOLOGY_PLUGIN_TREE,
+            "fab-a",
+        )
+        self.assertEqual(result, "topology=default:fab-a:spine01:leaf01")
+
+    def test_fabric_key_value_and_bare_forms(self):
+        """The fabric also applies to key/value and bare-name inputs."""
+        self.assertEqual(
+            worker_init.format_slurm_topology(
+                "tier-1=leaf01", worker_init.TOPOLOGY_PLUGIN_TREE, "fab-a"
+            ),
+            "topology=default:fab-a:leaf01",
+        )
+        self.assertEqual(
+            worker_init.format_slurm_topology(
+                "leaf01", worker_init.TOPOLOGY_PLUGIN_TREE, "fab-a"
+            ),
+            "topology=default:fab-a:leaf01",
+        )
+
+    def test_fabric_empty_defaults_to_root(self):
+        """An empty/whitespace fabric falls back to the legacy "root" top switch."""
+        result = worker_init.format_slurm_topology(
+            '{"tier-1":"leaf01"}', worker_init.TOPOLOGY_PLUGIN_TREE, "  "
+        )
+        self.assertEqual(result, "topology=default:root:leaf01")
+
+    def test_fabric_ignored_for_block_topology(self):
+        """Block topology has no root hierarchy, so the fabric is not applied."""
+        result = worker_init.format_slurm_topology(
+            '{"tier-0":"block1"}', worker_init.TOPOLOGY_PLUGIN_BLOCK, "fab-a"
+        )
+        self.assertEqual(result, "topology=default:block1")
+
     def test_named_block_topology_preserves_topology_name(self):
         """Block topology with an explicit topology name is preserved."""
         result = worker_init.format_slurm_topology(
@@ -320,6 +358,26 @@ class TestGetEnvironmentVariables(unittest.TestCase):
         with mock.patch.dict(os.environ, env, clear=True):
             with self.assertRaises(KeyError):
                 worker_init.get_node_name()
+
+    def test_get_topology_fabric_default(self):
+        """Get fabric returns "root" when the env var is not set."""
+        env = os.environ.copy()
+        env.pop("SLURM_TOPOLOGY_FABRIC", None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = worker_init.get_topology_fabric()
+        self.assertEqual(result, "root")
+
+    def test_get_topology_fabric_custom(self):
+        """Get fabric returns the configured value when set."""
+        with mock.patch.dict(os.environ, {"SLURM_TOPOLOGY_FABRIC": "fab-a"}):
+            result = worker_init.get_topology_fabric()
+        self.assertEqual(result, "fab-a")
+
+    def test_get_topology_fabric_empty_defaults_to_root(self):
+        """An empty fabric env var falls back to "root"."""
+        with mock.patch.dict(os.environ, {"SLURM_TOPOLOGY_FABRIC": "  "}):
+            result = worker_init.get_topology_fabric()
+        self.assertEqual(result, "root")
 
     def test_get_topology_path_default(self):
         """Get topology path returns default when not set."""
@@ -746,6 +804,46 @@ class TestWaitForTopologyNonGpu(unittest.TestCase):
 
         mock_wait_hostname.assert_called_once_with("worker-0", 180, 5)
         mock_apply.assert_called_once_with("worker-0", "topology=default:unknown")
+
+    @mock.patch("worker_init.wait_for_hostname_in_topology_conf")
+    @mock.patch("worker_init.apply_node_topology")
+    @mock.patch("worker_init.is_gpu_enabled", return_value=False)
+    @mock.patch.dict(
+        os.environ, {"HOSTNAME": "worker-0", "SLURM_TOPOLOGY_FABRIC": "fab-a"}
+    )
+    def test_non_gpu_applies_per_fabric_unknown_topology(
+        self, mock_gpu, mock_apply, mock_wait_hostname
+    ):
+        """Non-GPU node with a fabric joins <fabric>:<fabric>.unknown."""
+        with mock.patch(
+            "worker_init.get_topology_plugin",
+            return_value=worker_init.TOPOLOGY_PLUGIN_TREE,
+        ):
+            worker_init.wait_for_topology()
+
+        mock_apply.assert_called_once_with(
+            "worker-0", "topology=default:fab-a:fab-a.unknown"
+        )
+
+    @mock.patch("worker_init.wait_for_hostname_in_topology_conf")
+    @mock.patch("worker_init.apply_node_topology")
+    @mock.patch("worker_init.is_gpu_enabled", return_value=False)
+    @mock.patch.dict(
+        os.environ, {"HOSTNAME": "worker-0", "SLURM_TOPOLOGY_FABRIC": "fab-a"}
+    )
+    def test_non_gpu_applies_per_fabric_unknown_block(
+        self, mock_gpu, mock_apply, mock_wait_hostname
+    ):
+        """Non-GPU node with a fabric in block mode joins the <fabric>.unknown block."""
+        with mock.patch(
+            "worker_init.get_topology_plugin",
+            return_value=worker_init.TOPOLOGY_PLUGIN_BLOCK,
+        ):
+            worker_init.wait_for_topology()
+
+        mock_apply.assert_called_once_with(
+            "worker-0", "topology=default:fab-a.unknown"
+        )
 
     @mock.patch("worker_init.wait_for_hostname_in_topology_conf")
     @mock.patch("worker_init.apply_node_topology")

--- a/internal/consts/slurm.go
+++ b/internal/consts/slurm.go
@@ -38,4 +38,8 @@ const (
 	SlurmConfigRawStrategyOverride = "override"
 	SlurmTopologyTree              = "topology/tree"
 	SlurmTopologyBlock             = "topology/block"
+
+	// SlurmTopologyDefaultFabric is the default IB fabric / top-of-tree switch name used for
+	// NodeSets without an explicit spec.topology.fabric. It preserves the legacy single-root tree.
+	SlurmTopologyDefaultFabric = "root"
 )

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -27,6 +27,7 @@ func RenderContainerWorkerInit(
 	topologyEnabled, gpuEnabled bool,
 	waitTimeoutSeconds int32,
 	topologyPlugin string,
+	topologyFabric string,
 ) corev1.Container {
 	command := []string{
 		"python3",
@@ -123,6 +124,16 @@ func RenderContainerWorkerInit(
 				},
 			)
 		}
+		fabric := topologyFabric
+		if fabric == "" {
+			fabric = consts.SlurmTopologyDefaultFabric
+		}
+		env = append(env,
+			corev1.EnvVar{
+				Name:  "SLURM_TOPOLOGY_FABRIC",
+				Value: fabric,
+			},
+		)
 	}
 
 	return corev1.Container{

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -67,6 +67,7 @@ func RenderNodeSetStatefulSet(
 			nodeSet.GPU.Enabled,
 			topologyTimeOut,
 			topologyPlugin,
+			nodeSet.TopologyFabric,
 		),
 	)
 

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -47,15 +47,17 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 			true,
 			300,
 			consts.SlurmTopologyBlock,
+			"fab-test",
 		)
 
 		assert.Equal(t, consts.ContainerNameWorkerInit, result.Name)
 		assert.Equal(t, container.Image, result.Image)
 		assert.Equal(t, container.ImagePullPolicy, result.ImagePullPolicy)
 		assert.Equal(t, []string{"python3", "/opt/bin/slurm/worker_init.py", "wait-controller", "wait-topology"}, result.Command)
-		assert.Equal(t, 11, len(result.Env)) // 6 base + 1 NODESET_GPU_ENABLED + 4 topology
+		assert.Equal(t, 12, len(result.Env)) // 6 base + 1 NODESET_GPU_ENABLED + 5 topology
 		assert.Equal(t, 3, len(result.VolumeMounts))
 		assertEnvValue(t, result.Env, "SLURM_TOPOLOGY_PLUGIN", consts.SlurmTopologyBlock)
+		assertEnvValue(t, result.Env, "SLURM_TOPOLOGY_FABRIC", "fab-test")
 
 		expectedMounts := map[string]string{
 			consts.VolumeNameJail:               consts.VolumeMountPathJail,
@@ -77,6 +79,7 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 			false,
 			false,
 			0,
+			"",
 			"",
 		)
 
@@ -106,6 +109,7 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 				"TOPOLOGY_WAIT_TIMEOUT",
 				"TOPOLOGY_POLL_INTERVAL",
 				"SLURM_TOPOLOGY_PLUGIN",
+				"SLURM_TOPOLOGY_FABRIC",
 			}, envVar.Name,
 				"topology env var %s should not be present when topology is disabled", envVar.Name)
 		}
@@ -169,6 +173,7 @@ func Test_RenderContainerWorkerInit_K8SServiceName(t *testing.T) {
 				false,
 				tt.gpuEnabled,
 				0,
+				"",
 				"",
 			)
 

--- a/internal/values/slurm_nodeset.go
+++ b/internal/values/slurm_nodeset.go
@@ -60,6 +60,11 @@ type SlurmNodeSet struct {
 	EphemeralNodes               *bool
 	EphemeralTopologyWaitTimeout int32
 
+	// TopologyFabric is the IB fabric / top-of-tree switch name (spec.topology.fabric). It is
+	// passed to worker-init so the dynamic topology path it declares matches the operator's
+	// per-fabric root switch in topology.conf.
+	TopologyFabric string
+
 	ActiveNodes []int32
 }
 
@@ -137,6 +142,7 @@ func BuildSlurmNodeSetFrom(
 		//
 		EphemeralNodes:               nsSpec.EphemeralNodes,
 		EphemeralTopologyWaitTimeout: nsSpec.EphemeralTopologyWaitTimeout,
+		TopologyFabric:               nsSpec.Topology.Fabric,
 	}
 
 	// region Submounts


### PR DESCRIPTION
## Problem
All worker nodes were placed under a single root switch in topology.conf, telling Slurm that IB connectivity exists between every node. This is false for heterogeneous clusters whose NodeSets live in different IB fabrics — Slurm could schedule a single job across fabrics that aren't physically connected.

## Solution
Make the IB fabric configurable per NodeSet and render one unconnected root switch per fabric, end to end:

New spec.topology.fabric field on the NodeSet CR (defaults to root).
Operator (topologyconfcontroller): builds one root switch per fabric instead of a shared synthetic root. A NodeSet's workers and its tier switches sit under <fabric>; powered-down/unscheduled nodes go under <fabric>.unknown. The fabric roots stay unconnected, so a job can never span fabrics. NodeSets without a fabric fall back to root/unknown, so existing single-fabric clusters render byte-for-byte identical topology.conf.
Worker (worker_init.py): the dynamic topology path it declares via scontrol update topology=… must match the rendered tree. The operator now passes the fabric to worker-init via the SLURM_TOPOLOGY_FABRIC env var, and the worker uses it (and <fabric>.unknown for unlabeled/non-GPU nodes) as the top-of-tree switch instead of a hardcoded root. Without this, fabric-configured (especially ephemeral) NodeSets would be rejected by slurmctld with "Invalid node topology specified".

## Testing
Go unit tests: topologyconfcontroller (per-fabric roots, fabric as the tier-path root, powered-down → <fabric>.unknown, mixed explicit/defaulted NodeSets, no-fabric → legacy root, per-fabric unknown blocks), plus render/worker and values asserting the SLURM_TOPOLOGY_FABRIC env. go vet clean; CRD/deepcopy regenerated.
Python unit tests (worker_init_test.py, 101 passing): fabric as top switch for JSON/key-value/bare tier inputs, empty fabric → root, fabric ignored for block topology, get_topology_fabric env handling, and non-GPU per-fabric <fabric>.unknown for tree and block.
Backward compatibility verified: all pre-existing tree/block topology cases still pass unchanged.
e2e and manually in a live cluster

## Release Notes
fix: NodeSets can now declare an IB fabric via spec.topology.fabric. Workers are grouped under a per-fabric root switch so Slurm never schedules a job across physically disconnected fabrics; NodeSets without a fabric keep the previous single-root behavior.
