### PR TITLE
SCHED-1943: Fix OpenTelemetry Collector JSON parsing errors for slurm_scripts

### DIFF
--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -365,11 +365,15 @@ spec:
             - type: remove
               field: attributes.base_name
 
+            # Files on the shared jail FS are truncated and rewritten in place by check_runner.py,
+            # so the reader can see partially flushed lines (zero-filled tails). Skip bodies with
+            # NUL bytes and send the entry unparsed instead of logging an error on any parse failure.
             - id: parse_json_body # parse json body to extract fields
               type: json_parser
               parse_from: body
               parse_to: attributes.hc_json
-              if: body matches "^\\s*\\{"
+              if: body matches "^\\s*\\{" and not (body matches "\\x00")
+              on_error: send_quiet
 
             - type: move
               from: attributes.hc_json.status


### PR DESCRIPTION
## Problem

The jail-logs otel collector spams error-level logs with huge stacktraces: `invalid character '\u0000' looking for beginning of value`. Check output files on the shared jail FS are truncated and rewritten in place by `check_runner.py`, so the collector (tailing from another node) can read partially flushed lines with zero-filled tails, and the `json_parser` fails on them. Logs are still delivered — it's pure noise. Reproduces on some clusters (m42-h200, ami-labs) depending on storage/timing.

## Solution

Hardened the `parse_json_body` operator in the jail-logs collector config:
- extended the `if` guard to skip lines containing NUL bytes;
- added `on_error: send_quiet` so any other parse failure sends the entry unparsed and logs at debug instead of error.

The parser is kept because it feeds `slurm_run_status` / `slurm_run_resolution` log labels (added in #2125).

## Testing

- `make helmtest`
- `helm template` — verified the rendered operator config is valid and contains the new condition and `on_error`.
- on the live cluster

## Release Notes

Fix: jail-logs otel collector no longer emits error-level noise when reading partially flushed health check output files containing NUL bytes.
