### PR TITLE
SCHED-1887: Rate limit worker startups

### DIFF
--- a/api/v1alpha1/nodeset_types.go
+++ b/api/v1alpha1/nodeset_types.go
@@ -189,6 +189,19 @@ type NodeSetSpec struct {
 	// +kubebuilder:default=false
 	EnableHostUserNamespace bool `json:"enableHostUserNamespace,omitempty"`
 
+	// WorkerInitRandomDelaySeconds is the upper bound (in seconds) of a random delay the
+	// worker-init container sleeps before running its readiness checks. The actual delay is
+	// picked uniformly from [0, WorkerInitRandomDelaySeconds]. It spreads slurmd registrations
+	// across workers to avoid overloading the Slurm controller (thundering herd) when many
+	// worker pods start at once, e.g. after a cluster-wide restart.
+	// Set to 0 to disable the delay.
+	// Defaults to 0.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=0
+	WorkerInitRandomDelaySeconds int32 `json:"workerInitRandomDelaySeconds,omitempty"`
+
 	// Slurmd defines the Slurm worker daemon configuration.
 	//
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/slurm.nebius.ai_nodesets.yaml
+++ b/config/crd/bases/slurm.nebius.ai_nodesets.yaml
@@ -12089,6 +12089,19 @@ spec:
                 description: WorkerAnnotations represent K8S annotations that should
                   be added to the worker pods.
                 type: object
+              workerInitRandomDelaySeconds:
+                default: 0
+                description: |-
+                  WorkerInitRandomDelaySeconds is the upper bound (in seconds) of a random delay the
+                  worker-init container sleeps before running its readiness checks. The actual delay is
+                  picked uniformly from [0, WorkerInitRandomDelaySeconds]. It spreads slurmd registrations
+                  across workers to avoid overloading the Slurm controller (thundering herd) when many
+                  worker pods start at once, e.g. after a cluster-wide restart.
+                  Set to 0 to disable the delay.
+                  Defaults to 0.
+                format: int32
+                minimum: 0
+                type: integer
             required:
             - munge
             - slurmd

--- a/helm/nodesets/templates/nodeset.yaml
+++ b/helm/nodesets/templates/nodeset.yaml
@@ -275,6 +275,10 @@ spec:
   enableHostUserNamespace: {{ . }}
   {{- end }}
 
+  {{- if hasKey . "workerInitRandomDelaySeconds" }}
+  workerInitRandomDelaySeconds: {{ .workerInitRandomDelaySeconds }}
+  {{- end }}
+
   {{- with (.priorityClass | default "") }}
   priorityClass: {{ . | quote }}
   {{- end }}

--- a/helm/nodesets/values.yaml
+++ b/helm/nodesets/values.yaml
@@ -245,6 +245,12 @@ nodesets:
     # Whether the worker pod containers can use the host user namespace
     # Optional, defaults to false
     enableHostUserNamespace: false
+    # Upper bound (in seconds) of a random delay the worker-init container sleeps before
+    # running its readiness checks. The actual delay is picked uniformly from
+    # [0, workerInitRandomDelaySeconds]. Spreads slurmd registrations across workers to avoid
+    # overloading the Slurm controller when many worker pods start at once.
+    # Optional, 0 disables the delay, defaults to 0
+    workerInitRandomDelaySeconds: 30
     # PriorityClass to be used for worker pod
     # Optional
     priorityClass: *priorityClassHigh
@@ -266,6 +272,12 @@ nodesets:
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
+      # Keep worker pods on a node that became unreachable for up to tolerationSeconds
+      # (3 minutes) before they are evicted.
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
     # Additional annotations to be added to the worker pods
     # Optional, defaults to empty dict
     workerAnnotations:

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -27183,6 +27183,19 @@ spec:
                 description: WorkerAnnotations represent K8S annotations that should
                   be added to the worker pods.
                 type: object
+              workerInitRandomDelaySeconds:
+                default: 0
+                description: |-
+                  WorkerInitRandomDelaySeconds is the upper bound (in seconds) of a random delay the
+                  worker-init container sleeps before running its readiness checks. The actual delay is
+                  picked uniformly from [0, WorkerInitRandomDelaySeconds]. It spreads slurmd registrations
+                  across workers to avoid overloading the Slurm controller (thundering herd) when many
+                  worker pods start at once, e.g. after a cluster-wide restart.
+                  Set to 0 to disable the delay.
+                  Defaults to 0.
+                format: int32
+                minimum: 0
+                type: integer
             required:
             - munge
             - slurmd

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -27183,6 +27183,19 @@ spec:
                 description: WorkerAnnotations represent K8S annotations that should
                   be added to the worker pods.
                 type: object
+              workerInitRandomDelaySeconds:
+                default: 0
+                description: |-
+                  WorkerInitRandomDelaySeconds is the upper bound (in seconds) of a random delay the
+                  worker-init container sleeps before running its readiness checks. The actual delay is
+                  picked uniformly from [0, WorkerInitRandomDelaySeconds]. It spreads slurmd registrations
+                  across workers to avoid overloading the Slurm controller (thundering herd) when many
+                  worker pods start at once, e.g. after a cluster-wide restart.
+                  Set to 0 to disable the delay.
+                  Defaults to 0.
+                format: int32
+                minimum: 0
+                type: integer
             required:
             - munge
             - slurmd

--- a/images/worker/worker_init.py
+++ b/images/worker/worker_init.py
@@ -6,6 +6,12 @@ Supports two modes:
   wait-controller  - Wait for Slurm controller (slurmctld) to be ready
   wait-topology    - Wait for topology data from ConfigMap (for ephemeral nodes)
 
+Environment Variables (all modes):
+    WORKER_INIT_RANDOM_DELAY_SECONDS: Upper bound of a random startup delay applied before
+        running any command. The actual delay is picked uniformly from
+        [0, WORKER_INIT_RANDOM_DELAY_SECONDS]. Spreads slurmd registrations across workers to
+        avoid overloading the controller. Unset or 0 disables the delay (default: 0).
+
 Environment Variables (wait-controller):
     CONTROLLER_MAX_ATTEMPTS: Max ping attempts (default: 60)
     CONTROLLER_POLL_INTERVAL: Seconds between attempts (default: 5)
@@ -22,6 +28,7 @@ import argparse
 import json
 import logging
 import os
+import random
 import re
 import shutil
 import subprocess
@@ -49,6 +56,32 @@ TOPOLOGY_PLUGIN_BLOCK: str = "topology/block"
 
 
 # region Common env functions
+
+
+def apply_random_startup_delay() -> None:
+    """Sleep a random duration before running commands to spread out worker startup.
+
+    The upper bound is read from WORKER_INIT_RANDOM_DELAY_SECONDS; the actual delay is picked
+    uniformly from [0, upper_bound]. A non-positive or unparsable value disables the delay.
+    """
+    raw_value: str = os.environ.get("WORKER_INIT_RANDOM_DELAY_SECONDS", "0").strip()
+    try:
+        max_delay: int = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid WORKER_INIT_RANDOM_DELAY_SECONDS=%r, skipping startup delay",
+            raw_value,
+        )
+        return
+
+    if max_delay <= 0:
+        return
+
+    delay: int = random.randint(0, max_delay)
+    logger.info(
+        "Sleeping %ds (random, max %ds) before starting worker init", delay, max_delay
+    )
+    time.sleep(delay)
 
 
 def get_from_env_required(name: str) -> str:
