### PR TITLE
SCHED-1934: Works around NCCL Inspector

### DIFF
--- a/ansible/roles/spank-nccl-inspector-preconf/defaults/main.yml
+++ b/ansible/roles/spank-nccl-inspector-preconf/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+spank_nccl_inspector_preconf_dump_dir: "/opt/soperator-outputs/nccl_profiles"
+spank_nccl_inspector_preconf_dump_dir_mode: "0777"
+spank_nccl_inspector_preconf_dump_dir_create: true

--- a/ansible/roles/spank-nccl-inspector-preconf/tasks/main.yml
+++ b/ansible/roles/spank-nccl-inspector-preconf/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Ensure NCCL Inspector PreConf SPANK plugin is installed
+  ansible.builtin.apt:
+    name:
+      - spank-nccl-inspector-preconf
+    state: present
+    update_cache: true
+  tags:
+    - spank-nccl-inspector-preconf
+
+- name: Ensure default NCCL Inspector PreConf profile directory exists
+  ansible.builtin.file:
+    path: "{{ spank_nccl_inspector_preconf_dump_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "{{ spank_nccl_inspector_preconf_dump_dir_mode }}"
+  when: spank_nccl_inspector_preconf_dump_dir_create | bool
+  tags:
+    - spank-nccl-inspector-preconf

--- a/ansible/run.yml
+++ b/ansible/run.yml
@@ -38,6 +38,7 @@
     - soperator-scripts
     - slurm-divert
     - slurm-client
+    - spank-nccl-inspector-preconf
     - slurm-divert # role doubled here, because we need to do that after Slurm version upgrade
     - sssd
     - motd

--- a/ansible/spank-nccl-inspector-preconf.yml
+++ b/ansible/spank-nccl-inspector-preconf.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Install NCCL Inspector PreConf SPANK plugin
+  hosts:
+    - all
+    - localhost
+  become: true
+  roles:
+    - spank-nccl-inspector-preconf
+  tags:
+    - spank-nccl-inspector-preconf

--- a/helm/soperator-activechecks/scripts/soperator-outputs-logs-cleaner.sh
+++ b/helm/soperator-activechecks/scripts/soperator-outputs-logs-cleaner.sh
@@ -1,5 +1,54 @@
+#!/bin/bash
+
 set -euxo pipefail
 
 echo "Cleaning old Soperator outputs"
 
 find /mnt/jail/opt/soperator-outputs -type f -mmin +60 -print -delete
