### PR TITLE
SCHED-1010: Create nccl_logs dir in jail instead of active check

### DIFF
--- a/helm/soperator-activechecks/scripts/ensure-dir-snccld-logs.sh
+++ b/helm/soperator-activechecks/scripts/ensure-dir-snccld-logs.sh
@@ -1,4 +1,0 @@
-set -ex
-
-echo "Ensuring log directory for NCCL Debug plugin (${SNCCLD_LOG_DIR_PATH})..."
-chroot /mnt/jail /bin/bash -c "mkdir -p '${SNCCLD_LOG_DIR_PATH}'; chmod 777 '${SNCCLD_LOG_DIR_PATH}'"

--- a/helm/soperator-activechecks/values.yaml
+++ b/helm/soperator-activechecks/values.yaml
@@ -279,18 +279,6 @@ checks:
     slurmJobSpec:
       sbatchScriptFile: "scripts/enroot-cleanup.sh"
       eachWorkerJobs: true
-  ensure-dir-snccld-logs:
-    enabled: true
-    checkType: "k8sJob"
-    schedule: "15 0 * * *"
-    suspend: false
-    runAfterCreation: true
-    k8sJobSpec:
-      scriptFile: "scripts/ensure-dir-snccld-logs.sh"
-      jobContainer:
-        env:
-          - name: "SNCCLD_LOG_DIR_PATH"
-            value: "/opt/soperator-outputs/nccl_logs"
   prepull-container-image:
     enabled: true
     checkType: "slurmJob"

--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -184,6 +184,9 @@ pushd "${jaildir}"
 
     log "[outputs] Creating Soperator output directory"
     mkdir -m 777 -p opt/soperator-outputs
+    # The NCCL debug SPANK plugin writes per-job logs here; ensure it exists and is world-writable
+    # on every startup so all clusters have it (previously done by the ensure-dir-snccld-logs active check).
+    mkdir -m 777 -p opt/soperator-outputs/nccl_logs
 
     # For login nodes in GPU clusters and CPU workers in GPU clusters
     if { [ -z "$worker" ] && [ "$SLURM_CLUSTER_WITH_GPU" = "true" ]; } || { [ -n "$worker" ] && [ "$SLURM_CLUSTER_WITH_GPU" = "true" ] && [ "$NODESET_GPU_ENABLED" != "true" ]; }; then


### PR DESCRIPTION
## Problem

`/opt/soperator-outputs/nccl_logs` (used for NCCL debug logs) was created by the `ensure-dir-snccld-logs` active check, which only runs on a schedule and depends on the active-checks stack.

## Solution

Create the directory during jail startup in `complement_jail.sh`, next to the existing `/opt/soperator-outputs`. Removed the `ensure-dir-snccld-logs` check and its script.

## Testing

`helm unittest helm/soperator-activechecks` passes; `bash -n` on the script is clean.

## Release Notes

Change: `/opt/soperator-outputs/nccl_logs` is now created during jail startup instead of by an active check.
