### PR TITLE
SCHED-1903 / SCHED-1906: Improve OTel Collector runtime and queue reliability

### DIFF
--- a/docs/logs-pipeline.md
+++ b/docs/logs-pipeline.md
@@ -64,6 +64,18 @@ The public logging endpoint defaults to `dns:///write.logging.eu-north1.nebius.c
 - Purpose: Collects Kubernetes events
 - Deployment: Single pod deployment
 
+### Collector Runtime Limits
+
+The log collectors set Go runtime limits from their configured pod resources:
+
+- `GOMAXPROCS` is derived from CPU limits when present, otherwise CPU requests.
+- CPU quantities are rounded up to a positive whole number: `500m` becomes `1`, `2` stays `2`.
+- When `useGOMEMLIMIT` or `useGoMemLimit` is enabled, `GOMEMLIMIT` is derived from memory limits when present, otherwise memory requests.
+- `GOMEMLIMIT` targets about 85% of the selected memory value and rounds up to a whole Go memory unit. For example, `200Mi` becomes `170MiB`, `128Mi` becomes `109MiB`, and `500Gi` becomes `425GiB`.
+- When `spec.values.useGOMEMLIMIT` is false, no `GOMEMLIMIT` environment variable is configured by Soperator.
+
+This applies to the system logs, jail logs, and events collectors. Override values that replace the collector chart values are responsible for setting their own runtime environment.
+
 ### Log Storage
 
 #### VictoriaLogs

--- a/docs/metrics-pipeline.md
+++ b/docs/metrics-pipeline.md
@@ -133,6 +133,19 @@ curl -k -H "Authorization: Bearer ${TOKEN}" https://localhost:8443/metrics
 
 Note: Production scraping requires a ServiceMonitor with proper RBAC authentication.
 
+#### 7. NCCL Profiles Collector
+- Purpose: Reads NCCL profile files from the jail filesystem and exports metrics through an OpenTelemetry collector
+- Deployment: Single deployment on system nodes by default, or DaemonSet on worker nodes with `observability.ncclProfiles.values.mode: nodeLocal`
+- Storage: Uses file storage under `/var/lib/otelcol` when `observability.ncclProfiles.values.enableFileStorage` is enabled
+- Runtime limits: Sets `GOMAXPROCS` and, when `useGoMemLimit` is enabled, `GOMEMLIMIT` from `observability.ncclProfiles.values.resources`
+
+The NCCL profiles collector follows the same Go runtime sizing rules as the log collectors:
+
+- CPU limits are preferred over CPU requests; values are rounded up to at least one process (`500m` -> `1`, `2` -> `2`).
+- Memory limits are preferred over memory requests.
+- `GOMEMLIMIT` targets about 85% of selected memory and rounds up to whole Go units (`200Mi` -> `170MiB`, `500Gi` -> `425GiB`).
+- When `spec.values.useGOMEMLIMIT` is false, no `GOMEMLIMIT` environment variable is configured by Soperator.
+
 ### Metrics Processing & Storage
 
 #### VictoriaMetrics Agent (VMAgent)

--- a/helm/soperator-fluxcd/templates/_helpers.tpl
+++ b/helm/soperator-fluxcd/templates/_helpers.tpl
@@ -152,3 +152,29 @@ Render Go runtime env vars for opentelemetry-collector from container resources.
   value: {{ include "soperator-fluxcd.memoryQuantityPercentGoMemLimit" (dict "quantity" $memory "percent" 85) | quote }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Render exporter sending_queue settings with exporter-side batching.
+*/}}
+{{- define "soperator-fluxcd.otelExporterSendingQueue" -}}
+{{- $batch := .batch | default dict -}}
+{{- $queue := .queue | default dict -}}
+{{- $timeout := get $batch "timeout" | default "1s" -}}
+{{- $minSize := get $batch "sendBatchSize" | default 2000 | int -}}
+{{- $maxSize := get $batch "sendBatchMaxSize" | default 5000 | int -}}
+{{- $queueSize := get $queue "queueSize" | default 30000 | int -}}
+{{- $numConsumers := get $queue "numConsumers" | default 10 | int -}}
+sending_queue:
+  enabled: true
+  sizer: items
+  queue_size: {{ max $queueSize $minSize }}
+  num_consumers: {{ $numConsumers }}
+  {{- if .storage }}
+  storage: {{ .storage }}
+  {{- end }}
+  batch:
+    sizer: items
+    flush_timeout: {{ $timeout }}
+    min_size: {{ $minSize }}
+    max_size: {{ $maxSize }}
+{{- end -}}

--- a/helm/soperator-fluxcd/templates/_helpers.tpl
+++ b/helm/soperator-fluxcd/templates/_helpers.tpl
@@ -62,3 +62,93 @@ Validate observability.publicEndpointTokenKind is one of: secret, hostPath
   {{- fail (printf "observability.publicEndpointTokenKind must be one of: secret, hostPath (got %q)" $kind) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Convert a Kubernetes CPU quantity to a positive GOMAXPROCS value.
+*/}}
+{{- define "soperator-fluxcd.cpuQuantityToGOMAXPROCS" -}}
+{{- $quantity := toString . | trim -}}
+{{- if eq $quantity "" -}}
+1
+{{- else if regexMatch "^[0-9]+(\\.[0-9]+)?m$" $quantity -}}
+{{- max 1 (int (ceil (divf (trimSuffix "m" $quantity | float64) 1000.0))) -}}
+{{- else if regexMatch "^[0-9]+(\\.[0-9]+)?$" $quantity -}}
+{{- max 1 (int (ceil ($quantity | float64))) -}}
+{{- else -}}
+{{- fail (printf "unsupported CPU quantity %q; use cores (2) or millicores (500m)" $quantity) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Convert a Kubernetes memory quantity to bytes.
+*/}}
+{{- define "soperator-fluxcd.memoryQuantityToBytes" -}}
+{{- $quantity := toString . | trim -}}
+{{- if not (regexMatch "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|Pi|Ei|[kKMGTP])?$" $quantity) -}}
+{{- fail (printf "unsupported memory quantity %q; use bytes, decimal units (500G), or binary units (500Gi)" $quantity) -}}
+{{- end -}}
+{{- $number := regexFind "^[0-9]+(\\.[0-9]+)?" $quantity -}}
+{{- $suffix := regexReplaceAll "^[0-9]+(\\.[0-9]+)?" $quantity "" -}}
+{{- $multiplier := 1 -}}
+{{- if eq $suffix "Ki" -}}
+{{- $multiplier = 1024 -}}
+{{- else if eq $suffix "Mi" -}}
+{{- $multiplier = 1048576 -}}
+{{- else if eq $suffix "Gi" -}}
+{{- $multiplier = 1073741824 -}}
+{{- else if eq $suffix "Ti" -}}
+{{- $multiplier = 1099511627776 -}}
+{{- else if or (eq $suffix "k") (eq $suffix "K") -}}
+{{- $multiplier = 1000 -}}
+{{- else if eq $suffix "M" -}}
+{{- $multiplier = 1000000 -}}
+{{- else if eq $suffix "G" -}}
+{{- $multiplier = 1000000000 -}}
+{{- else if eq $suffix "T" -}}
+{{- $multiplier = 1000000000000 -}}
+{{- end -}}
+{{- if regexMatch "^[0-9]+$" $number -}}
+{{- mul ($number | int) $multiplier -}}
+{{- else -}}
+{{- int (mulf ($number | float64) ($multiplier | float64)) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return N percent of a Kubernetes memory quantity as a GOMEMLIMIT value, rounded up to MiB.
+*/}}
+{{- define "soperator-fluxcd.memoryQuantityPercentGoMemLimit" -}}
+{{- $bytes := include "soperator-fluxcd.memoryQuantityToBytes" .quantity | int -}}
+{{- $percent := .percent | default 85 | int -}}
+{{- $mib := 1048576 -}}
+{{- $divisor := mul 100 $mib -}}
+{{- $whole := mul (div $bytes $divisor) $percent -}}
+{{- $remainder := mul (mod $bytes $divisor) $percent -}}
+{{- $roundedRemainder := div (add $remainder (sub $divisor 1)) $divisor -}}
+{{- $limitMiB := max 1 (add $whole $roundedRemainder) -}}
+{{- if eq (mod $limitMiB 1024) 0 -}}
+{{- printf "%dGiB" (div $limitMiB 1024) -}}
+{{- else -}}
+{{- printf "%dMiB" $limitMiB -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render Go runtime env vars for opentelemetry-collector from container resources.
+*/}}
+{{- define "soperator-fluxcd.otelCollectorGoEnv" -}}
+{{- $resources := .resources | default dict -}}
+{{- $requests := get $resources "requests" | default dict -}}
+{{- $limits := get $resources "limits" | default dict -}}
+{{- $cpu := coalesce (get $limits "cpu") (get $requests "cpu") -}}
+- name: GOMAXPROCS
+  value: {{ include "soperator-fluxcd.cpuQuantityToGOMAXPROCS" $cpu | quote }}
+{{- if .useGoMemLimit }}
+{{- $memory := coalesce (get $limits "memory") (get $requests "memory") -}}
+{{- if not $memory -}}
+{{- fail "GOMEMLIMIT is enabled but no resources.limits.memory or resources.requests.memory is configured" -}}
+{{- end }}
+- name: GOMEMLIMIT
+  value: {{ include "soperator-fluxcd.memoryQuantityPercentGoMemLimit" (dict "quantity" $memory "percent" 85) | quote }}
+{{- end -}}
+{{- end -}}

--- a/helm/soperator-fluxcd/templates/helmrepository.yaml
+++ b/helm/soperator-fluxcd/templates/helmrepository.yaml
@@ -73,7 +73,7 @@ spec:
   url: {{ .Values.helmRepository.mariadbOperator.url }}
   type: {{ .Values.helmRepository.mariadbOperator.type }}
 {{- end }}
-{{- if and .Values.observability.enabled .Values.observability.opentelemetry.enabled }}
+{{- if and .Values.observability.enabled (or .Values.observability.opentelemetry.enabled .Values.observability.ncclProfiles.enabled) }}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -44,9 +44,7 @@ spec:
   {{- $eventsQueueStorage = "file_storage" }}
   {{- end }}
   {{- $eventsUseGoMemLimit := true }}
-  {{- if hasKey $eventsValues "useGOMEMLIMIT" }}
-  {{- $eventsUseGoMemLimit = $eventsValues.useGOMEMLIMIT }}
-  {{- else if hasKey $eventsValues "useGoMemLimit" }}
+  {{- if hasKey $eventsValues "useGoMemLimit" }}
   {{- $eventsUseGoMemLimit = $eventsValues.useGoMemLimit }}
   {{- end }}
   {{- if .Values.observability.opentelemetry.events.overrideValues }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -1,16 +1,23 @@
-{{- if and .Values.observability.enabled .Values.observability.opentelemetry.enabled }}
+{{- if
+  and
+    .Values.observability.enabled
+    .Values.observability.opentelemetry.enabled
+}}
+
 {{- include "soperator-fluxcd.validatePublicEndpointTokenKind" . -}}
+
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: {{ include "soperator-fluxcd.fullname" . }}-opentelemetry-collector-events
   labels:
-  {{- include "soperator-fluxcd.labels" . | nindent 4 }}
+    {{- include "soperator-fluxcd.labels" . | nindent 4 }}
 spec:
   {{- with .Values.observability.opentelemetry.events.driftDetection }}
   driftDetection:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+
   chart:
     spec:
       chart: opentelemetry-collector
@@ -19,9 +26,11 @@ spec:
         kind: HelmRepository
         name: {{ include "soperator-fluxcd.fullname" . }}-opentelemetry-collector
       version: {{ .Values.observability.opentelemetry.events.version }}
+
   dependsOn:
-  - name: {{ include "soperator-fluxcd.fullname" . }}-ns
-  - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
+    - name: {{ include "soperator-fluxcd.fullname" . }}-ns
+    - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
+
   install:
     {{- toYaml .Values.observability.opentelemetry.events.install | nindent 4 }}
   upgrade:
@@ -30,6 +39,7 @@ spec:
   timeout: {{ .Values.observability.opentelemetry.events.timeout }}
   releaseName: opentelemetry-collector-events
   targetNamespace: logs-system
+
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
@@ -47,29 +57,211 @@ spec:
   {{- if hasKey $eventsValues "useGoMemLimit" }}
   {{- $eventsUseGoMemLimit = $eventsValues.useGoMemLimit }}
   {{- end }}
+
   {{- if .Values.observability.opentelemetry.events.overrideValues }}
     {{- toYaml .Values.observability.opentelemetry.events.overrideValues | nindent 4 }}
   {{- else }}
     clusterRole:
       create: true
       rules:
-      - apiGroups:
-        - ""
-        resources:
-        - pods
-        - namespaces
-        verbs:
-        - get
-        - watch
-        - list
-      - apiGroups:
-        - events.k8s.io
-        resources:
-        - events
-        verbs:
-        - watch
-        - list
+        - apiGroups:
+            - ""
+          resources:
+            - pods
+            - namespaces
+          verbs:
+            - get
+            - watch
+            - list
+
+        - apiGroups:
+            - events.k8s.io
+          resources:
+            - events
+          verbs:
+            - watch
+            - list
+
+    image:
+      pullPolicy: IfNotPresent
+      repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
+      tag: 2.0.10
+
+    mode: deployment
+
+    rollout:
+      rollingUpdate:
+        maxUnavailable: 50%
+      strategy: RollingUpdate
+
+    tolerations: []
+
+    {{- if or $eventsEnableFileStorage $hasPublicEndpoint }}
+    extraVolumes:
+      {{- if $eventsEnableFileStorage }}
+      - name: varlibotelcol
+        hostPath:
+          path: /var/lib/otelcol-events
+          type: DirectoryOrCreate
+      {{- end }}
+
+      {{- if $hasPublicEndpoint }}
+      - name: o11ytoken
+        {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
+        secret:
+          secretName: o11y-writer-sa-token
+        {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
+        hostPath:
+          path: /mnt/cloud-metadata
+          type: Directory
+        {{- end }}
+      {{- end }}
+
+    {{- end }}
+
+    {{- if or $eventsEnableFileStorage $hasPublicEndpoint }}
+    extraVolumeMounts:
+      {{- if $eventsEnableFileStorage }}
+      - name: varlibotelcol
+        mountPath: /var/lib/otelcol-events
+      {{- end }}
+
+      {{- if $hasPublicEndpoint }}
+      - mountPath: /o11ytoken
+        name: o11ytoken
+        readOnly: true
+      {{- end }}
+
+    {{- end }}
+
+    securityContext:
+      runAsGroup: 10001
+      runAsUser: 10001
+    serviceAccount:
+      create: true
+
+    extraEnvs:
+      {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $eventsValues.resources "useGoMemLimit" $eventsUseGoMemLimit) | nindent 6 }}
+
+      - name: K8S_NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+
+      - name: CLUSTER_NAME
+        value: {{ .Values.observability.clusterName | quote }}
+
+      {{- if .Values.observability.clusterId }}
+      - name: CLUSTER_ID
+        value: {{ .Values.observability.clusterId | quote }}
+      {{- end }}
+
+    {{- if $eventsEnableFileStorage }}
+    initContainers:
+      - name: init-fs
+        image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
+        volumeMounts:
+          - mountPath: /var/lib/otelcol-events
+            name: varlibotelcol
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        command:
+          - sh
+          - "-c"
+          - 'chown -R 10001: /var/lib/otelcol-events'
+    {{- end }}
+
+    {{- if and .Values.observability.opentelemetry.events.values .Values.observability.opentelemetry.events.values.resources }}
+    resources: {{- toYaml .Values.observability.opentelemetry.events.values.resources | nindent 6 }}
+    {{- end }}
+
+    useGOMEMLIMIT: {{ $eventsUseGoMemLimit }}
+
+    {{- if .Values.observability.opentelemetry.metrics.enabled }}
+    command:
+      extraArgs:
+        - --feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress
+
+    ports:
+      metrics:
+        enabled: true
+
+    podMonitor:
+      enabled: true
+      metricsEndpoints:
+        - port: metrics
+          interval: {{ .Values.observability.opentelemetry.metrics.interval | default "30s" }}
+          scrapeTimeout: {{ .Values.observability.opentelemetry.metrics.scrapeTimeout | default "10s" }}
+          relabelings:
+            - sourceLabels: [__meta_kubernetes_pod_name]
+              targetLabel: pod
+            - replacement: otel-collector-events
+              targetLabel: collector
+    {{- end }}
+
     config:
+      receivers:
+        k8sobjects:
+          auth_type: serviceAccount
+          objects:
+            - group: events.k8s.io
+              mode: watch
+              name: events
+        zipkin: null
+
+      processors:
+        k8s_attributes:
+          extract:
+            labels:
+              - from: pod
+                key: external-o11y
+                tag_name: external_o11y
+              - from: namespace
+                key: o11y_resource_id
+                tag_name: resource_id
+              - from: namespace
+                key: o11y_service_provider
+                tag_name: service_provider
+            metadata:
+              - k8s.namespace.name
+              - k8s.node.name
+              - k8s.pod.name
+              - k8s.pod.uid
+              - k8s.pod.start_time
+          filter:
+            node_from_env_var: K8S_NODE_NAME
+          passthrough: false
+          pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.ip
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.uid
+            - sources:
+                - from: connection
+          wait_for_metadata: true
+          wait_for_metadata_timeout: 30s
+
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 25
+
+        transform:
+          log_statements:
+            - context: log
+              error_mode: ignore
+              statements:
+                - set(attributes["cache"], ParseJSON(body.string)) where IsMatch(body.string,
+                  "^\\{")
+                - set(severity_text, "INFO")
+                - set(attributes["cluster"], "${env:CLUSTER_NAME}")
+            {{- if .Values.observability.clusterId }}
+                - set(attributes["sp_resource_id"], "${env:CLUSTER_ID}")
+            {{- end }}
+
       exporters:
         otlp_http/victoriametrics:
           compression: gzip
@@ -81,6 +273,7 @@ spec:
             max_elapsed_time: 0
           timeout: 5s
 {{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $eventsQueueStorage) | indent 10 }}
+
         {{- if $hasPublicEndpoint }}
         otlp:
           endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
@@ -101,78 +294,26 @@ spec:
           auth:
             authenticator: bearertokenauth
         {{- end }}
+
       extensions:
         {{- if $eventsEnableFileStorage }}
         file_storage:
           directory: /var/lib/otelcol-events
         {{- end }}
+
         health_check:
           endpoint: 0.0.0.0:13133
+
         {{- if $hasPublicEndpoint }}
         bearertokenauth:
-        {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
+          {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
           filename: "/o11ytoken/accessToken"
-        {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
+          {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
           filename: "/o11ytoken/tsa-token"
+          {{- end }}
         {{- end }}
-        {{- end }}
-      processors:
-        k8s_attributes:
-          extract:
-            labels:
-            - from: pod
-              key: external-o11y
-              tag_name: external_o11y
-            - from: namespace
-              key: o11y_resource_id
-              tag_name: resource_id
-            - from: namespace
-              key: o11y_service_provider
-              tag_name: service_provider
-            metadata:
-            - k8s.namespace.name
-            - k8s.node.name
-            - k8s.pod.name
-            - k8s.pod.uid
-            - k8s.pod.start_time
-          filter:
-            node_from_env_var: K8S_NODE_NAME
-          passthrough: false
-          pod_association:
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.ip
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.uid
-          - sources:
-            - from: connection
-          wait_for_metadata: true
-          wait_for_metadata_timeout: 30s
-        memory_limiter:
-          check_interval: 5s
-          limit_percentage: 80
-          spike_limit_percentage: 25
-        transform:
-          log_statements:
-          - context: log
-            error_mode: ignore
-            statements:
-            - set(attributes["cache"], ParseJSON(body.string)) where IsMatch(body.string,
-              "^\\{")
-            - set(severity_text, "INFO")
-            - set(attributes["cluster"], "${env:CLUSTER_NAME}")
-            {{- if .Values.observability.clusterId }}
-            - set(attributes["sp_resource_id"], "${env:CLUSTER_ID}")
-            {{- end }}
-      receivers:
-        k8sobjects:
-          auth_type: serviceAccount
-          objects:
-          - group: events.k8s.io
-            mode: watch
-            name: events
-        zipkin: null
+
+
       service:
         {{- if .Values.observability.opentelemetry.metrics.enabled }}
         telemetry:
@@ -184,136 +325,47 @@ spec:
                       host: 0.0.0.0
                       port: 8888
         {{- end }}
+
         extensions:
-        - health_check
-        {{- if $eventsEnableFileStorage }}
-        - file_storage
-        {{- end }}
-        {{- if $hasPublicEndpoint }}
-        - bearertokenauth
-        {{- end }}
+          - health_check
+
+          {{- if $eventsEnableFileStorage }}
+          - file_storage
+          {{- end }}
+
+          {{- if $hasPublicEndpoint }}
+          - bearertokenauth
+          {{- end }}
+
         pipelines:
           logs/events:
-            exporters:
-            - otlp_http/victoriametrics
-            {{- if $hasPublicEndpoint }}
-            - otlp
-            {{- end }}
-            processors:
-            - k8s_attributes
-            - transform
-            - memory_limiter
             receivers:
-            - k8sobjects
+              - k8sobjects
+            processors:
+              - k8s_attributes
+              - transform
+              - memory_limiter
+            exporters:
+              - otlp_http/victoriametrics
+
+              {{- if $hasPublicEndpoint }}
+              - otlp
+              {{- end }}
+
           metrics: null
           traces: null
-    extraEnvs:
-    - name: K8S_NODE_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    - name: CLUSTER_NAME
-      value: {{ .Values.observability.clusterName | quote }}
-    {{- if .Values.observability.clusterId }}
-    - name: CLUSTER_ID
-      value: {{ .Values.observability.clusterId | quote }}
-    {{- end }}
-    {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $eventsValues.resources "useGoMemLimit" $eventsUseGoMemLimit) | nindent 4 }}
-    image:
-      pullPolicy: IfNotPresent
-      repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
-      tag: 2.0.10
-    mode: deployment
-    rollout:
-      rollingUpdate:
-        maxUnavailable: 50%
-      strategy: RollingUpdate
-    securityContext:
-      runAsGroup: 10001
-      runAsUser: 10001
-    serviceAccount:
-      create: true
-    {{- if $eventsEnableFileStorage }}
-    initContainers:
-    - command:
-      - sh
-      - -c
-      - 'chown -R 10001: /var/lib/otelcol-events'
-      image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
-      name: init-fs
-      securityContext:
-        runAsGroup: 0
-        runAsUser: 0
-      volumeMounts:
-      - mountPath: /var/lib/otelcol-events
-        name: varlibotelcol
-    {{- end }}
-    tolerations: []
-    useGOMEMLIMIT: {{ $eventsUseGoMemLimit }}
-    {{- if and .Values.observability.opentelemetry.events.values
-    .Values.observability.opentelemetry.events.values.resources }}
-    resources:
-    {{- toYaml .Values.observability.opentelemetry.events.values.resources | nindent 6 }}
-    {{- end }}
-    {{- if or $eventsEnableFileStorage $hasPublicEndpoint }}
-    extraVolumes:
-      {{- if $eventsEnableFileStorage }}
-      - hostPath:
-          path: /var/lib/otelcol-events
-          type: DirectoryOrCreate
-        name: varlibotelcol
-      {{- end }}
-    {{- if $hasPublicEndpoint }}
-      - name: o11ytoken
-        {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
-        secret:
-          secretName: o11y-writer-sa-token
-        {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
-        hostPath:
-          path: /mnt/cloud-metadata
-          type: Directory
-        {{- end }}
-    {{- end }}
-    {{- end }}
-    {{- if or $eventsEnableFileStorage $hasPublicEndpoint }}
-    extraVolumeMounts:
-      {{- if $eventsEnableFileStorage }}
-      - mountPath: /var/lib/otelcol-events
-        name: varlibotelcol
-      {{- end }}
-    {{- if $hasPublicEndpoint }}
-      - mountPath: /o11ytoken
-        name: o11ytoken
-        readOnly: true
-    {{- end }}
-    {{- end }}
-    {{- if .Values.observability.opentelemetry.metrics.enabled }}
-    command:
-      extraArgs:
-        - --feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress
-    ports:
-      metrics:
-        enabled: true
-    podMonitor:
-      enabled: true
-      metricsEndpoints:
-        - port: metrics
-          interval: {{ .Values.observability.opentelemetry.metrics.interval | default "30s" }}
-          scrapeTimeout: {{ .Values.observability.opentelemetry.metrics.scrapeTimeout | default "10s" }}
-          relabelings:
-            - sourceLabels: [__meta_kubernetes_pod_name]
-              targetLabel: pod
-            - replacement: otel-collector-events
-              targetLabel: collector
-    {{- end }}
+
   {{- end }}
+
   valuesFrom:
-  - kind: ConfigMap
-    name: terraform-opentelemetry-collector-events
-    optional: true
-    valuesKey: values.yaml
-  - kind: ConfigMap
-    name: opentelemetry-collector-events
-    optional: true
-    valuesKey: values.yaml
+    - kind: ConfigMap
+      name: terraform-opentelemetry-collector-events
+      optional: true
+      valuesKey: values.yaml
+
+    - kind: ConfigMap
+      name: opentelemetry-collector-events
+      optional: true
+      valuesKey: values.yaml
+
 {{- end }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -33,6 +33,13 @@ spec:
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
+  {{- $eventsValues := .Values.observability.opentelemetry.events.values | default dict }}
+  {{- $eventsUseGoMemLimit := true }}
+  {{- if hasKey $eventsValues "useGOMEMLIMIT" }}
+  {{- $eventsUseGoMemLimit = $eventsValues.useGOMEMLIMIT }}
+  {{- else if hasKey $eventsValues "useGoMemLimit" }}
+  {{- $eventsUseGoMemLimit = $eventsValues.useGoMemLimit }}
+  {{- end }}
   {{- if .Values.observability.opentelemetry.events.overrideValues }}
     {{- toYaml .Values.observability.opentelemetry.events.overrideValues | nindent 4 }}
   {{- else }}
@@ -196,8 +203,7 @@ spec:
     - name: CLUSTER_ID
       value: {{ .Values.observability.clusterId | quote }}
     {{- end }}
-    - name: GOMAXPROCS
-      value: "1"
+    {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $eventsValues.resources "useGoMemLimit" $eventsUseGoMemLimit) | nindent 4 }}
     image:
       pullPolicy: IfNotPresent
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
@@ -213,7 +219,7 @@ spec:
     serviceAccount:
       create: true
     tolerations: []
-    useGOMEMLIMIT: {{ .Values.observability.opentelemetry.events.values.useGOMEMLIMIT | default true }}
+    useGOMEMLIMIT: {{ $eventsUseGoMemLimit }}
     {{- if and .Values.observability.opentelemetry.events.values
     .Values.observability.opentelemetry.events.values.resources }}
     resources:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -33,7 +33,16 @@ spec:
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
+  {{- $sendingQueue := .Values.observability.opentelemetry.sendingQueue | default dict }}
   {{- $eventsValues := .Values.observability.opentelemetry.events.values | default dict }}
+  {{- $eventsEnableFileStorage := true }}
+  {{- if hasKey $eventsValues "enableFileStorage" }}
+  {{- $eventsEnableFileStorage = $eventsValues.enableFileStorage }}
+  {{- end }}
+  {{- $eventsQueueStorage := "" }}
+  {{- if $eventsEnableFileStorage }}
+  {{- $eventsQueueStorage = "file_storage" }}
+  {{- end }}
   {{- $eventsUseGoMemLimit := true }}
   {{- if hasKey $eventsValues "useGOMEMLIMIT" }}
   {{- $eventsUseGoMemLimit = $eventsValues.useGOMEMLIMIT }}
@@ -69,16 +78,22 @@ spec:
           encoding: proto
           logs_endpoint: http://vm-logs-victoria-logs-single-server:9428/insert/opentelemetry/v1/logs
           retry_on_failure:
+            enabled: true
             initial_interval: 200ms
+            max_elapsed_time: 0
           timeout: 5s
+{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $eventsQueueStorage) | indent 10 }}
         {{- if $hasPublicEndpoint }}
         otlp:
           endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
           balancer_name: round_robin
           compression: snappy
           retry_on_failure:
+            enabled: true
             initial_interval: 200ms
+            max_elapsed_time: 0
           timeout: 5s
+{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $eventsQueueStorage) | indent 10 }}
           headers:
             iam-container: {{ .Values.observability.logsProjectId }}
             {{- $extraHeaders := .Values.observability.opentelemetry.extraHeaders }}
@@ -89,6 +104,10 @@ spec:
             authenticator: bearertokenauth
         {{- end }}
       extensions:
+        {{- if $eventsEnableFileStorage }}
+        file_storage:
+          directory: /var/lib/otelcol-events
+        {{- end }}
         health_check:
           endpoint: 0.0.0.0:13133
         {{- if $hasPublicEndpoint }}
@@ -100,10 +119,6 @@ spec:
         {{- end }}
         {{- end }}
       processors:
-        batch:
-          timeout: {{ $batch.timeout | default "1s" }}
-          send_batch_size: {{ $batch.sendBatchSize | default 2000 }}
-          send_batch_max_size: {{ $batch.sendBatchMaxSize | default 5000 }}
         k8s_attributes:
           extract:
             labels:
@@ -173,6 +188,9 @@ spec:
         {{- end }}
         extensions:
         - health_check
+        {{- if $eventsEnableFileStorage }}
+        - file_storage
+        {{- end }}
         {{- if $hasPublicEndpoint }}
         - bearertokenauth
         {{- end }}
@@ -187,7 +205,6 @@ spec:
             - k8s_attributes
             - transform
             - memory_limiter
-            - batch
             receivers:
             - k8sobjects
           metrics: null
@@ -218,6 +235,21 @@ spec:
       runAsUser: 10001
     serviceAccount:
       create: true
+    {{- if $eventsEnableFileStorage }}
+    initContainers:
+    - command:
+      - sh
+      - -c
+      - 'chown -R 10001: /var/lib/otelcol-events'
+      image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
+      name: init-fs
+      securityContext:
+        runAsGroup: 0
+        runAsUser: 0
+      volumeMounts:
+      - mountPath: /var/lib/otelcol-events
+        name: varlibotelcol
+    {{- end }}
     tolerations: []
     useGOMEMLIMIT: {{ $eventsUseGoMemLimit }}
     {{- if and .Values.observability.opentelemetry.events.values
@@ -225,8 +257,15 @@ spec:
     resources:
     {{- toYaml .Values.observability.opentelemetry.events.values.resources | nindent 6 }}
     {{- end }}
-    {{- if $hasPublicEndpoint }}
+    {{- if or $eventsEnableFileStorage $hasPublicEndpoint }}
     extraVolumes:
+      {{- if $eventsEnableFileStorage }}
+      - hostPath:
+          path: /var/lib/otelcol-events
+          type: DirectoryOrCreate
+        name: varlibotelcol
+      {{- end }}
+    {{- if $hasPublicEndpoint }}
       - name: o11ytoken
         {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
         secret:
@@ -236,10 +275,19 @@ spec:
           path: /mnt/cloud-metadata
           type: Directory
         {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if or $eventsEnableFileStorage $hasPublicEndpoint }}
     extraVolumeMounts:
+      {{- if $eventsEnableFileStorage }}
+      - mountPath: /var/lib/otelcol-events
+        name: varlibotelcol
+      {{- end }}
+    {{- if $hasPublicEndpoint }}
       - mountPath: /o11ytoken
         name: o11ytoken
         readOnly: true
+    {{- end }}
     {{- end }}
     {{- if .Values.observability.opentelemetry.metrics.enabled }}
     command:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -55,11 +55,9 @@ spec:
   {{- if hasKey $jailDeleteAfterRead "enabled" }}
   {{- $jailDeleteAfterReadEnabled = $jailDeleteAfterRead.enabled }}
   {{- end }}
-  {{- $logsUseGoMemLimit := true }}
-  {{- if hasKey $logsValues "useGOMEMLIMIT" }}
-  {{- $logsUseGoMemLimit = $logsValues.useGOMEMLIMIT }}
-  {{- else if hasKey $logsValues "useGoMemLimit" }}
-  {{- $logsUseGoMemLimit = $logsValues.useGoMemLimit }}
+  {{- $jailLogsUseGoMemLimit := true }}
+  {{- if hasKey $jailLogsValues "useGoMemLimit" }}
+  {{- $jailLogsUseGoMemLimit = $jailLogsValues.useGoMemLimit }}
   {{- end }}
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}
     {{- toYaml .Values.observability.opentelemetry.logs.overrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -39,6 +39,14 @@ spec:
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
+  {{- $logsValues := .Values.observability.opentelemetry.logs.values | default dict }}
+  {{- $jailLogsValues := $logsValues.jailLogs | default dict }}
+  {{- $logsUseGoMemLimit := true }}
+  {{- if hasKey $logsValues "useGOMEMLIMIT" }}
+  {{- $logsUseGoMemLimit = $logsValues.useGOMEMLIMIT }}
+  {{- else if hasKey $logsValues "useGoMemLimit" }}
+  {{- $logsUseGoMemLimit = $logsValues.useGoMemLimit }}
+  {{- end }}
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}
     {{- toYaml .Values.observability.opentelemetry.logs.overrideValues | nindent 4 }}
   {{- else }}
@@ -331,8 +339,7 @@ spec:
           metrics: null
           traces: null
     extraEnvs:
-    - name: GOMAXPROCS
-      value: "1"
+    {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $jailLogsValues.resources "useGoMemLimit" $logsUseGoMemLimit) | nindent 4 }}
     {{- if .Values.observability.clusterId }}
     - name: CLUSTER_ID
       value: {{ .Values.observability.clusterId | quote }}
@@ -436,7 +443,7 @@ spec:
       enabled: false
     serviceAccount:
       create: true
-    useGOMEMLIMIT: {{ .Values.observability.opentelemetry.logs.values.useGOMEMLIMIT | default true }}
+    useGOMEMLIMIT: {{ $logsUseGoMemLimit }}
     {{- if .Values.observability.opentelemetry.logs.values.jailLogs.resources }}
     resources: {{- toYaml .Values.observability.opentelemetry.logs.values.jailLogs.resources | nindent 6 }}
     {{- end }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -39,8 +39,22 @@ spec:
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
+  {{- $sendingQueue := .Values.observability.opentelemetry.sendingQueue | default dict }}
   {{- $logsValues := .Values.observability.opentelemetry.logs.values | default dict }}
   {{- $jailLogsValues := $logsValues.jailLogs | default dict }}
+  {{- $jailEnableFileStorage := true }}
+  {{- if hasKey $jailLogsValues "enableFileStorage" }}
+  {{- $jailEnableFileStorage = $jailLogsValues.enableFileStorage }}
+  {{- end }}
+  {{- $jailQueueStorage := "" }}
+  {{- if $jailEnableFileStorage }}
+  {{- $jailQueueStorage = "file_storage" }}
+  {{- end }}
+  {{- $jailDeleteAfterRead := $jailLogsValues.deleteAfterRead | default dict }}
+  {{- $jailDeleteAfterReadEnabled := false }}
+  {{- if hasKey $jailDeleteAfterRead "enabled" }}
+  {{- $jailDeleteAfterReadEnabled = $jailDeleteAfterRead.enabled }}
+  {{- end }}
   {{- $logsUseGoMemLimit := true }}
   {{- if hasKey $logsValues "useGOMEMLIMIT" }}
   {{- $logsUseGoMemLimit = $logsValues.useGOMEMLIMIT }}
@@ -177,8 +191,17 @@ spec:
               if: attributes.hc_json != nil
           retry_on_failure:
             enabled: true
+            max_elapsed_time: 0
+          {{- if $jailDeleteAfterReadEnabled }}
+          start_at: beginning
+          delete_after_read: true
+          delete_after_read_min_age: {{ $jailDeleteAfterRead.minAge | default "1m" }}
+          {{- else }}
           start_at: end  # Start reading from the end of the file on startup.
+          {{- end }}
+          {{- if $jailEnableFileStorage }}
           storage: file_storage  # Storage for the state (file offsets).
+          {{- end }}
         filelog/health_checker:
           include:
             - "/mnt/jail/opt/soperator-outputs/health_checker_cmd_stdout/*.out"
@@ -214,18 +237,23 @@ spec:
 
           retry_on_failure:
             enabled: true
+            max_elapsed_time: 0
+          {{- if $jailDeleteAfterReadEnabled }}
+          start_at: beginning
+          delete_after_read: true
+          delete_after_read_min_age: {{ $jailDeleteAfterRead.minAge | default "1m" }}
+          {{- else }}
           start_at: end  # Start reading from the end of the file on startup.
+          {{- end }}
+          {{- if $jailEnableFileStorage }}
           storage: file_storage  # Storage for the state (file offsets).
+          {{- end }}
         # Disable irrelevant receivers that might be added by valuesFrom ConfigMap:
         zipkin: null
         jaeger: null
         otlp: null
         prometheus: null
       processors:
-        batch:
-          timeout: {{ $batch.timeout | default "1s" }}
-          send_batch_size: {{ $batch.sendBatchSize | default 2000 }}
-          send_batch_max_size: {{ $batch.sendBatchMaxSize | default 5000 }}
         k8s_attributes:
           pod_association:
           - sources:
@@ -272,16 +300,22 @@ spec:
           encoding: proto
           logs_endpoint: http://vm-logs-victoria-logs-single-server:9428/insert/opentelemetry/v1/logs
           retry_on_failure:
+            enabled: true
             initial_interval: 200ms
+            max_elapsed_time: 0
           timeout: 5s
+{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $jailQueueStorage) | indent 10 }}
         {{- if $hasPublicEndpoint }}
         otlp:
           endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
           balancer_name: round_robin
           compression: snappy
           retry_on_failure:
+            enabled: true
             initial_interval: 200ms
+            max_elapsed_time: 0
           timeout: 5s
+{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $jailQueueStorage) | indent 10 }}
           headers:
             iam-container: {{ .Values.observability.logsProjectId }}
             {{- $extraHeaders := .Values.observability.opentelemetry.extraHeaders }}
@@ -292,8 +326,10 @@ spec:
             authenticator: bearertokenauth
         {{- end }}
       extensions:
+        {{- if $jailEnableFileStorage }}
         file_storage:
           directory: /var/lib/otelcol-jail
+        {{- end }}
         health_check:
           endpoint: 0.0.0.0:13133
         {{- if $hasPublicEndpoint }}
@@ -317,7 +353,9 @@ spec:
         {{- end }}
         extensions:
         - health_check
+        {{- if $jailEnableFileStorage }}
         - file_storage
+        {{- end }}
         {{- if $hasPublicEndpoint }}
         - bearertokenauth
         {{- end }}
@@ -330,7 +368,6 @@ spec:
             - k8s_attributes
             - transform
             - memory_limiter
-            - batch
             exporters:
             - otlp_http/victorialogs
             {{- if $hasPublicEndpoint }}
@@ -350,8 +387,10 @@ spec:
       name: o11ytoken
       readOnly: true
     {{- end }}
+    {{- if $jailEnableFileStorage }}
     - mountPath: /var/lib/otelcol-jail
       name: varlibotelcol
+    {{- end }}
     - mountPath: /mnt/jail
       name: jail
       readOnly: true
@@ -371,15 +410,18 @@ spec:
       hostPath:
         path: /mnt/jail
         type: Directory
+    {{- if $jailEnableFileStorage }}
     - hostPath:
         path: /var/lib/otelcol-jail
         type: DirectoryOrCreate
       name: varlibotelcol
+    {{- end }}
     image:
       pullPolicy: IfNotPresent
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
       tag: 2.0.10
     initContainers:
+    {{- if $jailEnableFileStorage }}
     - command:
       - sh
       - -c
@@ -392,6 +434,7 @@ spec:
       volumeMounts:
       - mountPath: /var/lib/otelcol-jail
         name: varlibotelcol
+    {{- end }}
     # /mnt/jail/opt/soperator-outputs is created by complement_jail.sh on first
     # worker/login startup; we mount the jail NFS root and gate on this directory here
     # so the HelmRelease does not get marked Stalled before workers come up.
@@ -447,10 +490,19 @@ spec:
     {{- if .Values.observability.opentelemetry.logs.values.jailLogs.resources }}
     resources: {{- toYaml .Values.observability.opentelemetry.logs.values.jailLogs.resources | nindent 6 }}
     {{- end }}
+    {{- $featureGates := list }}
     {{- if .Values.observability.opentelemetry.metrics.enabled }}
+    {{- $featureGates = append $featureGates "-telemetry.UseLocalHostAsDefaultMetricsAddress" }}
+    {{- end }}
+    {{- if $jailDeleteAfterReadEnabled }}
+    {{- $featureGates = append $featureGates "filelog.allowFileDeletion" }}
+    {{- end }}
+    {{- if $featureGates }}
     command:
       extraArgs:
-        - --feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress
+        - "--feature-gates={{ join "," $featureGates }}"
+    {{- end }}
+    {{- if .Values.observability.opentelemetry.metrics.enabled }}
     podMonitor:
       enabled: true
       metricsEndpoints:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -1,18 +1,24 @@
-{{- if and .Values.observability.enabled
-            .Values.observability.opentelemetry.enabled
-            .Values.observability.opentelemetry.logs.values.jailLogs.enabled }}
+{{- if
+  and
+    .Values.observability.enabled
+    .Values.observability.opentelemetry.enabled
+    .Values.observability.opentelemetry.logs.values.jailLogs.enabled
+-}}
+
 {{- include "soperator-fluxcd.validatePublicEndpointTokenKind" . -}}
+
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: {{ include "soperator-fluxcd.fullname" . }}-opentelemetry-collector-jail-logs
   labels:
-  {{- include "soperator-fluxcd.labels" . | nindent 4 }}
+    {{- include "soperator-fluxcd.labels" . | nindent 4 }}
 spec:
   {{- with .Values.observability.opentelemetry.logs.driftDetection }}
   driftDetection:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+
   chart:
     spec:
       chart: opentelemetry-collector
@@ -21,13 +27,15 @@ spec:
         kind: HelmRepository
         name: {{ include "soperator-fluxcd.fullname" . }}-opentelemetry-collector
       version: {{ .Values.observability.opentelemetry.logs.version }}
+
   dependsOn:
-  - name: {{ include "soperator-fluxcd.fullname" . }}-ns
-  - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
-  # nodesets itself reaches Ready very quickly (it just creates NodeSet CRs), so this is
-  # not sufficient on its own — the init container below waits for actual worker output.
-  # But the ordering is logically correct: jail logs cannot appear before nodesets exist.
-  - name: {{ include "soperator-fluxcd.fullname" . }}-nodesets
+    - name: {{ include "soperator-fluxcd.fullname" . }}-ns
+    - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
+    # nodesets itself reaches Ready very quickly (it just creates NodeSet CRs), so this is
+    # not sufficient on its own — the init container below waits for actual worker output.
+    # But the ordering is logically correct: jail logs cannot appear before nodesets exist.
+    - name: {{ include "soperator-fluxcd.fullname" . }}-nodesets
+
   install:
     {{- toYaml .Values.observability.opentelemetry.logs.install | nindent 4 }}
   upgrade:
@@ -36,6 +44,7 @@ spec:
   timeout: {{ .Values.observability.opentelemetry.logs.timeout }}
   releaseName: opentelemetry-collector-jail-logs
   targetNamespace: logs-system
+
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
@@ -59,21 +68,183 @@ spec:
   {{- if hasKey $jailLogsValues "useGoMemLimit" }}
   {{- $jailLogsUseGoMemLimit = $jailLogsValues.useGoMemLimit }}
   {{- end }}
+
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}
     {{- toYaml .Values.observability.opentelemetry.logs.overrideValues | nindent 4 }}
   {{- else }}
     clusterRole:
       create: true
       rules:
-      - apiGroups:
-        - ""
-        resources:
-        - pods
-        - namespaces
-        verbs:
-        - get
-        - watch
-        - list
+        - apiGroups:
+            - ""
+          resources:
+            - pods
+            - namespaces
+          verbs:
+            - get
+            - watch
+            - list
+
+    image:
+      pullPolicy: IfNotPresent
+      repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
+      tag: 2.0.10
+
+    mode: deployment  # Single deployment on system nodes instead of DaemonSet on all workers
+    replicaCount: 1   # Only one replica to avoid file lock conflicts on shared storage and prevent log duplication
+
+    rollout:
+      strategy: Recreate  # Ensure old pod terminates before new one starts to maintain max one pod running
+
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: slurm.nebius.ai/nodeset
+                  operator: In
+                  values: ["system"]
+
+    extraVolumes:
+      - name: jail
+        hostPath:
+          path: /mnt/jail
+          type: Directory
+
+      {{- if $jailEnableFileStorage }}
+      - name: varlibotelcol
+        hostPath:
+          path: /var/lib/otelcol-jail
+          type: DirectoryOrCreate
+      {{- end }}
+
+      {{- if $hasPublicEndpoint }}
+      - name: o11ytoken
+        {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
+        secret:
+          secretName: o11y-writer-sa-token
+        {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
+        hostPath:
+          path: /mnt/cloud-metadata
+          type: Directory
+        {{- end }}
+      {{- end }}
+
+    extraVolumeMounts:
+      - name: jail
+        mountPath: /mnt/jail
+        readOnly: true
+
+    {{- if $jailEnableFileStorage }}
+      - name: varlibotelcol
+        mountPath: /var/lib/otelcol-jail
+    {{- end }}
+
+    {{- if $hasPublicEndpoint }}
+      - name: o11ytoken
+        mountPath: /o11ytoken
+        readOnly: true
+    {{- end }}
+
+    securityContext:
+      runAsGroup: 0
+      runAsUser: 10001
+    service:  # No external access needed - this collector only reads files and sends to Victoria Logs
+      enabled: false
+    serviceAccount:
+      create: true
+
+    extraEnvs:
+      {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $jailLogsValues.resources "useGoMemLimit" $jailLogsUseGoMemLimit) | nindent 6 }}
+
+      {{- if .Values.observability.clusterId }}
+      - name: CLUSTER_ID
+        value: {{ .Values.observability.clusterId | quote }}
+      {{- end }}
+
+    initContainers:
+      # /mnt/jail/opt/soperator-outputs is created by complement_jail.sh on first
+      # worker/login startup; we mount the jail NFS root and gate on this directory here
+      # so the HelmRelease does not get marked Stalled before workers come up.
+      - name: wait-soperator-outputs
+        image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
+        volumeMounts:
+          - mountPath: /mnt/jail
+            name: jail
+            readOnly: true
+        command:
+          - sh
+          - "-c"
+          - |
+            until [ -d /mnt/jail/opt/soperator-outputs ]; do
+              echo "Waiting for /mnt/jail/opt/soperator-outputs to be created by a worker or login pod"
+              sleep 5
+            done
+
+    {{- if $jailEnableFileStorage }}
+      - name: init-fs
+        image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
+        volumeMounts:
+          - name: varlibotelcol
+            mountPath: /var/lib/otelcol-jail
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        command:
+          - sh
+          - "-c"
+          - 'chown -R 10001: /var/lib/otelcol-jail'
+    {{- end }}
+
+    {{- if .Values.observability.opentelemetry.logs.values.jailLogs.resources }}
+    resources: {{- toYaml .Values.observability.opentelemetry.logs.values.jailLogs.resources | nindent 6 }}
+    {{- end }}
+
+    useGOMEMLIMIT: {{ $jailLogsUseGoMemLimit }}
+
+    {{- $featureGates := list }}
+    {{- if .Values.observability.opentelemetry.metrics.enabled }}
+    {{- $featureGates = append $featureGates "-telemetry.UseLocalHostAsDefaultMetricsAddress" }}
+    {{- end }}
+    {{- if $jailDeleteAfterReadEnabled }}
+    {{- $featureGates = append $featureGates "filelog.allowFileDeletion" }}
+    {{- end }}
+    {{- if $featureGates }}
+    command:
+      extraArgs:
+        - "--feature-gates={{ join "," $featureGates }}"
+    {{- end }}
+
+    ports:  # Disable all network receivers since this collector only reads files
+      jaeger-compact:
+        enabled: false
+      jaeger-grpc:
+        enabled: false
+      jaeger-thrift:
+        enabled: false
+      otlp:
+        enabled: false
+      otlp-http:
+        enabled: false
+      zipkin:
+        enabled: false
+      metrics:
+        enabled: {{ .Values.observability.opentelemetry.metrics.enabled | default true }}
+
+    {{- if .Values.observability.opentelemetry.metrics.enabled }}
+    podMonitor:
+      enabled: true
+      metricsEndpoints:
+        - port: metrics
+          interval: {{ .Values.observability.opentelemetry.metrics.interval | default "30s" }}
+          scrapeTimeout: {{ .Values.observability.opentelemetry.metrics.scrapeTimeout | default "10s" }}
+          relabelings:
+            - sourceLabels: [__meta_kubernetes_pod_name]
+              targetLabel: pod
+            - replacement: otel-collector-jail-logs
+              targetLabel: collector
+    {{- end }}
+
     config:
       receivers:
         filelog:
@@ -85,111 +256,139 @@ spec:
           include_file_path: true  # Adds attributes["log.file.path"]
           preserve_leading_whitespaces: true
           poll_interval: {{ .Values.observability.opentelemetry.logs.values.jailLogs.pollInterval | default "5s" }}
+
           operators:
             - id: extract_base_name_and_pod
               type: regex_parser
               parse_from: attributes["log.file.name"]
               regex: ^(?P<slurm_node_name>[^.]+)\.(?P<base_name>.+)\.out$
+
             - type: copy
               from: attributes.slurm_node_name
               to: resource["slurm_node_name"]
+
             - type: move
               from: attributes.slurm_node_name
               to: resource["k8s.pod.name"]
+
             - type: add
               field: resource["k8s.namespace.name"]
               value: {{ .Values.slurmCluster.namespace | default "soperator" | quote }}
+
             - type: add
               field: resource["region"]
               value: {{ .Values.observability.region | quote }}
+
             - id: extract_directory
               type: regex_parser
               parse_from: attributes["log.file.path"]
               regex: ^.*/(?P<log_directory>nccl_logs|slurm_jobs|slurm_scripts|task_prolog)/.*$
+
             - type: move
               from: attributes.log_directory
               to: resource["log_type"]
+
             - id: parse_nccl_log_base_name
               type: regex_parser
               parse_from: attributes.base_name
               regex: ^(?P<job_id>\d+)\.(?P<job_step_id>\d+)$
               if: resource["log_type"] == "nccl_logs"
+
             - type: move
               from: attributes.job_id
               to: resource["job_id"]
               if: resource["log_type"] == "nccl_logs" and attributes["job_id"] != nil
+
             - type: move
               from: attributes.job_step_id
               to: resource["job_step_id"]
               if: resource["log_type"] == "nccl_logs" and attributes["job_step_id"] != nil
+
             - id: parse_task_prolog_base_name
               type: regex_parser
               parse_from: attributes.base_name
               regex: ^(?P<job_id>\d+)\.(?P<job_step_id>\d+)?\.(?P<job_array_id>\d+)?$
               if: resource["log_type"] == "task_prolog"
+
             - type: move
               from: attributes.job_id
               to: resource["job_id"]
               if: resource["log_type"] == "task_prolog" and attributes["job_id"] != nil
+
             - type: move
               from: attributes.job_step_id
               to: resource["job_step_id"]
               if: resource["log_type"] == "task_prolog" and attributes["job_step_id"] != nil
+
             - type: move
               from: attributes.job_array_id
               to: resource["job_array_id"]
               if: resource["log_type"] == "task_prolog" and attributes["job_array_id"] != nil
+
             - id: parse_slurm_job_log_base_name
               type: regex_parser
               parse_from: attributes.base_name
               regex: ^(?P<job_name>[^.]+)\.(?P<job_id>\d+)(?:\.(?P<job_array_id>\d+))?$
               if: resource["log_type"] == "slurm_jobs"
+
             - type: move
               from: attributes.job_name
               to: resource["job_name"]
               if: resource["log_type"] == "slurm_jobs" and attributes["job_name"] != nil
+
             - type: move
               from: attributes.job_id
               to: resource["job_id"]
               if: resource["log_type"] == "slurm_jobs" and attributes["job_id"] != nil
+
             - type: move
               from: attributes.job_array_id
               to: resource["job_array_id"]
               if: resource["log_type"] == "slurm_jobs" and attributes["job_array_id"] != nil
+
             - id: parse_script_log_base_name
               type: regex_parser
               parse_from: attributes.base_name
               regex: ^(?P<script_name>[^.]+)\.(?P<script_context>[^.]+)$
               if: resource["log_type"] == "slurm_scripts"
+
             - type: move
               from: attributes.script_name
               to: resource["slurm_script_name"]
               if: resource["log_type"] == "slurm_scripts" and attributes["script_name"] != nil
+
             - type: move
               from: attributes.script_context
               to: resource["slurm_script_context"]
               if: resource["log_type"] == "slurm_scripts" and attributes["script_context"] != nil
+
             - type: remove
               field: attributes.base_name
+
             - id: parse_json_body # parse json body to extract fields
               type: json_parser
               parse_from: body
               parse_to: attributes.hc_json
               if: body matches "^\\s*\\{"
+
             - type: move
               from: attributes.hc_json.status
               to: resource["slurm_run_status"]
               if: attributes.hc_json != nil && attributes.hc_json["status"] != nil
+
             - type: move
               from: attributes.hc_json.resolution
               to: resource["slurm_run_resolution"]
               if: attributes.hc_json != nil && attributes.hc_json["resolution"] != nil
+
             - type: remove # drop the parsed json body
               field: attributes.hc_json
               if: attributes.hc_json != nil
+
           retry_on_failure:
             enabled: true
             max_elapsed_time: 0
+
           {{- if $jailDeleteAfterReadEnabled }}
           start_at: beginning
           delete_after_read: true
@@ -197,9 +396,11 @@ spec:
           {{- else }}
           start_at: end  # Start reading from the end of the file on startup.
           {{- end }}
+
           {{- if $jailEnableFileStorage }}
           storage: file_storage  # Storage for the state (file offsets).
           {{- end }}
+
         filelog/health_checker:
           include:
             - "/mnt/jail/opt/soperator-outputs/health_checker_cmd_stdout/*.out"
@@ -207,15 +408,18 @@ spec:
           include_file_path: true  # Adds attributes["log.file.path"]
           preserve_leading_whitespaces: true
           poll_interval: {{ .Values.observability.opentelemetry.logs.values.jailLogs.pollInterval | default "5s" }}
+
           operators:
             # Extract check_name and run_id
             - id: extract_check_name_and_run_id
               type: regex_parser
               parse_from: attributes["log.file.name"]
               regex: ^(?P<check_name>.+)\.(?P<run_id>[0-9a-fA-F-]+)\.out$
+
             - type: copy
               from: attributes.check_name
               to: resource["health_checker.check_name"]
+
             - type: copy
               from: attributes.run_id
               to: resource["health_checker.run_id"]
@@ -224,6 +428,7 @@ spec:
             - type: add
               field: resource["k8s.namespace.name"]
               value: {{ .Values.slurmCluster.namespace | default "soperator" | quote }}
+
             - type: add
               field: resource["region"]
               value: {{ .Values.observability.region | quote }}
@@ -236,6 +441,7 @@ spec:
           retry_on_failure:
             enabled: true
             max_elapsed_time: 0
+
           {{- if $jailDeleteAfterReadEnabled }}
           start_at: beginning
           delete_after_read: true
@@ -243,14 +449,17 @@ spec:
           {{- else }}
           start_at: end  # Start reading from the end of the file on startup.
           {{- end }}
+
           {{- if $jailEnableFileStorage }}
           storage: file_storage  # Storage for the state (file offsets).
           {{- end }}
+
         # Disable irrelevant receivers that might be added by valuesFrom ConfigMap:
         zipkin: null
         jaeger: null
         otlp: null
         prometheus: null
+
       processors:
         k8s_attributes:
           pod_association:
@@ -279,10 +488,12 @@ spec:
           passthrough: false
           wait_for_metadata: true  # Wait for k8s metadata on startup.
           wait_for_metadata_timeout: 30s
+
         memory_limiter:
           check_interval: 5s
           limit_percentage: 80
           spike_limit_percentage: 25
+
         transform:
           log_statements:
           - context: log
@@ -292,6 +503,7 @@ spec:
             {{- if .Values.observability.clusterId }}
             - set(attributes["sp_resource_id"], "${env:CLUSTER_ID}")
             {{- end }}
+
       exporters:
         otlp_http/victorialogs:
           compression: gzip
@@ -303,6 +515,7 @@ spec:
             max_elapsed_time: 0
           timeout: 5s
 {{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $jailQueueStorage) | indent 10 }}
+
         {{- if $hasPublicEndpoint }}
         otlp:
           endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
@@ -323,21 +536,25 @@ spec:
           auth:
             authenticator: bearertokenauth
         {{- end }}
+
       extensions:
         {{- if $jailEnableFileStorage }}
         file_storage:
           directory: /var/lib/otelcol-jail
         {{- end }}
+
         health_check:
           endpoint: 0.0.0.0:13133
+
         {{- if $hasPublicEndpoint }}
         bearertokenauth:
-        {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
+          {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
           filename: "/o11ytoken/accessToken"
-        {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
+          {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
           filename: "/o11ytoken/tsa-token"
+          {{- end }}
         {{- end }}
-        {{- end }}
+
       service:
         {{- if .Values.observability.opentelemetry.metrics.enabled }}
         telemetry:
@@ -349,178 +566,48 @@ spec:
                       host: 0.0.0.0
                       port: 8888
         {{- end }}
+
         extensions:
-        - health_check
-        {{- if $jailEnableFileStorage }}
-        - file_storage
-        {{- end }}
-        {{- if $hasPublicEndpoint }}
-        - bearertokenauth
-        {{- end }}
+          - health_check
+
+          {{- if $jailEnableFileStorage }}
+          - file_storage
+          {{- end }}
+
+          {{- if $hasPublicEndpoint }}
+          - bearertokenauth
+          {{- end }}
+
         pipelines:
           logs:
             receivers:
-            - filelog
-            - filelog/health_checker
+              - filelog
+              - filelog/health_checker
             processors:
-            - k8s_attributes
-            - transform
-            - memory_limiter
+              - k8s_attributes
+              - transform
+              - memory_limiter
             exporters:
-            - otlp_http/victorialogs
-            {{- if $hasPublicEndpoint }}
-            - otlp
-            {{- end }}
+              - otlp_http/victorialogs
+
+              {{- if $hasPublicEndpoint }}
+              - otlp
+              {{- end }}
+
           metrics: null
           traces: null
-    extraEnvs:
-    {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $jailLogsValues.resources "useGoMemLimit" $logsUseGoMemLimit) | nindent 4 }}
-    {{- if .Values.observability.clusterId }}
-    - name: CLUSTER_ID
-      value: {{ .Values.observability.clusterId | quote }}
-    {{- end }}
-    extraVolumeMounts:
-    {{- if $hasPublicEndpoint }}
-    - mountPath: /o11ytoken
-      name: o11ytoken
-      readOnly: true
-    {{- end }}
-    {{- if $jailEnableFileStorage }}
-    - mountPath: /var/lib/otelcol-jail
-      name: varlibotelcol
-    {{- end }}
-    - mountPath: /mnt/jail
-      name: jail
-      readOnly: true
-    extraVolumes:
-    {{- if $hasPublicEndpoint }}
-    - name: o11ytoken
-      {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
-      secret:
-        secretName: o11y-writer-sa-token
-      {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
-      hostPath:
-        path: /mnt/cloud-metadata
-        type: Directory
-      {{- end }}
-    {{- end }}
-    - name: jail
-      hostPath:
-        path: /mnt/jail
-        type: Directory
-    {{- if $jailEnableFileStorage }}
-    - hostPath:
-        path: /var/lib/otelcol-jail
-        type: DirectoryOrCreate
-      name: varlibotelcol
-    {{- end }}
-    image:
-      pullPolicy: IfNotPresent
-      repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
-      tag: 2.0.10
-    initContainers:
-    {{- if $jailEnableFileStorage }}
-    - command:
-      - sh
-      - -c
-      - 'chown -R 10001: /var/lib/otelcol-jail'
-      image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
-      name: init-fs
-      securityContext:
-        runAsGroup: 0
-        runAsUser: 0
-      volumeMounts:
-      - mountPath: /var/lib/otelcol-jail
-        name: varlibotelcol
-    {{- end }}
-    # /mnt/jail/opt/soperator-outputs is created by complement_jail.sh on first
-    # worker/login startup; we mount the jail NFS root and gate on this directory here
-    # so the HelmRelease does not get marked Stalled before workers come up.
-    - command:
-      - sh
-      - -c
-      - |
-        until [ -d /mnt/jail/opt/soperator-outputs ]; do
-          echo "Waiting for /mnt/jail/opt/soperator-outputs to be created by a worker or login pod"
-          sleep 5
-        done
-      image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
-      name: wait-soperator-outputs
-      volumeMounts:
-      - mountPath: /mnt/jail
-        name: jail
-        readOnly: true
-    mode: deployment  # Single deployment on system nodes instead of DaemonSet on all workers
-    replicaCount: 1   # Only one replica to avoid file lock conflicts on shared storage and prevent log duplication
-    rollout:
-      strategy: Recreate  # Ensure old pod terminates before new one starts to maintain max one pod running
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: slurm.nebius.ai/nodeset
-                  operator: In
-                  values: ["system"]
-    ports:  # Disable all network receivers since this collector only reads files
-      jaeger-compact:
-        enabled: false
-      jaeger-grpc:
-        enabled: false
-      jaeger-thrift:
-        enabled: false
-      otlp:
-        enabled: false
-      otlp-http:
-        enabled: false
-      zipkin:
-        enabled: false
-      metrics:
-        enabled: {{ .Values.observability.opentelemetry.metrics.enabled | default true }}
-    securityContext:
-      runAsGroup: 0
-      runAsUser: 10001
-    service:  # No external access needed - this collector only reads files and sends to Victoria Logs
-      enabled: false
-    serviceAccount:
-      create: true
-    useGOMEMLIMIT: {{ $logsUseGoMemLimit }}
-    {{- if .Values.observability.opentelemetry.logs.values.jailLogs.resources }}
-    resources: {{- toYaml .Values.observability.opentelemetry.logs.values.jailLogs.resources | nindent 6 }}
-    {{- end }}
-    {{- $featureGates := list }}
-    {{- if .Values.observability.opentelemetry.metrics.enabled }}
-    {{- $featureGates = append $featureGates "-telemetry.UseLocalHostAsDefaultMetricsAddress" }}
-    {{- end }}
-    {{- if $jailDeleteAfterReadEnabled }}
-    {{- $featureGates = append $featureGates "filelog.allowFileDeletion" }}
-    {{- end }}
-    {{- if $featureGates }}
-    command:
-      extraArgs:
-        - "--feature-gates={{ join "," $featureGates }}"
-    {{- end }}
-    {{- if .Values.observability.opentelemetry.metrics.enabled }}
-    podMonitor:
-      enabled: true
-      metricsEndpoints:
-        - port: metrics
-          interval: {{ .Values.observability.opentelemetry.metrics.interval | default "30s" }}
-          scrapeTimeout: {{ .Values.observability.opentelemetry.metrics.scrapeTimeout | default "10s" }}
-          relabelings:
-            - sourceLabels: [__meta_kubernetes_pod_name]
-              targetLabel: pod
-            - replacement: otel-collector-jail-logs
-              targetLabel: collector
-    {{- end }}
+
   {{- end }}
+
   valuesFrom:
-  - kind: ConfigMap
-    name: terraform-opentelemetry-collector-jail-logs
-    optional: true
-    valuesKey: values.yaml
-  - kind: ConfigMap
-    name: opentelemetry-collector-jail-logs
-    optional: true
-    valuesKey: values.yaml
+    - kind: ConfigMap
+      name: terraform-opentelemetry-collector-jail-logs
+      optional: true
+      valuesKey: values.yaml
+
+    - kind: ConfigMap
+      name: opentelemetry-collector-jail-logs
+      optional: true
+      valuesKey: values.yaml
+
 {{- end }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -133,7 +133,7 @@ spec:
     extraVolumeMounts:
       - name: jail
         mountPath: /mnt/jail
-        readOnly: true
+        readOnly: {{ not $jailDeleteAfterReadEnabled }}
 
     {{- if $jailEnableFileStorage }}
       - name: varlibotelcol

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -33,7 +33,16 @@ spec:
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
+  {{- $sendingQueue := .Values.observability.opentelemetry.sendingQueue | default dict }}
   {{- $logsValues := .Values.observability.opentelemetry.logs.values | default dict }}
+  {{- $logsEnableFileStorage := true }}
+  {{- if hasKey $logsValues "enableFileStorage" }}
+  {{- $logsEnableFileStorage = $logsValues.enableFileStorage }}
+  {{- end }}
+  {{- $logsQueueStorage := "" }}
+  {{- if $logsEnableFileStorage }}
+  {{- $logsQueueStorage = "file_storage" }}
+  {{- end }}
   {{- $logsUseGoMemLimit := true }}
   {{- if hasKey $logsValues "useGOMEMLIMIT" }}
   {{- $logsUseGoMemLimit = $logsValues.useGOMEMLIMIT }}
@@ -62,16 +71,22 @@ spec:
           encoding: proto
           logs_endpoint: http://vm-logs-victoria-logs-single-server:9428/insert/opentelemetry/v1/logs
           retry_on_failure:
+            enabled: true
             initial_interval: 200ms
+            max_elapsed_time: 0
           timeout: 5s
+{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $logsQueueStorage) | indent 10 }}
         {{- if $hasPublicEndpoint }}
         otlp:
           endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
           balancer_name: round_robin
           compression: snappy
           retry_on_failure:
+            enabled: true
             initial_interval: 200ms
+            max_elapsed_time: 0
           timeout: 5s
+{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $logsQueueStorage) | indent 10 }}
           headers:
             iam-container: {{ .Values.observability.logsProjectId }}
             {{- $extraHeaders := .Values.observability.opentelemetry.extraHeaders }}
@@ -82,8 +97,10 @@ spec:
             authenticator: bearertokenauth
         {{- end }}
       extensions:
+        {{- if $logsEnableFileStorage }}
         file_storage:
           directory: /var/lib/otelcol
+        {{- end }}
         health_check:
           endpoint: 0.0.0.0:13133
         {{- if $hasPublicEndpoint }}
@@ -95,10 +112,6 @@ spec:
         {{- end }}
         {{- end }}
       processors:
-        batch:
-          timeout: {{ $batch.timeout | default "1s" }}
-          send_batch_size: {{ $batch.sendBatchSize | default 2000 }}
-          send_batch_max_size: {{ $batch.sendBatchMaxSize | default 5000 }}
         k8s_attributes:
           extract:
             labels:
@@ -214,6 +227,9 @@ spec:
               type: move
               from: attributes["logtype"]
               to: resource["app.kubernetes.io/name"]
+          {{- if $logsEnableFileStorage }}
+          storage: file_storage
+          {{- end }}
         {{- end }}
         filelog/pods:
           exclude:
@@ -321,8 +337,11 @@ spec:
             type: json_parser
           retry_on_failure:
             enabled: true
+            max_elapsed_time: 0
           start_at: end
+          {{- if $logsEnableFileStorage }}
           storage: file_storage
+          {{- end }}
         zipkin: null
       service:
         {{- if .Values.observability.opentelemetry.metrics.enabled }}
@@ -337,7 +356,9 @@ spec:
         {{- end }}
         extensions:
         - health_check
+        {{- if $logsEnableFileStorage }}
         - file_storage
+        {{- end }}
         {{- if $hasPublicEndpoint }}
         - bearertokenauth
         {{- end }}
@@ -352,7 +373,6 @@ spec:
             - k8s_attributes
             - transform
             - memory_limiter
-            - batch
             receivers:
             - filelog/pods
             {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
@@ -384,8 +404,10 @@ spec:
     - mountPath: /var/lib/docker/containers
       name: varlibdockercontainers
       readOnly: true
+    {{- if $logsEnableFileStorage }}
     - mountPath: /var/lib/otelcol
       name: varlibotelcol
+    {{- end }}
     {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
     - name: node-logs
       mountPath: /var/nodelogs
@@ -412,10 +434,12 @@ spec:
         type: Directory
       name: node-logs
     {{- end }}
+    {{- if $logsEnableFileStorage }}
     - hostPath:
         path: /var/lib/otelcol
         type: DirectoryOrCreate
       name: varlibotelcol
+    {{- end }}
     - hostPath:
         path: /var/lib/docker/containers
       name: varlibdockercontainers
@@ -423,14 +447,17 @@ spec:
       pullPolicy: IfNotPresent
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
       tag: 2.0.10
+    {{- if or $logsEnableFileStorage .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
     initContainers:
     - command:
       - sh
       - -c
-      {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
+      {{- if and $logsEnableFileStorage .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
       - 'chown -R 10001: /var/lib/otelcol /var/nodelogs'
-      {{- else }}
+      {{- else if $logsEnableFileStorage }}
       - 'chown -R 10001: /var/lib/otelcol'
+      {{- else }}
+      - 'chown -R 10001: /var/nodelogs'
       {{- end }}
       image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
       name: init-fs
@@ -438,12 +465,15 @@ spec:
         runAsGroup: 0
         runAsUser: 0
       volumeMounts:
+      {{- if $logsEnableFileStorage }}
       - mountPath: /var/lib/otelcol
         name: varlibotelcol
+      {{- end }}
       {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
       - name: node-logs
         mountPath: /var/nodelogs
       {{- end }}
+    {{- end }}
     mode: daemonset
     rollout:
       rollingUpdate:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -1,16 +1,23 @@
-{{- if and .Values.observability.enabled .Values.observability.opentelemetry.enabled }}
+{{- if
+  and
+    .Values.observability.enabled
+    .Values.observability.opentelemetry.enabled
+}}
+
 {{- include "soperator-fluxcd.validatePublicEndpointTokenKind" . -}}
+
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: {{ include "soperator-fluxcd.fullname" . }}-opentelemetry-collector-logs
   labels:
-  {{- include "soperator-fluxcd.labels" . | nindent 4 }}
+    {{- include "soperator-fluxcd.labels" . | nindent 4 }}
 spec:
   {{- with .Values.observability.opentelemetry.logs.driftDetection }}
   driftDetection:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+
   chart:
     spec:
       chart: opentelemetry-collector
@@ -19,9 +26,11 @@ spec:
         kind: HelmRepository
         name: {{ include "soperator-fluxcd.fullname" . }}-opentelemetry-collector
       version: {{ .Values.observability.opentelemetry.logs.version }}
+
   dependsOn:
-  - name: {{ include "soperator-fluxcd.fullname" . }}-ns
-  - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
+    - name: {{ include "soperator-fluxcd.fullname" . }}-ns
+    - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
+
   install:
     {{- toYaml .Values.observability.opentelemetry.logs.install | nindent 4 }}
   upgrade:
@@ -30,6 +39,7 @@ spec:
   timeout: {{ .Values.observability.opentelemetry.logs.timeout }}
   releaseName: opentelemetry-collector-logs
   targetNamespace: logs-system
+
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
@@ -47,22 +57,475 @@ spec:
   {{- if hasKey $logsValues "useGoMemLimit" }}
   {{- $logsUseGoMemLimit = $logsValues.useGoMemLimit }}
   {{- end }}
+
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}
     {{- toYaml .Values.observability.opentelemetry.logs.overrideValues | nindent 4 }}
   {{- else }}
     clusterRole:
       create: true
       rules:
-      - apiGroups:
-        - ""
-        resources:
-        - pods
-        - namespaces
-        verbs:
-        - get
-        - watch
-        - list
+        - apiGroups:
+            - ""
+          resources:
+            - pods
+            - namespaces
+          verbs:
+            - get
+            - watch
+            - list
+
+    image:
+      pullPolicy: IfNotPresent
+      repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
+      tag: 2.0.10
+
+    mode: daemonset
+
+    rollout:
+      rollingUpdate:
+        maxUnavailable: 50%
+      strategy: RollingUpdate
+
+    tolerations:
+      - operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/disk-pressure
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/memory-pressure
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/pid-pressure
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/unschedulable
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/network-unavailable
+        operator: Exists
+      - effect: NoSchedule
+        key: node.cilium.io/agent-not-ready
+        operator: Exists
+
+    extraVolumes:
+      - name: varlogpods
+        hostPath:
+          path: /var/log/pods
+
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+
+      {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
+      - name: node-logs
+        hostPath:
+          path: /var/log
+          type: Directory
+      {{- end }}
+
+      {{- if $logsEnableFileStorage }}
+      - name: varlibotelcol
+        hostPath:
+          path: /var/lib/otelcol
+          type: DirectoryOrCreate
+      {{- end }}
+
+      {{- if $hasPublicEndpoint }}
+      - name: o11ytoken
+        {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
+        secret:
+          secretName: o11y-writer-sa-token
+        {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
+        hostPath:
+          path: /mnt/cloud-metadata
+          type: Directory
+        {{- end }}
+      {{- end }}
+
+    extraVolumeMounts:
+      - name: varlogpods
+        mountPath: /var/log/pods
+        readOnly: true
+
+      - name: varlibdockercontainers
+        mountPath: /var/lib/docker/containers
+        readOnly: true
+
+      {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
+      - name: node-logs
+        mountPath: /var/nodelogs
+        readOnly: true
+      {{- end }}
+
+      {{- if $logsEnableFileStorage }}
+      - name: varlibotelcol
+        mountPath: /var/lib/otelcol
+      {{- end }}
+
+      {{- if $hasPublicEndpoint }}
+      - name: o11ytoken
+        mountPath: /o11ytoken
+        readOnly: true
+      {{- end }}
+
+    securityContext:
+      runAsGroup: 0
+      runAsUser: 10001
+    serviceAccount:
+      create: true
+
+    extraEnvs:
+      {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $logsValues.resources "useGoMemLimit" $logsUseGoMemLimit) | nindent 6 }}
+
+      - name: K8S_NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+
+      - name: CLUSTER_NAME
+        value: {{ .Values.observability.clusterName | quote }}
+
+      {{- if .Values.observability.clusterId }}
+      - name: CLUSTER_ID
+        value: {{ .Values.observability.clusterId | quote }}
+      {{- end }}
+
+    {{- if or $logsEnableFileStorage .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
+    initContainers:
+      - name: init-fs
+        image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
+        volumeMounts:
+          {{- if $logsEnableFileStorage }}
+          - name: varlibotelcol
+            mountPath: /var/lib/otelcol
+          {{- end }}
+
+          {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
+          - name: node-logs
+            mountPath: /var/nodelogs
+          {{- end }}
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        command:
+          - sh
+          - "-c"
+          {{- if and $logsEnableFileStorage .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
+          - 'chown -R 10001: /var/lib/otelcol /var/nodelogs'
+          {{- else if $logsEnableFileStorage }}
+          - 'chown -R 10001: /var/lib/otelcol'
+          {{- else }}
+          - 'chown -R 10001: /var/nodelogs'
+          {{- end }}
+    {{- end }}
+
+    {{- if and .Values.observability.opentelemetry.logs.values .Values.observability.opentelemetry.logs.values.resources }}
+    resources: {{- toYaml .Values.observability.opentelemetry.logs.values.resources | nindent 6 }}
+    {{- end }}
+
+    useGOMEMLIMIT: {{ $logsUseGoMemLimit }}
+
+    {{- if .Values.observability.opentelemetry.metrics.enabled }}
+    command:
+      extraArgs:
+        - --feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress
+
+    ports:
+      metrics:
+        enabled: true
+
+    podMonitor:
+      enabled: true
+      metricsEndpoints:
+        - port: metrics
+          interval: {{ .Values.observability.opentelemetry.metrics.interval | default "30s" }}
+          scrapeTimeout: {{ .Values.observability.opentelemetry.metrics.scrapeTimeout | default "10s" }}
+          relabelings:
+            - sourceLabels: [__meta_kubernetes_pod_name]
+              targetLabel: pod
+            - sourceLabels: [__meta_kubernetes_node_name]
+              targetLabel: node
+            - replacement: otel-collector-logs
+              targetLabel: collector
+    {{- end }}
+
     config:
+      receivers:
+        {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
+        filelog/nodelogs:
+          include:
+            - '/var/nodelogs/kern.log*'
+            - '/var/nodelogs/syslog*'
+            - '/var/nodelogs/dmesg*'
+            - '/var/nodelogs/fabricmanager.log*'
+          exclude:
+            - '/var/nodelogs/*.gz'
+            - '/var/nodelogs/*.tmp'
+          include_file_name: true
+
+          operators:
+            - type: add
+              field: resource["o11y_agent_raw_logs"]
+              value: 'yes'
+
+            - type: add
+              field: resource["workspace.id"]
+              value: node-system
+
+            - id: extract_logtype
+              type: regex_parser
+              parse_from: attributes["log.file.name"]
+              regex: '^(?P<logtype>[^.]+).*$'
+
+            - type: remove
+              field: attributes["log.file.name"]
+
+            - id: get-format
+              type: router
+              # From ubuntu24:04 syslog format was changed.
+              routes:
+                - expr: attributes["logtype"] matches "syslog|kern" && body matches "^[0-9]{4}-[0-9]{2}-[0-9]{2}T"
+                  output: parse-iso8601
+                - expr: attributes["logtype"] matches "syslog|kern"
+                  output: parse-syslog
+              default: not-syslog
+
+            - id: parse-iso8601
+              type: regex_parser
+              parse_from: body
+              # 2025-11-15T23:10:32.025480+00:00 host app: msg
+              regex: '^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})) (?P<host>\S+) (?P<app>[^:]+): (?P<msg>.*)$'
+
+            - id: ts-iso8601
+              type: time_parser
+              parse_from: attributes.ts
+              layout_type: gotime
+              layout: '2006-01-02T15:04:05.999999Z07:00'
+
+            - id: move-msg
+              type: move
+              from: attributes.msg
+              to: body
+
+            - type: move
+              from: attributes.host
+              to: resource["host.name"]
+
+            - type: move
+              from: attributes.app
+              to: attributes["syslog.appname"]
+              output: move-logtype
+
+            - id: parse-syslog
+              type: syslog_parser
+              protocol: rfc3164
+              allow_skip_pri_header: true
+
+            - type: move
+              from: attributes["message"]
+              to: body
+              if: '"message" in attributes'
+
+            - id: not-syslog
+              type: noop
+
+            - id: move-logtype
+              type: move
+              from: attributes["logtype"]
+              to: resource["app.kubernetes.io/name"]
+
+          {{- if $logsEnableFileStorage }}
+          storage: file_storage
+          {{- end }}
+        {{- end }}
+
+        filelog/pods:
+          exclude:
+            - /var/log/pods/*/otc-container/*.log
+            - /var/log/pods/*/munge/*.log
+            - /var/log/pods/kube-system_hubble-*/**/*.log
+            - /var/log/pods/monitoring-system_*/**/*.log
+            - /var/log/pods/logs-system_*/**/*.log
+          include:
+            - /var/log/pods/gpu-operator_*/**/*.log
+            - /var/log/pods/network-operator_*/**/*.log
+            - /var/log/pods/*-system_*/**/*.log
+            - /var/log/pods/soperator_*/**/*.log
+          include_file_name: false
+          include_file_path: true
+
+          operators:
+            - id: get-format
+              routes:
+                - expr: body matches "^[^ Z]+Z"
+                  output: parser-containerd
+                - expr: body matches "^\\{"
+                  output: parser-docker
+              type: router
+
+            - id: parser-docker
+              output: extract_metadata_from_filepath
+              timestamp:
+                layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+                parse_from: attributes.timestamp
+              type: json_parser
+
+            - combine_field: attributes.log
+              combine_with: ""
+              id: crio-recombine
+              is_last_entry: attributes.logtag == 'F'
+              max_log_size: 102400
+              output: extract_metadata_from_filepath
+              source_identifier: attributes["log.file.path"]
+              type: recombine
+
+            - id: parser-containerd
+              regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)
+                ?(?P<log>.*)$
+              timestamp:
+                layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+                parse_from: attributes.time
+              type: regex_parser
+
+            - combine_field: attributes.log
+              combine_with: ""
+              id: containerd-recombine
+              is_last_entry: attributes.logtag == 'F'
+              max_log_size: 102400
+              output: extract_metadata_from_filepath
+              source_identifier: attributes["log.file.path"]
+              type: recombine
+
+            - id: extract_metadata_from_filepath
+              parse_from: attributes["log.file.path"]
+              regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+              type: regex_parser
+
+            - from: attributes.stream
+              to: attributes["log.iostream"]
+              type: move
+
+            - from: attributes.container_name
+              to: resource["k8s.container.name"]
+              type: move
+
+            - from: attributes.namespace
+              to: resource["k8s.namespace.name"]
+              type: move
+
+            - from: attributes.pod_name
+              to: resource["k8s.pod.name"]
+              type: move
+
+            - from: attributes.restart_count
+              to: resource["k8s.container.restart_count"]
+              type: move
+
+            - from: attributes.uid
+              to: resource["k8s.pod.uid"]
+              type: move
+
+            - from: attributes.log
+              to: body
+              type: move
+
+            - field: attributes.level
+              type: add
+              value: unknown
+
+            - id: parse-json-logs
+              if: body matches "^\\{.+\\}$"
+              parse_from: body
+              parse_to: attributes
+              severity:
+                mapping:
+                  debug:
+                    - debug
+                    - DEBUG
+                  error:
+                    - error
+                    - ERROR
+                  fatal:
+                    - fatal
+                    - FATAL
+                  info:
+                    - info
+                    - INFO
+                  warn:
+                    - warn
+                    - WARN
+                    - warning
+                    - WARNING
+                parse_from: attributes.level
+              type: json_parser
+
+          retry_on_failure:
+            enabled: true
+            max_elapsed_time: 0
+          start_at: end
+
+          {{- if $logsEnableFileStorage }}
+          storage: file_storage
+          {{- end }}
+
+        zipkin: null
+
+      processors:
+        k8s_attributes:
+          extract:
+            labels:
+              - from: pod
+                key: external-o11y
+                tag_name: external_o11y
+              - from: namespace
+                key: o11y_resource_id
+                tag_name: resource_id
+              - from: namespace
+                key: o11y_service_provider
+                tag_name: service_provider
+            metadata:
+              - k8s.namespace.name
+              - k8s.node.name
+              - k8s.pod.name
+              - k8s.pod.uid
+              - k8s.pod.start_time
+          filter:
+            node_from_env_var: K8S_NODE_NAME
+          passthrough: false
+          pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.ip
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.uid
+            - sources:
+                - from: connection
+          wait_for_metadata: true
+          wait_for_metadata_timeout: 30s
+
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 25
+
+        transform:
+          log_statements:
+            - context: log
+              error_mode: ignore
+              statements:
+                - set(attributes["cluster"], "${env:CLUSTER_NAME}")
+                - set(attributes["k8s.node.name"], "${env:K8S_NODE_NAME}")
+                {{- if .Values.observability.clusterId }}
+                - set(attributes["sp_resource_id"], "${env:CLUSTER_ID}")
+                {{- end }}
+
       exporters:
         otlp_http/victoriametrics:
           compression: gzip
@@ -74,6 +537,7 @@ spec:
             max_elapsed_time: 0
           timeout: 5s
 {{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $logsQueueStorage) | indent 10 }}
+
         {{- if $hasPublicEndpoint }}
         otlp:
           endpoint: {{ .Values.observability.opentelemetry.publicEndpoint }}
@@ -94,253 +558,26 @@ spec:
           auth:
             authenticator: bearertokenauth
         {{- end }}
+
       extensions:
         {{- if $logsEnableFileStorage }}
         file_storage:
           directory: /var/lib/otelcol
         {{- end }}
+
         health_check:
           endpoint: 0.0.0.0:13133
+
         {{- if $hasPublicEndpoint }}
         bearertokenauth:
-        {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
+          {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
           filename: "/o11ytoken/accessToken"
-        {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
+          {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
           filename: "/o11ytoken/tsa-token"
         {{- end }}
+
         {{- end }}
-      processors:
-        k8s_attributes:
-          extract:
-            labels:
-            - from: pod
-              key: external-o11y
-              tag_name: external_o11y
-            - from: namespace
-              key: o11y_resource_id
-              tag_name: resource_id
-            - from: namespace
-              key: o11y_service_provider
-              tag_name: service_provider
-            metadata:
-            - k8s.namespace.name
-            - k8s.node.name
-            - k8s.pod.name
-            - k8s.pod.uid
-            - k8s.pod.start_time
-          filter:
-            node_from_env_var: K8S_NODE_NAME
-          passthrough: false
-          pod_association:
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.ip
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.uid
-          - sources:
-            - from: connection
-          wait_for_metadata: true
-          wait_for_metadata_timeout: 30s
-        memory_limiter:
-          check_interval: 5s
-          limit_percentage: 80
-          spike_limit_percentage: 25
-        transform:
-          log_statements:
-          - context: log
-            error_mode: ignore
-            statements:
-            - set(attributes["cluster"], "${env:CLUSTER_NAME}")
-            - set(attributes["k8s.node.name"], "${env:K8S_NODE_NAME}")
-            {{- if .Values.observability.clusterId }}
-            - set(attributes["sp_resource_id"], "${env:CLUSTER_ID}")
-            {{- end }}
-      receivers:
-        {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
-        filelog/nodelogs:
-          include:
-            - '/var/nodelogs/kern.log*'
-            - '/var/nodelogs/syslog*'
-            - '/var/nodelogs/dmesg*'
-            - '/var/nodelogs/fabricmanager.log*'
-          exclude:
-            - '/var/nodelogs/*.gz'
-            - '/var/nodelogs/*.tmp'
-          include_file_name: true
-          operators:
-            - type: add
-              field: resource["o11y_agent_raw_logs"]
-              value: 'yes'
-            - type: add
-              field: resource["workspace.id"]
-              value: node-system
-            - id: extract_logtype
-              type: regex_parser
-              parse_from: attributes["log.file.name"]
-              regex: '^(?P<logtype>[^.]+).*$'
-            - type: remove
-              field: attributes["log.file.name"]
-            - id: get-format
-              type: router
-              # From ubuntu24:04 syslog format was changed.
-              routes:
-                - expr: attributes["logtype"] matches "syslog|kern" && body matches "^[0-9]{4}-[0-9]{2}-[0-9]{2}T"
-                  output: parse-iso8601
-                - expr: attributes["logtype"] matches "syslog|kern"
-                  output: parse-syslog
-              default: not-syslog
-            - id: parse-iso8601
-              type: regex_parser
-              parse_from: body
-              # 2025-11-15T23:10:32.025480+00:00 host app: msg
-              regex: '^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})) (?P<host>\S+) (?P<app>[^:]+): (?P<msg>.*)$'
-            - id: ts-iso8601
-              type: time_parser
-              parse_from: attributes.ts
-              layout_type: gotime
-              layout: '2006-01-02T15:04:05.999999Z07:00'
-            - id: move-msg
-              type: move
-              from: attributes.msg
-              to: body
-            - type: move
-              from: attributes.host
-              to: resource["host.name"]
-            - type: move
-              from: attributes.app
-              to: attributes["syslog.appname"]
-              output: move-logtype
-            - id: parse-syslog
-              type: syslog_parser
-              protocol: rfc3164
-              allow_skip_pri_header: true
-            - type: move
-              from: attributes["message"]
-              to: body
-              if: '"message" in attributes'
-            - id: not-syslog
-              type: noop
-            - id: move-logtype
-              type: move
-              from: attributes["logtype"]
-              to: resource["app.kubernetes.io/name"]
-          {{- if $logsEnableFileStorage }}
-          storage: file_storage
-          {{- end }}
-        {{- end }}
-        filelog/pods:
-          exclude:
-          - /var/log/pods/*/otc-container/*.log
-          - /var/log/pods/*/munge/*.log
-          - /var/log/pods/kube-system_hubble-*/**/*.log
-          - /var/log/pods/monitoring-system_*/**/*.log
-          - /var/log/pods/logs-system_*/**/*.log
-          include:
-          - /var/log/pods/gpu-operator_*/**/*.log
-          - /var/log/pods/network-operator_*/**/*.log
-          - /var/log/pods/*-system_*/**/*.log
-          - /var/log/pods/soperator_*/**/*.log
-          include_file_name: false
-          include_file_path: true
-          operators:
-          - id: get-format
-            routes:
-            - expr: body matches "^[^ Z]+Z"
-              output: parser-containerd
-            - expr: body matches "^\\{"
-              output: parser-docker
-            type: router
-          - id: parser-docker
-            output: extract_metadata_from_filepath
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: attributes.timestamp
-            type: json_parser
-          - combine_field: attributes.log
-            combine_with: ""
-            id: crio-recombine
-            is_last_entry: attributes.logtag == 'F'
-            max_log_size: 102400
-            output: extract_metadata_from_filepath
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - id: parser-containerd
-            regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)
-              ?(?P<log>.*)$
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: attributes.time
-            type: regex_parser
-          - combine_field: attributes.log
-            combine_with: ""
-            id: containerd-recombine
-            is_last_entry: attributes.logtag == 'F'
-            max_log_size: 102400
-            output: extract_metadata_from_filepath
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - id: extract_metadata_from_filepath
-            parse_from: attributes["log.file.path"]
-            regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
-            type: regex_parser
-          - from: attributes.stream
-            to: attributes["log.iostream"]
-            type: move
-          - from: attributes.container_name
-            to: resource["k8s.container.name"]
-            type: move
-          - from: attributes.namespace
-            to: resource["k8s.namespace.name"]
-            type: move
-          - from: attributes.pod_name
-            to: resource["k8s.pod.name"]
-            type: move
-          - from: attributes.restart_count
-            to: resource["k8s.container.restart_count"]
-            type: move
-          - from: attributes.uid
-            to: resource["k8s.pod.uid"]
-            type: move
-          - from: attributes.log
-            to: body
-            type: move
-          - field: attributes.level
-            type: add
-            value: unknown
-          - id: parse-json-logs
-            if: body matches "^\\{.+\\}$"
-            parse_from: body
-            parse_to: attributes
-            severity:
-              mapping:
-                debug:
-                - debug
-                - DEBUG
-                error:
-                - error
-                - ERROR
-                fatal:
-                - fatal
-                - FATAL
-                info:
-                - info
-                - INFO
-                warn:
-                - warn
-                - WARN
-                - warning
-                - WARNING
-              parse_from: attributes.level
-            type: json_parser
-          retry_on_failure:
-            enabled: true
-            max_elapsed_time: 0
-          start_at: end
-          {{- if $logsEnableFileStorage }}
-          storage: file_storage
-          {{- end }}
-        zipkin: null
+
       service:
         {{- if .Values.observability.opentelemetry.metrics.enabled }}
         telemetry:
@@ -352,195 +589,52 @@ spec:
                       host: 0.0.0.0
                       port: 8888
         {{- end }}
+
         extensions:
-        - health_check
-        {{- if $logsEnableFileStorage }}
-        - file_storage
-        {{- end }}
-        {{- if $hasPublicEndpoint }}
-        - bearertokenauth
-        {{- end }}
+          - health_check
+
+          {{- if $logsEnableFileStorage }}
+          - file_storage
+          {{- end }}
+
+          {{- if $hasPublicEndpoint }}
+          - bearertokenauth
+          {{- end }}
+
         pipelines:
           logs:
             exporters:
-            - otlp_http/victoriametrics
-            {{- if $hasPublicEndpoint }}
-            - otlp
-            {{- end }}
+              - otlp_http/victoriametrics
+
+              {{- if $hasPublicEndpoint }}
+              - otlp
+              {{- end }}
+
             processors:
-            - k8s_attributes
-            - transform
-            - memory_limiter
+              - k8s_attributes
+              - transform
+              - memory_limiter
             receivers:
-            - filelog/pods
-            {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
-            - filelog/nodelogs
-            {{- end }}
+              - filelog/pods
+
+              {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
+              - filelog/nodelogs
+              {{- end }}
+
           metrics: null
           traces: null
-    extraEnvs:
-    - name: K8S_NODE_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    - name: CLUSTER_NAME
-      value: {{ .Values.observability.clusterName | quote }}
-    {{- if .Values.observability.clusterId }}
-    - name: CLUSTER_ID
-      value: {{ .Values.observability.clusterId | quote }}
-    {{- end }}
-    {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $logsValues.resources "useGoMemLimit" $logsUseGoMemLimit) | nindent 4 }}
-    extraVolumeMounts:
-    {{- if $hasPublicEndpoint }}
-    - mountPath: /o11ytoken
-      name: o11ytoken
-      readOnly: true
-    {{- end }}
-    - mountPath: /var/log/pods
-      name: varlogpods
-      readOnly: true
-    - mountPath: /var/lib/docker/containers
-      name: varlibdockercontainers
-      readOnly: true
-    {{- if $logsEnableFileStorage }}
-    - mountPath: /var/lib/otelcol
-      name: varlibotelcol
-    {{- end }}
-    {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
-    - name: node-logs
-      mountPath: /var/nodelogs
-      readOnly: true
-    {{- end }}
-    extraVolumes:
-    {{- if $hasPublicEndpoint }}
-    - name: o11ytoken
-      {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
-      secret:
-        secretName: o11y-writer-sa-token
-      {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
-      hostPath:
-        path: /mnt/cloud-metadata
-        type: Directory
-      {{- end }}
-    {{- end }}
-    - hostPath:
-        path: /var/log/pods
-      name: varlogpods
-    {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
-    - hostPath:
-        path: /var/log
-        type: Directory
-      name: node-logs
-    {{- end }}
-    {{- if $logsEnableFileStorage }}
-    - hostPath:
-        path: /var/lib/otelcol
-        type: DirectoryOrCreate
-      name: varlibotelcol
-    {{- end }}
-    - hostPath:
-        path: /var/lib/docker/containers
-      name: varlibdockercontainers
-    image:
-      pullPolicy: IfNotPresent
-      repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
-      tag: 2.0.10
-    {{- if or $logsEnableFileStorage .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
-    initContainers:
-    - command:
-      - sh
-      - -c
-      {{- if and $logsEnableFileStorage .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
-      - 'chown -R 10001: /var/lib/otelcol /var/nodelogs'
-      {{- else if $logsEnableFileStorage }}
-      - 'chown -R 10001: /var/lib/otelcol'
-      {{- else }}
-      - 'chown -R 10001: /var/nodelogs'
-      {{- end }}
-      image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
-      name: init-fs
-      securityContext:
-        runAsGroup: 0
-        runAsUser: 0
-      volumeMounts:
-      {{- if $logsEnableFileStorage }}
-      - mountPath: /var/lib/otelcol
-        name: varlibotelcol
-      {{- end }}
-      {{- if .Values.observability.opentelemetry.logs.values.nodeLogs.enabled }}
-      - name: node-logs
-        mountPath: /var/nodelogs
-      {{- end }}
-    {{- end }}
-    mode: daemonset
-    rollout:
-      rollingUpdate:
-        maxUnavailable: 50%
-      strategy: RollingUpdate
-    securityContext:
-      runAsGroup: 0
-      runAsUser: 10001
-    serviceAccount:
-      create: true
-    tolerations:
-    - operator: Exists
-    - effect: NoExecute
-      key: node.kubernetes.io/not-ready
-      operator: Exists
-    - effect: NoExecute
-      key: node.kubernetes.io/unreachable
-      operator: Exists
-    - effect: NoSchedule
-      key: node.kubernetes.io/disk-pressure
-      operator: Exists
-    - effect: NoSchedule
-      key: node.kubernetes.io/memory-pressure
-      operator: Exists
-    - effect: NoSchedule
-      key: node.kubernetes.io/pid-pressure
-      operator: Exists
-    - effect: NoSchedule
-      key: node.kubernetes.io/unschedulable
-      operator: Exists
-    - effect: NoSchedule
-      key: node.kubernetes.io/network-unavailable
-      operator: Exists
-    - effect: NoSchedule
-      key: node.cilium.io/agent-not-ready
-      operator: Exists
-    useGOMEMLIMIT: {{ $logsUseGoMemLimit }}
-    {{- if and .Values.observability.opentelemetry.logs.values .Values.observability.opentelemetry.logs.values.resources }}
-    resources: {{- toYaml .Values.observability.opentelemetry.logs.values.resources | nindent 6 }}
-    {{- end }}
-    {{- if .Values.observability.opentelemetry.metrics.enabled }}
-    command:
-      extraArgs:
-        - --feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress
-    ports:
-      metrics:
-        enabled: true
-    podMonitor:
-      enabled: true
-      metricsEndpoints:
-        - port: metrics
-          interval: {{ .Values.observability.opentelemetry.metrics.interval | default "30s" }}
-          scrapeTimeout: {{ .Values.observability.opentelemetry.metrics.scrapeTimeout | default "10s" }}
-          relabelings:
-            - sourceLabels: [__meta_kubernetes_pod_name]
-              targetLabel: pod
-            - sourceLabels: [__meta_kubernetes_node_name]
-              targetLabel: node
-            - replacement: otel-collector-logs
-              targetLabel: collector
-    {{- end }}
+
   {{- end }}
+
   valuesFrom:
-  - kind: ConfigMap
-    name: terraform-opentelemetry-collector-logs
-    optional: true
-    valuesKey: values.yaml
-  - kind: ConfigMap
-    name: opentelemetry-collector-logs
-    optional: true
-    valuesKey: values.yaml
+    - kind: ConfigMap
+      name: terraform-opentelemetry-collector-logs
+      optional: true
+      valuesKey: values.yaml
+
+    - kind: ConfigMap
+      name: opentelemetry-collector-logs
+      optional: true
+      valuesKey: values.yaml
+
 {{- end }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -44,9 +44,7 @@ spec:
   {{- $logsQueueStorage = "file_storage" }}
   {{- end }}
   {{- $logsUseGoMemLimit := true }}
-  {{- if hasKey $logsValues "useGOMEMLIMIT" }}
-  {{- $logsUseGoMemLimit = $logsValues.useGOMEMLIMIT }}
-  {{- else if hasKey $logsValues "useGoMemLimit" }}
+  {{- if hasKey $logsValues "useGoMemLimit" }}
   {{- $logsUseGoMemLimit = $logsValues.useGoMemLimit }}
   {{- end }}
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -33,6 +33,13 @@ spec:
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
+  {{- $logsValues := .Values.observability.opentelemetry.logs.values | default dict }}
+  {{- $logsUseGoMemLimit := true }}
+  {{- if hasKey $logsValues "useGOMEMLIMIT" }}
+  {{- $logsUseGoMemLimit = $logsValues.useGOMEMLIMIT }}
+  {{- else if hasKey $logsValues "useGoMemLimit" }}
+  {{- $logsUseGoMemLimit = $logsValues.useGoMemLimit }}
+  {{- end }}
   {{- if .Values.observability.opentelemetry.logs.overrideValues }}
     {{- toYaml .Values.observability.opentelemetry.logs.overrideValues | nindent 4 }}
   {{- else }}
@@ -364,8 +371,7 @@ spec:
     - name: CLUSTER_ID
       value: {{ .Values.observability.clusterId | quote }}
     {{- end }}
-    - name: GOMAXPROCS
-      value: "1"
+    {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $logsValues.resources "useGoMemLimit" $logsUseGoMemLimit) | nindent 4 }}
     extraVolumeMounts:
     {{- if $hasPublicEndpoint }}
     - mountPath: /o11ytoken
@@ -474,7 +480,7 @@ spec:
     - effect: NoSchedule
       key: node.cilium.io/agent-not-ready
       operator: Exists
-    useGOMEMLIMIT: {{ .Values.observability.opentelemetry.logs.values.useGOMEMLIMIT | default true }}
+    useGOMEMLIMIT: {{ $logsUseGoMemLimit }}
     {{- if and .Values.observability.opentelemetry.logs.values .Values.observability.opentelemetry.logs.values.resources }}
     resources: {{- toYaml .Values.observability.opentelemetry.logs.values.resources | nindent 6 }}
     {{- end }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -1,11 +1,16 @@
-{{- if and .Values.observability.enabled .Values.observability.vmStack.enabled .Values.observability.ncclProfiles.enabled -}}
+{{- if
+  and
+    .Values.observability.enabled
+    .Values.observability.vmStack.enabled
+    .Values.observability.ncclProfiles.enabled
+-}}
 
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: {{ include "soperator-fluxcd.fullname" . }}-otelcol-nccl-profiles-cm
   labels:
-  {{- include "soperator-fluxcd.labels" . | nindent 4 }}
+    {{- include "soperator-fluxcd.labels" . | nindent 4 }}
 spec:
   {{- with .Values.observability.ncclProfiles.driftDetection }}
   driftDetection:
@@ -67,19 +72,6 @@ spec:
         name: {{ .Values.observability.ncclProfiles.releaseName }}-agent
       data:
         relay: |
-          exporters:
-            otlp_http/victoriametrics:
-              compression: gzip
-              encoding: proto
-              metrics_endpoint: {{ $values.metricsEndpoint | default "http://vmsingle-metrics-victoria-metrics-k8s-stack:8428/opentelemetry/v1/metrics" }}
-              timeout: {{ $values.metricsExporterTimeout | default "15s" }}
-              retry_on_failure:
-                enabled: true
-                initial_interval: 1s
-                max_interval: 10s
-                max_elapsed_time: 0
-{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $queueStorage) | indent 14 }}
-
           receivers:
             filelog/nccl_metrics:
               include:
@@ -90,10 +82,12 @@ spec:
                 max_elapsed_time: 0
               include_file_path: true
               start_at: beginning
+
               {{- if $deleteAfterReadEnabled }}
               delete_after_read: true
               delete_after_read_min_age: {{ $deleteAfterRead.minAge | default "1m" }}
               {{- end }}
+
               {{- if $enableFileStorage }}
               storage: file_storage
               {{- end }}
@@ -119,8 +113,30 @@ spec:
                   from: attributes.hostname_pid
                   to: resource["{{ $exportLabels.hostnamePid | default "hostname_pid" }}"]
 
+          exporters:
+            otlp_http/victoriametrics:
+              compression: gzip
+              encoding: proto
+              metrics_endpoint: {{ $values.metricsEndpoint | default "http://vmsingle-metrics-victoria-metrics-k8s-stack:8428/opentelemetry/v1/metrics" }}
+              timeout: {{ $values.metricsExporterTimeout | default "15s" }}
+              retry_on_failure:
+                enabled: true
+                initial_interval: 1s
+                max_interval: 10s
+                max_elapsed_time: 0
+{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $queueStorage) | indent 14 }}
+
           connectors:
             ncclmetrics:
+
+          extensions:
+            {{- if $enableFileStorage }}
+            file_storage:
+              directory: /var/lib/otelcol-nccl-profiles
+            {{- end }}
+
+            health_check:
+              endpoint: 0.0.0.0:13133
 
           service:
             {{- if $metricsEnabled }}
@@ -133,11 +149,14 @@ spec:
                           host: 0.0.0.0
                           port: 8889
             {{- end }}
+
             extensions:
               - health_check
+
               {{- if $enableFileStorage }}
               - file_storage
               {{- end }}
+
             pipelines:
               logs/nccl_metrics:
                 receivers:
@@ -150,14 +169,6 @@ spec:
                   - ncclmetrics
                 exporters:
                   - otlp_http/victoriametrics
-
-          extensions:
-            {{- if $enableFileStorage }}
-            file_storage:
-              directory: /var/lib/otelcol-nccl-profiles
-            {{- end }}
-            health_check:
-              endpoint: 0.0.0.0:13133
   {{- end }}
 
   valuesFrom:
@@ -177,7 +188,7 @@ kind: HelmRelease
 metadata:
   name: {{ include "soperator-fluxcd.fullname" . }}-otelcol-nccl-profiles
   labels:
-  {{- include "soperator-fluxcd.labels" . | nindent 4 }}
+    {{- include "soperator-fluxcd.labels" . | nindent 4 }}
 spec:
   {{- with .Values.observability.ncclProfiles.driftDetection }}
   driftDetection:
@@ -228,6 +239,7 @@ spec:
   {{- if hasKey $values "useGoMemLimit" }}
   {{- $useGoMemLimit = $values.useGoMemLimit }}
   {{- end }}
+
   {{- if .Values.observability.ncclProfiles.collectorOverrideValues }}
     {{- toYaml .Values.observability.ncclProfiles.collectorOverrideValues | nindent 4 }}
   {{- else }}
@@ -324,7 +336,33 @@ spec:
       {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $values.resources "useGoMemLimit" $useGoMemLimit) | nindent 6 }}
 
     initContainers:
-      - command:
+      - name: wait-jail-populated
+        image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
+        volumeMounts:
+          - name: jail
+            mountPath: /mnt/jail
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        command:
+          - sh
+          - "-c"
+          - |
+            set -eu
+            until [ -f /mnt/jail/etc/soperator-jail-populated ]; do
+              echo "Waiting for /mnt/jail to be populated"
+              sleep 5
+            done
+
+      - name: init-nccl-profiles-dump-dir
+        image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
+        volumeMounts:
+          - name: jail
+            mountPath: /mnt/jail
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        command:
           - sh
           - "-c"
           - |
@@ -337,33 +375,21 @@ spec:
                 exit 1
                 ;;
             esac
-            until [ -f /mnt/jail/etc/soperator-jail-populated ]; do
-              echo "Waiting for /mnt/jail to be populated"
-              sleep 5
-            done
             install -d -m 0777 "$dump_dir"
-        image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
-        name: init-nccl-profiles-dir
-        securityContext:
-          runAsGroup: 0
-          runAsUser: 0
-        volumeMounts:
-          - name: jail
-            mountPath: /mnt/jail
 
       {{- if $enableFileStorage }}
-      - command:
-          - sh
-          - "-c"
-          - 'chown -R 10001: /var/lib/otelcol-nccl-profiles'
+      - name: init-fs
         image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
-        name: init-fs
-        securityContext:
-          runAsGroup: 0
-          runAsUser: 0
         volumeMounts:
           - name: varlibotelcol
             mountPath: /var/lib/otelcol-nccl-profiles
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        command:
+          - sh
+          - "-c"
+          - 'chown -R 10001: /var/lib/otelcol-nccl-profiles'
       {{- end }}
 
     resources:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -37,7 +37,28 @@ spec:
   {{- if .Values.observability.ncclProfiles.configMapOverrideValues }}
     {{- toYaml .Values.observability.ncclProfiles.configMapOverrideValues | nindent 4 }}
   {{- else }}
-  {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
+  {{- $values := .Values.observability.ncclProfiles.values | default dict }}
+  {{- $batch := $values.batch | default dict }}
+  {{- $sendingQueue := $values.sendingQueue | default dict }}
+  {{- $metrics := $values.metrics | default dict }}
+  {{- $metricsEnabled := true }}
+  {{- if hasKey $metrics "enabled" }}
+  {{- $metricsEnabled = $metrics.enabled }}
+  {{- end }}
+  {{- $enableFileStorage := true }}
+  {{- if hasKey $values "enableFileStorage" }}
+  {{- $enableFileStorage = $values.enableFileStorage }}
+  {{- end }}
+  {{- $queueStorage := "" }}
+  {{- if $enableFileStorage }}
+  {{- $queueStorage = "file_storage" }}
+  {{- end }}
+  {{- $deleteAfterRead := $values.deleteAfterRead | default dict }}
+  {{- $deleteAfterReadEnabled := false }}
+  {{- if hasKey $deleteAfterRead "enabled" }}
+  {{- $deleteAfterReadEnabled = $deleteAfterRead.enabled }}
+  {{- end }}
+  {{- $exportLabels := $values.exportLabels | default dict }}
     resources:
     - apiVersion: v1
       kind: ConfigMap
@@ -50,35 +71,30 @@ spec:
             otlp_http/victoriametrics:
               compression: gzip
               encoding: proto
-              metrics_endpoint: {{ .Values.observability.ncclProfiles.values.metricsEndpoint | default "http://vmsingle-metrics-victoria-metrics-k8s-stack:8428/opentelemetry/v1/metrics" }}
-              timeout: {{ .Values.observability.ncclProfiles.values.metricsExporterTimeout | default "15s" }}
+              metrics_endpoint: {{ $values.metricsEndpoint | default "http://vmsingle-metrics-victoria-metrics-k8s-stack:8428/opentelemetry/v1/metrics" }}
+              timeout: {{ $values.metricsExporterTimeout | default "15s" }}
               retry_on_failure:
                 enabled: true
                 initial_interval: 1s
                 max_interval: 10s
-                max_elapsed_time: 5m
-              sending_queue:
-                enabled: true
-                queue_size: {{ .Values.observability.ncclProfiles.values.metricsExporterSendingQueueSize | default 2000 }}
-                num_consumers: {{ .Values.observability.ncclProfiles.values.metricsExporterNumConsumers | default 4 }}
-                {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
-                storage: file_storage
-                {{- end }}
+                max_elapsed_time: 0
+{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $queueStorage) | indent 14 }}
 
           receivers:
             filelog/nccl_metrics:
               include:
-                - {{ .Values.observability.ncclProfiles.values.dumpDir }}/*/*/*.log
-              poll_interval: {{ .Values.observability.ncclProfiles.values.pollInterval | default "30s" }}
+                - {{ $values.dumpDir }}/*/*/*.log
+              poll_interval: {{ $values.pollInterval | default "30s" }}
               retry_on_failure:
                 enabled: true
+                max_elapsed_time: 0
               include_file_path: true
               start_at: beginning
-              {{- if .Values.observability.ncclProfiles.values.deleteAfterRead.enabled }}
+              {{- if $deleteAfterReadEnabled }}
               delete_after_read: true
-              delete_after_read_min_age: {{ .Values.observability.ncclProfiles.values.deleteAfterRead.minAge | default "1m" }}
+              delete_after_read_min_age: {{ $deleteAfterRead.minAge | default "1m" }}
               {{- end }}
-              {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+              {{- if $enableFileStorage }}
               storage: file_storage
               {{- end }}
 
@@ -91,29 +107,23 @@ spec:
                 - if: attributes["job_id"] != nil
                   type: copy
                   from: attributes.job_id
-                  to: resource["{{ .Values.observability.ncclProfiles.values.exportLabels.slurmJobId | default "slurm_job_id" }}"]
+                  to: resource["{{ $exportLabels.slurmJobId | default "slurm_job_id" }}"]
 
                 - if: attributes["step_id"] != nil
                   type: copy
                   from: attributes.step_id
-                  to: resource["{{ .Values.observability.ncclProfiles.values.exportLabels.slurmStepId | default "slurm_step_id" }}"]
+                  to: resource["{{ $exportLabels.slurmStepId | default "slurm_step_id" }}"]
 
                 - if: attributes["hostname_pid"] != nil
                   type: copy
                   from: attributes.hostname_pid
-                  to: resource["{{ .Values.observability.ncclProfiles.values.exportLabels.hostnamePid | default "hostname_pid" }}"]
+                  to: resource["{{ $exportLabels.hostnamePid | default "hostname_pid" }}"]
 
           connectors:
             ncclmetrics:
 
-          processors:
-            batch:
-              timeout: {{ $batch.timeout | default "5s" }}
-              send_batch_size: {{ $batch.sendBatchSize | default 2000 }}
-              send_batch_max_size: {{ $batch.sendBatchMaxSize | default 5000 }}
-
           service:
-            {{- if .Values.observability.opentelemetry.metrics.enabled }}
+            {{- if $metricsEnabled }}
             telemetry:
               metrics:
                 readers:
@@ -125,7 +135,7 @@ spec:
             {{- end }}
             extensions:
               - health_check
-              {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+              {{- if $enableFileStorage }}
               - file_storage
               {{- end }}
             pipelines:
@@ -138,15 +148,13 @@ spec:
               metrics/nccl_metrics:
                 receivers:
                   - ncclmetrics
-                processors:
-                  - batch
                 exporters:
                   - otlp_http/victoriametrics
 
           extensions:
-            {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+            {{- if $enableFileStorage }}
             file_storage:
-              directory: /var/lib/otelcol
+              directory: /var/lib/otelcol-nccl-profiles
             {{- end }}
             health_check:
               endpoint: 0.0.0.0:13133
@@ -200,12 +208,27 @@ spec:
   targetNamespace: {{ .Values.observability.vmStack.namespace }}
 
   values:
-  {{- $ncclValues := .Values.observability.ncclProfiles.values | default dict }}
-  {{- $ncclUseGoMemLimit := true }}
-  {{- if hasKey $ncclValues "useGoMemLimit" }}
-  {{- $ncclUseGoMemLimit = $ncclValues.useGoMemLimit }}
-  {{- else if hasKey $ncclValues "useGOMEMLIMIT" }}
-  {{- $ncclUseGoMemLimit = $ncclValues.useGOMEMLIMIT }}
+  {{- $values := .Values.observability.ncclProfiles.values | default dict }}
+  {{- $metrics := $values.metrics | default dict }}
+  {{- $metricsEnabled := true }}
+  {{- if hasKey $metrics "enabled" }}
+  {{- $metricsEnabled = $metrics.enabled }}
+  {{- end }}
+  {{- $mode := $values.mode | default "shared" }}
+  {{- $enableFileStorage := true }}
+  {{- if hasKey $values "enableFileStorage" }}
+  {{- $enableFileStorage = $values.enableFileStorage }}
+  {{- end }}
+  {{- $deleteAfterRead := $values.deleteAfterRead | default dict }}
+  {{- $deleteAfterReadEnabled := false }}
+  {{- if hasKey $deleteAfterRead "enabled" }}
+  {{- $deleteAfterReadEnabled = $deleteAfterRead.enabled }}
+  {{- end }}
+  {{- $useGoMemLimit := true }}
+  {{- if hasKey $values "useGoMemLimit" }}
+  {{- $useGoMemLimit = $values.useGoMemLimit }}
+  {{- else if hasKey $values "useGOMEMLIMIT" }}
+  {{- $useGoMemLimit = $values.useGOMEMLIMIT }}
   {{- end }}
   {{- if .Values.observability.ncclProfiles.collectorOverrideValues }}
     {{- toYaml .Values.observability.ncclProfiles.collectorOverrideValues | nindent 4 }}
@@ -226,9 +249,9 @@ spec:
     image:
       pullPolicy: IfNotPresent
       repository: cr.eu-north1.nebius.cloud/observability/nebius-o11y-agent
-      tag: {{ .Values.observability.ncclProfiles.values.nebiusO11yAgentVersion | default "2.0.10" }}
+      tag: {{ $values.nebiusO11yAgentVersion | default "2.0.10" }}
 
-    {{- if eq (.Values.observability.ncclProfiles.values.mode | default "shared") "shared" }}
+    {{- if eq $mode "shared" }}
     mode: deployment
     replicaCount: 1   # Only one replica to avoid file lock conflicts on shared storage and prevent log duplication
 
@@ -244,7 +267,7 @@ spec:
                   operator: In
                   values:
                     - "system"
-    {{- else }}{{- if eq (.Values.observability.ncclProfiles.values.mode | default "shared") "nodeLocal" }}
+    {{- else }}{{- if eq $mode "nodeLocal" }}
     mode: daemonset
 
     rollout:
@@ -274,10 +297,10 @@ spec:
           path: /mnt/jail
           type: Directory
 
-      {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+      {{- if $enableFileStorage }}
       - name: varlibotelcol
         hostPath:
-          path: /var/lib/otelcol
+          path: /var/lib/otelcol-nccl-profiles
           type: DirectoryOrCreate
       {{- end }}
 
@@ -286,9 +309,9 @@ spec:
         mountPath: /mnt/jail
         readOnly: true
 
-      {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+      {{- if $enableFileStorage }}
       - name: varlibotelcol
-        mountPath: /var/lib/otelcol
+        mountPath: /var/lib/otelcol-nccl-profiles
       {{- end }}
 
     securityContext:
@@ -300,7 +323,7 @@ spec:
       create: true
 
     extraEnvs:
-      {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $ncclValues.resources "useGoMemLimit" $ncclUseGoMemLimit) | nindent 6 }}
+      {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $values.resources "useGoMemLimit" $useGoMemLimit) | nindent 6 }}
 
     initContainers:
       - command:
@@ -308,7 +331,7 @@ spec:
           - "-c"
           - |
             set -eu
-            dump_dir="{{ .Values.observability.ncclProfiles.values.dumpDir }}"
+            dump_dir="{{ $values.dumpDir }}"
             case "$dump_dir" in
               /mnt/jail/*) ;;
               *)
@@ -330,11 +353,11 @@ spec:
           - name: jail
             mountPath: /mnt/jail
 
-      {{- if .Values.observability.ncclProfiles.values.enableFileStorage }}
+      {{- if $enableFileStorage }}
       - command:
           - sh
           - "-c"
-          - 'chown -R 10001: /var/lib/otelcol'
+          - 'chown -R 10001: /var/lib/otelcol-nccl-profiles'
         image: cr.eu-north1.nebius.cloud/soperator/busybox:latest
         name: init-fs
         securityContext:
@@ -342,19 +365,19 @@ spec:
           runAsUser: 0
         volumeMounts:
           - name: varlibotelcol
-            mountPath: /var/lib/otelcol
+            mountPath: /var/lib/otelcol-nccl-profiles
       {{- end }}
 
     resources:
-      {{- toYaml .Values.observability.ncclProfiles.values.resources | nindent 6 }}
+      {{- toYaml $values.resources | nindent 6 }}
 
-    useGOMEMLIMIT: {{ $ncclUseGoMemLimit }}
+    useGOMEMLIMIT: {{ $useGoMemLimit }}
 
     {{- $featureGates := list }}
-    {{- if .Values.observability.opentelemetry.metrics.enabled }}
+    {{- if $metricsEnabled }}
     {{- $featureGates = append $featureGates "-telemetry.UseLocalHostAsDefaultMetricsAddress" }}
     {{- end }}
-    {{- if .Values.observability.ncclProfiles.values.deleteAfterRead.enabled }}
+    {{- if $deleteAfterReadEnabled }}
     {{- $featureGates = append $featureGates "filelog.allowFileDeletion" }}
     {{- end }}
     {{- if $featureGates }}
@@ -371,7 +394,7 @@ spec:
       jaeger-thrift:
         enabled: false
       metrics:
-        {{- if .Values.observability.opentelemetry.metrics.enabled }}
+        {{- if $metricsEnabled }}
         enabled: true
         containerPort: 8889
         servicePort: 8889
@@ -386,12 +409,12 @@ spec:
         enabled: false
 
     podMonitor:
-      {{- if .Values.observability.opentelemetry.metrics.enabled }}
+      {{- if $metricsEnabled }}
       enabled: true
       metricsEndpoints:
         - port: metrics
-          interval: {{ .Values.observability.opentelemetry.metrics.interval | default "30s" }}
-          scrapeTimeout: {{ .Values.observability.opentelemetry.metrics.scrapeTimeout | default "10s" }}
+          interval: {{ $metrics.interval | default "30s" }}
+          scrapeTimeout: {{ $metrics.scrapeTimeout | default "10s" }}
           relabelings:
             - sourceLabels: [ __meta_kubernetes_pod_name ]
               targetLabel: pod

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -200,6 +200,13 @@ spec:
   targetNamespace: {{ .Values.observability.vmStack.namespace }}
 
   values:
+  {{- $ncclValues := .Values.observability.ncclProfiles.values | default dict }}
+  {{- $ncclUseGoMemLimit := true }}
+  {{- if hasKey $ncclValues "useGoMemLimit" }}
+  {{- $ncclUseGoMemLimit = $ncclValues.useGoMemLimit }}
+  {{- else if hasKey $ncclValues "useGOMEMLIMIT" }}
+  {{- $ncclUseGoMemLimit = $ncclValues.useGOMEMLIMIT }}
+  {{- end }}
   {{- if .Values.observability.ncclProfiles.collectorOverrideValues }}
     {{- toYaml .Values.observability.ncclProfiles.collectorOverrideValues | nindent 4 }}
   {{- else }}
@@ -292,6 +299,9 @@ spec:
     serviceAccount:
       create: true
 
+    extraEnvs:
+      {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $ncclValues.resources "useGoMemLimit" $ncclUseGoMemLimit) | nindent 6 }}
+
     initContainers:
       - command:
           - sh
@@ -338,7 +348,7 @@ spec:
     resources:
       {{- toYaml .Values.observability.ncclProfiles.values.resources | nindent 6 }}
 
-    useGOMEMLIMIT: {{ .Values.observability.ncclProfiles.values.useGoMemLimit | default true }}
+    useGOMEMLIMIT: {{ $ncclUseGoMemLimit }}
 
     {{- $featureGates := list }}
     {{- if .Values.observability.opentelemetry.metrics.enabled }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -227,8 +227,6 @@ spec:
   {{- $useGoMemLimit := true }}
   {{- if hasKey $values "useGoMemLimit" }}
   {{- $useGoMemLimit = $values.useGoMemLimit }}
-  {{- else if hasKey $values "useGOMEMLIMIT" }}
-  {{- $useGoMemLimit = $values.useGOMEMLIMIT }}
   {{- end }}
   {{- if .Values.observability.ncclProfiles.collectorOverrideValues }}
     {{- toYaml .Values.observability.ncclProfiles.collectorOverrideValues | nindent 4 }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -317,7 +317,7 @@ spec:
     extraVolumeMounts:
       - name: jail
         mountPath: /mnt/jail
-        readOnly: true
+        readOnly: {{ not $deleteAfterReadEnabled }}
 
       {{- if $enableFileStorage }}
       - name: varlibotelcol
@@ -341,6 +341,7 @@ spec:
         volumeMounts:
           - name: jail
             mountPath: /mnt/jail
+            readOnly: true
         securityContext:
           runAsGroup: 0
           runAsUser: 0

--- a/helm/soperator-fluxcd/tests/helmrepository_test.yaml
+++ b/helm/soperator-fluxcd/tests/helmrepository_test.yaml
@@ -1,0 +1,18 @@
+suite: test HelmRepository rendering
+templates:
+  - templates/helmrepository.yaml
+tests:
+  - it: should render opentelemetry collector repository for nccl profiles when opentelemetry is disabled
+    set:
+      observability.enabled: true
+      observability.opentelemetry.enabled: false
+      observability.ncclProfiles.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-opentelemetry-collector
+    asserts:
+      - isKind:
+          of: HelmRepository
+      - equal:
+          path: spec.url
+          value: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
+++ b/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
@@ -2,7 +2,7 @@ suite: test opentelemetry collector logs config
 templates:
   - templates/opentelemetry-collector-logs.yaml
 tests:
-  - it: should use eu-north public endpoint regardless of observability region and render default batch settings
+  - it: should use eu-north public endpoint regardless of observability region and render default queue batch settings
     set:
       observability.region: eu-west1
     asserts:
@@ -11,14 +11,34 @@ tests:
       - equal:
           path: spec.values.config.exporters.otlp.endpoint
           value: dns:///write.logging.eu-north1.nebius.cloud.:443
+      - notExists:
+          path: spec.values.config.processors.batch
       - equal:
-          path: spec.values.config.processors.batch.timeout
+          path: spec.values.config.exporters.otlp.sending_queue.sizer
+          value: items
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.queue_size
+          value: 30000
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.num_consumers
+          value: 10
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.storage
+          value: file_storage
+      - equal:
+          path: spec.values.config.receivers["filelog/pods"].storage
+          value: file_storage
+      - equal:
+          path: spec.values.config.receivers["filelog/nodelogs"].storage
+          value: file_storage
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.batch.flush_timeout
           value: 1s
       - equal:
-          path: spec.values.config.processors.batch.send_batch_size
+          path: spec.values.config.exporters.otlp.sending_queue.batch.min_size
           value: 2000
       - equal:
-          path: spec.values.config.processors.batch.send_batch_max_size
+          path: spec.values.config.exporters.otlp.sending_queue.batch.max_size
           value: 5000
 
   - it: should prefer explicit public endpoint override
@@ -38,43 +58,126 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+      - notExists:
+          path: spec.values.config.processors.batch
       - equal:
-          path: spec.values.config.processors.batch.timeout
+          path: spec.values.config.exporters.otlp.sending_queue.batch.flush_timeout
           value: 1s
       - equal:
-          path: spec.values.config.processors.batch.send_batch_size
+          path: spec.values.config.exporters.otlp.sending_queue.batch.min_size
           value: 2000
       - equal:
-          path: spec.values.config.processors.batch.send_batch_max_size
+          path: spec.values.config.exporters.otlp.sending_queue.batch.max_size
           value: 5000
+
+  - it: should omit file storage when log file storage is disabled
+    set:
+      observability.opentelemetry.logs.values.enableFileStorage: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.values.config.extensions.file_storage
+      - notContains:
+          path: spec.values.config.service.extensions
+          content: file_storage
+      - notExists:
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.storage
+      - notExists:
+          path: spec.values.config.exporters.otlp.sending_queue.storage
+      - notExists:
+          path: spec.values.config.receivers["filelog/pods"].storage
+      - notExists:
+          path: spec.values.config.receivers["filelog/nodelogs"].storage
+      - notContains:
+          path: spec.values.extraVolumeMounts
+          content:
+            mountPath: /var/lib/otelcol
+            name: varlibotelcol
+      - notContains:
+          path: spec.values.extraVolumes
+          content:
+            hostPath:
+              path: /var/lib/otelcol
+              type: DirectoryOrCreate
+            name: varlibotelcol
+      - notContains:
+          path: spec.values.initContainers[0].volumeMounts
+          content:
+            mountPath: /var/lib/otelcol
+            name: varlibotelcol
+
 ---
 suite: test opentelemetry collector events config
 templates:
   - templates/opentelemetry-collector-events.yaml
 tests:
-  - it: should render configured batch settings
+  - it: should render configured queue batch settings
     set:
       observability.opentelemetry.batch.timeout: 2s
       observability.opentelemetry.batch.sendBatchSize: 3000
       observability.opentelemetry.batch.sendBatchMaxSize: 7000
+      observability.opentelemetry.sendingQueue.queueSize: 9000
+      observability.opentelemetry.sendingQueue.numConsumers: 3
     asserts:
       - hasDocuments:
           count: 1
+      - notExists:
+          path: spec.values.config.processors.batch
       - equal:
-          path: spec.values.config.processors.batch.timeout
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.queue_size
+          value: 9000
+      - equal:
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.num_consumers
+          value: 3
+      - equal:
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.storage
+          value: file_storage
+      - equal:
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.batch.flush_timeout
           value: 2s
       - equal:
-          path: spec.values.config.processors.batch.send_batch_size
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.batch.min_size
           value: 3000
       - equal:
-          path: spec.values.config.processors.batch.send_batch_max_size
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.batch.max_size
           value: 7000
+
+  - it: should omit file storage when events file storage is disabled
+    set:
+      observability.opentelemetry.events.values.enableFileStorage: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.values.config.extensions.file_storage
+      - notContains:
+          path: spec.values.config.service.extensions
+          content: file_storage
+      - notExists:
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.storage
+      - notExists:
+          path: spec.values.config.exporters.otlp.sending_queue.storage
+      - notExists:
+          path: spec.values.initContainers
+      - notContains:
+          path: spec.values.extraVolumeMounts
+          content:
+            mountPath: /var/lib/otelcol-events
+            name: varlibotelcol
+      - notContains:
+          path: spec.values.extraVolumes
+          content:
+            hostPath:
+              path: /var/lib/otelcol-events
+              type: DirectoryOrCreate
+            name: varlibotelcol
 ---
 suite: test opentelemetry collector jail logs config
 templates:
   - templates/opentelemetry-collector-jail-logs.yaml
 tests:
-  - it: should use eu-north public endpoint regardless of observability region and render default batch settings
+  - it: should use eu-north public endpoint regardless of observability region and render default queue batch settings
     set:
       observability.region: me-west1
     asserts:
@@ -83,12 +186,82 @@ tests:
       - equal:
           path: spec.values.config.exporters.otlp.endpoint
           value: dns:///write.logging.eu-north1.nebius.cloud.:443
+      - notExists:
+          path: spec.values.config.processors.batch
       - equal:
-          path: spec.values.config.processors.batch.timeout
+          path: spec.values.config.exporters.otlp.sending_queue.sizer
+          value: items
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.queue_size
+          value: 30000
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.storage
+          value: file_storage
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.batch.flush_timeout
           value: 1s
       - equal:
-          path: spec.values.config.processors.batch.send_batch_size
+          path: spec.values.config.exporters.otlp.sending_queue.batch.min_size
           value: 2000
       - equal:
-          path: spec.values.config.processors.batch.send_batch_max_size
+          path: spec.values.config.exporters.otlp.sending_queue.batch.max_size
           value: 5000
+
+  - it: should omit file storage when jail log file storage is disabled
+    set:
+      observability.opentelemetry.logs.values.jailLogs.enableFileStorage: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.values.config.extensions.file_storage
+      - notContains:
+          path: spec.values.config.service.extensions
+          content: file_storage
+      - notExists:
+          path: spec.values.config.exporters.otlp.sending_queue.storage
+      - notExists:
+          path: spec.values.config.receivers.filelog.storage
+      - notExists:
+          path: spec.values.config.receivers["filelog/health_checker"].storage
+      - notContains:
+          path: spec.values.extraVolumeMounts
+          content:
+            mountPath: /var/lib/otelcol-jail
+            name: varlibotelcol
+      - notContains:
+          path: spec.values.extraVolumes
+          content:
+            hostPath:
+              path: /var/lib/otelcol-jail
+              type: DirectoryOrCreate
+            name: varlibotelcol
+
+  - it: should render delete_after_read when jail log deletion is enabled
+    set:
+      observability.opentelemetry.logs.values.jailLogs.deleteAfterRead.enabled: true
+      observability.opentelemetry.logs.values.jailLogs.deleteAfterRead.minAge: 30m
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.config.receivers.filelog.start_at
+          value: beginning
+      - equal:
+          path: spec.values.config.receivers.filelog.delete_after_read
+          value: true
+      - equal:
+          path: spec.values.config.receivers.filelog.delete_after_read_min_age
+          value: 30m
+      - equal:
+          path: spec.values.config.receivers["filelog/health_checker"].start_at
+          value: beginning
+      - equal:
+          path: spec.values.config.receivers["filelog/health_checker"].delete_after_read
+          value: true
+      - equal:
+          path: spec.values.config.receivers["filelog/health_checker"].delete_after_read_min_age
+          value: 30m
+      - equal:
+          path: spec.values.command.extraArgs[0]
+          value: --feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress,filelog.allowFileDeletion

--- a/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
+++ b/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
@@ -206,6 +206,9 @@ tests:
       - equal:
           path: spec.values.config.exporters.otlp.sending_queue.batch.max_size
           value: 5000
+      - equal:
+          path: spec.values.extraVolumeMounts[0].readOnly
+          value: true
 
   - it: should omit file storage when jail log file storage is disabled
     set:
@@ -262,6 +265,9 @@ tests:
       - equal:
           path: spec.values.config.receivers["filelog/health_checker"].delete_after_read_min_age
           value: 30m
+      - equal:
+          path: spec.values.extraVolumeMounts[0].readOnly
+          value: false
       - equal:
           path: spec.values.command.extraArgs[0]
           value: --feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress,filelog.allowFileDeletion

--- a/helm/soperator-fluxcd/tests/opentelemetry_collector_go_runtime_test.yaml
+++ b/helm/soperator-fluxcd/tests/opentelemetry_collector_go_runtime_test.yaml
@@ -1,0 +1,176 @@
+suite: test opentelemetry collector Go runtime env
+templates:
+  - templates/opentelemetry-collector-logs.yaml
+tests:
+  - it: should derive GOMAXPROCS and GOMEMLIMIT from logs resources
+    set:
+      observability.opentelemetry.logs.values.resources:
+        requests:
+          cpu: 500m
+          memory: 100Mi
+        limits:
+          memory: 200Mi
+    asserts:
+      - contains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMAXPROCS
+            value: "1"
+      - contains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMEMLIMIT
+            value: "170MiB"
+      - equal:
+          path: spec.values.useGOMEMLIMIT
+          value: true
+---
+suite: test opentelemetry collector events Go runtime env
+templates:
+  - templates/opentelemetry-collector-events.yaml
+tests:
+  - it: should support whole-core CPU and large binary memory quantities
+    set:
+      observability.opentelemetry.events.values.resources:
+        requests:
+          cpu: "2"
+          memory: 200Mi
+        limits:
+          memory: 500Gi
+    asserts:
+      - contains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMAXPROCS
+            value: "2"
+      - contains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMEMLIMIT
+            value: "425GiB"
+      - equal:
+          path: spec.values.useGOMEMLIMIT
+          value: true
+
+  - it: should round fractional GOMEMLIMIT values up to MiB
+    set:
+      observability.opentelemetry.events.values.resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          memory: null
+    asserts:
+      - contains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMEMLIMIT
+            value: "109MiB"
+      - equal:
+          path: spec.values.useGOMEMLIMIT
+          value: true
+
+  - it: should omit GOMEMLIMIT when useGOMEMLIMIT is false
+    set:
+      observability.opentelemetry.events.values.useGOMEMLIMIT: false
+      observability.opentelemetry.events.values.resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          memory: null
+    asserts:
+      - notContains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMEMLIMIT
+      - equal:
+          path: spec.values.useGOMEMLIMIT
+          value: false
+---
+suite: test opentelemetry collector jail logs Go runtime env
+templates:
+  - templates/opentelemetry-collector-jail-logs.yaml
+tests:
+  - it: should use jail logs resources for Go runtime env
+    set:
+      observability.opentelemetry.logs.values.resources:
+        requests:
+          cpu: "2"
+          memory: 500Gi
+        limits:
+          memory: 500Gi
+      observability.opentelemetry.logs.values.jailLogs.resources:
+        requests:
+          cpu: 500m
+          memory: 100Mi
+        limits:
+          memory: 200Mi
+    asserts:
+      - contains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMAXPROCS
+            value: "1"
+      - contains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMEMLIMIT
+            value: "170MiB"
+      - equal:
+          path: spec.values.useGOMEMLIMIT
+          value: true
+---
+suite: test opentelemetry collector NCCL profiles Go runtime env
+templates:
+  - templates/opentelemetry-collector-nccl-profiles.yaml
+tests:
+  - it: should derive Go runtime env from NCCL collector resources
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.ncclProfiles.values.resources:
+        requests:
+          cpu: "2"
+          memory: 200Mi
+        limits:
+          memory: 500Gi
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles
+    asserts:
+      - contains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMAXPROCS
+            value: "2"
+      - contains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMEMLIMIT
+            value: "425GiB"
+      - equal:
+          path: spec.values.useGOMEMLIMIT
+          value: true
+
+  - it: should omit GOMEMLIMIT when useGoMemLimit is false
+    set:
+      observability.enabled: true
+      observability.ncclProfiles.enabled: true
+      observability.ncclProfiles.values.useGoMemLimit: false
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-otelcol-nccl-profiles
+    asserts:
+      - contains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMAXPROCS
+            value: "1"
+      - notContains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMEMLIMIT
+      - equal:
+          path: spec.values.useGOMEMLIMIT
+          value: false

--- a/helm/soperator-fluxcd/tests/opentelemetry_collector_go_runtime_test.yaml
+++ b/helm/soperator-fluxcd/tests/opentelemetry_collector_go_runtime_test.yaml
@@ -24,6 +24,18 @@ tests:
       - equal:
           path: spec.values.useGOMEMLIMIT
           value: true
+
+  - it: should omit GOMEMLIMIT when useGoMemLimit is false
+    set:
+      observability.opentelemetry.logs.values.useGoMemLimit: false
+    asserts:
+      - notContains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMEMLIMIT
+      - equal:
+          path: spec.values.useGOMEMLIMIT
+          value: false
 ---
 suite: test opentelemetry collector events Go runtime env
 templates:
@@ -70,9 +82,9 @@ tests:
           path: spec.values.useGOMEMLIMIT
           value: true
 
-  - it: should omit GOMEMLIMIT when useGOMEMLIMIT is false
+  - it: should omit GOMEMLIMIT when useGoMemLimit is false
     set:
-      observability.opentelemetry.events.values.useGOMEMLIMIT: false
+      observability.opentelemetry.events.values.useGoMemLimit: false
       observability.opentelemetry.events.values.resources:
         requests:
           cpu: 100m
@@ -120,6 +132,18 @@ tests:
       - equal:
           path: spec.values.useGOMEMLIMIT
           value: true
+
+  - it: should omit GOMEMLIMIT when jailLogs.useGoMemLimit is false
+    set:
+      observability.opentelemetry.logs.values.jailLogs.useGoMemLimit: false
+    asserts:
+      - notContains:
+          path: spec.values.extraEnvs
+          content:
+            name: GOMEMLIMIT
+      - equal:
+          path: spec.values.useGOMEMLIMIT
+          value: false
 ---
 suite: test opentelemetry collector NCCL profiles Go runtime env
 templates:

--- a/helm/soperator-fluxcd/tests/values_override_test.yaml
+++ b/helm/soperator-fluxcd/tests/values_override_test.yaml
@@ -164,7 +164,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: spec.values.extraVolumes[0].name
+          path: spec.values.extraVolumes[4].name
           value: o11ytoken
   - it: should use custom values when provided
     set:
@@ -178,7 +178,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: spec.values.extraVolumes[0].name
+          path: spec.values.extraVolumes[4].name
           value: o11ytoken
       - equal:
           path: spec.values.resources.requests
@@ -288,8 +288,8 @@ tests:
           path: spec.values.extraVolumes[0].hostPath.type
           value: Directory
       - equal:
-          path: spec.values.initContainers[0].name
-          value: init-nccl-profiles-dir
+          path: spec.values.initContainers[1].name
+          value: init-nccl-profiles-dump-dir
       - equal:
           path: spec.values.command.extraArgs[0]
           value: --feature-gates=-telemetry.UseLocalHostAsDefaultMetricsAddress,filelog.allowFileDeletion
@@ -355,13 +355,13 @@ tests:
           path: spec.values.extraVolumes[0].hostPath.type
           value: Directory
       - equal:
-          path: spec.values.initContainers[0].name
-          value: init-nccl-profiles-dir
+          path: spec.values.initContainers[1].name
+          value: init-nccl-profiles-dump-dir
       - equal:
-          path: spec.values.initContainers[0].volumeMounts[0].name
+          path: spec.values.initContainers[1].volumeMounts[0].name
           value: jail
       - matchRegex:
-          path: spec.values.initContainers[0].command[2]
+          path: spec.values.initContainers[1].command[2]
           pattern: '/mnt/jail/custom/nccl'
       - equal:
           path: spec.values.resources.requests

--- a/helm/soperator-fluxcd/tests/values_override_test.yaml
+++ b/helm/soperator-fluxcd/tests/values_override_test.yaml
@@ -288,6 +288,9 @@ tests:
           path: spec.values.extraVolumes[0].hostPath.type
           value: Directory
       - equal:
+          path: spec.values.extraVolumeMounts[0].readOnly
+          value: false
+      - equal:
           path: spec.values.initContainers[1].name
           value: init-nccl-profiles-dump-dir
       - equal:
@@ -307,6 +310,9 @@ tests:
       - equal:
           path: spec.values.command.extraArgs[0]
           value: --feature-gates=filelog.allowFileDeletion
+      - equal:
+          path: spec.values.extraVolumeMounts[0].readOnly
+          value: false
 
   - it: should use daemonset mode on worker nodes for node-local storage
     set:
@@ -338,6 +344,7 @@ tests:
       observability.ncclProfiles.enabled: true
       observability.ncclProfiles.values.dumpDir: /mnt/jail/custom/nccl
       observability.ncclProfiles.values.enableFileStorage: false
+      observability.ncclProfiles.values.deleteAfterRead.enabled: false
       observability.ncclProfiles.values.resources:
         requests:
           cpu: 250m
@@ -360,6 +367,9 @@ tests:
       - equal:
           path: spec.values.initContainers[1].volumeMounts[0].name
           value: jail
+      - equal:
+          path: spec.values.extraVolumeMounts[0].readOnly
+          value: true
       - matchRegex:
           path: spec.values.initContainers[1].command[2]
           pattern: '/mnt/jail/custom/nccl'

--- a/helm/soperator-fluxcd/tests/values_override_test.yaml
+++ b/helm/soperator-fluxcd/tests/values_override_test.yaml
@@ -131,7 +131,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: spec.values.extraVolumes[0].name
+          path: spec.values.extraVolumes[1].name
           value: o11ytoken
   - it: should use custom values when provided
     set:
@@ -145,7 +145,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: spec.values.extraVolumes[0].name
+          path: spec.values.extraVolumes[1].name
           value: o11ytoken
       - equal:
           path: spec.values.resources.requests
@@ -298,7 +298,7 @@ tests:
     set:
       observability.enabled: true
       observability.ncclProfiles.enabled: true
-      observability.opentelemetry.metrics.enabled: false
+      observability.ncclProfiles.values.metrics.enabled: false
       observability.ncclProfiles.values.deleteAfterRead.enabled: true
     documentSelector:
       path: metadata.name
@@ -380,8 +380,8 @@ tests:
       observability.ncclProfiles.values.enableFileStorage: true
       observability.ncclProfiles.values.metricsEndpoint: http://example.test:8428/custom
       observability.ncclProfiles.values.metricsExporterTimeout: 25s
-      observability.ncclProfiles.values.metricsExporterSendingQueueSize: 4321
-      observability.ncclProfiles.values.metricsExporterNumConsumers: 7
+      observability.ncclProfiles.values.sendingQueue.queueSize: 4321
+      observability.ncclProfiles.values.sendingQueue.numConsumers: 7
       observability.ncclProfiles.values.deleteAfterRead.enabled: true
       observability.ncclProfiles.values.deleteAfterRead.minAge: 30m
     documentSelector:
@@ -399,10 +399,25 @@ tests:
           pattern: 'timeout: 25s'
       - matchRegex:
           path: spec.values.resources[0].data.relay
+          pattern: 'max_elapsed_time: 0'
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'sizer: items'
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
           pattern: 'queue_size: 4321'
       - matchRegex:
           path: spec.values.resources[0].data.relay
           pattern: 'num_consumers: 7'
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'flush_timeout: 1s'
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'min_size: 2000'
+      - matchRegex:
+          path: spec.values.resources[0].data.relay
+          pattern: 'max_size: 5000'
       - matchRegex:
           path: spec.values.resources[0].data.relay
           pattern: 'delete_after_read: true'

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -155,10 +155,19 @@ observability:
     publicEndpoint: dns:///write.logging.eu-north1.nebius.cloud.:443
     namespace: logs-system
     extraHeaders: {}
+    # These values are rendered as exporter sending_queue.batch settings.
+    # The chart intentionally does not use the batch processor for collector pipelines.
+    # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44845#issuecomment-3877056774
     batch:
       timeout: 1s
       sendBatchSize: 2000
       sendBatchMaxSize: 5000
+    # Exporter queue sizing shared by logs, events, and jail logs collectors.
+    # queueSize is measured in telemetry items because exporter queues use sizer: items
+    # (log records for logs/events), and it applies separately to each exporter.
+    sendingQueue:
+      queueSize: 30000
+      numConsumers: 10
     metrics:
       enabled: true
       interval: 30s
@@ -175,9 +184,16 @@ observability:
           retries: 6
           remediateLastFailure: true
       values:
+        enableFileStorage: true
         jailLogs:
           enabled: true
           pollInterval: 30s
+          enableFileStorage: true
+          deleteAfterRead:
+            enabled: false
+            # Nebius O11y agent fork option; not part of upstream filelogreceiver.
+            # Files are deleted only after they have not been modified for at least this duration.
+            minAge: 15m
           resources:
             requests:
               memory: 200Mi
@@ -213,6 +229,7 @@ observability:
           retries: 3
           remediateLastFailure: true
       values:
+        enableFileStorage: true
         resources:
           requests:
             memory: 128Mi
@@ -422,8 +439,20 @@ observability:
       useGoMemLimit: true
       metricsEndpoint: http://vmsingle-metrics-victoria-metrics-k8s-stack:8428/opentelemetry/v1/metrics
       metricsExporterTimeout: 15s
-      metricsExporterSendingQueueSize: 2000
-      metricsExporterNumConsumers: 4
+      # These values are rendered as exporter sending_queue.batch settings.
+      # The chart intentionally does not use the batch processor for collector pipelines.
+      batch:
+        timeout: 1s
+        sendBatchSize: 2000
+        sendBatchMaxSize: 5000
+      # Measured in metric data points because the exporter queue uses sizer: items.
+      sendingQueue:
+        queueSize: 30000
+        numConsumers: 10
+      metrics:
+        enabled: true
+        interval: 30s
+        scrapeTimeout: 10s
       dumpDir: /mnt/jail/opt/soperator-outputs/nccl_profiles
       pollInterval: 30s
       exportLabels:
@@ -433,6 +462,8 @@ observability:
       enableFileStorage: true
       deleteAfterRead:
         enabled: true
+        # Nebius O11y agent fork option; not part of upstream filelogreceiver.
+        # Files are deleted only after they have not been modified for at least this duration.
         minAge: 15m
 securityProfilesOperator:
   enabled: true

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -185,10 +185,12 @@ observability:
           remediateLastFailure: true
       values:
         enableFileStorage: true
+        useGoMemLimit: true
         jailLogs:
           enabled: true
           pollInterval: 30s
           enableFileStorage: true
+          useGoMemLimit: true
           deleteAfterRead:
             enabled: false
             # Nebius O11y agent fork option; not part of upstream filelogreceiver.
@@ -230,6 +232,7 @@ observability:
           remediateLastFailure: true
       values:
         enableFileStorage: true
+        useGoMemLimit: true
         resources:
           requests:
             memory: 128Mi
@@ -435,8 +438,8 @@ observability:
           cpu: 500m
         limits:
           memory: 1Gi
-      nebiusO11yAgentVersion: 2.0.10
       useGoMemLimit: true
+      nebiusO11yAgentVersion: 2.0.10
       metricsEndpoint: http://vmsingle-metrics-victoria-metrics-k8s-stack:8428/opentelemetry/v1/metrics
       metricsExporterTimeout: 15s
       # These values are rendered as exporter sending_queue.batch settings.


### PR DESCRIPTION
## Problem

### 1. Insufficient resource usage

OpenTelemetry collectors could use Go runtime defaults that did not match their Kubernetes resource requests/limits, making CPU and memory behavior less predictable.

### 2. Slowing down of jail listing on big clusters

Jail logs and NCCL profile files could also accumulate after ingestion, and telemetry could be dropped during collector restarts or exporter backpressure.

## Solution

1. Derive `GOMAXPROCS` and `GOMEMLIMIT` from collector resources across logs, jail logs, events, and NCCL profiles.

2. Add file-backed exporter queues with queue-side batching, enable delete-after-read for jail logs/NCCL profiles, and make `/mnt/jail` writable only when deletion is enabled. Standardize collector config on `useGoMemLimit`.

## Testing

### Helm unit tests

Ran Helm unit tests:

`helm unittest helm/soperator-fluxcd`

Result: 29 suites passed, 107 tests passed. Coverage includes Go runtime env rendering, file storage toggles, exporter queue settings, delete-after-read behavior, `/mnt/jail` readOnly behavior, and values override paths.

### Dev cluster

Checking with the following script:
```bash
dir="/opt/soperator-outputs"
now=$(date +%s)

