### PR TITLE
SCHED-1178: Don't run ldconfig on each worker pod start

### DIFF
--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -24,6 +24,12 @@ if [ -z "$jaildir" ] || [ -z "$upperdir" ]; then
     usage
 fi
 
+# Default optional variables so `set -u` doesn't abort: `worker` is only set via -w (unset on
+# login nodes), and the GPU env vars may be absent depending on the cluster/nodeset.
+worker="${worker:-}"
+NODESET_GPU_ENABLED="${NODESET_GPU_ENABLED:-}"
+SLURM_CLUSTER_WITH_GPU="${SLURM_CLUSTER_WITH_GPU:-}"
+
 ALT_ARCH="$(uname -m)"
 log "🔧 Using ALT_ARCH = ${ALT_ARCH}"
 

--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -3,7 +3,9 @@
 # Complement jaildir by bind-mounting virtual filesystems, users, and NVIDIA binaries from the host filesystem
 
 set -x # Print actual command before executing it
-set -e # Exit immediately if any command returns a non-zero error code
+set -euo pipefail
+
+log() { { set +x; } 2>/dev/null; echo "[$(date -u +%H:%M:%S)] $*"; set -x; }
 
 usage() { echo "usage: ${0} -j <path_to_jail_dir> -u <path_to_upper_jail_dir> [-w] [-h]" >&2; exit 1; }
 
@@ -23,44 +25,44 @@ if [ -z "$jaildir" ] || [ -z "$upperdir" ]; then
 fi
 
 ALT_ARCH="$(uname -m)"
-echo "🔧 Using ALT_ARCH = ${ALT_ARCH}"
+log "🔧 Using ALT_ARCH = ${ALT_ARCH}"
 
 SLURM_LIB_PATH="usr/lib/${ALT_ARCH}-linux-gnu/slurm"
 
 pushd "${jaildir}"
-    echo "Bind-mount virtual filesystems"
+    log "[virtual-fs] Bind-mount virtual filesystems"
     mount -t proc /proc proc/
     mount -t sysfs /sys sys/
     mount --rbind /dev dev/
     mount --rbind /run run/
 
-    echo "Bind-mount cgroup filesystem"
+    log "[virtual-fs] Bind-mount cgroup filesystem"
     mount --rbind /sys/fs/cgroup sys/fs/cgroup
 
-    echo "Bind-mount /tmp"
+    log "[virtual-fs] Bind-mount /tmp"
     mount --bind /tmp tmp/
 
-    echo "Bind-mount /var/log because it should be node-local"
+    log "[virtual-fs] Bind-mount /var/log because it should be node-local"
     mount --bind /var/log var/log
 
-    echo "Bind-mount DNS configuration"
+    log "[dns] Bind-mount DNS configuration"
     mount --bind /etc/resolv.conf etc/resolv.conf
 
-    echo "Bind-mount /etc/hosts"
+    log "[dns] Bind-mount /etc/hosts"
     mount --bind /etc/hosts etc/hosts
 
-    echo "Bind mount sssd.conf if exists"
+    log "[sssd] Bind mount sssd.conf if exists"
     if [[ -f /etc/sssd/sssd.conf ]]; then
       mount --bind /etc/sssd etc/sssd
     fi
 
-    echo "Bind-mount SSSD sockets if they exist"
+    log "[sssd] Bind-mount SSSD sockets if they exist"
     if [[ -d /var/lib/sss/pipes ]]; then
       mkdir -p var/lib/sss/pipes
       mount --bind /var/lib/sss/pipes var/lib/sss/pipes
     fi
 
-    echo "Bind-mount jail submounts from upper ${upperdir} into the actual ${jaildir}"
+    log "[submounts] Bind-mount jail submounts from upper ${upperdir} into the actual ${jaildir}"
     submounts=$( \
         findmnt --output TARGET --submounts --target / --pairs | \
         grep "^TARGET=\"${upperdir}/" | \
@@ -68,7 +70,7 @@ pushd "${jaildir}"
     )
     while IFS= read -r path; do
         if [ -n "$path" ]; then
-            echo "Bind-mount jail submount ${path}"
+            log "[submounts] Bind-mount jail submount ${path}"
             if [ -d "${upperdir}/${path}" ]; then
                 mkdir -p "${path}" # TODO: Support setting configurable permissions for jail submounts, this should be implemented in K8S VolumeMount
                 mount --rbind "${upperdir}/${path}" "${path}"