+
+clean_sncclprecon_dump_dirs() {
+  if [[ "$SNCCLPRECON_DUMP_DIR" != /* || "$SNCCLPRECON_DUMP_DIR" == "/" ]]; then
+    echo "Skipping NCCL Inspector Profiling dump cleanup: SNCCLPRECON_DUMP_DIR must be an absolute non-root path"
+    return
+  fi
+
+  local dump_dir="/mnt/jail${SNCCLPRECON_DUMP_DIR}"
+
+  if [[ ! -d "$dump_dir" ]]; then
+    echo "Skipping NCCL Inspector Profiling dump cleanup: ${dump_dir} does not exist"
+    return
+  fi
+
+  echo "Cleaning empty NCCL Inspector Profiling dump job directories in ${dump_dir}"
+
+  find "$dump_dir" -mindepth 1 -maxdepth 1 -type d -print0 | while IFS= read -r -d '' job_dir; do
+    # If there are log files left
+    if [[ -n "$(find "$job_dir" -type f -print -quit)" ]]; then
+      continue
+    fi
+
+    # If there are no step directories for the job
+    if [[ -z "$(find "$job_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)" ]]; then
+      # If the job directory itself is changed recently, it may be a new job without steps created yet, so skip removing it
+      if [[ -n "$(find "$job_dir" -maxdepth 0 -type d -mmin -180 -print -quit)" ]]; then
+        continue
+      fi
+
+      echo "Removing stale empty NCCL Inspector Profiling dump job directory without steps: ${job_dir}"
+      rm -rf -- "$job_dir"
+      continue
+    fi
+
+    # If there are step directories changed recently
+    if [[ -n "$(find "$job_dir" -mindepth 1 -maxdepth 1 -type d -mmin -180 -print -quit)" ]]; then
+      continue
+    fi
+
+    echo "Removing empty NCCL Inspector Profiling dump job directory: ${job_dir}"
+    rm -rf -- "$job_dir"
+  done
+}
+
+if [[ -n "${SNCCLPRECON_DUMP_DIR:-}" ]]; then
+  clean_sncclprecon_dump_dirs
+fi

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -341,6 +341,9 @@ checks:
       scriptFile: "scripts/soperator-outputs-logs-cleaner.sh"
       jobContainer:
         appArmorProfile: unconfined
+        env:
+          - name: "SNCCLPRECON_DUMP_DIR"
+            value: "/opt/soperator-outputs/nccl_profiles"
   manage-jail-state:
     enabled: true
     checkType: "k8sJob"

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -77,8 +77,6 @@ spec:
               {{- if .Values.observability.ncclProfiles.values.deleteAfterRead.enabled }}
               delete_after_read: true
               delete_after_read_min_age: {{ .Values.observability.ncclProfiles.values.deleteAfterRead.minAge | default "1m" }}
-              {{- else }}
-              delete_after_read: false
               {{- end }}
               {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
               storage: file_storage
@@ -317,10 +315,17 @@ spec:
 
     useGOMEMLIMIT: {{ .Values.observability.ncclProfiles.values.useGoMemLimit | default true }}
 
+    {{- $featureGates := list }}
     {{- if .Values.observability.opentelemetry.metrics.enabled }}
+    {{- $featureGates = append $featureGates "-telemetry.UseLocalHostAsDefaultMetricsAddress" }}
+    {{- end }}
+    {{- if .Values.observability.ncclProfiles.values.deleteAfterRead.enabled }}
+    {{- $featureGates = append $featureGates "filelog.allowFileDeletion" }}
+    {{- end }}
+    {{- if $featureGates }}
     command:
       extraArgs:
-        - "--feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress"
+        - "--feature-gates={{ join "," $featureGates }}"
     {{- end }}
 
     ports:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -262,9 +262,9 @@ spec:
     {{- end }}{{- end }}
 
     extraVolumes:
-      - name: nccl-profiles
+      - name: jail
         hostPath:
-          path: {{ .Values.observability.ncclProfiles.values.dumpDir }}
+          path: /mnt/jail
           type: Directory
 
       {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
@@ -275,8 +275,8 @@ spec:
       {{- end }}
 
     extraVolumeMounts:
-      - name: nccl-profiles
-        mountPath: /mnt/jail/opt/soperator-outputs/nccl_profiles/
+      - name: jail
+        mountPath: /mnt/jail
         readOnly: true
 
       {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
@@ -292,8 +292,35 @@ spec:
     serviceAccount:
       create: true
 
-    {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
     initContainers:
+      - command:
+          - sh
+          - "-c"
+          - |
+            set -eu
+            dump_dir="{{ .Values.observability.ncclProfiles.values.dumpDir }}"
+            case "$dump_dir" in
+              /mnt/jail/*) ;;
+              *)
+                echo "observability.ncclProfiles.values.dumpDir must be under /mnt/jail"
+                exit 1
+                ;;
+            esac
+            until [ -f /mnt/jail/etc/soperator-jail-populated ]; do
+              echo "Waiting for /mnt/jail to be populated"
+              sleep 5
+            done
+            install -d -m 0777 "$dump_dir"
+        image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
+        name: init-nccl-profiles-dir
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        volumeMounts:
+          - name: jail
+            mountPath: /mnt/jail
+
+      {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
       - command:
           - sh
           - "-c"
@@ -306,9 +333,7 @@ spec:
         volumeMounts:
           - name: varlibotelcol
             mountPath: /var/lib/otelcol
-    {{- else }}
-    initContainers: []
-    {{- end }}
+      {{- end }}
 
     resources:
       {{- toYaml .Values.observability.ncclProfiles.values.resources | nindent 6 }}

--- a/helm/soperator-fluxcd/tests/values_override_test.yaml
+++ b/helm/soperator-fluxcd/tests/values_override_test.yaml
@@ -282,6 +282,15 @@ tests:
           path: spec.values.configMap.existingName
           value: opentelemetry-collector-nccl-profiles-agent
       - equal:
+          path: spec.values.extraVolumes[0].hostPath.path
+          value: /mnt/jail
+      - equal:
+          path: spec.values.extraVolumes[0].hostPath.type
+          value: Directory
+      - equal:
+          path: spec.values.initContainers[0].name
+          value: init-nccl-profiles-dir
+      - equal:
           path: spec.values.command.extraArgs[0]
           value: --feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress,filelog.allowFileDeletion
 
@@ -327,7 +336,7 @@ tests:
     set:
       observability.enabled: true
       observability.ncclProfiles.enabled: true
-      observability.ncclProfiles.values.dumpDir: /custom/nccl
+      observability.ncclProfiles.values.dumpDir: /mnt/jail/custom/nccl
       observability.ncclProfiles.values.enableFileStorage: false
       observability.ncclProfiles.values.resources:
         requests:
@@ -341,10 +350,19 @@ tests:
     asserts:
       - equal:
           path: spec.values.extraVolumes[0].hostPath.path
-          value: /custom/nccl
+          value: /mnt/jail
       - equal:
-          path: spec.values.initContainers
-          value: []
+          path: spec.values.extraVolumes[0].hostPath.type
+          value: Directory
+      - equal:
+          path: spec.values.initContainers[0].name
+          value: init-nccl-profiles-dir
+      - equal:
+          path: spec.values.initContainers[0].volumeMounts[0].name
+          value: jail
+      - matchRegex:
+          path: spec.values.initContainers[0].command[2]
+          pattern: '/mnt/jail/custom/nccl'
       - equal:
           path: spec.values.resources.requests
           value:

--- a/helm/soperator-fluxcd/tests/values_override_test.yaml
+++ b/helm/soperator-fluxcd/tests/values_override_test.yaml
@@ -281,6 +281,23 @@ tests:
       - equal:
           path: spec.values.configMap.existingName
           value: opentelemetry-collector-nccl-profiles-agent
+      - equal:
+          path: spec.values.command.extraArgs[0]
+          value: --feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress,filelog.allowFileDeletion
+
+  - it: should enable file deletion feature gate when delete after read is enabled
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.opentelemetry.metrics.enabled: false
+      observability.ncclProfiles.values.deleteAfterRead.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles
+    asserts:
+      - equal:
+          path: spec.values.command.extraArgs[0]
+          value: --feature-gates=filelog.allowFileDeletion
 
   - it: should use daemonset mode on worker nodes for node-local storage
     set:
@@ -397,9 +414,9 @@ tests:
       path: metadata.name
       value: RELEASE-NAME-otelcol-nccl-profiles-cm
     asserts:
-      - matchRegex:
+      - notMatchRegex:
           path: spec.values.resources[0].data.relay
-          pattern: 'delete_after_read: false'
+          pattern: 'delete_after_read'
       - notMatchRegex:
           path: spec.values.resources[0].data.relay
           pattern: 'delete_after_read_min_age'

--- a/images/common/scripts/install_spank_nccl_inspector_preconf.sh
+++ b/images/common/scripts/install_spank_nccl_inspector_preconf.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e # Exit immediately if any command returns a non-zero error code
-
-apt-get update
-apt-get -y install --reinstall spank-nccl-inspector-preconf
-apt-get clean
-rm -rf /var/lib/apt/lists/*

--- a/images/login/sshd.dockerfile
+++ b/images/login/sshd.dockerfile
@@ -44,10 +44,12 @@ RUN chmod +x /opt/bin/install_nccld_debug_plugin.sh && \
     rm /opt/bin/install_nccld_debug_plugin.sh
 
 # Install NCCL Inspector PreConf SPANK plugin
-COPY images/common/scripts/install_spank_nccl_inspector_preconf.sh /opt/bin/
-RUN chmod +x /opt/bin/install_spank_nccl_inspector_preconf.sh && \
-    /opt/bin/install_spank_nccl_inspector_preconf.sh && \
-    rm /opt/bin/install_spank_nccl_inspector_preconf.sh
+COPY ansible/spank-nccl-inspector-preconf.yml /opt/ansible/spank-nccl-inspector-preconf.yml
+COPY ansible/roles/spank-nccl-inspector-preconf /opt/ansible/roles/spank-nccl-inspector-preconf
+RUN cd /opt/ansible && \
+    ansible-playbook -i inventory/ -c local \
+      -e spank_nccl_inspector_preconf_dump_dir_create=false \
+      spank-nccl-inspector-preconf.yml
 
 # Install enroot
 COPY images/common/scripts/install_enroot.sh /opt/bin/

--- a/images/slurm_check_job/slurm_check_job.dockerfile
+++ b/images/slurm_check_job/slurm_check_job.dockerfile
@@ -42,10 +42,12 @@ RUN chmod +x /opt/bin/install_nccld_debug_plugin.sh && \
     rm /opt/bin/install_nccld_debug_plugin.sh
 
 # Install NCCL Inspector PreConf SPANK plugin
-COPY images/common/scripts/install_spank_nccl_inspector_preconf.sh /opt/bin/
-RUN chmod +x /opt/bin/install_spank_nccl_inspector_preconf.sh && \
-    /opt/bin/install_spank_nccl_inspector_preconf.sh && \
-    rm /opt/bin/install_spank_nccl_inspector_preconf.sh
+COPY ansible/spank-nccl-inspector-preconf.yml /opt/ansible/spank-nccl-inspector-preconf.yml
+COPY ansible/roles/spank-nccl-inspector-preconf /opt/ansible/roles/spank-nccl-inspector-preconf
+RUN cd /opt/ansible && \
+    ansible-playbook -i inventory/ -c local \
+      -e spank_nccl_inspector_preconf_dump_dir_create=false \
+      spank-nccl-inspector-preconf.yml
 
 # Install kubectl
 RUN ARCH="$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')" && \

--- a/images/worker/slurmd.dockerfile
+++ b/images/worker/slurmd.dockerfile
@@ -63,10 +63,12 @@ RUN chmod +x /opt/bin/install_nccld_debug_plugin.sh && \
     rm /opt/bin/install_nccld_debug_plugin.sh
 
 # Install NCCL Inspector PreConf SPANK plugin
-COPY images/common/scripts/install_spank_nccl_inspector_preconf.sh /opt/bin/
-RUN chmod +x /opt/bin/install_spank_nccl_inspector_preconf.sh && \
-    /opt/bin/install_spank_nccl_inspector_preconf.sh && \
-    rm /opt/bin/install_spank_nccl_inspector_preconf.sh
+COPY ansible/spank-nccl-inspector-preconf.yml /opt/ansible/spank-nccl-inspector-preconf.yml
+COPY ansible/roles/spank-nccl-inspector-preconf /opt/ansible/roles/spank-nccl-inspector-preconf
+RUN cd /opt/ansible && \
+    ansible-playbook -i inventory/ -c local \
+      -e spank_nccl_inspector_preconf_dump_dir_create=false \
+      spank-nccl-inspector-preconf.yml
 
 # Install enroot
 COPY images/common/scripts/install_enroot.sh /opt/bin/


### PR DESCRIPTION
## Problem
1. It's worth installing the plugin with Ansible instead of bash
2. NCCL Inspector's `DUMP_DIR` should be created beforehand otel-collector startup
3. `deleteAfterRead` requires a feature gate opened
4. SCHED-1594: Old empty dump dirs should be cleaned up to reduce FS listing by otel-collector

## Solution
1. Installation of the SPANK plugin is done via Ansible. Creation of the default dump dir is executed during `manage-jail-state` active check
2. Create provided `DUMP_DIR` during otel-collector pod startup
3. Open the feature gate if `deleteAfterRead`
4. Extend `soperator-outputs-log-cleaner`

## Testing
Tested on dev cluster.

## Release Notes
Feature: Added automatic creation NCCL Inspector profiles directory.
Feature: Added automatic cleanup of NCCL Inspector profile directories.