### PR TITLE
SCHED-1683: Isolate exporter sub-collectors so one API failure does not drop the others' metrics

### DIFF
--- a/docs/slurm-exporter.md
+++ b/docs/slurm-exporter.md
@@ -134,6 +134,7 @@ The exporter provides self-monitoring metrics to track its own health and perfor
 | **slurm_exporter_collection_duration_seconds**<br>*Gauge* | Duration of the most recent metrics collection from SLURM APIs<br><br>**Labels:** None |
 | **slurm_exporter_collection_attempts_total**<br>*Counter* | Total number of metrics collection attempts<br><br>**Labels:** None |
 | **slurm_exporter_collection_failures_total**<br>*Counter* | Total number of failed metrics collection attempts<br><br>**Labels:** None |
+| **slurm_exporter_collector_errors_total**<br>*Counter* | Total number of errors per sub-collector during metrics collection. Sub-collectors are isolated, so a failure in one does not drop the others' metrics for that cycle; the failed collector's metrics simply gap until it recovers.<br><br>**Labels:** `collector` (one of `nodes`, `jobs`, `diag`) |
 | **slurm_exporter_metrics_requests_total**<br>*Counter* | Total number of requests to the `/metrics` endpoint<br><br>**Labels:** None |
 | **slurm_exporter_metrics_exported**<br>*Gauge* | Number of metrics exported in the last scrape<br><br>**Labels:** None |
 

--- a/internal/exporter/collector.go
+++ b/internal/exporter/collector.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"maps"
@@ -354,6 +355,36 @@ func (c *MetricsCollector) updateState(ctx context.Context) (err error) {
 		c.state.Store(newState)
 	}()
 
+	// Each sub-collector is isolated: a failure in one neither aborts the others nor drops
+	// their metrics. The failing collector's metrics simply gap for this cycle; the error
+	// is logged and counted via slurm_exporter_collector_errors_total{collector="..."}.
+	collectors := []struct {
+		name string
+		run  func() error
+	}{
+		{"nodes", func() error { return c.collectNodes(ctx, previousState, newState) }},
+		{"jobs", func() error { return c.collectJobs(ctx, newState) }},
+		{"diag", func() error { return c.collectDiag(ctx, newState) }},
+	}
+
+	var errs []error
+	for _, col := range collectors {
+		if cerr := col.run(); cerr != nil {
+			logger.Error(cerr, "Sub-collector failed", "collector", col.name)
+			c.Monitoring.RecordCollectorError(col.name)
+			errs = append(errs, fmt.Errorf("%s: %w", col.name, cerr))
+		}
+	}
+
+	logger.Info("Collected metrics", "elapsed_seconds", time.Since(startTime).Seconds())
+
+	return errors.Join(errs...)
+}
+
+// collectNodes fetches nodes and updates node-derived metrics on the new state.
+func (c *MetricsCollector) collectNodes(ctx context.Context, previousState, newState *metricsCollectorState) error {
+	logger := log.FromContext(ctx).WithName(ControllerName)
+
 	nodesStart := time.Now()
 	nodes, err := c.slurmAPIClient.ListNodes(ctx)
 	if err != nil {
@@ -365,6 +396,13 @@ func (c *MetricsCollector) updateState(ctx context.Context) (err error) {
 	c.updateNodeFailureMetrics(nodes, previousState.nodes)
 	c.updateNodeStateMetrics(nodes, previousState, newState, time.Now())
 	newState.lastGPUSecondsUpdate = c.updateGPUSecondsMetrics(ctx, nodes, previousState.lastGPUSecondsUpdate, time.Now())
+
+	return nil
+}
+
+// collectJobs fetches jobs and stores them on the new state.
+func (c *MetricsCollector) collectJobs(ctx context.Context, newState *metricsCollectorState) error {
+	logger := log.FromContext(ctx).WithName(ControllerName)
 
 	jobsStart := time.Now()
 	jobs, err := c.slurmAPIClient.ListJobsWithParams(ctx, c.jobListParams)
@@ -378,6 +416,13 @@ func (c *MetricsCollector) updateState(ctx context.Context) (err error) {
 	)
 	newState.jobs = jobs
 
+	return nil
+}
+
+// collectDiag fetches controller diagnostics and stores them on the new state.
+func (c *MetricsCollector) collectDiag(ctx context.Context, newState *metricsCollectorState) error {
+	logger := log.FromContext(ctx).WithName(ControllerName)
+
 	diagStart := time.Now()
 	diag, err := c.slurmAPIClient.GetDiag(ctx)
 	if err != nil {
@@ -385,8 +430,6 @@ func (c *MetricsCollector) updateState(ctx context.Context) (err error) {
 	}
 	logger.Info("Fetched controller diag", "elapsed_seconds", time.Since(diagStart).Seconds())
 	newState.diag = diag
-
-	logger.Info("Collected metrics", "elapsed_seconds", time.Since(startTime).Seconds())
 
 	return nil
 }

--- a/internal/exporter/collector_test.go
+++ b/internal/exporter/collector_test.go
@@ -253,36 +253,133 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 	})
 }
 