@@ -81,7 +83,7 @@ pushd "${jaildir}"
     done <<< "$submounts"
 
     if [ -n "$worker" ] && [ "$NODESET_GPU_ENABLED" = "true" ]; then
-        echo "Run nvidia-container-cli to propagate NVIDIA drivers, CUDA, NVML and other GPU-related stuff to the jail"
+        log "[gpu] Run nvidia-container-cli to propagate NVIDIA drivers, CUDA, NVML and other GPU-related stuff to the jail"
 
         # Disable ldconfig to prevent race between the workers.
         # ldconfig is run further in this script under flock.
@@ -118,7 +120,7 @@ pushd "${jaildir}"
             "${cap_args[@]}" \
             "${jaildir}"
 
-        echo "Checking NVIDIA lib state after nvidia-container-cli:"
+        log "[gpu] Checking NVIDIA lib state after nvidia-container-cli:"
         echo "  /lib symlink: $(readlink lib 2>/dev/null || echo 'NOT a symlink')"
         echo "  libnvidia-ml.so.1 exists: $(test -e usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.1 && echo 'yes' || echo 'NO')"
         echo "  libnvidia-ml.so.1 target: $(readlink usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.1 2>/dev/null || echo 'MISSING')"
@@ -127,23 +129,23 @@ pushd "${jaildir}"
         touch "etc/gpu_libs_installed.flag"
     fi
 
-    echo "Bind-mount slurm client"
+    log "[slurm] Bind-mount slurm client"
     /opt/bin/slurm/bind_slurm_common.sh -j "${jaildir}"
 
-    echo "Bind-mount slurm chroot plugin from container to the jail"
+    log "[slurm] Bind-mount slurm chroot plugin from container to the jail"
     mkdir -p usr/lib/slurm
     touch usr/lib/slurm/chroot.so
     mount --bind "/${SLURM_LIB_PATH}/chroot.so" "usr/lib/slurm/chroot.so"
 
-    echo "Bind-mount NCCL debug SPANK plugin from container to the jail"
+    log "[slurm] Bind-mount NCCL debug SPANK plugin from container to the jail"
     touch usr/lib/slurm/spanknccldebug.so
     mount --bind "/${SLURM_LIB_PATH}/spanknccldebug.so" "usr/lib/slurm/spanknccldebug.so"
 
-    echo "Bind-mount NCCL Inspector PreConf SPANK plugin from container to the jail"
+    log "[slurm] Bind-mount NCCL Inspector PreConf SPANK plugin from container to the jail"
     touch usr/lib/slurm/spank_nccl_inspector_preconf.so
     mount --bind "/${SLURM_LIB_PATH}/spank_nccl_inspector_preconf.so" "usr/lib/slurm/spank_nccl_inspector_preconf.so"
 
-    echo "Bind-mount /etc/enroot, /usr/share/enroot and /usr/lib/enroot"
+    log "[enroot] Bind-mount /etc/enroot, /usr/share/enroot and /usr/lib/enroot"
     mkdir -p etc/enroot usr/share/enroot usr/lib/enroot
     mkdir -p /etc/enroot/mounts.d
     printf '%s\n' '/opt/slurm_scripts/task_prolog.sh /opt/slurm_scripts/task_prolog.sh none x-create=file,bind,ro,nosuid,nodev,private,nofail 0 0' | sudo tee /etc/enroot/mounts.d/task_prolog.fstab
@@ -151,38 +153,38 @@ pushd "${jaildir}"
     mount --bind /usr/share/enroot usr/share/enroot
     mount --bind /usr/lib/enroot usr/lib/enroot
 
-    echo "Bind-mount enroot binaries"
+    log "[enroot] Bind-mount enroot binaries"
     for file in /usr/bin/enroot*; do
         filename=$(basename "$file")
         touch "usr/bin/$filename" && mount --bind "$file" "usr/bin/$filename"
     done
 
     if ! getcap usr/bin/enroot-mksquashovlfs | grep -q 'cap_sys_admin+pe'; then
-        echo "Set capabilities for enroot-mksquashovlfs to run containers without privileges"
+        log "[enroot] Set capabilities for enroot-mksquashovlfs to run containers without privileges"
         flock etc/complement_jail_setcap_enroot_mksquashovlfs.lock -c "setcap cap_sys_admin+pe usr/bin/enroot-mksquashovlfs"
     fi
     if ! getcap usr/bin/enroot-aufs2ovlfs | grep -q 'cap_sys_admin,cap_mknod+pe'; then
