### PR TITLE
SCHED-1456: Fix vmagent remotewrite in umbrella chart

### DIFF
--- a/helm/soperator-fluxcd/files/tsa-token-writer.sh
+++ b/helm/soperator-fluxcd/files/tsa-token-writer.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+set -eu
+
+# Maintains the o11y bearer token in a Kubernetes Secret so that consumers
+# (vmagent, otel collectors) can reference it via bearerTokenSecret. The token
+# is obtained from one of two sources:
+#   imds - fetched from the instance metadata service (IMDS_BASE_URL may be a proxy)
+#   file - read from a mounted file (e.g. a host-provided token file)
+
+: "${TOKEN_SOURCE:=imds}"
+: "${SECRET_NAME:?SECRET_NAME is required}"
+: "${SECRET_KEY:=accessToken}"
+: "${SECRET_NAMESPACES:?SECRET_NAMESPACES is required}"
+: "${IMDS_BASE_URL:=http://169.254.169.254}"
+: "${TOKEN_FILE:=/o11ytoken/tsa-token}"
+: "${TOKEN_EXPIRY_FILE:=}"
+: "${REFRESH_SAFETY_MARGIN_SECONDS:=900}"
+: "${POLL_INTERVAL_SECONDS:=300}"
+
+SA_DIR=/var/run/secrets/kubernetes.io/serviceaccount
+APISERVER="https://kubernetes.default.svc"
+CACERT="${SA_DIR}/ca.crt"
+
+json_string_field() {
+  field="$1"
+  sed -n "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n 1
+}
+
+timestamp_to_epoch() {
+  timestamp="$1"
+  case "${timestamp}" in
+    *.*Z) timestamp="${timestamp%%.*}Z" ;;
+  esac
+  if date -u -d "${timestamp}" +%s 2>/dev/null; then
+    return 0
+  fi
+  date -u -D "%Y-%m-%dT%H:%M:%SZ" -d "${timestamp}" +%s
+}
+
+# Sets ACCESS_TOKEN and EXPIRES_AT (EXPIRES_AT may be empty)
+obtain_token() {
+  case "${TOKEN_SOURCE}" in
+    imds)
+      response="$(curl -fsSL -H "Metadata: true" "${IMDS_BASE_URL}/v1/iam/tsa/token")"
+      ACCESS_TOKEN="$(printf '%s\n' "${response}" | json_string_field "access_token")"
+      EXPIRES_AT="$(printf '%s\n' "${response}" | json_string_field "expires_at")"
+      ;;
+    file)
+      ACCESS_TOKEN="$(cat "${TOKEN_FILE}")"
+      if [ -n "${TOKEN_EXPIRY_FILE}" ] && [ -f "${TOKEN_EXPIRY_FILE}" ]; then
+        EXPIRES_AT="$(cat "${TOKEN_EXPIRY_FILE}")"
+      else
+        EXPIRES_AT=""
+      fi
+      ;;
+    *)
+      echo "unsupported TOKEN_SOURCE=${TOKEN_SOURCE} (want: imds|file)" >&2
+      return 1
+      ;;
+  esac
+
+  if [ -z "${ACCESS_TOKEN}" ]; then
+    echo "obtained empty token from source=${TOKEN_SOURCE}" >&2
+    return 1
+  fi
+}
+
+upsert_secret() {
+  token_b64="$(printf '%s' "${ACCESS_TOKEN}" | base64 | tr -d '\n')"
+  k8s_token="$(cat "${SA_DIR}/token")"
+  patch="{\"data\":{\"${SECRET_KEY}\":\"${token_b64}\"}}"
+  create="{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"name\":\"${SECRET_NAME}\"},\"data\":{\"${SECRET_KEY}\":\"${token_b64}\"}}"
+
+  for ns in ${SECRET_NAMESPACES}; do
+    code="$(curl -sS -o /tmp/api.out -w '%{http_code}' \
+      --cacert "${CACERT}" -H "Authorization: Bearer ${k8s_token}" \
+      -H 'Content-Type: application/merge-patch+json' \
+      -X PATCH "${APISERVER}/api/v1/namespaces/${ns}/secrets/${SECRET_NAME}" -d "${patch}")"
+    if [ "${code}" = "404" ]; then
+      code="$(curl -sS -o /tmp/api.out -w '%{http_code}' \
+        --cacert "${CACERT}" -H "Authorization: Bearer ${k8s_token}" \
+        -H 'Content-Type: application/json' \
+        -X POST "${APISERVER}/api/v1/namespaces/${ns}/secrets" -d "${create}")"
+    fi
+    case "${code}" in
+      2*) echo "synced secret ${ns}/${SECRET_NAME}" ;;
+      *) echo "sync secret ${ns}/${SECRET_NAME} failed: HTTP ${code}: $(cat /tmp/api.out)" >&2; return 1 ;;
+    esac
+  done
+}
+
+seconds_until_refresh() {
+  if [ -z "${EXPIRES_AT}" ]; then
+    echo "${POLL_INTERVAL_SECONDS}"
+    return 0
+  fi
+  expires_epoch="$(timestamp_to_epoch "${EXPIRES_AT}")"
+  now_epoch="$(date -u +%s)"
+  sleep_seconds=$((expires_epoch - now_epoch - REFRESH_SAFETY_MARGIN_SECONDS))
+  if [ "${sleep_seconds}" -lt 1 ]; then
+    echo 1
+  else
+    echo "${sleep_seconds}"
+  fi
+}
+
+while true; do
+  obtain_token
+  upsert_secret
+  sleep "$(seconds_until_refresh)"
+done

