### PR TITLE
feat: Adjust e2e tests for managed

### DIFF
--- a/internal/e2e/acceptance/framework/helpers.go
+++ b/internal/e2e/acceptance/framework/helpers.go
@@ -145,3 +145,10 @@ func AnnotateWithJobLog(ctx context.Context, exec Exec, slurm *SlurmClient, job 
 func singleLine(s string) string {
 	return strings.Join(strings.Fields(strings.ReplaceAll(s, "\n", " ")), " ")
 }
+
+func ClusterPrefixedName(clusterName, podName string) string {
+	if clusterName == "" {
+		return podName
+	}
+	return fmt.Sprintf("%s-%s", clusterName, podName)
+}

--- a/internal/e2e/acceptance/framework/model.go
+++ b/internal/e2e/acceptance/framework/model.go
@@ -19,6 +19,10 @@ type ClusterState struct {
 	DiscoveredNodeSets []DiscoveredNodeSet
 }
 
+func (s *ClusterState) PodName(podName string) string {
+	return ClusterPrefixedName(s.SlurmClusterName, podName)
+}
+
 func (s *ClusterState) DesiredWorkerCount() int {
 	total := 0
 	for _, nodeSet := range s.DiscoveredNodeSets {

--- a/internal/e2e/acceptance/options.go
+++ b/internal/e2e/acceptance/options.go
@@ -62,9 +62,6 @@ func parseOptions(args []string) (options, error) {
 		return options{}, fmt.Errorf("--kubectl-context is required")
 	}
 	opts.SlurmClusterName = strings.TrimSpace(opts.SlurmClusterName)
-	if opts.SlurmClusterName == "" {
-		return options{}, fmt.Errorf("--slurm-cluster-name must not be empty")
-	}
 	opts.ReportDir = strings.TrimSpace(opts.ReportDir)
 
 	return opts, nil

--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -116,10 +116,10 @@ func discoverCluster(ctx context.Context, w *world, state *framework.ClusterStat
 	if _, err := w.Kubectl().RunWithDefaultRetry(ctx, "get", "pods", "-n", soperatorNamespace); err != nil {
 		return err
 	}
-	if err := verifyPodReady(ctx, w, soperatorNamespace, state.SlurmClusterName+"-login-0"); err != nil {
+	if err := verifyPodReady(ctx, w, soperatorNamespace, state.PodName("login-0")); err != nil {
 		return fmt.Errorf("verify login pod: %w", err)
 	}
-	if err := verifyPodReady(ctx, w, soperatorNamespace, state.SlurmClusterName+"-controller-0"); err != nil {
+	if err := verifyPodReady(ctx, w, soperatorNamespace, state.PodName("controller-0")); err != nil {
 		return fmt.Errorf("verify controller pod: %w", err)
 	}
 	if _, err := w.Controller().RunWithDefaultRetry(ctx, "true"); err != nil {

--- a/internal/e2e/acceptance/steps/cluster_creation.go
+++ b/internal/e2e/acceptance/steps/cluster_creation.go
@@ -316,7 +316,7 @@ func (s *ClusterCreation) checkActiveChecks(ctx context.Context) error {
 
 func (s *ClusterCreation) checkWelcomeOutput(ctx context.Context) error {
 	output, err := s.exec.Kubectl().RunWithDefaultRetry(ctx,
-		"exec", "-n", clusterCreationNamespace, s.state.SlurmClusterName+"-login-0", "--", "sh", "-lc",
+		"exec", "-n", clusterCreationNamespace, s.state.PodName("login-0"), "--", "sh", "-lc",
 		"/etc/update-motd.d/00-welcome && /etc/update-motd.d/20-slurm-stats")
 	if err != nil {
 		return fmt.Errorf("render welcome output: %w", err)

--- a/internal/e2e/acceptance/steps/prepull_container_image.go
+++ b/internal/e2e/acceptance/steps/prepull_container_image.go
@@ -18,7 +18,7 @@ var containerImageRegex = regexp.MustCompile(`--container-image=(\S+)`)
 // prepull-container-image ActiveCheck's sbatch script
 // (e.g. "cr.eu-north1.nebius.cloud#ml-containers/training_diag:<tag>").
 func PrepullContainerImagePyxis(ctx context.Context, exec framework.Exec, clusterName string) (string, error) {
-	checkName := clusterName + "-" + prepullActiveCheckBaseName
+	checkName := framework.ClusterPrefixedName(clusterName, prepullActiveCheckBaseName)
 	var checks slurmv1alpha1.ActiveCheckList
 	if err := kubectlJSON(ctx, exec, &checks, "get", "activechecks", "-A", "-o", "json"); err != nil {
 		return "", fmt.Errorf("list ActiveChecks: %w", err)

--- a/internal/e2e/acceptance/world.go
+++ b/internal/e2e/acceptance/world.go
@@ -59,7 +59,7 @@ func (w *world) Local() framework.ArgsScope {
 func (w *world) Controller() framework.CommandScope {
 	return commandScope{
 		run: func(ctx context.Context, command string) (string, error) {
-			return w.Kubectl().Run(ctx, "exec", "-n", soperatorNamespace, w.state.SlurmClusterName+"-controller-0", "--", "bash", "-lc", command)
+			return w.Kubectl().Run(ctx, "exec", "-n", soperatorNamespace, w.state.PodName("controller-0"), "--", "bash", "-lc", command)
 		},
 	}
 }
@@ -67,7 +67,7 @@ func (w *world) Controller() framework.CommandScope {
 func (w *world) Jail() framework.CommandScope {
 	return commandScope{
 		run: func(ctx context.Context, command string) (string, error) {
-			return w.Kubectl().Run(ctx, "exec", "-n", soperatorNamespace, w.state.SlurmClusterName+"-login-0", "--", "chroot", "/mnt/jail", "bash", "-lc", command)
+			return w.Kubectl().Run(ctx, "exec", "-n", soperatorNamespace, w.state.PodName("login-0"), "--", "chroot", "/mnt/jail", "bash", "-lc", command)
 		},
 	}
 }


### PR DESCRIPTION
  ## Problem
  Acceptance e2e tests assumed Slurm pods and ActiveChecks were always prefixed with the SlurmCluster resource
  name. Managed deployments use unprefixed names, which made the tests fail or impossible to run when
  `--slurm-cluster-name` needed to be empty.

  ## Solution
  Allow an empty Slurm cluster name in acceptance test options and centralize pod/check name construction so
  names are only prefixed when a cluster name is provided. Updated controller/login pod access, readiness checks,
  welcome-output validation, and prepull ActiveCheck lookup to use the shared naming helper.

  ## Testing
  Ran focused Go tests for the touched acceptance packages:

  `go test ./internal/e2e/acceptance/...`
  
  ```
  bin/acceptance --kubectl-context soperator-prod --slurm-cluster-name ""
  
  ...
  7 scenarios (7 passed)
  61 steps (40 passed, 21 skipped)
  9m15.917990917s
  acceptance: suite finished duration=9m15.919s
  ```

  ## Release Notes
  Fix: Acceptance e2e tests now support managed deployments with unprefixed Slurm pod and ActiveCheck names.
  Risk: Test harness behavior only; no runtime behavior, migration, or config changes for Soperator users.