@@ -778,6 +811,8 @@ def main():
     )
 
     args: argparse.Namespace = parser.parse_args()
+
+    apply_random_startup_delay()
 
     # Ensure wait-controller always runs first
     commands: list[str] = sorted(

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -28,6 +28,7 @@ func RenderContainerWorkerInit(
 	waitTimeoutSeconds int32,
 	topologyPlugin string,
 	topologyFabric string,
+	randomDelaySeconds int32,
 ) corev1.Container {
 	command := []string{
 		"python3",
@@ -90,6 +91,13 @@ func RenderContainerWorkerInit(
 			Name:  "K8S_SERVICE_NAME",
 			Value: naming.BuildServiceName(consts.ComponentTypeNodeSet, clusterName),
 		},
+	}
+
+	if randomDelaySeconds > 0 {
+		env = append(env, corev1.EnvVar{
+			Name:  "WORKER_INIT_RANDOM_DELAY_SECONDS",
+			Value: strconv.Itoa(int(randomDelaySeconds)),
+		})
 	}
 
 	if gpuEnabled {

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -68,6 +68,7 @@ func RenderNodeSetStatefulSet(
 			topologyTimeOut,
 			topologyPlugin,
 			nodeSet.TopologyFabric,
+			nodeSet.WorkerInitRandomDelaySeconds,
 		),
 	)
 

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -48,6 +48,7 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 			300,
 			consts.SlurmTopologyBlock,
 			"fab-test",
+			0,
 		)
 
 		assert.Equal(t, consts.ContainerNameWorkerInit, result.Name)
@@ -81,6 +82,7 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 			0,
 			"",
 			"",
+			0,
 		)
 
 		assert.Equal(t, consts.ContainerNameWorkerInit, result.Name)
