### PR TITLE
SCHED-1741: Make sure we have Active or Passive check to drain nodes where there are empty libnvidia.so files (amended)

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/check_nvidia_libraries.sh
+++ b/helm/slurm-cluster/slurm_scripts/check_nvidia_libraries.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+fail_if_lib_dne () {
+	checklib=$1
+	if python -c "import ctypes; ctypes.CDLL('$checklib')"; then
+		echo "...found $checklib, continuing"
+	else
+		echo "ERROR: missing $checklib"
+		exit 1
+	fi
+}
+
+# first check if I can load libnvidia-ml.so.1, because nothing works without it
+# (also not a typo, looks specifically for .1)
+
+fail_if_lib_dne "libnvidia-ml.so.1"
+
+# get list of base Nvidia libraries to check from nvidia-container-cli
+full_library_list=$(nvidia-container-cli list -l | grep \\.so)
+for x in $full_library_list; do
+	fail_if_lib_dne "$x"
+done
+
+# check against a list of commonly needed CUDA libraries that are common in a
+# standard Pytorch training session
+
+cudalibs="libcuda libcudart libcublas libcublasLt libcufft libcurand libcusolver libcusparse libcudnn libnccl libucp libucs libuct libgdrapi libmpi libnuma"
+libs_w_version="libibverbs.so.1 librdmacm.so.1 libgomp.so.1"
+
+for x in $cudalibs; do
+	fail_if_lib_dne "$x.so"
+done
+for x in $libs_w_version; do
+	fail_if_lib_dne "$x"
+done
+
+echo "OK: all libraries exist"
+exit 0 

--- a/helm/slurm-cluster/slurm_scripts/check_nvidia_libraries.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/check_nvidia_libraries.sh.json
@@ -1,0 +1,17 @@
+{
+  "name": "check_nvidia_libraries",
+  "command": "./check_nvidia_libraries.sh",
+  "platforms": ["8xGPU", "1xGPU", "4xGPU"],
+  "skip_for_cpu_jobs": false,
+  "skip_for_partial_gpu_jobs": false,
+  "skip_for_reservation_prefixes": [],
+  "contexts": ["prolog", "hc_program"],
+  "node_states": ["any"],
+  "on_fail": "drain",
+  "on_ok": "undrain",
+  "reason_base": "[node_problem] $name",
+  "reason_append_details": true,
+  "run_in_jail": true,
+  "log": "slurm_scripts/$worker.$name.$context.out",
+  "need_env": []
+}

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -744,6 +744,10 @@ slurmScripts:
       enabled: true
       customContent: null
       customConfig: null
+    check_nvidia_libraries.sh:
+      enabled: true
+      customContent: null
+      customConfig: null
     chmod_enroot_layers.sh:
       enabled: true
       customContent: null


### PR DESCRIPTION
## Problem

Intermittently, Nvidia libraries on worker nodes can be mounted incorrectly, leading to an error state where the library exists but is either not loadable or has a size of 0. This causes problems work ML workloads running on said workers.

## Solution

This patch creates an active check that confirms the existence of Nvidia libraries and their ability to load. If those libraries cannot be loaded, then the worker node drains, thus preventing future workloads from running on that node until the issue is resolved.

## Testing

This patch was tested on an existing 2-node Soperator cluster running 3.0.2, both in positive (libraries existing, passed check) and negative tests (library did not exist, check failed, node drained). All cases worked as expected. _Even though this is tested against a 3.0.2 soperator cluster, it is expected to work with all versions, including latest._

## Release Notes

Adding a new health check to existing clusters may cause worker nodes to drain, because libraries were missing that were unexpected, or maybe not used by previous workloads (but given the list of libraries, that is a vanishingly small probability). While this is intended behavior, it may be surprising.