### PR TITLE
NOTASK: added an updateStrategy block

### DIFF
--- a/helm/slurm-cluster-storage/templates/accounting-mount-daemonset.yaml
+++ b/helm/slurm-cluster-storage/templates/accounting-mount-daemonset.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "slurm-cluster-storage.volume.accounting.mount" . }}
 spec:
+  {{- with .Values.storage.accounting.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       slurm: {{ include "slurm-cluster-storage.volume.accounting.mount" . }}

--- a/helm/slurm-cluster-storage/templates/controller-spool-mount-daemonset.yaml
+++ b/helm/slurm-cluster-storage/templates/controller-spool-mount-daemonset.yaml
@@ -4,6 +4,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "slurm-cluster-storage.volume.controller-spool.mount" . }}
 spec:
+  {{- with .Values.storage.controllerSpool.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       slurm: {{ include "slurm-cluster-storage.volume.controller-spool.mount" . }}

--- a/helm/slurm-cluster-storage/templates/jail-mount-daemonset.yaml
+++ b/helm/slurm-cluster-storage/templates/jail-mount-daemonset.yaml
@@ -4,6 +4,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "slurm-cluster-storage.volume.jail.mount" . }}
 spec:
+  {{- with .Values.storage.jail.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       slurm: {{ include "slurm-cluster-storage.volume.jail.mount" . }}

--- a/helm/slurm-cluster-storage/templates/jail-submounts-mount-daemonset.yaml
+++ b/helm/slurm-cluster-storage/templates/jail-submounts-mount-daemonset.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   name: {{ include "slurm-cluster-storage.volume.jail-submount.mount" . }}
 spec:
+  {{- with $.Values.storage.jail.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       slurm: {{ include "slurm-cluster-storage.volume.jail-submount.mount" . }}

--- a/helm/slurm-cluster-storage/tests/update-strategy_test.yaml
+++ b/helm/slurm-cluster-storage/tests/update-strategy_test.yaml
@@ -1,0 +1,80 @@
+suite: test mount DaemonSet updateStrategy
+templates:
+  - templates/jail-mount-daemonset.yaml
+  - templates/accounting-mount-daemonset.yaml
+  - templates/controller-spool-mount-daemonset.yaml
+  - templates/jail-submounts-mount-daemonset.yaml
+tests:
+  - it: should render default RollingUpdate strategy on the jail mount DaemonSet
+    template: templates/jail-mount-daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.updateStrategy.rollingUpdate.maxUnavailable
+          value: 20%
+
+  - it: should override the jail mount update strategy
+    template: templates/jail-mount-daemonset.yaml
+    set:
+      storage:
+        jail:
+          updateStrategy:
+            type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+
+  - it: should omit updateStrategy when unset
+    template: templates/jail-mount-daemonset.yaml
+    set:
+      storage:
+        jail:
+          updateStrategy: null
+    asserts:
+      - isNull:
+          path: spec.updateStrategy
+
+  - it: should render the strategy on the accounting mount DaemonSet
+    template: templates/accounting-mount-daemonset.yaml
+    set:
+      volume:
+        accounting:
+          enabled: true
+      storage:
+        accounting:
+          updateStrategy:
+            type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+
+  - it: should render the default strategy on the controller-spool mount DaemonSet
+    template: templates/controller-spool-mount-daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.updateStrategy.rollingUpdate.maxUnavailable
+          value: 20%
+
+  - it: should render the jail strategy on jail-submount DaemonSets
+    template: templates/jail-submounts-mount-daemonset.yaml
+    set:
+      volume:
+        jailSubMounts:
+          - name: mlperf-sd
+            size: 1500Gi
+            filestoreDeviceName: mlperf-sd
+      storage:
+        jail:
+          updateStrategy:
+            type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete

--- a/helm/slurm-cluster-storage/values.yaml
+++ b/helm/slurm-cluster-storage/values.yaml
@@ -41,6 +41,11 @@ storage:
     #   - key: nvidia.com/gpu
     #     operator: Exists
     #     effect: NoSchedule
+    # Update strategy for the mount DaemonSet
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 20%
 
   controllerSpool:
     matchExpressions: []
@@ -54,6 +59,11 @@ storage:
     #   - key: nvidia.com/gpu
     #     operator: Exists
     #     effect: NoSchedule
+    # Update strategy for the mount DaemonSet
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 20%
 
   jail:
     matchExpressions: []
@@ -67,3 +77,8 @@ storage:
     #   - key: nvidia.com/gpu
     #     operator: Exists
     #     effect: NoSchedule
+    # Update strategy for the jail and jail-submounts mount DaemonSets
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 20%


### PR DESCRIPTION
## Testing
- make helmtest

## Release Notes
added an updateStrategy block (default RollingUpdate with maxUnavailable: 20%) under storage.accounting, storage.controllerSpool, and storage.jail.