### PR TITLE
SCHED-1618/SCHED-1983/SCHED-1756: Destroy leftover e2e state with saved Terraform bundle

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: "false"
         type: string
+      skip_destroy:
+        description: "Skip Terraform Destroy to leave leftover state (for testing cleanup-previous)"
+        required: false
+        default: "false"
+        type: string
 
 permissions:
   contents: read
@@ -598,7 +603,7 @@ jobs:
           retention-days: 7
 
       - name: Terraform Destroy
-        if: always()
+        if: always() && inputs.skip_destroy != 'true'
         timeout-minutes: 30
         env:
           # Opt in to terraform DEBUG logging only for the destroy flow.
@@ -620,6 +625,16 @@ jobs:
 
           bin/e2e destroy
 
+      - name: Skip Terraform Destroy (leftover-state simulation)
+        if: always() && inputs.skip_destroy == 'true'
+        shell: bash
+        run: |
+          {
+            echo "### Terraform Destroy skipped"
+            echo "\`skip_destroy=true\` — leaving the cluster, terraform state, and the saved bundle in place."
+            echo "The next run on this project will exercise \`cleanup-previous\` against this leftover state."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Terraform Destroy debug log
         if: always()
         uses: actions/upload-artifact@v6
@@ -633,7 +648,7 @@ jobs:
           compression-level: 9
 
       - name: Force cleanup compute instances on failure
-        if: failure()
+        if: failure() && inputs.skip_destroy != 'true'
         shell: bash
         run: |
           echo "=== Node groups state before cleanup ==="

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -344,6 +344,23 @@ jobs:
           bin/e2e check-capacity 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Cleanup previous Terraform state
+        timeout-minutes: 30
+        run: |
+          cd ${{ env.PATH_TO_INSTALLATION }}
+          source .envrc
+          cd -
+
+          aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+          aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+          aws configure set region $NEBIUS_REGION
+          aws configure set endpoint_url https://storage.$NEBIUS_REGION.nebius.cloud:443
+
+          # Destroy any leftover resources from a previous run using the saved terraform bundle
+          # (the exact code that created the state), falling back to the current checkout.
+          # Runs before init so the new run starts from a clean, empty state.
+          bin/e2e cleanup-previous
+
       - name: Terraform Init
         timeout-minutes: 30
         run: |

--- a/cmd/e2e/main.go
+++ b/cmd/e2e/main.go
@@ -19,7 +19,7 @@ func main() {
 	log.SetFlags(0)
 
 	if len(os.Args) < 2 {
-		_, _ = fmt.Fprintf(os.Stderr, "Usage: e2e <init|apply|destroy|check-capacity|acceptance>\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: e2e <check-capacity|cleanup-previous|init|apply|destroy|acceptance>\n")
 		os.Exit(2)
 	}
 
@@ -34,6 +34,9 @@ func main() {
 	switch os.Args[1] {
 	case "check-capacity":
 		err = runCheckCapacity(ctx, profile)
+	case "cleanup-previous":
+		cfg := loadFullConfig(profile)
+		err = e2e.RunCleanupPrevious(ctx, cfg)
 	case "init":
 		cfg := loadFullConfig(profile)
 		err = e2e.RunInit(ctx, cfg)
@@ -47,7 +50,7 @@ func main() {
 		cfg := loadFullConfig(profile)
 		err = e2e.RunAcceptance(ctx, cfg)
 	default:
-		_, _ = fmt.Fprintf(os.Stderr, "Unknown command: %s\nUsage: e2e <init|apply|destroy|check-capacity|acceptance>\n", os.Args[1])
+		_, _ = fmt.Fprintf(os.Stderr, "Unknown command: %s\nUsage: e2e <check-capacity|cleanup-previous|init|apply|destroy|acceptance>\n", os.Args[1])
 		os.Exit(2)
 	}
 	if err != nil {

--- a/internal/e2e/cleanup_previous.go
+++ b/internal/e2e/cleanup_previous.go
@@ -1,0 +1,102 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// RunCleanupPrevious destroys whatever infrastructure a previous e2e run left in
+// the shared remote state, before the current run inits and applies.
+//
+// Stage A destroys with the saved terraform bundle — the exact code that created the leftover state
+// — which is immune to provider/schema drift between branches.
+// If no bundle exists, or its destroy fails, Stage B falls back to a destroy with the current checkout.
+func RunCleanupPrevious(ctx context.Context, cfg Config) error {
+	if bundleExists(ctx) {
+		if err := cleanupFromBundle(ctx, cfg); err != nil {
+			log.Printf("Saved-bundle destroy failed: %v", err)
+			log.Printf("Falling back to current checkout")
+		} else {
+			deleteBundle(ctx)
+			return nil
+		}
+	} else {
+		log.Print("No saved terraform bundle, cleaning up leftover state with the current checkout")
+	}
+
+	// Stage B: current checkout
+	tf, varFilePath, cleanup, err := Init(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if err := stripHelmThenDestroy(ctx, tf, varFilePath); err != nil {
+		return fmt.Errorf("current-checkout cleanup destroy: %w", err)
+	}
+	deleteBundle(ctx)
+	return nil
+}
+
+// cleanupFromBundle:
+// - downloads and extracts the saved bundle
+// - inits terraform against the cached providers/modules (offline)
+// - selects the e2e-test workspace, and
+// - destroys the leftover resources recorded in the shared remote state.
+func cleanupFromBundle(ctx context.Context, cfg Config) error {
+	workdir, cleanup, err := downloadAndExtractBundle(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	execPath, err := exec.LookPath("terraform")
+	if err != nil {
+		return fmt.Errorf("find terraform binary: %w", err)
+	}
+	tf, err := tfexec.NewTerraform(workdir, execPath)
+	if err != nil {
+		return fmt.Errorf("create terraform executor for bundle: %w", err)
+	}
+	tf.SetStdout(os.Stdout)
+	tf.SetStderr(os.Stderr)
+
+	// -reconfigure: the bundle carries a .terraform backend cache; reconfigure against the current AWS creds
+	// (from the process env) without prompting for state migration.
+	if err := tf.Init(ctx, tfexec.Reconfigure(true)); err != nil {
+		return fmt.Errorf("terraform init (bundle): %w", err)
+	}
+	if err := workspaceSelectOrNew(ctx, tf, "e2e-test"); err != nil {
+		return fmt.Errorf("select workspace (bundle): %w", err)
+	}
+	logState(ctx, tf)
+
+	varFilePath := filepath.Join(workdir, "e2e-override.tfvars.json")
+	return stripHelmThenDestroy(ctx, tf, varFilePath)
+}
+
+// stripHelmThenDestroy empties the backups bucket, removes all helm_release resources from state,
+// then runs terraform destroy.
+//
+// Removing helm_release first is what makes a leftover-cluster destroy robust:
+// helm_release is the only resource type that depends on the cluster host (there are no kubernetes_* resources),
+// so once it is out of the plan terraform never needs to configure the helm provider and the destroy cannot wedge on
+// "Kubernetes cluster unreachable: no configuration has been provided" (SCHED-1618).
+// The helm-installed workloads are torn down when the cluster itself is destroyed.
+//
+// This is used only for cleaning up previous/leftover runs. The current run's
+// final destroy keeps the graceful destroyWithK8sRecovery path.
+func stripHelmThenDestroy(ctx context.Context, tf *tfexec.Terraform, varFilePath string) error {
+	bestEffortEmptyBackupsBucket(ctx)
+	removeHelmReleasesFromState(ctx, tf)
+	if err := tf.Destroy(ctx, tfexec.VarFile(varFilePath)); err != nil {
+		return fmt.Errorf("terraform destroy: %w", err)
+	}
+	return nil
+}

--- a/internal/e2e/destroy.go
+++ b/internal/e2e/destroy.go
@@ -32,7 +32,13 @@ func Destroy(ctx context.Context, cfg Config) error {
 
 	enableTFDestroyLogging(tf)
 
-	return destroyWithK8sRecovery(ctx, tf, varFilePath, cfg.Profile.NebiusProjectID)
+	if err := destroyWithK8sRecovery(ctx, tf, varFilePath, cfg.Profile.NebiusProjectID); err != nil {
+		return err
+	}
+
+	// State is now empty; drop the saved bundle so the next fresh run has nothing to clean up.
+	deleteBundle(ctx)
+	return nil
 }
 
 func enableTFDestroyLogging(tf *tfexec.Terraform) {

--- a/internal/e2e/e2e_init.go
+++ b/internal/e2e/e2e_init.go
@@ -2,20 +2,27 @@ package e2e
 
 import (
 	"context"
+	"log"
 )
 
+// RunInit prepares the current checkout for apply: it runs terraform init and
+// selects the e2e-test workspace, then saves the terraform bundle to S3 so the
+// next run can destroy whatever this run creates with matching code. The
+// destroy of any leftover state from a previous run is handled earlier, by the
+// separate `cleanup-previous` command.
 func RunInit(ctx context.Context, cfg Config) error {
-	tf, varFilePath, cleanup, err := Init(ctx, cfg)
+	_, _, cleanup, err := Init(ctx, cfg)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	// Recover from the SCHED-1401 leak pattern: a previous run's terraform
-	// destroy failed with BucketNotEmpty and left the backups bucket (plus
-	// objects) behind. On that next run cleanup_bucket is already out of
-	// state so tf destroy can't re-empty the bucket; empty it here first.
-	bestEffortEmptyBackupsBucket(ctx)
-
-	return destroyWithK8sRecovery(ctx, tf, varFilePath, cfg.Profile.NebiusProjectID)
+	// Save the bundle before the deferred cleanup removes the override var file,
+	// and before apply creates any resource. Best-effort: a failed upload only
+	// degrades the next run to a current-checkout cleanup, it must not block this
+	// run.
+	if err := saveBundle(ctx, cfg); err != nil {
+		log.Printf("WARNING: failed to save terraform bundle, next run will fall back to current-checkout cleanup: %v", err)
+	}
+	return nil
 }

--- a/internal/e2e/tf_bundle.go
+++ b/internal/e2e/tf_bundle.go
@@ -1,0 +1,164 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// tfBundleS3Key is the object key, within the same bucket that holds the e2e terraform state.
+// A single object is overwritten on each run.
+const tfBundleS3Key = "e2e-tf-bundle/e2e-test/bundle.tar.gz"
+
+// bundleBucket returns the S3 bucket used for the e2e terraform state.
+func bundleBucket() (string, error) {
+	bucket := os.Getenv("NEBIUS_BUCKET_NAME")
+	if bucket == "" {
+		return "", fmt.Errorf("NEBIUS_BUCKET_NAME is not set")
+	}
+	return bucket, nil
+}
+
+// terraformRepoRoot returns the root of the checked-out terraform repository (.../terraform-repo).
+// PathToInstallation points at <repo>/soperator/installations/example, three levels below the repo root.
+func terraformRepoRoot(cfg Config) string {
+	return filepath.Clean(filepath.Join(cfg.PathToInstallation, "..", "..", ".."))
+}
+
+// saveBundle tars the whole terraform-repo working tree — sources, the .terraform provider/module cache,
+// the lockfile, and the generated var/backend files — and uploads it to S3.
+func saveBundle(ctx context.Context, cfg Config) error {
+	bucket, err := bundleBucket()
+	if err != nil {
+		return err
+	}
+
+	repoRoot := terraformRepoRoot(cfg)
+	parent := filepath.Dir(repoRoot)
+	repoName := filepath.Base(repoRoot)
+
+	archive, err := os.CreateTemp("", "e2e-tf-bundle-*.tar.gz")
+	if err != nil {
+		return fmt.Errorf("create temp bundle file: %w", err)
+	}
+	archivePath := archive.Name()
+	_ = archive.Close()
+	defer func() { _ = os.Remove(archivePath) }()
+
+	tarCmd := exec.CommandContext(ctx, "tar",
+		"-C", parent,
+		"--exclude", filepath.Join(repoName, ".git"),
+		"-czf", archivePath,
+		repoName,
+	)
+	if out, err := tarCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tar terraform bundle: %w\nOutput: %s", err, string(out))
+	}
+
+	dst := fmt.Sprintf("s3://%s/%s", bucket, tfBundleS3Key)
+	log.Printf("Uploading terraform bundle (%s) to %s", bundleArchiveSize(archivePath), dst)
+	if out, err := exec.CommandContext(ctx, "aws", "s3", "cp", archivePath, dst).CombinedOutput(); err != nil {
+		return fmt.Errorf("upload terraform bundle to %s: %w\nOutput: %s", dst, err, string(out))
+	}
+	log.Printf("Terraform bundle uploaded to %s", dst)
+	return nil
+}
+
+// bundleExists reports whether a saved terraform bundle is present in S3.
+// Any error (missing object, auth failure, missing CLI) is treated as "no usable bundle".
+func bundleExists(ctx context.Context) bool {
+	bucket, err := bundleBucket()
+	if err != nil {
+		log.Printf("Cannot check for terraform bundle: %v", err)
+		return false
+	}
+	if err := exec.CommandContext(ctx, "aws", "s3api", "head-object",
+		"--bucket", bucket, "--key", tfBundleS3Key).Run(); err != nil {
+		log.Printf("No saved terraform bundle at s3://%s/%s", bucket, tfBundleS3Key)
+		return false
+	}
+	return true
+}
+
+// deleteBundle removes the saved terraform bundle from S3. It is best-effort: failures are logged and swallowed.
+func deleteBundle(ctx context.Context) {
+	bucket, err := bundleBucket()
+	if err != nil {
+		log.Printf("Skipping terraform bundle delete: %v", err)
+		return
+	}
+	dst := fmt.Sprintf("s3://%s/%s", bucket, tfBundleS3Key)
+	if out, err := exec.CommandContext(ctx, "aws", "s3", "rm", dst).CombinedOutput(); err != nil {
+		log.Printf("Best-effort delete of terraform bundle %s failed: %v\nOutput: %s", dst, err, string(out))
+		return
+	}
+	log.Printf("Deleted terraform bundle %s", dst)
+}
+
+// downloadAndExtractBundle downloads the saved terraform bundle and extracts it into a fresh temp directory,
+// returning the extracted installation directory (where terraform should run)
+// and a cleanup func that removes the temp tree.
+func downloadAndExtractBundle(ctx context.Context, cfg Config) (workdir string, cleanup func(), err error) {
+	bucket, err := bundleBucket()
+	if err != nil {
+		return "", nil, err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "e2e-tf-bundle-extract-")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp extract dir: %w", err)
+	}
+	cleanup = func() { _ = os.RemoveAll(tmpDir) }
+
+	archivePath := filepath.Join(tmpDir, "bundle.tar.gz")
+	src := fmt.Sprintf("s3://%s/%s", bucket, tfBundleS3Key)
+	if out, err := exec.CommandContext(ctx, "aws", "s3", "cp", src, archivePath).CombinedOutput(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("download terraform bundle from %s: %w\nOutput: %s", src, err, string(out))
+	}
+	log.Printf("Downloaded terraform bundle (%s) from %s", bundleArchiveSize(archivePath), src)
+
+	if out, err := exec.CommandContext(ctx, "tar", "-C", tmpDir, "-xzf", archivePath).CombinedOutput(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("extract terraform bundle: %w\nOutput: %s", err, string(out))
+	}
+
+	repoRoot := terraformRepoRoot(cfg)
+	relInstall, err := filepath.Rel(repoRoot, cfg.PathToInstallation)
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("resolve installation path relative to repo root: %w", err)
+	}
+	workdir = filepath.Join(tmpDir, filepath.Base(repoRoot), relInstall)
+	if _, err := os.Stat(workdir); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("extracted bundle missing installation dir %s: %w", workdir, err)
+	}
+	return workdir, cleanup, nil
+}
+
+// bundleArchiveSize returns a human-readable size of the bundle archive,
+// or "unknown size" if it can't be stat'd.
+func bundleArchiveSize(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "unknown size"
+	}
+	return formatBytes(info.Size())
+}
+
+func formatBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/e2e/tf_bundle_test.go
+++ b/internal/e2e/tf_bundle_test.go
@@ -1,0 +1,37 @@
+package e2e
+
+import "testing"
+
+func TestTerraformRepoRoot(t *testing.T) {
+	cfg := Config{PathToInstallation: "/ws/terraform-repo/soperator/installations/example"}
+	got := terraformRepoRoot(cfg)
+	const want = "/ws/terraform-repo"
+	if got != want {
+		t.Fatalf("terraformRepoRoot = %q, want %q", got, want)
+	}
+}
+
+func TestBundleBucket(t *testing.T) {
+	t.Setenv("NEBIUS_BUCKET_NAME", "tfstate-slurm-k8s-abc123")
+	got, err := bundleBucket()
+	if err != nil {
+		t.Fatalf("bundleBucket returned error: %v", err)
+	}
+	if got != "tfstate-slurm-k8s-abc123" {
+		t.Fatalf("bundleBucket = %q", got)
+	}
+}
+
+func TestBundleBucketUnset(t *testing.T) {
+	t.Setenv("NEBIUS_BUCKET_NAME", "")
+	if _, err := bundleBucket(); err == nil {
+		t.Fatal("expected error when NEBIUS_BUCKET_NAME is unset")
+	}
+}
+
+func TestTFBundleS3Key(t *testing.T) {
+	const want = "e2e-tf-bundle/e2e-test/bundle.tar.gz"
+	if tfBundleS3Key != want {
+		t.Fatalf("tfBundleS3Key = %q, want %q", tfBundleS3Key, want)
+	}
+}


### PR DESCRIPTION
## Problem

e2e runs share one remote Terraform state. When a previous run leaves resources behind (a leftover cluster), the next run on a different branch often can't destroy them:

- Provider source/schema drift between branches wedges `terraform init` and `destroy` (SCHED-1983, SCHED-1756).
- A leftover running cluster wedges `destroy` on the helm provider: `Kubernetes cluster unreachable: no configuration has been provided` (SCHED-1618).

Apply is then skipped, the cluster is orphaned, and the next run hits the same wall.

## Solution

- During `init`, save a self-contained Terraform bundle (the `terraform-repo` tree plus the `.terraform` provider/module cache, lockfile, and generated var/backend files, minus `.git`) to S3, next to the state it describes.
- New `cleanup-previous` command runs before `init` in CI. Stage A destroys leftover state with the saved bundle, the exact code that created it, so it is immune to cross-branch provider drift. Stage B falls back to a current-checkout destroy when there is no bundle or Stage A fails.
- Both stages remove `helm_release` from state before destroying, so Terraform never configures the helm provider and cannot wedge on "Kubernetes cluster unreachable" (SCHED-1618).
- `init` no longer runs the leftover-destroy itself; the current run's final `destroy` deletes the saved bundle once state is empty.

## Testing

- Unit tests for the bundle bucket/path helpers; `go build ./cmd/e2e/...` passes.
- E2E run (success path): https://github.com/nebius/soperator/actions/runs/28397165264
- E2E run (restore path): https://github.com/nebius/soperator/actions/runs/28446130527/job/84295929925

## Release Notes

None (internal e2e/CI tooling).