find "$dir" -type f -print0 |
while IFS= read -r -d '' file; do
  mtime=$(stat -c %Y "$file")
  age=$((now - mtime))
  printf '%10s seconds  %s\n' "$age" "$file"
done |
sort -n |
awk -F '\t' '{printf "%10s seconds  %s\n", $1, $2}'
```

Log files older than 5m got deleted by collector:
```
Every 10.0s: bash ./checkage.sh | tail                                                                               soperator-login-0: Fri Jun 26 16:33:58 2026

       185 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_nvlink.24379295-0dd6-472e-8716-328135bfc698.out seconds
       185 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_nvlink.bf6ac24b-4b91-41d1-ad81-b68b09a8ee3b.out seconds
       185 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_topo.24379295-0dd6-472e-8716-328135bfc698.out seconds
       185 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_topo.bf6ac24b-4b91-41d1-ad81-b68b09a8ee3b.out seconds
       305 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi.3333fed0-3eb0-4acc-8db0-17dc7040b551.out seconds
       305 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi.9019c68f-bf33-4d12-855f-a0140dcf67c7.out seconds
       305 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_nvlink.3333fed0-3eb0-4acc-8db0-17dc7040b551.out seconds
       305 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_nvlink.9019c68f-bf33-4d12-855f-a0140dcf67c7.out seconds
       305 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_topo.3333fed0-3eb0-4acc-8db0-17dc7040b551.out seconds
       305 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_topo.9019c68f-bf33-4d12-855f-a0140dcf67c7.out seconds