-func TestMetricsCollector_Collect_APIError(t *testing.T) {
+// TestMetricsCollector_CollectorIsolation verifies that a failure in one sub-collector
+// (nodes, jobs, or diag) neither aborts the others nor drops their metrics, and that the
+// failure is counted in slurm_exporter_collector_errors_total{collector="..."}.
+func TestMetricsCollector_CollectorIsolation(t *testing.T) {
 	log.SetLogger(zap.New(zap.UseDevMode(true)))
 
-	mockClient := &fake.MockClient{}
-	collector := newTestMetricsCollector(mockClient)
+	const (
+		nodeMarker = "slurm_node_info"
+		jobMarker  = "slurm_job_info"
+		diagMarker = "slurm_controller_server_thread_count"
+	)
 
-	// Mock failed ListNodes response - with early return, other APIs won't be called
-	mockClient.EXPECT().ListNodes(mock.Anything).Return(nil, assert.AnError)
-
-	// Test that updateState fails early when critical APIs fail
-	ctx := context.Background()
-	err := collector.updateState(ctx)
-	assert.Error(t, err) // Should error - ListNodes is critical
-
-	// Collect should return no node metrics since ListNodes failed, but might have job metrics
-	ch := make(chan prometheus.Metric, 10)
-	go func() {
-		collector.Collect(ch)
-		close(ch)
-	}()
-
-	var metrics []prometheus.Metric
-	for metric := range ch {
-		metrics = append(metrics, metric)
+	healthyNodes := []slurmapi.Node{
+		{
+			Name:       "iso-node",
+			InstanceID: "iso-instance",
+			States:     map[api.V0041NodeState]struct{}{api.V0041NodeStateIDLE: {}},
+			Tres:       "cpu=4,mem=8000M,gres/gpu=0",
+			Address:    "10.0.0.1",
+		},
+	}
+	healthyJobs := []slurmapi.Job{
+		{ID: 555, Name: "iso-job", State: "RUNNING", Partition: "gpu"},
+	}
+	serverThreadCount := int32(7)
+	healthyDiag := &api.V0041OpenapiDiagResp{
+		Statistics: api.V0041StatsMsg{ServerThreadCount: &serverThreadCount},
 	}
 
-	// Should have no metrics when state is empty/initial
-	assert.Equal(t, 0, len(metrics))
+	tests := []struct {
+		name           string
+		failCollector  string
+		setupMocks     func(*fake.MockClient)
+		absentMarker   string
+		presentMarkers []string
+	}{
+		{
+			name:          "nodes fails",
+			failCollector: "nodes",
+			setupMocks: func(m *fake.MockClient) {
+				m.EXPECT().ListNodes(mock.Anything).Return(nil, assert.AnError).Once()
+				m.EXPECT().ListJobsWithParams(mock.Anything, mock.Anything).Return(healthyJobs, nil).Once()
+				m.EXPECT().GetDiag(mock.Anything).Return(healthyDiag, nil).Once()
+			},
+			absentMarker:   nodeMarker,
+			presentMarkers: []string{jobMarker, diagMarker},
+		},
+		{
+			name:          "jobs fails",
+			failCollector: "jobs",
+			setupMocks: func(m *fake.MockClient) {
+				m.EXPECT().ListNodes(mock.Anything).Return(healthyNodes, nil).Once()
+				m.EXPECT().ListJobsWithParams(mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
+				m.EXPECT().GetDiag(mock.Anything).Return(healthyDiag, nil).Once()
+			},
+			absentMarker:   jobMarker,
+			presentMarkers: []string{nodeMarker, diagMarker},
+		},
+		{
+			name:          "diag fails",
+			failCollector: "diag",
+			setupMocks: func(m *fake.MockClient) {
+				m.EXPECT().ListNodes(mock.Anything).Return(healthyNodes, nil).Once()
+				m.EXPECT().ListJobsWithParams(mock.Anything, mock.Anything).Return(healthyJobs, nil).Once()
+				m.EXPECT().GetDiag(mock.Anything).Return(nil, assert.AnError).Once()
+			},
+			absentMarker:   diagMarker,
+			presentMarkers: []string{nodeMarker, jobMarker},
+		},
+	}
 
-	mockClient.AssertExpectations(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &fake.MockClient{}
+			collector := newTestMetricsCollector(mockClient)
+			tt.setupMocks(mockClient)
+
+			registry := prometheus.NewRegistry()
+			require.NoError(t, collector.Monitoring.Register(registry))
+
+			ctx := context.Background()
+			err := collector.updateState(ctx)
+			assert.Error(t, err, "updateState should report the failed collector")
+
+			ch := make(chan prometheus.Metric, 50)
+			go func() {
+				collector.Collect(ch)
+				close(ch)
+			}()
+
+			var metricsText []string
+			for metric := range ch {
+				metricsText = append(metricsText, toPrometheusLikeString(t, metric))
+			}
+			joined := strings.Join(metricsText, "\n")
+
+			assert.NotContains(t, joined, tt.absentMarker, "failed collector's metrics must be absent")
+			for _, marker := range tt.presentMarkers {
+				assert.Contains(t, joined, marker, "healthy collectors' metrics must still be present")
+			}
+
+			families, err := registry.Gather()
+			require.NoError(t, err)
+			assert.Equal(t, float64(1), collectorErrorValue(families, tt.failCollector),
+				"failed collector's error counter must be incremented once")
+
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+// collectorErrorValue returns the value of slurm_exporter_collector_errors_total for the
+// given collector label, or 0 if the series is absent.
+func collectorErrorValue(families []*dto.MetricFamily, collector string) float64 {
+	for _, mf := range families {
+		if mf.GetName() != "slurm_exporter_collector_errors_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "collector" && lp.GetValue() == collector {
+					return m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
 }
 
 func TestMetricsCollector_NodeFails(t *testing.T) {
@@ -995,10 +1092,13 @@ func TestMetricsCollector_WithMonitoringMetrics(t *testing.T) {
 		err := collector.updateState(ctx)
 		assert.NoError(t, err)
 
-		// Test failed collection - create a new mock client to avoid call conflicts
+		// Test failed collection - create a new mock client to avoid call conflicts.
+		// Only ListNodes fails; jobs and diag still run because collectors are isolated.
 		mockClientFail := &fake.MockClient{}
 		collector.slurmAPIClient = mockClientFail
 		mockClientFail.EXPECT().ListNodes(mock.Anything).Return(nil, errors.New("API error"))
+		mockClientFail.EXPECT().ListJobsWithParams(mock.Anything, mock.Anything).Return([]slurmapi.Job{}, nil)
+		mockClientFail.EXPECT().GetDiag(mock.Anything).Return(nil, nil)
 		err = collector.updateState(ctx)
 		assert.Error(t, err)
 

--- a/internal/exporter/monitoring.go
+++ b/internal/exporter/monitoring.go
@@ -9,6 +9,7 @@ type MonitoringMetrics struct {
 	collectionDuration prometheus.Gauge
 	collectionAttempts prometheus.Counter
 	collectionFailures prometheus.Counter
+	collectorErrors    *prometheus.CounterVec
 	metricsRequests    prometheus.Counter
 	metricsExported    prometheus.Gauge
 }
@@ -28,6 +29,10 @@ func NewMonitoringMetrics() *MonitoringMetrics {
 			Name: "slurm_exporter_collection_failures_total",
 			Help: "Total number of failed metrics collection attempts",
 		}),
+		collectorErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "slurm_exporter_collector_errors_total",
+			Help: "Total number of errors per sub-collector during metrics collection, labeled by collector",
+		}, []string{"collector"}),
 		metricsRequests: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "slurm_exporter_metrics_requests_total",
 			Help: "Total number of requests to /metrics endpoint",
@@ -45,6 +50,7 @@ func (m *MonitoringMetrics) Register(registry *prometheus.Registry) error {
 		m.collectionDuration,
 		m.collectionAttempts,
 		m.collectionFailures,
+		m.collectorErrors,
 		m.metricsRequests,
 		m.metricsExported,
 	}
@@ -65,6 +71,11 @@ func (m *MonitoringMetrics) RecordCollection(duration float64, err error) {
 	if err != nil {
 		m.collectionFailures.Inc()
 	}
+}
+
+// RecordCollectorError increments the error counter for the named sub-collector
+func (m *MonitoringMetrics) RecordCollectorError(collector string) {
+	m.collectorErrors.WithLabelValues(collector).Inc()
 }
 
 // RecordMetricsRequest increments the metrics request counter

--- a/internal/exporter/monitoring_test.go
+++ b/internal/exporter/monitoring_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,6 +72,23 @@ func TestMonitoringMetrics_RecordCollection(t *testing.T) {
 	assert.Equal(t, float64(0.5), durationValue, "Expected duration to be set to the last collection (0.5s)")
 }
 
+func TestMonitoringMetrics_RecordCollectorError(t *testing.T) {
+	metrics := NewMonitoringMetrics()
+	registry := prometheus.NewRegistry()
+	require.NoError(t, metrics.Register(registry))
+
+	metrics.RecordCollectorError("diag")
+	metrics.RecordCollectorError("diag")
+	metrics.RecordCollectorError("nodes")
+
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(2), collectorErrorValue(metricFamilies, "diag"), "Expected 2 diag collector errors")
+	assert.Equal(t, float64(1), collectorErrorValue(metricFamilies, "nodes"), "Expected 1 nodes collector error")
+	assert.Equal(t, float64(0), collectorErrorValue(metricFamilies, "jobs"), "Expected no jobs collector errors")
+}
+
 func TestMonitoringMetrics_RecordMetricsRequest(t *testing.T) {
 	metrics := NewMonitoringMetrics()
 	registry := prometheus.NewRegistry()
@@ -120,19 +136,4 @@ func TestMonitoringMetrics_RecordMetricsExported(t *testing.T) {
 	}
 
 	assert.Equal(t, float64(200), exportedCount, "Expected 200 exported metrics")
-}
-
-func getMetricValue(families []*dto.MetricFamily, name string, metricType string) float64 {
-	for _, mf := range families {
-		if *mf.Name == name && len(mf.Metric) > 0 {
-			metric := mf.Metric[0]
-			switch metricType {
-			case "counter":
-				return *metric.Counter.Value
-			case "gauge":
-				return *metric.Gauge.Value
-			}
-		}
-	}
-	return 0
 }


### PR DESCRIPTION
## Problem

The exporter collected nodes, jobs, and diag in one `updateState` pass with early returns. If `ListNodes`, `ListJobsWithParams`, or `GetDiag` failed, the whole cycle aborted and every metric — including the ones that fetched fine — gapped for that scrape.

## Solution

- Split `updateState` into three isolated sub-collectors (`collectNodes`, `collectJobs`, `collectDiag`). A failure in one logs, increments a counter, and joins into the returned error, but does not stop the others.
- Add `slurm_exporter_collector_errors_total{collector="nodes|jobs|diag"}` so a failing sub-collector is observable. Only the failed collector's metrics gap until it recovers.

## Testing

- New `TestMetricsCollector_CollectorIsolation` table test: fails each collector in turn and asserts the failed one's metrics are absent, the other two are present, and the error counter increments.
- New `TestMonitoringMetrics_RecordCollectorError`. Updated existing exporter tests to mock all three calls now that they always run.

## Release Notes

Feature: exporter sub-collectors (nodes, jobs, diag) are now isolated, so one Slurm API failure no longer drops the other metrics. Added `slurm_exporter_collector_errors_total`.