### PR TITLE
SCHED-1971: fix slurmctld fatal on topology.conf — switch name with >19-digit decimal tail overflows Slurm hostlist parser → controller CrashLoopBackOff

### DIFF
--- a/internal/controller/topologyconfcontroller/switch_name.go
+++ b/internal/controller/topologyconfcontroller/switch_name.go
@@ -1,0 +1,43 @@
+package topologyconfcontroller
+
+// maxSafeTrailingDigits is the longest trailing decimal-digit run a switch or block name may end
+// with before Slurm's hostlist parser risks overflowing it. Slurm decomposes every name into a
+// prefix plus a trailing contiguous decimal run and stores that run as a uint64. UINT64_MAX
+// (18446744073709551615) is 20 digits; runs of 19 digits always fit (max 9_999_999_999_999_999_999
+// < UINT64_MAX), so 20+ digit runs are the real risk. We keep one extra digit of margin below the
+// boundary and treat any run longer than 18 digits as unsafe.
+const maxSafeTrailingDigits = 18
+
+// slurmNameTerminator is appended to unsafe names. '_' never appears in hex IB-fabric switch IDs
+// and carries no special meaning to Slurm's hostlist syntax, so it cannot collide with a real name
+// or be misparsed.
+const slurmNameTerminator = "_"
+
+// slurmSafeSwitchName makes a switch or block name safe to emit in topology.conf.
+//
+// Slurm only numerically parses the *trailing* decimal run of a name; when that run is long enough
+// to exceed the uint64 range Slurm saturates it to UINT64_MAX and rewrites the name, so a parent's
+// "Switches=" child reference no longer matches the child's "SwitchName=" line and slurmctld dies
+// with "has invalid child". Appending a non-digit terminator empties the trailing run, so Slurm
+// stores the name verbatim. Applying this consistently to a switch both where it is declared and
+// where it is referenced keeps the two in sync.
+//
+// It must never be applied to worker node names: those must match real Slurm node names exactly.
+func slurmSafeSwitchName(name string) string {
+	if trailingDigitCount(name) <= maxSafeTrailingDigits {
+		return name
+	}
+	return name + slurmNameTerminator
+}
+
+// trailingDigitCount returns the length of the trailing contiguous run of ASCII decimal digits.
+func trailingDigitCount(name string) int {
+	count := 0
+	for i := len(name) - 1; i >= 0; i-- {
+		if name[i] < '0' || name[i] > '9' {
+			break
+		}
+		count++
+	}
+	return count
+}

