### PR TITLE
SCHED-2069: Unpin nebius cli & log python version

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -270,6 +270,10 @@ jobs:
           which go
           go version
 
+          echo "python:"
+          which python
+          python --version
+
       - name: Find latest successful build run on current branch
         id: find_build
         shell: bash

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -202,7 +202,6 @@ jobs:
       - name: Install Nebius CLI
         shell: bash
         env:
-          NEBIUS_CLI_VERSION: "0.12.164"
           NEBIUS_INSTALL_FOLDER: "${{ github.workspace }}/bin"
         run: |
           echo "Installing Nebius CLI ${NEBIUS_CLI_VERSION}..."


### PR DESCRIPTION
## Problem

e2e is broken because we are using new nebius cli capabilities:

```
module.cleanup.terraform_data.disk_cleanup (local-exec): Disk cleanup config: start_delete_parallelism=100, page_size=999, cli_retries=5, max_requeue=3, start_rate_per_second=100.00
module.cleanup.terraform_data.disk_cleanup (local-exec): command failed with exit code 2: nebius compute disk list --parent-id project-i00mcd6ppr005c007e7tqw --page-size 999 --format json --no-progress --retries 5
module.cleanup.terraform_data.disk_cleanup (local-exec): stderr: Error: unknown flag: --no-progress
```

## Solution

nebius cli was pinned earlier just in case.
Since nebius api almost never breaks backward compatibility, it's better not to pin it.
