### PR TITLE
SCHED-1906: Use upstream chart's `useGOMEMLIMIT` only

### DIFF
--- a/docs/logs-pipeline.md
+++ b/docs/logs-pipeline.md
@@ -70,9 +70,9 @@ The log collectors set Go runtime limits from their configured pod resources:
 
 - `GOMAXPROCS` is derived from CPU limits when present, otherwise CPU requests.
 - CPU quantities are rounded up to a positive whole number: `500m` becomes `1`, `2` stays `2`.
-- When `useGOMEMLIMIT` or `useGoMemLimit` is enabled, `GOMEMLIMIT` is derived from memory limits when present, otherwise memory requests.
-- `GOMEMLIMIT` targets about 85% of the selected memory value and rounds up to a whole Go memory unit. For example, `200Mi` becomes `170MiB`, `128Mi` becomes `109MiB`, and `500Gi` becomes `425GiB`.
-- When `spec.values.useGOMEMLIMIT` is false, no `GOMEMLIMIT` environment variable is configured by Soperator.
+- When `useGoMemLimit` is enabled, the upstream OpenTelemetry collector chart derives `GOMEMLIMIT` from `resources.limits.memory`.
+- Upstream `GOMEMLIMIT` targets about 80% of the memory limit and does not fall back to memory requests.
+- When `spec.values.useGOMEMLIMIT` is false, the upstream chart does not inject a `GOMEMLIMIT` environment variable.
 
 This applies to the system logs, jail logs, and events collectors. Override values that replace the collector chart values are responsible for setting their own runtime environment.
 

--- a/docs/metrics-pipeline.md
+++ b/docs/metrics-pipeline.md
@@ -137,14 +137,14 @@ Note: Production scraping requires a ServiceMonitor with proper RBAC authenticat
 - Purpose: Reads NCCL profile files from the jail filesystem and exports metrics through an OpenTelemetry collector
 - Deployment: Single deployment on system nodes by default, or DaemonSet on worker nodes with `observability.ncclProfiles.values.mode: nodeLocal`
 - Storage: Uses file storage under `/var/lib/otelcol` when `observability.ncclProfiles.values.enableFileStorage` is enabled
-- Runtime limits: Sets `GOMAXPROCS` and, when `useGoMemLimit` is enabled, `GOMEMLIMIT` from `observability.ncclProfiles.values.resources`
+- Runtime limits: Sets `GOMAXPROCS` from `observability.ncclProfiles.values.resources`; passes `useGoMemLimit` through to upstream `useGOMEMLIMIT`
 
 The NCCL profiles collector follows the same Go runtime sizing rules as the log collectors:
 
 - CPU limits are preferred over CPU requests; values are rounded up to at least one process (`500m` -> `1`, `2` -> `2`).
-- Memory limits are preferred over memory requests.
-- `GOMEMLIMIT` targets about 85% of selected memory and rounds up to whole Go units (`200Mi` -> `170MiB`, `500Gi` -> `425GiB`).
-- When `spec.values.useGOMEMLIMIT` is false, no `GOMEMLIMIT` environment variable is configured by Soperator.
+- When `useGoMemLimit` is enabled, the upstream OpenTelemetry collector chart derives `GOMEMLIMIT` from `resources.limits.memory`.
+- Upstream `GOMEMLIMIT` targets about 80% of the memory limit and does not fall back to memory requests.
+- When `spec.values.useGOMEMLIMIT` is false, the upstream chart does not inject a `GOMEMLIMIT` environment variable.
 
 ### Metrics Processing & Storage
 

--- a/helm/soperator-fluxcd/templates/_helpers.tpl
+++ b/helm/soperator-fluxcd/templates/_helpers.tpl
@@ -80,77 +80,15 @@ Convert a Kubernetes CPU quantity to a positive GOMAXPROCS value.
 {{- end -}}
 
 {{/*
-Convert a Kubernetes memory quantity to bytes.
+Render GOMAXPROCS for opentelemetry-collector from container resources.
 */}}
