### PR TITLE
SCHED-1903: Enable deletion of Jail logs by default

### DIFF
--- a/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
+++ b/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
@@ -208,7 +208,7 @@ tests:
           value: 5000
       - equal:
           path: spec.values.extraVolumeMounts[0].readOnly
-          value: true
+          value: false
 
   - it: should omit file storage when jail log file storage is disabled
     set:

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -192,7 +192,7 @@ observability:
           enableFileStorage: true
           useGoMemLimit: true
           deleteAfterRead:
-            enabled: false
+            enabled: true
             # Nebius O11y agent fork option; not part of upstream filelogreceiver.
             # Files are deleted only after they have not been modified for at least this duration.
             minAge: 15m


### PR DESCRIPTION
## Problem
Even on small clusters, cluttering the Jail with tons of expired log files could be a trouble.

## Solution
Delete Jail log files after reading by default.

## Testing
No testing required.

## Release Notes
Feature: Enabled deletion of Jail log files by default.