-        echo "Set capabilities for enroot-aufs2ovlfs to run containers without privileges"
+        log "[enroot] Set capabilities for enroot-aufs2ovlfs to run containers without privileges"
         flock etc/complement_jail_setcap_enroot_aufs2ovlfs.lock -c "setcap cap_sys_admin,cap_mknod+pe usr/bin/enroot-aufs2ovlfs"
     fi
 
-    echo "Create shared directories for caching Pyxis sqshfs files and Enroot OCI data"
+    log "[enroot] Create shared directories for caching Pyxis sqshfs files and Enroot OCI data"
     install -d -m 1777 var/cache/enroot-container-images var/cache/enroot
 
-    echo "Bind-mount pyxis plugin from container to the jail"
+    log "[pyxis] Bind-mount pyxis plugin from container to the jail"
     touch "usr/lib/slurm/spank_pyxis.so"
     mount --bind "/${SLURM_LIB_PATH}/spank_pyxis.so" "usr/lib/slurm/spank_pyxis.so"
 
-    echo 'Creating Soperator output directory'
+    log "[outputs] Creating Soperator output directory"
     mkdir -m 777 -p opt/soperator-outputs
 
     # For login nodes in GPU clusters and CPU workers in GPU clusters
     if { [ -z "$worker" ] && [ "$SLURM_CLUSTER_WITH_GPU" = "true" ]; } || { [ -n "$worker" ] && [ "$SLURM_CLUSTER_WITH_GPU" = "true" ] && [ "$NODESET_GPU_ENABLED" != "true" ]; }; then
         while [ ! -f "etc/gpu_libs_installed.flag" ]; do
-            echo "Waiting for GPU libs to be propagated to the jail from a worker node"
+            log "[gpu-wait] Waiting for GPU libs to be propagated to the jail from a worker node"
             sleep 10
         done
-        echo "Bind-mount all GPU-specific empty lib files into the host's libdummy"
+        log "[gpu-wait] Bind-mount all GPU-specific empty lib files into the host's libdummy"
         find "${jaildir}/lib/${ALT_ARCH}-linux-gnu" -maxdepth 1 -type f ! -type l -empty -print0 | while IFS= read -r -d '' file; do
             mount --bind "/lib/${ALT_ARCH}-linux-gnu/libdummy.so" "$file"
         done
@@ -190,32 +192,63 @@ pushd "${jaildir}"
 
     # For worker node only
     if [ -n "$worker" ]; then
-        echo "Bind-mount slurmd spool directory from the host because it should be propagated to the jail"
+        log "[slurmd] Bind-mount slurmd spool directory from the host because it should be propagated to the jail"
         mount --bind /var/spool/slurmd var/spool/slurmd/
 
         # slurmd package tree https://gist.github.com/asteny/9eb5089a10a793834d12a5b2449cc2b9
-        echo "Bind-mount slurmd binaries from container to the jail"
+        log "[slurmd] Bind-mount slurmd binaries from container to the jail"
         touch usr/sbin/slurmd usr/sbin/slurmstepd
         mount --bind /usr/sbin/slurmd usr/sbin/slurmd
         mount --bind /usr/sbin/slurmstepd usr/sbin/slurmstepd
 
-        echo "Bind-mount dockerd stuff from container to the jail"
+        log "[docker] Bind-mount dockerd stuff from container to the jail"
         mkdir -p etc/docker
         touch etc/docker/daemon.json
         mount --bind "/etc/docker/daemon.json" "etc/docker/daemon.json"
 