-{{- define "soperator-fluxcd.memoryQuantityToBytes" -}}
-{{- $quantity := toString . | trim -}}
-{{- if not (regexMatch "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|Pi|Ei|[kKMGTP])?$" $quantity) -}}
-{{- fail (printf "unsupported memory quantity %q; use bytes, decimal units (500G), or binary units (500Gi)" $quantity) -}}
-{{- end -}}
-{{- $number := regexFind "^[0-9]+(\\.[0-9]+)?" $quantity -}}
-{{- $suffix := regexReplaceAll "^[0-9]+(\\.[0-9]+)?" $quantity "" -}}
-{{- $multiplier := 1 -}}
-{{- if eq $suffix "Ki" -}}
-{{- $multiplier = 1024 -}}
-{{- else if eq $suffix "Mi" -}}
-{{- $multiplier = 1048576 -}}
-{{- else if eq $suffix "Gi" -}}
-{{- $multiplier = 1073741824 -}}
-{{- else if eq $suffix "Ti" -}}
-{{- $multiplier = 1099511627776 -}}
-{{- else if or (eq $suffix "k") (eq $suffix "K") -}}
-{{- $multiplier = 1000 -}}
-{{- else if eq $suffix "M" -}}
-{{- $multiplier = 1000000 -}}
-{{- else if eq $suffix "G" -}}
-{{- $multiplier = 1000000000 -}}
-{{- else if eq $suffix "T" -}}
-{{- $multiplier = 1000000000000 -}}
-{{- end -}}
-{{- if regexMatch "^[0-9]+$" $number -}}
-{{- mul ($number | int) $multiplier -}}
-{{- else -}}
-{{- int (mulf ($number | float64) ($multiplier | float64)) -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return N percent of a Kubernetes memory quantity as a GOMEMLIMIT value, rounded up to MiB.
-*/}}
-{{- define "soperator-fluxcd.memoryQuantityPercentGoMemLimit" -}}
-{{- $bytes := include "soperator-fluxcd.memoryQuantityToBytes" .quantity | int -}}
-{{- $percent := .percent | default 85 | int -}}
-{{- $mib := 1048576 -}}
-{{- $divisor := mul 100 $mib -}}
-{{- $whole := mul (div $bytes $divisor) $percent -}}
-{{- $remainder := mul (mod $bytes $divisor) $percent -}}
-{{- $roundedRemainder := div (add $remainder (sub $divisor 1)) $divisor -}}
-{{- $limitMiB := max 1 (add $whole $roundedRemainder) -}}
-{{- if eq (mod $limitMiB 1024) 0 -}}
-{{- printf "%dGiB" (div $limitMiB 1024) -}}
-{{- else -}}
-{{- printf "%dMiB" $limitMiB -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Render Go runtime env vars for opentelemetry-collector from container resources.
-*/}}
-{{- define "soperator-fluxcd.otelCollectorGoEnv" -}}
+{{- define "soperator-fluxcd.otelCollectorGoMaxProcsEnv" -}}
 {{- $resources := .resources | default dict -}}
 {{- $requests := get $resources "requests" | default dict -}}
 {{- $limits := get $resources "limits" | default dict -}}
 {{- $cpu := coalesce (get $limits "cpu") (get $requests "cpu") -}}
 - name: GOMAXPROCS
   value: {{ include "soperator-fluxcd.cpuQuantityToGOMAXPROCS" $cpu | quote }}
-{{- if .useGoMemLimit }}
-{{- $memory := coalesce (get $limits "memory") (get $requests "memory") -}}
-{{- if not $memory -}}
-{{- fail "GOMEMLIMIT is enabled but no resources.limits.memory or resources.requests.memory is configured" -}}
-{{- end }}
-- name: GOMEMLIMIT
-  value: {{ include "soperator-fluxcd.memoryQuantityPercentGoMemLimit" (dict "quantity" $memory "percent" 85) | quote }}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -141,7 +141,7 @@ spec:
       create: true
 
     extraEnvs:
-      {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $eventsValues.resources "useGoMemLimit" $eventsUseGoMemLimit) | nindent 6 }}
+      {{- include "soperator-fluxcd.otelCollectorGoMaxProcsEnv" (dict "resources" $eventsValues.resources) | nindent 6 }}
 
       - name: K8S_NODE_NAME
         valueFrom:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -155,7 +155,7 @@ spec:
       create: true
 
     extraEnvs:
-      {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $jailLogsValues.resources "useGoMemLimit" $jailLogsUseGoMemLimit) | nindent 6 }}
+      {{- include "soperator-fluxcd.otelCollectorGoMaxProcsEnv" (dict "resources" $jailLogsValues.resources) | nindent 6 }}
 
       {{- if .Values.observability.clusterId }}
       - name: CLUSTER_ID

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -181,7 +181,7 @@ spec:
       create: true
 
     extraEnvs:
-      {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $logsValues.resources "useGoMemLimit" $logsUseGoMemLimit) | nindent 6 }}
+      {{- include "soperator-fluxcd.otelCollectorGoMaxProcsEnv" (dict "resources" $logsValues.resources) | nindent 6 }}
 
       - name: K8S_NODE_NAME
         valueFrom:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-nccl-profiles.yaml
@@ -333,7 +333,7 @@ spec:
       create: true
 
     extraEnvs:
-      {{- include "soperator-fluxcd.otelCollectorGoEnv" (dict "resources" $values.resources "useGoMemLimit" $useGoMemLimit) | nindent 6 }}
+      {{- include "soperator-fluxcd.otelCollectorGoMaxProcsEnv" (dict "resources" $values.resources) | nindent 6 }}
 
     initContainers:
       - name: wait-jail-populated

--- a/helm/soperator-fluxcd/tests/opentelemetry_collector_go_runtime_test.yaml
+++ b/helm/soperator-fluxcd/tests/opentelemetry_collector_go_runtime_test.yaml
@@ -2,7 +2,7 @@ suite: test opentelemetry collector Go runtime env
 templates:
   - templates/opentelemetry-collector-logs.yaml
 tests:
-  - it: should derive GOMAXPROCS and GOMEMLIMIT from logs resources
+  - it: should derive GOMAXPROCS and enable upstream GOMEMLIMIT for logs
     set:
       observability.opentelemetry.logs.values.resources:
         requests:
@@ -16,23 +16,14 @@ tests:
           content:
             name: GOMAXPROCS
             value: "1"
-      - contains:
-          path: spec.values.extraEnvs
-          content:
-            name: GOMEMLIMIT
-            value: "170MiB"
       - equal:
           path: spec.values.useGOMEMLIMIT
           value: true
 
-  - it: should omit GOMEMLIMIT when useGoMemLimit is false
+  - it: should disable upstream GOMEMLIMIT when useGoMemLimit is false
     set:
       observability.opentelemetry.logs.values.useGoMemLimit: false
     asserts:
-      - notContains:
-          path: spec.values.extraEnvs
-          content:
-            name: GOMEMLIMIT
       - equal:
           path: spec.values.useGOMEMLIMIT
           value: false
@@ -41,7 +32,7 @@ suite: test opentelemetry collector events Go runtime env
 templates:
   - templates/opentelemetry-collector-events.yaml
 tests:
-  - it: should support whole-core CPU and large binary memory quantities
+  - it: should support whole-core CPU and enable upstream GOMEMLIMIT for events
     set:
       observability.opentelemetry.events.values.resources:
         requests:
@@ -55,16 +46,11 @@ tests:
           content:
             name: GOMAXPROCS
             value: "2"
-      - contains:
-          path: spec.values.extraEnvs
-          content:
-            name: GOMEMLIMIT
-            value: "425GiB"
       - equal:
           path: spec.values.useGOMEMLIMIT
           value: true
 
-  - it: should round fractional GOMEMLIMIT values up to MiB
+  - it: should enable upstream GOMEMLIMIT when enabled
     set:
       observability.opentelemetry.events.values.resources:
         requests:
@@ -73,16 +59,11 @@ tests:
         limits:
           memory: null
     asserts:
-      - contains:
-          path: spec.values.extraEnvs
-          content:
-            name: GOMEMLIMIT
-            value: "109MiB"
       - equal:
           path: spec.values.useGOMEMLIMIT
           value: true
 