#

Every 10.0s: bash ./checkage.sh | tail                                                                               soperator-login-0: Fri Jun 26 16:34:08 2026

        77 seconds  /opt/soperator-outputs/slurm_scripts/worker-0.boot_disk_full.hc_program.out seconds
        77 seconds  /opt/soperator-outputs/slurm_scripts/worker-0.job_tmpfs_delete_leftover.hc_program.out seconds
        77 seconds  /opt/soperator-outputs/slurm_scripts/worker-1.boot_disk_full.hc_program.out seconds
        77 seconds  /opt/soperator-outputs/slurm_scripts/worker-1.job_tmpfs_delete_leftover.hc_program.out seconds
       195 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi.24379295-0dd6-472e-8716-328135bfc698.out seconds
       195 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi.bf6ac24b-4b91-41d1-ad81-b68b09a8ee3b.out seconds
       195 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_nvlink.24379295-0dd6-472e-8716-328135bfc698.out seconds
       195 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_nvlink.bf6ac24b-4b91-41d1-ad81-b68b09a8ee3b.out seconds
       195 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_topo.24379295-0dd6-472e-8716-328135bfc698.out seconds
       195 seconds  /opt/soperator-outputs/health_checker_cmd_stdout/nvidia_smi_topo.bf6ac24b-4b91-41d1-ad81-b68b09a8ee3b.out seconds