--- a/internal/controller/topologyconfcontroller/switch_name_test.go
+++ b/internal/controller/topologyconfcontroller/switch_name_test.go
@@ -1,0 +1,52 @@
+package topologyconfcontroller
+
+import "testing"
+
+func TestSlurmSafeSwitchName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "no trailing digits", in: "spine-a", want: "spine-a"},
+		{name: "short digit tail", in: "switch1", want: "switch1"},
+		{name: "hex hash ending in letter", in: "66b2be03e8b30ab5bcf8c9fd57d6c293", want: "66b2be03e8b30ab5bcf8c9fd57d6c293"},
+		{name: "18-digit tail stays", in: "sw123456789012345678", want: "sw123456789012345678"},
+		// 19 digits fit uint64 but exceed our 18-digit safety margin, so they are terminated.
+		{name: "19-digit tail terminated", in: "sw1234567890123456789", want: "sw1234567890123456789_"},
+		{
+			name: "overflowing bug value terminated",
+			in:   "6f84b74219aa22869602735141708147",
+			want: "6f84b74219aa22869602735141708147_",
+		},
+		{name: "all digits overflowing", in: "123456789012345678901", want: "123456789012345678901_"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := slurmSafeSwitchName(tt.in); got != tt.want {
+				t.Errorf("slurmSafeSwitchName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrailingDigitCount(t *testing.T) {
+	tests := []struct {
+		in   string
+		want int
+	}{
+		{in: "", want: 0},
+		{in: "abc", want: 0},
+		{in: "abc1", want: 1},
+		{in: "1a2b3", want: 1},
+		{in: "12345", want: 5},
+		{in: "6f84b74219aa22869602735141708147", want: 20},
+	}
+	for _, tt := range tests {
+		if got := trailingDigitCount(tt.in); got != tt.want {
+			t.Errorf("trailingDigitCount(%q) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/controller/topologyconfcontroller/topology_blocks.go
+++ b/internal/controller/topologyconfcontroller/topology_blocks.go
@@ -45,7 +45,9 @@ func (b TopologyBlocks) RenderConfigLines() []string {
 			lines,
 			fmt.Sprintf(
 				"BlockName=%s Nodes=%s",
-				blockName,
+				// Block names are external tier-0 labels; sanitize them like switch names. The
+				// worker list must stay verbatim to match real Slurm node names.
+				slurmSafeSwitchName(blockName),
 				slurmpattern.Merge(workers),
 			),
 		)

--- a/internal/controller/topologyconfcontroller/topology_blocks_test.go
+++ b/internal/controller/topologyconfcontroller/topology_blocks_test.go
@@ -110,6 +110,26 @@ func TestBuildTopologyBlocks_RenderMergesWorkerNodes(t *testing.T) {
 	}, lines)
 }
 
+// Regression (SCHED-1971): a block name (external tier-0 label) ending in an overflowing decimal
+// run must be terminated so Slurm's hostlist parser does not rewrite it; the worker list stays
+// verbatim.
+func TestBuildTopologyBlocks_SanitizesBlockName(t *testing.T) {
+	labelsByNode := map[string]tc.NodeTopologyLabels{
+		"node1": {"tier-0": "6f84b74219aa22869602735141708147"},
+	}
+	gpuPodsByNode := map[string][]string{
+		"node1": {"worker-0"},
+	}
+	allNodeNames := []string{"worker-0"}
+
+	blocks := tc.BuildTopologyBlocks(context.Background(), labelsByNode, gpuPodsByNode, allNodeNames, nil)
+	lines := blocks.RenderConfigLines()
+
+	require.Equal(t, []string{
+		"BlockName=6f84b74219aa22869602735141708147_ Nodes=worker-0",
+	}, lines)
+}
+
 func TestBuildTopologyBlocks_RenderEmpty(t *testing.T) {
 	blocks := tc.BuildTopologyBlocks(context.Background(), map[string]tc.NodeTopologyLabels{}, map[string][]string{}, nil, nil)
 	require.Nil(t, blocks.RenderConfigLines())

--- a/internal/controller/topologyconfcontroller/topology_graph.go
+++ b/internal/controller/topologyconfcontroller/topology_graph.go
@@ -94,9 +94,16 @@ func (g TopologyGraph) RenderConfigLines() []string {
 		}
 		slices.Sort(children)
 		if hasGrandChildren {
-			lines = append(lines, fmt.Sprintf("SwitchName=%s Switches=%s", parent, slurmpattern.Merge(children)))
+			// Children are switches: sanitize each so Slurm's hostlist parser cannot overflow a
+			// long trailing decimal run and break the parent/child reference.
+			safeChildren := make([]string, len(children))
+			for i, child := range children {
+				safeChildren[i] = slurmSafeSwitchName(child)
+			}
+			lines = append(lines, fmt.Sprintf("SwitchName=%s Switches=%s", slurmSafeSwitchName(parent), slurmpattern.Merge(safeChildren)))
 		} else {
-			lines = append(lines, fmt.Sprintf("SwitchName=%s Nodes=%s", parent, strings.Join(children, ",")))
+			// Children are worker nodes: their names must match real Slurm node names verbatim.
+			lines = append(lines, fmt.Sprintf("SwitchName=%s Nodes=%s", slurmSafeSwitchName(parent), strings.Join(children, ",")))
 		}
 	}
 	slices.Sort(lines)

--- a/internal/controller/topologyconfcontroller/topology_graph_test.go
+++ b/internal/controller/topologyconfcontroller/topology_graph_test.go
@@ -446,6 +446,28 @@ func TestRenderTopologyConfig(t *testing.T) {
 			},
 		},
 		{
+			// Regression: a switch ID whose trailing decimal run exceeds the uint64 range
+			// (here a 20-digit tail) must be terminated identically wherever it appears, so the
+			// parent's Switches= reference still matches the child's SwitchName= line and Slurm
+			// does not overflow it to UINT64_MAX (SCHED-1971).
+			name: "Switch ID with overflowing decimal tail is sanitized consistently",
+			labelsByNode: map[string]tc.NodeTopologyLabels{
+				"node1": {
+					"tier-1": "6f84b74219aa22869602735141708147",
+					"tier-2": "66b2be03e8b30ab5bcf8c9fd57d6c293",
+				},
+			},
+			gpuPodsByNode: map[string][]string{
+				"node1": {"worker-0"},
+			},
+			allNodeNames: []string{"worker-0"},
+			expected: []string{
+				"SwitchName=root Switches=66b2be03e8b30ab5bcf8c9fd57d6c293",
+				"SwitchName=66b2be03e8b30ab5bcf8c9fd57d6c293 Switches=6f84b74219aa22869602735141708147_",
+				"SwitchName=6f84b74219aa22869602735141708147_ Nodes=worker-0",
+			},
+		},
+		{
 			name: "Running node with tiers but no fabric stays under root",
 			labelsByNode: map[string]tc.NodeTopologyLabels{
 				"node1": {"tier-1": "switch1", "tier-2": "spine1"},


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
