### PR TITLE
SCHED-1128: Get rid of AccountingStorageUser

### DIFF
--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -405,7 +405,6 @@ func generateSlurmConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
 			naming.BuildServiceName(consts.ComponentTypeAccounting, cluster.Name),
 			cluster.Namespace,
 		))
-		res.AddProperty("AccountingStorageUser", consts.HostnameAccounting)
 		res.AddProperty("AccountingStoragePort", consts.DefaultAccountingPort)
 		res.AddProperty("JobCompType", "jobcomp/none")
 


### PR DESCRIPTION
## Release Notes
Get rid of AccountingStorageUserusers. It was deprecated in slurm 25.11.