```

while fallback `soperator-outputs-cleaner` removed no files as it's configured to delete files older than 1h:
```
2026-06-26T18:30:01+02:00 + echo 'Cleaning old Soperator outputs'
2026-06-26T18:30:01+02:00 Cleaning old Soperator outputs
2026-06-26T18:30:01+02:00 + find /mnt/jail/opt/soperator-outputs -type f -mmin +60 -print -delete
2026-06-26T18:30:01+02:00 + [[ -n /opt/soperator-outputs/nccl_profiles ]]
2026-06-26T18:30:01+02:00 + clean_sncclprecon_dump_dirs
2026-06-26T18:30:01+02:00 + [[ /opt/soperator-outputs/nccl_profiles != /* ]]
2026-06-26T18:30:01+02:00 + [[ /opt/soperator-outputs/nccl_profiles == \/ ]]
2026-06-26T18:30:01+02:00 + local dump_dir=/mnt/jail/opt/soperator-outputs/nccl_profiles
2026-06-26T18:30:01+02:00 + [[ ! -d /mnt/jail/opt/soperator-outputs/nccl_profiles ]]
2026-06-26T18:30:01+02:00 + echo 'Cleaning empty NCCL Inspector Profiling dump job directories in /mnt/jail/opt/soperator-outputs/nccl_profiles'
2026-06-26T18:30:01+02:00 Cleaning empty NCCL Inspector Profiling dump job directories in /mnt/jail/opt/soperator-outputs/nccl_profiles
2026-06-26T18:30:01+02:00 + find /mnt/jail/opt/soperator-outputs/nccl_profiles -mindepth 1 -maxdepth 1 -type d -print0
2026-06-26T18:30:01+02:00 + IFS=
2026-06-26T18:30:01+02:00 + read -r -d '' job_dir
```

## Release Notes

Feature: OpenTelemetry collectors now use resource-aware Go runtime limits, persistent exporter queues, and optional cleanup of jail logs/NCCL profiles after ingestion. 

Breaking: Collector values now use `useGoMemLimit`; NCCL queue settings moved to `sendingQueue.queueSize` and `sendingQueue.numConsumers`.