-  - it: should omit GOMEMLIMIT when useGoMemLimit is false
+  - it: should disable upstream GOMEMLIMIT when useGoMemLimit is false
     set:
       observability.opentelemetry.events.values.useGoMemLimit: false
       observability.opentelemetry.events.values.resources:
@@ -92,10 +73,6 @@ tests:
         limits:
           memory: null
     asserts:
-      - notContains:
-          path: spec.values.extraEnvs
-          content:
-            name: GOMEMLIMIT
       - equal:
           path: spec.values.useGOMEMLIMIT
           value: false
@@ -104,7 +81,7 @@ suite: test opentelemetry collector jail logs Go runtime env
 templates:
   - templates/opentelemetry-collector-jail-logs.yaml
 tests:
-  - it: should use jail logs resources for Go runtime env
+  - it: should use jail logs resources for GOMAXPROCS and enable upstream GOMEMLIMIT
     set:
       observability.opentelemetry.logs.values.resources:
         requests:
@@ -124,23 +101,14 @@ tests:
           content:
             name: GOMAXPROCS
             value: "1"
-      - contains:
-          path: spec.values.extraEnvs
-          content:
-            name: GOMEMLIMIT
-            value: "170MiB"
       - equal:
           path: spec.values.useGOMEMLIMIT
           value: true
 
-  - it: should omit GOMEMLIMIT when jailLogs.useGoMemLimit is false
+  - it: should disable upstream GOMEMLIMIT when jailLogs.useGoMemLimit is false
     set:
       observability.opentelemetry.logs.values.jailLogs.useGoMemLimit: false
     asserts:
-      - notContains:
-          path: spec.values.extraEnvs
-          content:
-            name: GOMEMLIMIT
       - equal:
           path: spec.values.useGOMEMLIMIT
           value: false
@@ -149,7 +117,7 @@ suite: test opentelemetry collector NCCL profiles Go runtime env
 templates:
   - templates/opentelemetry-collector-nccl-profiles.yaml
 tests:
-  - it: should derive Go runtime env from NCCL collector resources
+  - it: should derive GOMAXPROCS and enable upstream GOMEMLIMIT for NCCL collector
     set:
       observability.enabled: true
       observability.ncclProfiles.enabled: true
@@ -168,16 +136,11 @@ tests:
           content:
             name: GOMAXPROCS
             value: "2"
-      - contains:
-          path: spec.values.extraEnvs
-          content:
-            name: GOMEMLIMIT
-            value: "425GiB"
       - equal:
           path: spec.values.useGOMEMLIMIT
           value: true
 
-  - it: should omit GOMEMLIMIT when useGoMemLimit is false
+  - it: should disable upstream GOMEMLIMIT when useGoMemLimit is false
     set:
       observability.enabled: true
       observability.ncclProfiles.enabled: true
@@ -191,10 +154,6 @@ tests:
           content:
             name: GOMAXPROCS
             value: "1"
-      - notContains:
-          path: spec.values.extraEnvs
-          content:
-            name: GOMEMLIMIT
       - equal:
           path: spec.values.useGOMEMLIMIT
           value: false


### PR DESCRIPTION
## Problem

The upstream `opentelemetry-collector` chart has its own logic of calculation 80% of pod spec's `resources.limit.memory` for `GOMEMLIMIT` with its exposure into the container env. Our own logic used 85% and added the variable to the env causing duplication at final rendered object. This led to confusing FluxCD with:

```
flux-system-soperator-fluxcd-opentelemetry-collector-events  False
  Could not determine release state: unable to determine cluster state:
  Deployment/logs-system/opentelemetry-collector-events dry-run failed:
  failed to create typed patch object: .spec.template.spec.containers[name="opentelemetry-collector"].env:
  duplicate entries for key [name="GOMEMLIMIT"]
```

The only valuable difference was that we used `resources.request.memory` as a fallback if limit is not set.
 
## Solution

Remove duplicate implementation of `GOMEMLIMIT` calculation leaving it to the upstream chart logic.

## Testing
It's not worth testing on the cluster as the change is rendering only. Fixed and ran the Helm unit-test suite to check the behaviour.

## Release Notes
Feature: Removed redundant calculation of the `GOMEMLIMIT` for `opentelemetry-collector` pods.