--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.observability.enabled .Values.observability.vmStack.enabled }}
+{{- if .Values.observability.publicEndpointEnabled }}
+{{- include "soperator-fluxcd.validatePublicEndpointTokenKind" . -}}
+{{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -386,7 +389,23 @@ spec:
       vmagent:
         spec:
           {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
+          {{- $tokenKind := .Values.observability.publicEndpointTokenKind }}
           {{- $hasVmagentSpec := .Values.observability.vmStack.values.vmagent.spec }}
+          {{- $tsaToken := .Values.observability.vmStack.tsaToken | default dict }}
+          {{- $tokenSecretName := $tsaToken.secretName | default "o11y-writer-sa-token" }}
+          {{- $tokenSecretKey := $tsaToken.secretKey | default "accessToken" }}
+          {{- $tokenHostPath := $tsaToken.hostPath | default "/mnt/cloud-metadata" }}
+          {{- $tokenMountPath := $tsaToken.mountPath | default "/o11ytoken" }}
+          {{- $tokenHostPathFilename := $tsaToken.hostPathFilename | default "tsa-token" }}
+          {{- $useHostPathToken := and $hasPublicEndpoint (eq $tokenKind "hostPath") }}
+          {{- $hasHostNetwork := and $hasVmagentSpec (hasKey $hasVmagentSpec "hostNetwork") }}
+          {{- $hasDnsPolicy := and $hasVmagentSpec (hasKey $hasVmagentSpec "dnsPolicy") }}
+          {{- if $hasHostNetwork }}
+          hostNetwork: {{ $hasVmagentSpec.hostNetwork }}
+          {{- end }}
+          {{- if $hasDnsPolicy }}
+          dnsPolicy: {{ $hasVmagentSpec.dnsPolicy }}
+          {{- end }}
 
           {{- $hasExternalLabels := and $hasVmagentSpec $hasVmagentSpec.externalLabels }}
           {{- if and $hasExternalLabels (gt (len $hasExternalLabels) 0) }}
@@ -416,6 +435,11 @@ spec:
           {{- $remoteWriteNotEmpty := and $hasRemoteWrite (gt (len $hasVmagentSpec.remoteWrite) 0) }}
           {{- if $hasPublicEndpoint }}
             - url: https://write.monitoring.{{ .Values.observability.region }}.nebius.cloud/projects/{{ .Values.observability.metricsProjectId }}/buckets/soperator/prometheus
+              {{- if eq $tokenKind "secret" }}
+              bearerTokenSecret:
+                name: {{ $tokenSecretName | quote }}
+                key: {{ $tokenSecretKey | quote }}
+              {{- end }}
               inlineUrlRelabelConfig:
                 - action: labeldrop
                   regex: feature_node_kubernetes_io_.*|kubernetes_io_.*|nvidia_com_gpu.*
@@ -428,33 +452,40 @@ spec:
           {{- toYaml $hasVmagentSpec.remoteWrite | nindent 12 }}
           {{- end }}
 
-          volumeMounts:
+          {{- $hasContainers := and $hasVmagentSpec $hasVmagentSpec.containers }}
+          {{- $containersNotEmpty := and $hasContainers (gt (len $hasVmagentSpec.containers) 0) }}
+          {{- if $containersNotEmpty }}
+          containers:
+          {{- toYaml $hasVmagentSpec.containers | nindent 12 }}
+          {{- end }}
+
           {{- $hasVolumeMounts := and $hasVmagentSpec $hasVmagentSpec.volumeMounts }}
           {{- $volumeMountsNotEmpty := and $hasVolumeMounts (gt (len $hasVmagentSpec.volumeMounts) 0) }}
-          {{- if $hasPublicEndpoint }}
-            - name: cloud-metadata
-              mountPath: /mnt/cloud-metadata
+          {{- if or $useHostPathToken $volumeMountsNotEmpty }}
+          volumeMounts:
+          {{- if $useHostPathToken }}
+            - name: o11ytoken
+              mountPath: {{ $tokenMountPath | quote }}
               readOnly: true
+          {{- end }}
           {{- if $volumeMountsNotEmpty }}
           {{- toYaml $hasVmagentSpec.volumeMounts | nindent 12 }}
           {{- end }}
-          {{- else}}
-          {{- toYaml $hasVmagentSpec.volumeMounts | nindent 12 }}
           {{- end }}
 
-          volumes:
           {{- $hasVolumes := and $hasVmagentSpec $hasVmagentSpec.volumes }}
           {{- $volumesNotEmpty := and $hasVolumes (gt (len $hasVmagentSpec.volumes) 0) }}
-          {{- if $hasPublicEndpoint }}
-            - name: cloud-metadata
+          {{- if or $useHostPathToken $volumesNotEmpty }}
+          volumes:
+          {{- if $useHostPathToken }}
+            - name: o11ytoken
               hostPath:
-                path: /mnt/cloud-metadata
+                path: {{ $tokenHostPath | quote }}
                 type: Directory
+          {{- end }}
           {{- if $volumesNotEmpty }}
           {{- toYaml $hasVmagentSpec.volumes | nindent 12 }}
           {{- end }}
-          {{- else}}
-          {{- toYaml $hasVmagentSpec.volumes | nindent 12 }}
           {{- end }}
 
           extraArgs:
@@ -462,8 +493,14 @@ spec:
           {{- $extraArgsNotEmpty := and $hasExtraArgs (gt (len $hasVmagentSpec.extraArgs) 0) }}
           {{- if $hasPublicEndpoint }}
             remoteWrite.flushInterval: 2s
-            remoteWrite.bearerTokenFile: /mnt/cloud-metadata/tsa-token
             remoteWrite.maxRowsPerBlock: "12000"
+          {{- if $useHostPathToken }}
+            {{- $rwCount := 1 }}
+            {{- if $remoteWriteNotEmpty }}
+            {{- $rwCount = add 1 (len $hasVmagentSpec.remoteWrite) }}
+            {{- end }}
+            remoteWrite.bearerTokenFile: {{ printf "%s/%s%s" $tokenMountPath $tokenHostPathFilename (repeat (int (sub $rwCount 1)) ",\"\"") | quote }}
+          {{- end }}
           {{- if $extraArgsNotEmpty }}
           {{- toYaml $hasVmagentSpec.extraArgs | nindent 12 }}
           {{- end }}

--- a/helm/soperator-fluxcd/templates/vm-tsa-token-writer.yaml
+++ b/helm/soperator-fluxcd/templates/vm-tsa-token-writer.yaml
@@ -1,0 +1,169 @@
+{{- if and .Values.observability.enabled .Values.observability.vmStack.enabled .Values.observability.publicEndpointEnabled }}
+{{- $tokenKind := .Values.observability.publicEndpointTokenKind }}
+{{- $tsaToken := .Values.observability.vmStack.tsaToken | default dict }}
+{{- $writer := $tsaToken.writer | default dict }}
+{{- $writerEnabled := true }}
+{{- if hasKey $writer "enabled" }}
+{{- $writerEnabled = $writer.enabled }}
+{{- end }}
+{{- if and $writerEnabled (eq $tokenKind "secret") }}
+{{- include "soperator-fluxcd.validatePublicEndpointTokenKind" . -}}
+{{- $ns := .Values.observability.vmStack.namespace }}
+{{- $secretName := $tsaToken.secretName | default "o11y-writer-sa-token" }}
+{{- $secretKey := $tsaToken.secretKey | default "accessToken" }}
+{{- $source := $writer.source | default "imds" }}
+{{- $namespaces := $writer.namespaces | default (list $ns) }}
+{{- $image := $writer.image | default dict }}
+{{- $repo := required "observability.vmStack.tsaToken.writer.image.repository is required" $image.repository }}
+{{- $tag := required "observability.vmStack.tsaToken.writer.image.tag is required" $image.tag }}
+{{- $pullPolicy := $image.pullPolicy | default "IfNotPresent" }}
+{{- $hostPath := $tsaToken.hostPath | default "/mnt/cloud-metadata" }}
+{{- $mountPath := $tsaToken.mountPath | default "/o11ytoken" }}
+{{- $tokenFilename := $tsaToken.hostPathFilename | default "tsa-token" }}
+{{- $hostNetwork := and (eq $source "imds") (ne (toString ($writer.hostNetwork | default true)) "false") }}
+{{- $name := printf "%s-tsa-token-writer" (include "soperator-fluxcd.fullname" .) }}
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "soperator-fluxcd.labels" . | nindent 4 }}
+spec:
+  {{- with $writer.driftDetection }}
+  driftDetection:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  chart:
+    spec:
+      chart: raw
+      interval: {{ $writer.interval }}
+      sourceRef:
+        kind: HelmRepository
+        name: {{ include "soperator-fluxcd.fullname" . }}-bedag
+      version: {{ $writer.version }}
+  dependsOn:
+  - name: {{ include "soperator-fluxcd.fullname" . }}-ns
+  install:
+    remediation:
+      retries: 3
+  interval: {{ $writer.interval }}
+  targetNamespace: {{ .Values.observability.vmStack.namespace }}
+  releaseName: tsa-token-writer
+  values:
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: {{ $name }}
+        namespace: {{ $ns }}
+        labels:
+          {{- include "soperator-fluxcd.labels" . | nindent 10 }}
+    {{- range $namespaces }}
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: {{ $name }}
+        namespace: {{ . }}
+        labels:
+          {{- include "soperator-fluxcd.labels" $ | nindent 10 }}
+      rules:
+        # resourceNames cannot restrict "create" (the object does not exist yet)
+        - apiGroups: [""]
+          resources: ["secrets"]
+          verbs: ["create"]
+        - apiGroups: [""]
+          resources: ["secrets"]
+          resourceNames: [{{ $secretName | quote }}]
+          verbs: ["get", "patch", "update"]
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: {{ $name }}
+        namespace: {{ . }}
+        labels:
+          {{- include "soperator-fluxcd.labels" $ | nindent 10 }}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: {{ $name }}
+      subjects:
+        - kind: ServiceAccount
+          name: {{ $name }}
+          namespace: {{ $ns }}
+    {{- end }}
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: {{ $name }}
+        namespace: {{ $ns }}
+        labels:
+          {{- include "soperator-fluxcd.labels" . | nindent 10 }}
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: {{ $name }}
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: {{ $name }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+          spec:
+            serviceAccountName: {{ $name }}
+            {{- if $hostNetwork }}
+            hostNetwork: true
+            dnsPolicy: ClusterFirstWithHostNet
+            {{- end }}
+            containers:
+              - name: tsa-token-writer
+                image: {{ printf "%s:%s" $repo $tag | quote }}
+                imagePullPolicy: {{ $pullPolicy | quote }}
+                command:
+                  - /bin/sh
+                  - -ec
+                  - |
+{{ $.Files.Get "files/tsa-token-writer.sh" | indent 20 }}
+                env:
+                  - name: TOKEN_SOURCE
+                    value: {{ $source | quote }}
+                  - name: SECRET_NAME
+                    value: {{ $secretName | quote }}
+                  - name: SECRET_KEY
+                    value: {{ $secretKey | quote }}
+                  - name: SECRET_NAMESPACES
+                    value: {{ join " " $namespaces | quote }}
+                  {{- if eq $source "imds" }}
+                  - name: IMDS_BASE_URL
+                    value: {{ $writer.imdsBaseUrl | default "http://169.254.169.254" | quote }}
+                  {{- end }}
+                  {{- if eq $source "file" }}
+                  - name: TOKEN_FILE
+                    value: {{ printf "%s/%s" $mountPath $tokenFilename | quote }}
+                  {{- with $writer.tokenExpiryFile }}
+                  - name: TOKEN_EXPIRY_FILE
+                    value: {{ . | quote }}
+                  {{- end }}
+                  {{- end }}
+                  - name: REFRESH_SAFETY_MARGIN_SECONDS
+                    value: {{ $writer.refreshSafetyMarginSeconds | default 900 | quote }}
+                  - name: POLL_INTERVAL_SECONDS
+                    value: {{ $writer.pollIntervalSeconds | default 300 | quote }}
+                {{- if eq $source "file" }}
+                volumeMounts:
+                  - name: o11ytoken
+                    mountPath: {{ $mountPath | quote }}
+                    readOnly: true
+                {{- end }}
+                {{- with $writer.resources }}
+                resources:
+                  {{- toYaml . | nindent 18 }}
+                {{- end }}
+            {{- if eq $source "file" }}
+            volumes:
+              - name: o11ytoken
+                hostPath:
+                  path: {{ $hostPath | quote }}
+                  type: Directory
+            {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/soperator-fluxcd/tests/vm_tsa_token_writer_test.yaml
+++ b/helm/soperator-fluxcd/tests/vm_tsa_token_writer_test.yaml
@@ -1,0 +1,188 @@
+suite: test vmagent tsa-token writer
+templates:
+  - templates/vm-tsa-token-writer.yaml
+
+tests:
+  - it: should render a HelmRelease using the bedag raw chart
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        publicEndpointTokenKind: secret
+        vmStack:
+          enabled: true
+          namespace: monitoring-system
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HelmRelease
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-tsa-token-writer
+      - equal:
+          path: spec.chart.spec.chart
+          value: raw
+      - equal:
+          path: spec.chart.spec.sourceRef.name
+          value: RELEASE-NAME-bedag
+      - equal:
+          path: spec.dependsOn[0].name
+          value: RELEASE-NAME-ns
+
+  - it: should maintain the token secret with imds source and host networking
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        publicEndpointTokenKind: secret
+        vmStack:
+          enabled: true
+          namespace: monitoring-system
+          tsaToken:
+            writer:
+              source: imds
+    asserts:
+      # resources: ServiceAccount + Role + RoleBinding + Deployment
+      - lengthEqual:
+          path: spec.values.resources
+          count: 4
+      - equal:
+          path: spec.values.resources[0].kind
+          value: ServiceAccount
+      - equal:
+          path: spec.values.resources[0].metadata.namespace
+          value: monitoring-system
+      - equal:
+          path: spec.values.resources[3].kind
+          value: Deployment
+      - equal:
+          path: spec.values.resources[3].spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.values.resources[3].spec.template.spec.containers[0].env[0].value
+          value: "imds"
+      - equal:
+          path: spec.values.resources[3].spec.template.spec.containers[0].env[3].value
+          value: "monitoring-system"
+
+  - it: should restrict secret access by resourceName but allow create
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        publicEndpointTokenKind: secret
+        vmStack:
+          enabled: true
+          namespace: monitoring-system
+    asserts:
+      - equal:
+          path: spec.values.resources[1].kind
+          value: Role
+      - equal:
+          path: spec.values.resources[1].rules[0].verbs
+          value: ["create"]
+      - equal:
+          path: spec.values.resources[1].rules[1].resourceNames
+          value: ["o11y-writer-sa-token"]
+      - equal:
+          path: spec.values.resources[1].rules[1].verbs
+          value: ["get", "patch", "update"]
+      - equal:
+          path: spec.values.resources[2].kind
+          value: RoleBinding
+      - equal:
+          path: spec.values.resources[2].subjects[0].namespace
+          value: monitoring-system
+
+  - it: should use file source without host networking and mount the host token
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        publicEndpointTokenKind: secret
+        vmStack:
+          enabled: true
+          namespace: monitoring-system
+          tsaToken:
+            writer:
+              source: file
+    asserts:
+      - notExists:
+          path: spec.values.resources[3].spec.template.spec.hostNetwork
+      - equal:
+          path: spec.values.resources[3].spec.template.spec.containers[0].env[0].value
+          value: "file"
+      - equal:
+          path: spec.values.resources[3].spec.template.spec.volumes[0].hostPath.path
+          value: "/mnt/cloud-metadata"
+      - equal:
+          path: spec.values.resources[3].spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: "/o11ytoken"
+
+  - it: should maintain the secret in every configured namespace
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        publicEndpointTokenKind: secret
+        vmStack:
+          enabled: true
+          namespace: monitoring-system
+          tsaToken:
+            writer:
+              namespaces:
+                - monitoring-system
+                - logs-system
+    asserts:
+      # SA + (Role + RoleBinding) x2 + Deployment
+      - lengthEqual:
+          path: spec.values.resources
+          count: 6
+      - equal:
+          path: spec.values.resources[3].metadata.namespace
+          value: logs-system
+      - equal:
+          path: spec.values.resources[5].kind
+          value: Deployment
+      - equal:
+          path: spec.values.resources[5].spec.template.spec.containers[0].env[3].value
+          value: "monitoring-system logs-system"
+
+  - it: should not render when publicEndpointEnabled is false
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: false
+        vmStack:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render for hostPath token kind
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        publicEndpointTokenKind: hostPath
+        vmStack:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when the writer is disabled
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        publicEndpointTokenKind: secret
+        vmStack:
+          enabled: true
+          tsaToken:
+            writer:
+              enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/soperator-fluxcd/tests/vmagent_test.yaml
+++ b/helm/soperator-fluxcd/tests/vmagent_test.yaml
@@ -82,6 +82,9 @@ tests:
                   - name: "cache-volume"
                     emptyDir:
                       sizeLimit: "1Gi"
+                containers:
+                  - name: "custom-sidecar"
+                    image: "busybox:1.36"
     asserts:
       - hasDocuments:
           count: 1
@@ -100,14 +103,21 @@ tests:
       - equal:
           path: spec.values.vmagent.spec.extraEnvs[2].valueFrom.secretKeyRef.key
           value: "token"
+      # secret token kind (default) adds no token volume mount/volume to vmagent
       - lengthEqual:
           path: spec.values.vmagent.spec.volumeMounts
-          count: 3  # 2 custom + 1 tsa-token
+          count: 2
       - lengthEqual:
           path: spec.values.vmagent.spec.volumes
-          count: 3   # 2 custom + 1 tsa-token
+          count: 2
+      - lengthEqual:
+          path: spec.values.vmagent.spec.containers
+          count: 1
+      - equal:
+          path: spec.values.vmagent.spec.containers[0].name
+          value: "custom-sidecar"
 
-  - it: should override default extraArgs correctly
+  - it: should override default extraArgs without managing the bearer token
     set:
       observability:
         enabled: true
@@ -141,9 +151,9 @@ tests:
       - equal:
           path: spec.values.vmagent.spec.extraArgs["promscrape.streamParse"]
           value: "true"
-      - equal:
+      # secret token kind must not set a global bearerTokenFile arg
+      - notExists:
           path: spec.values.vmagent.spec.extraArgs["remoteWrite.bearerTokenFile"]
-          value: "/mnt/cloud-metadata/tsa-token"
 
   - it: should handle special characters in projectId
     set:
@@ -163,7 +173,7 @@ tests:
           path: spec.values.vmagent.spec.remoteWrite[0].url
           pattern: "[.]*.test-project_123.dev.[.]*"
 
-  - it: should validate template conditionals structure
+  - it: should validate template conditionals structure for secret token kind
     set:
       observability:
         enabled: true
@@ -183,15 +193,16 @@ tests:
           path: spec.values.vmagent.spec.remoteWrite
       - exists:
           path: spec.values.vmagent.spec.extraArgs
-      - exists:
-          path: spec.values.vmagent.spec.volumeMounts
-      - exists:
-          path: spec.values.vmagent.spec.volumes
-      - exists:
-          path: spec.values.vmagent.spec.resources
-      # Should not have these sections when not provided
       - notExists:
-          path: spec.values.vmagent.spec.extraEnv
+          path: spec.values.vmagent.spec.volumeMounts
+      - notExists:
+          path: spec.values.vmagent.spec.volumes
+      - notExists:
+          path: spec.values.vmagent.spec.hostNetwork
+      - notExists:
+          path: spec.values.vmagent.spec.dnsPolicy
+      - notExists:
+          path: spec.values.vmagent.spec.extraArgs["remoteWrite.bearerTokenFile"]
 
   - it: should handle boolean and numeric values in extraArgs
     set:
@@ -317,13 +328,126 @@ tests:
           path: spec.values.vmagent.spec.remoteWrite[2].writeRelabelConfigs[0].action
           value: "keep"
 
-  - it: should merge custom volumeMounts and volumes with defaults when publicEndpointEnabled is true
+  - it: should let an extra destination carry its own bearerTokenSecret alongside o11y
     set:
       observability:
         enabled: true
         vmStack:
           enabled: true
           publicEndpointEnabled: true
+          publicEndpointTokenKind: secret
+          values:
+            vmagent:
+              spec:
+                remoteWrite:
+                  - url: "http://vmsingle.monitoring-system.svc.cluster.local.:8429/api/v1/write"
+                  - url: "https://intake.some-cool-observability.com/api/v1/metrics"
+                    bearerTokenSecret:
+                      name: bfl-dashboard-credentials
+                      key: ingestion-key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - lengthEqual:
+          path: spec.values.vmagent.spec.remoteWrite
+          count: 3
+      # o11y endpoint keeps its operator-managed secret
+      - equal:
+          path: spec.values.vmagent.spec.remoteWrite[0].bearerTokenSecret.name
+          value: "o11y-writer-sa-token"
+      # extra destination keeps its own secret - no global bearerTokenFile to clobber it
+      - equal:
+          path: spec.values.vmagent.spec.remoteWrite[2].bearerTokenSecret.name
+          value: "bfl-dashboard-credentials"
+      - equal:
+          path: spec.values.vmagent.spec.remoteWrite[2].bearerTokenSecret.key
+          value: "ingestion-key"
+      - notExists:
+          path: spec.values.vmagent.spec.extraArgs["remoteWrite.bearerTokenFile"]
+
+  - it: should allow overriding the o11y token secret name and key
+    set:
+      observability:
+        enabled: true
+        vmStack:
+          enabled: true
+          publicEndpointEnabled: true
+          publicEndpointTokenKind: secret
+          tsaToken:
+            secretName: my-token-secret
+            secretKey: my-key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.vmagent.spec.remoteWrite[0].bearerTokenSecret.name
+          value: "my-token-secret"
+      - equal:
+          path: spec.values.vmagent.spec.remoteWrite[0].bearerTokenSecret.key
+          value: "my-key"
+
+  - it: should mount the host token file and scope the bearer token to o11y for hostPath kind
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        publicEndpointTokenKind: hostPath
+        vmStack:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      # o11y endpoint must not use bearerTokenSecret in hostPath mode
+      - notExists:
+          path: spec.values.vmagent.spec.remoteWrite[0].bearerTokenSecret
+      # token file mounted from the host
+      - equal:
+          path: spec.values.vmagent.spec.volumeMounts[0].name
+          value: "o11ytoken"
+      - equal:
+          path: spec.values.vmagent.spec.volumeMounts[0].mountPath
+          value: "/o11ytoken"
+      - equal:
+          path: spec.values.vmagent.spec.volumes[0].hostPath.path
+          value: "/mnt/cloud-metadata"
+      # positional bearerTokenFile: token for o11y (index 0), empty for cluster-local (index 1)
+      - equal:
+          path: spec.values.vmagent.spec.extraArgs["remoteWrite.bearerTokenFile"]
+          value: '/o11ytoken/tsa-token,""'
+
+  - it: should pad the hostPath bearer token across all remote-write endpoints
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        publicEndpointTokenKind: hostPath
+        vmStack:
+          enabled: true
+          values:
+            vmagent:
+              spec:
+                remoteWrite:
+                  - url: "http://vmsingle.monitoring-system.svc.cluster.local.:8429/api/v1/write"
+                  - url: "https://intake.some-cool-observability.com/api/v1/metrics"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - lengthEqual:
+          path: spec.values.vmagent.spec.remoteWrite
+          count: 3
+      # 3 endpoints -> token only for index 0, two empty placeholders
+      - equal:
+          path: spec.values.vmagent.spec.extraArgs["remoteWrite.bearerTokenFile"]
+          value: '/o11ytoken/tsa-token,"",""'
+
+  - it: should merge custom volumeMounts and volumes for hostPath kind
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: true
+        publicEndpointTokenKind: hostPath
+        vmStack:
+          enabled: true
           values:
             vmagent:
               spec:
@@ -343,57 +467,30 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-      # Should have both default and custom volumeMounts
+      # Should have both default token mount and custom volumeMounts
       - lengthEqual:
           path: spec.values.vmagent.spec.volumeMounts
-          count: 3  # 1 default tsa-token + 2 custom
-      # Check default tsa-token mount
+          count: 3 # 1 default o11ytoken + 2 custom
       - equal:
           path: spec.values.vmagent.spec.volumeMounts[0].name
-          value: "cloud-metadata"
-      - equal:
-          path: spec.values.vmagent.spec.volumeMounts[0].mountPath
-          value: "/mnt/cloud-metadata"
-      - equal:
-          path: spec.values.vmagent.spec.volumeMounts[0].readOnly
-          value: true
-      # Check custom mounts
+          value: "o11ytoken"
       - equal:
           path: spec.values.vmagent.spec.volumeMounts[1].name
           value: "custom-config"
       - equal:
-          path: spec.values.vmagent.spec.volumeMounts[1].mountPath
-          value: "/etc/custom-config"
-      - equal:
-          path: spec.values.vmagent.spec.volumeMounts[2].name
-          value: "data-volume"
-      - equal:
           path: spec.values.vmagent.spec.volumeMounts[2].mountPath
           value: "/data"
-      # Should have both default and custom volumes
       - lengthEqual:
           path: spec.values.vmagent.spec.volumes
-          count: 3  # 1 default tsa-token + 2 custom
-      # Check default tsa-token volume
+          count: 3 # 1 default o11ytoken + 2 custom
       - equal:
           path: spec.values.vmagent.spec.volumes[0].name
-          value: "cloud-metadata"
-      - equal:
-          path: spec.values.vmagent.spec.volumes[0].hostPath.path
-          value: "/mnt/cloud-metadata"
-      - equal:
-          path: spec.values.vmagent.spec.volumes[0].hostPath.type
-          value: "Directory"
-      # Check custom volumes
-      - equal:
-          path: spec.values.vmagent.spec.volumes[1].name
-          value: "custom-config"
+          value: "o11ytoken"
+      - exists:
+          path: spec.values.vmagent.spec.volumes[0].hostPath
       - equal:
           path: spec.values.vmagent.spec.volumes[1].configMap.name
           value: "vmagent-custom-config"
-      - equal:
-          path: spec.values.vmagent.spec.volumes[2].name
-          value: "data-volume"
       - equal:
           path: spec.values.vmagent.spec.volumes[2].persistentVolumeClaim.claimName
           value: "vmagent-data"
@@ -415,26 +512,36 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-      # Should still have defaults when custom arrays are empty
+      # Should still have the default o11y endpoint when custom arrays are empty
       - lengthEqual:
           path: spec.values.vmagent.spec.remoteWrite
           count: 1  # Only default
       - equal:
           path: spec.values.vmagent.spec.remoteWrite[0].url
           value: "https://write.monitoring.eu-north1.nebius.cloud/projects/default-project-id/buckets/soperator/prometheus"
-      # Should have default volumeMounts and volumes
-      - lengthEqual:
-          path: spec.values.vmagent.spec.volumeMounts
-          count: 1  # Only default tsa-token
-      - equal:
-          path: spec.values.vmagent.spec.volumeMounts[0].name
-          value: "cloud-metadata"
-      - lengthEqual:
-          path: spec.values.vmagent.spec.volumes
-          count: 1  # Only default tsa-token
-      - equal:
-          path: spec.values.vmagent.spec.volumes[0].name
-          value: "cloud-metadata"
-      # Should not have extraEnv when empty
+      # Should not have token volumeMounts or volumes for secret token kind
       - notExists:
-          path: spec.values.vmagent.spec.extraEnv
+          path: spec.values.vmagent.spec.volumeMounts
+      - notExists:
+          path: spec.values.vmagent.spec.volumes
+      - notExists:
+          path: spec.values.vmagent.spec.containers
+
+  - it: should not render token volumes or host networking when publicEndpointEnabled is false
+    set:
+      observability:
+        enabled: true
+        publicEndpointEnabled: false
+        vmStack:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.values.vmagent.spec.containers
+      - notExists:
+          path: spec.values.vmagent.spec.hostNetwork
+      - notExists:
+          path: spec.values.vmagent.spec.volumeMounts
+      - notExists:
+          path: spec.values.vmagent.spec.extraArgs["remoteWrite.bearerTokenFile"]

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -257,6 +257,40 @@ observability:
       remediation:
         retries: 3
         remediateLastFailure: true
+    # Source of the o11y remote-write bearer token, consumed per `observability.publicEndpointTokenKind`:
+    #   secret   - vmagent references the token via remoteWrite[].bearerTokenSecret (operator-managed),
+    #              so extra remote-write destinations can carry their own auth without conflict
+    #   hostPath - the token file is mounted from the host and passed via -remoteWrite.bearerTokenFile,
+    #              scoped to the o11y endpoint only
+    tsaToken:
+      secretName: o11y-writer-sa-token
+      secretKey: accessToken
+      hostPath: /mnt/cloud-metadata
+      mountPath: /o11ytoken
+      hostPathFilename: tsa-token
+      writer:
+        enabled: true
+        interval: 5m
+        version: 2.0.0
+        driftDetection:
+          mode: warn
+        # Token source: `imds` (fetch from IMDS_BASE_URL, may be a proxy) or
+        # `file` (read a host-provided token file mounted from `hostPath`).
+        source: file
+        # Namespaces to maintain the Secret in. Empty means the vmStack namespace.
+        namespaces: []
+        image:
+          repository: cr.eu-north1.nebius.cloud/soperator-proxy-docker-io/alpine/curl
+          tag: "8.19.0"
+          pullPolicy: IfNotPresent
+        imdsBaseUrl: http://169.254.169.254
+        # hostNetwork is needed only to reach link-local IMDS directly; set false
+        # when IMDS_BASE_URL points at a routable proxy.
+        hostNetwork: true
+        tokenExpiryFile: ""
+        refreshSafetyMarginSeconds: 900
+        pollIntervalSeconds: 300
+        resources: {}
     values:
       dashboardNamespaces:
         - soperator


### PR DESCRIPTION
## Problem
vmagent received the Nebius o11y bearer token via a global `-remoteWrite.bearerTokenFile` arg, which vmagent applies to every remote-write URL. This leaked the token to other endpoints and blocked adding extra customer remote-write destinations with their own auth.

## Solution
Use per-URL `bearerTokenSecret` for the o11y endpoint (secret kind) and an o11y-scoped positional `bearerTokenFile` (hostPath kind), so extra destinations can carry their own auth. Replaced the in-pod IMDS sidecar with a standalone `tsa-token-writer` (bedag `raw` HelmRelease) that maintains the `o11y-writer-sa-token` Secret from IMDS or a host file.

## Testing
- `helm unittest` 117/117, `helm lint` clean, full `helm template` for both token kinds and writer sources.
- in live cluster

## Release Notes
Feature: vmagent authenticates o11y remote-write via per-URL `bearerTokenSecret`, allowing extra remote-write destinations with independent auth; token Secret maintained by the new `tsa-token-writer`. Breaking: removed the vmagent IMDS sidecar and `tsaTokenSidecar` values — use `publicEndpointTokenKind` (`secret`/`hostPath`).