@@ -112,6 +114,39 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 				"SLURM_TOPOLOGY_FABRIC",
 			}, envVar.Name,
 				"topology env var %s should not be present when topology is disabled", envVar.Name)
+		}
+	})
+
+	t.Run("random delay env present when positive", func(t *testing.T) {
+		result := worker.RenderContainerWorkerInit(
+			"test-cluster",
+			container,
+			false,
+			false,
+			0,
+			"",
+			"",
+			120,
+		)
+
+		assertEnvValue(t, result.Env, "WORKER_INIT_RANDOM_DELAY_SECONDS", "120")
+	})
+
+	t.Run("random delay env absent when zero", func(t *testing.T) {
+		result := worker.RenderContainerWorkerInit(
+			"test-cluster",
+			container,
+			false,
+			false,
+			0,
+			"",
+			"",
+			0,
+		)
+
+		for _, envVar := range result.Env {
+			assert.NotEqual(t, "WORKER_INIT_RANDOM_DELAY_SECONDS", envVar.Name,
+				"random delay env var should not be present when delay is 0")
 		}
 	})
 }
@@ -175,6 +210,7 @@ func Test_RenderContainerWorkerInit_K8SServiceName(t *testing.T) {
 				0,
 				"",
 				"",
+				0,
 			)
 
 			env, found := findEnv(result.Env, "K8S_SERVICE_NAME")

--- a/internal/values/slurm_nodeset.go
+++ b/internal/values/slurm_nodeset.go
@@ -53,9 +53,10 @@ type SlurmNodeSet struct {
 	SharedMemorySize                     *resource.Quantity
 	PersistentVolumeClaimRetentionPolicy *kruisev1b1.StatefulSetPersistentVolumeClaimRetentionPolicy
 
-	Maintenance             *consts.MaintenanceMode
-	NodeExtra               string
-	EnableHostUserNamespace bool
+	Maintenance                  *consts.MaintenanceMode
+	NodeExtra                    string
+	EnableHostUserNamespace      bool
+	WorkerInitRandomDelaySeconds int32
 
 	EphemeralNodes               *bool
 	EphemeralTopologyWaitTimeout int32
@@ -136,9 +137,10 @@ func BuildSlurmNodeSetFrom(
 			nsSpec.Slurmd.Volumes.PersistentVolumeClaimRetentionPolicy,
 		),
 		//
-		Maintenance:             maintenance,
-		NodeExtra:               nsSpec.NodeConfig.Dynamic,
-		EnableHostUserNamespace: nsSpec.EnableHostUserNamespace,
+		Maintenance:                  maintenance,
+		NodeExtra:                    nsSpec.NodeConfig.Dynamic,
+		EnableHostUserNamespace:      nsSpec.EnableHostUserNamespace,
+		WorkerInitRandomDelaySeconds: nsSpec.WorkerInitRandomDelaySeconds,
 		//
 		EphemeralNodes:               nsSpec.EphemeralNodes,
 		EphemeralTopologyWaitTimeout: nsSpec.EphemeralTopologyWaitTimeout,


### PR DESCRIPTION
## Problem
Worker pods all start their worker-init readiness checks simultaneously, causing a thundering-herd of slurmd registrations against the Slurm controller after a cluster-wide restart. There was also no toleration to control how long a worker survives on a node that became unreachable.

## Solution
Added spec.workerInitRandomDelaySeconds to NodeSet. When set, worker-init sleeps a random duration in [0, N] (via WORKER_INIT_RANDOM_DELAY_SECONDS) before its checks, spreading out registrations. 0 disables it.
Wired the field through values/render and the nodesets Helm chart.
Added a default node.kubernetes.io/unreachable:NoExecute toleration with tolerationSeconds: 180 (3 min) to the nodeset Helm values.
## Testing
go test ./internal/render/worker/... covering the new env var (present when positive, absent when 0).
Helm template render of the nodesets chart with the new field and toleration.

## Release Notes
Feature: NodeSets can now stagger worker startup via workerInitRandomDelaySeconds to avoid overloading the Slurm controller, and tolerate unreachable nodes for 3 minutes before eviction.