### PR TITLE
fix nodes watch in topology controller

### DIFF
--- a/internal/controller/topologyconfcontroller/nodetopology_controller.go
+++ b/internal/controller/topologyconfcontroller/nodetopology_controller.go
@@ -481,10 +481,12 @@ func (r *NodeTopologyReconciler) SetupWithManager(mgr ctrl.Manager,
 					return false
 				}
 
-				_, newHasLabel := newNode.Labels[r.tierOneLabel()]
-				_, oldHasLabel := oldNode.Labels[r.tierOneLabel()]
+				newLabel, newHasLabel := newNode.Labels[r.tierOneLabel()]
+				oldLabel, oldHasLabel := oldNode.Labels[r.tierOneLabel()]
 
-				return newHasLabel || (oldHasLabel && oldNode.Labels[r.tierOneLabel()] != newNode.Labels[r.tierOneLabel()])
+				return (newHasLabel && !oldHasLabel) ||
+					(!newHasLabel && oldHasLabel) ||
+					(newHasLabel && oldHasLabel && newLabel != oldLabel)
 			},
 			DeleteFunc: func(e event.DeleteEvent) bool {
 				node, ok := e.Object.(*corev1.Node)


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Too many reconcilations for topologyController due to incorrect event filtering

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Fix event filtering

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
Dev cluster

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Fix: event filtering in `topologyController`