-        echo "Update linker cache inside the jail"
-        echo "  libnvidia-ml.so.1 exists before ldconfig: $(test -e usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.1 && echo 'yes' || echo 'NO')"
-        echo "  libnvidia-ml versioned file size before ldconfig: $(stat -c%s usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.*.* 2>/dev/null || echo 'NOT FOUND')"
-        ldconfig_rc=0
-        flock --nonblock etc/complement_jail_ldconfig.lock -c "chroot \"${jaildir}\" /usr/sbin/ldconfig" || ldconfig_rc=$?
-        if [ "$ldconfig_rc" -eq 0 ]; then
-            echo "ldconfig completed successfully (got flock)"
-        elif [ "$ldconfig_rc" -eq 1 ]; then
-            echo "ldconfig SKIPPED (flock busy)"
+        # ld.so.cache lives in the shared jail root, so running ldconfig rewrites the cache
+        # that every running job on every node depends on, briefly leaving it empty. To avoid
+        # this on each worker pod start (e.g. node auto-replacement), rebuild the shared cache
+        # only when its contents would actually change.
+        #
+        # The check builds a throwaway candidate cache from the libraries currently visible in
+        # the jail and compares it with the cache already in place; the real ldconfig runs only
+        # if they differ. This detects any library change (driver upgrade, OpenMPI, custom
+        # libs) without a version heuristic or a shared marker file.
+        #
+        # /tmp inside the jail is node-local (bind-mounted from the host), so the candidate
+        # cache plus -X (don't update symlinks) and -i (don't touch the shared aux-cache)
+        # keep the shared jail untouched while we probe. The first line of `ldconfig -p`
+        # is a header that embeds the cache path, so compare only the entry lines (=>).
+        current_cache_dump=$(mktemp)
+        candidate_cache_dump=$(mktemp)
+        candidate_cache="tmp/ld.so.cache.candidate.$$"
+
+        log "[ldcache] Probing whether the linker cache is up to date"
+        chroot "${jaildir}" /usr/sbin/ldconfig -p 2>/dev/null | grep '=>' | sort > "$current_cache_dump"
+        chroot "${jaildir}" /usr/sbin/ldconfig -X -i -C "/${candidate_cache}"
+        chroot "${jaildir}" /usr/sbin/ldconfig -C "/${candidate_cache}" -p 2>/dev/null | grep '=>' | sort > "$candidate_cache_dump"
+        rm -f "${jaildir}/${candidate_cache}"
+
+        if cmp -s "$current_cache_dump" "$candidate_cache_dump"; then
+            log "[ldcache] Linker cache is already up to date, skipping ldconfig"
         else
-            echo "ldconfig FAILED with exit code ${ldconfig_rc}"
+            log "[ldcache] Linker cache is stale, updating it inside the jail"
+            ldconfig_rc=0
+            # --conflict-exit-code distinguishes "another worker holds the lock" (a benign skip,
+            # that worker rebuilds the shared cache) from a real ldconfig failure, which must
+            # fail the entry point so the container restarts instead of leaving a broken cache.
+            flock --nonblock --conflict-exit-code 75 etc/complement_jail_ldconfig.lock \
+                -c "chroot \"${jaildir}\" /usr/sbin/ldconfig" || ldconfig_rc=$?
+            if [ "$ldconfig_rc" -eq 0 ]; then
+                log "[ldcache] ldconfig completed successfully (got flock)"
+            elif [ "$ldconfig_rc" -eq 75 ]; then
+                log "[ldcache] ldconfig skipped: another worker holds the lock and is rebuilding the cache"
+            else
+                log "[ldcache] ldconfig FAILED with exit code ${ldconfig_rc}"
+                exit "$ldconfig_rc"
+            fi
         fi
-        echo "  libnvidia-ml.so.1 exists after ldconfig: $(test -e usr/lib/${ALT_ARCH}-linux-gnu/libnvidia-ml.so.1 && echo 'yes' || echo 'NO')"
+        rm -f "$current_cache_dump" "$candidate_cache_dump"
     fi
 popd


### PR DESCRIPTION
## Problem
The jail root (and its `etc/ld.so.cache`) is a shared filesystem mounted on every node. On each worker pod start (e.g. node auto-replacement), `complement_jail.sh` ran `ldconfig`, rewriting the shared cache and briefly leaving it empty — so jobs starting on other nodes failed to resolve shared libraries.

## Solution
Rebuild the linker cache only when its contents would actually change: probe a throwaway candidate cache against the current one and run `ldconfig` only if they differ. A real `ldconfig` failure now fails the entry point (container restarts) instead of being logged and ignored; a busy `flock` lock is still a benign skip.

## Testing
`bash -n images/common/scripts/complement_jail.sh` passes. Manual: verified on a live cluster that new worker pods skip `ldconfig` when libraries are unchanged and rebuild on driver/library changes, with no empty-cache window for running jobs.

## Release Notes
Fix: Worker pods no longer rebuild the shared linker cache on every start, eliminating a brief window where jobs on other nodes could fail to start.
