### PR TITLE
SCHED-2051: Removal of skip_for_reservation_prefixes

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/alloc_gpus_busy.drain.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/alloc_gpus_busy.drain.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["8xGPU", "1xGPU", "4xGPU"],
   "skip_for_cpu_jobs": true,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["prolog"],
   "node_states": ["any"],
   "on_fail": "drain",

--- a/helm/slurm-cluster/slurm_scripts/alloc_gpus_busy.undrain.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/alloc_gpus_busy.undrain.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["8xGPU", "1xGPU", "4xGPU"],
   "skip_for_cpu_jobs": true,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["hc_program"],
   "node_states": ["drain"],
   "on_fail": "none",

--- a/helm/slurm-cluster/slurm_scripts/alloc_mem_used.drain.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/alloc_mem_used.drain.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["prolog"],
   "node_states": ["any"],
   "on_fail": "drain",

--- a/helm/slurm-cluster/slurm_scripts/alloc_mem_used.undrain.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/alloc_mem_used.undrain.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["hc_program"],
   "node_states": ["drain"],
   "on_fail": "none",

--- a/helm/slurm-cluster/slurm_scripts/boot_disk_full.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/boot_disk_full.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["prolog", "hc_program"],
   "node_states": ["any"],
   "on_fail": "drain",

--- a/helm/slurm-cluster/slurm_scripts/check_runner.py
+++ b/helm/slurm-cluster/slurm_scripts/check_runner.py
@@ -160,7 +160,7 @@ def main():
     try:
         with open(CHECKS_CONFIG, encoding="utf-8") as f:
             checks_data = json.load(f)
-        checks = [load_check(entry) for entry in checks_data]
+        checks = [Check(**entry) for entry in checks_data]
     except Exception as e:
         logging.error(f"Failed to open checks config {CHECKS_CONFIG}, exiting: {e}")
         sys.exit(0)
@@ -200,18 +200,6 @@ def filter_applicable_checks(checks: list[Check]) -> list[Check]:
     # Filter by node_state (needs node info)
     checks = filter_by_node_state(checks)
     return checks
-
-def load_check(entry: dict) -> Check:
-    entry = dict(entry)
-    skip_for_reservation_prefixes = entry.pop("skip_for_reservation_prefixes", [])
-    if skip_for_reservation_prefixes:
-        check_name = entry.get("name", "noname")
-        logging.warning(
-            f"Check {check_name} uses deprecated field skip_for_reservation_prefixes="
-            f"{json.dumps(skip_for_reservation_prefixes)}; it is ignored and "
-            "reservation-based skipping is no longer supported."
-        )
-    return Check(**entry)
 
 def filter_by_context(checks: list[Check]) -> list[Check]:
     # Skip if all checks don't care

--- a/helm/slurm-cluster/slurm_scripts/check_runner.py
+++ b/helm/slurm-cluster/slurm_scripts/check_runner.py
@@ -53,10 +53,6 @@ class Check(typing.NamedTuple):
     # CPU-only jobs are not considered "partial GPU"
     skip_for_partial_gpu_jobs: bool = False
 
-    # Whether to skip this checks for nodes reserved with specific prefixes.
-    # Empty list means don't skip for any reservation.
-    skip_for_reservation_prefixes: list[str] = []
-
     # What contexts this check should run in.
     # Supported values:
     # - "any" - any context
@@ -125,7 +121,6 @@ class NodeInfo(typing.NamedTuple):
     state_flags: list[str] = []
     reason: str = ""
     comment: str = ""
-    reservation: str = ""
     real_memory_bytes: int = 0
 
 class JobInfo(typing.NamedTuple):
@@ -165,7 +160,7 @@ def main():
     try:
         with open(CHECKS_CONFIG, encoding="utf-8") as f:
             checks_data = json.load(f)
-        checks = [Check(**entry) for entry in checks_data]
+        checks = [load_check(entry) for entry in checks_data]
     except Exception as e:
         logging.error(f"Failed to open checks config {CHECKS_CONFIG}, exiting: {e}")
         sys.exit(0)
@@ -204,9 +199,19 @@ def filter_applicable_checks(checks: list[Check]) -> list[Check]:
     checks = filter_by_skip_for_partial_gpu_jobs(checks)
     # Filter by node_state (needs node info)
     checks = filter_by_node_state(checks)
-    # Filter by skip_for_reservation_prefixes (needs node info)
-    checks = filter_by_skip_for_reservation_prefixes(checks)
     return checks
+
+def load_check(entry: dict) -> Check:
+    entry = dict(entry)
+    skip_for_reservation_prefixes = entry.pop("skip_for_reservation_prefixes", [])
+    if skip_for_reservation_prefixes:
+        check_name = entry.get("name", "noname")
+        logging.warning(
+            f"Check {check_name} uses deprecated field skip_for_reservation_prefixes="
+            f"{json.dumps(skip_for_reservation_prefixes)}; it is ignored and "
+            "reservation-based skipping is no longer supported."
+        )
+    return Check(**entry)
 
 def filter_by_context(checks: list[Check]) -> list[Check]:
     # Skip if all checks don't care
@@ -274,19 +279,6 @@ def filter_by_node_state(checks: list[Check]) -> list[Check]:
         if (
             "any" in check.node_states or
             ("drain" in check.node_states and "DRAIN" in node_info.state_flags)
-        )
-    ]
-
-def filter_by_skip_for_reservation_prefixes(checks: list[Check]) -> list[Check]:
-    # Skip if all checks don't care
-    if all(len(check.skip_for_reservation_prefixes) == 0 for check in checks):
-        return checks
-    node_info = get_node_info()
-    return [
-        check for check in checks
-        if (
-            len(check.skip_for_reservation_prefixes) == 0 or
-            not node_info.reservation.startswith(tuple(check.skip_for_reservation_prefixes))
         )
     ]
 
@@ -443,7 +435,6 @@ def get_node_info() -> NodeInfo:
             state_flags=node.get("state", []),
             reason=node.get("reason", ""),
             comment=node.get("comment", ""),
-            reservation=node.get("reservation", ""),
             real_memory_bytes=(real_memory_mib * 1024 * 1024)
         )
         logging.info(f"Slurm node info: {json.dumps(info._asdict(), indent=2)}")

--- a/helm/slurm-cluster/slurm_scripts/chmod_enroot_layers.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/chmod_enroot_layers.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["prolog", "epilog"],
   "node_states": ["any"],
   "on_fail": "none",

--- a/helm/slurm-cluster/slurm_scripts/cleanup_enroot.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/cleanup_enroot.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["prolog", "epilog"],
   "node_states": ["any"],
   "on_fail": "none",

--- a/helm/slurm-cluster/slurm_scripts/cleanup_scratch_data.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/cleanup_scratch_data.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["none"],
   "node_states": ["any"],
   "on_fail": "none",

--- a/helm/slurm-cluster/slurm_scripts/drop_page_cache.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/drop_page_cache.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["epilog"],
   "node_states": ["any"],
   "on_fail": "none",

--- a/helm/slurm-cluster/slurm_scripts/drop_posix_shmem.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/drop_posix_shmem.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["any"],
   "skip_for_cpu_jobs": true,
   "skip_for_partial_gpu_jobs": true,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["epilog"],
   "node_states": ["any"],
   "on_fail": "none",

--- a/helm/slurm-cluster/slurm_scripts/gpu_health_check.py.json
+++ b/helm/slurm-cluster/slurm_scripts/gpu_health_check.py.json
@@ -4,7 +4,6 @@
   "platforms": ["8xH100", "8xH200", "8xB200", "8xB300", "4xGB300"],
   "skip_for_cpu_jobs": true,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["any"],
   "node_states": ["any"],
   "on_fail": "drain",

--- a/helm/slurm-cluster/slurm_scripts/job_tmpfs_delete.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/job_tmpfs_delete.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["epilog"],
   "node_states": ["any"],
   "on_fail": "none",

--- a/helm/slurm-cluster/slurm_scripts/job_tmpfs_delete_leftover.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/job_tmpfs_delete_leftover.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["hc_program"],
   "node_states": ["any"],
   "on_fail": "none",

--- a/helm/slurm-cluster/slurm_scripts/job_tmpfs_recreate.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/job_tmpfs_recreate.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["prolog"],
   "node_states": ["any"],
   "on_fail": "none",

--- a/helm/slurm-cluster/slurm_scripts/map_job_dcgm.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/map_job_dcgm.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["8xGPU", "1xGPU", "4xGPU"],
   "skip_for_cpu_jobs": true,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["prolog"],
   "node_states": ["any"],
   "on_fail": "none",

--- a/helm/slurm-cluster/slurm_scripts/nvme_raid_health.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/nvme_raid_health.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["8xB300", "4xGB300"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["hc_program"],
   "node_states": ["any"],
   "on_fail": "drain",

--- a/helm/slurm-cluster/slurm_scripts/unmap_job_dcgm.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/unmap_job_dcgm.sh.json
@@ -4,7 +4,6 @@
   "platforms": ["8xGPU", "1xGPU", "4xGPU"],
   "skip_for_cpu_jobs": true,
   "skip_for_partial_gpu_jobs": false,
-  "skip_for_reservation_prefixes": [],
   "contexts": ["epilog"],
   "node_states": ["any"],
   "on_fail": "none",

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -802,7 +802,6 @@ slurmScripts:
   #       "platforms": ["any"],
   #       "skip_for_cpu_jobs": false,
   #       "skip_for_partial_gpu_jobs": false,
-  #       "skip_for_reservation_prefixes": [],
   #       "contexts": ["prolog"],
   #       "node_states": ["any"],
   #       "on_fail": "drain",


### PR DESCRIPTION
## Problem

From https://github.com/nebius/soperator/pull/2671#discussion_r3505165317, the `skip_for_reservation_prefixes` is no longer used, so useless.

## Solution

Removal of the above flag with a warning in case of old scripts that are still using it.

## Testing

Testing in the dev cluster.

### 1. Confirm rendered Slurm scripts contain the new code path

```bash
kubectl -n soperator get configmap soperator-slurm-scripts -o yaml | \
  rg -n 'def load_check|skip_for_reservation_prefixes|filter_by_skip_for_reservation_prefixes'
```

Rationale: verify the rendered chart content before checking runtime pods.

Observed result: no longer seeing the code (empty result).

### 2. Confirm worker-0 is running the new script content

```bash
kubectl -n soperator exec worker-0 -c slurmd -- sh -c 'grep -R "def load_check\|filter_by_skip_for_reservation_prefixes\|skip_for_reservation_prefixes" -n /opt/slurm_scripts/check_runner.py /opt/slurm_scripts/checks.json /mnt/jail.upper/opt/slurm_scripts/check_runner.py /mnt/jail.upper/opt/slurm_scripts/checks.json /mnt/jail/opt/slurm_scripts/check_runner.py /mnt/jail/opt/slurm_scripts/checks.json 2>/dev/null | head -80'
```

Rationale: verify that the worker pod is actually using the updated script at runtime, not only that the ConfigMap was rendered.

Observed result: `worker-0` had no mentions of the old code.

### 3. Confirm worker-1 is running the new script content

```bash
kubectl -n soperator exec worker-1 -c slurmd -- sh -c 'grep -R "def load_check\|filter_by_skip_for_reservation_prefixes\|skip_for_reservation_prefixes" -n /opt/slurm_scripts/check_runner.py /opt/slurm_scripts/checks.json /mnt/jail.upper/opt/slurm_scripts/check_runner.py /mnt/jail.upper/opt/slurm_scripts/checks.json /mnt/jail/opt/slurm_scripts/check_runner.py /mnt/jail/opt/slurm_scripts/checks.json 2>/dev/null | head -80'
```

Rationale: verify the same runtime behavior on the second worker.

Observed result: `worker-1` had no mentsions of the old code.

### 4. Confirm Kubernetes worker health

```bash
kubectl -n soperator get nodeset worker -o wide
kubectl -n soperator get pods -o wide | rg 'worker-|NAME'
```

Rationale: confirm the worker NodeSet and pods are healthy after the deployment.

Observed result: `nodeset/worker` was `Ready`, desired `2`, ready `2`; both worker pods were `3/3 Running`.

### 5. Confirm Slurm sees both workers

```bash
kubectl -n soperator exec login-0 -- sinfo -Nel
```

Rationale: Kubernetes pod readiness alone does not prove Slurm can see the nodes.

Observed result: Slurm showed both `worker-0` and `worker-1` as `idle` with reason `none`.

### 6. Run a Slurm smoke test on worker-1

```bash
kubectl -n soperator exec login-0 -- chroot /mnt/jail timeout 60s srun -N1 -w worker-1 hostname
```

Rationale: prove that Slurm can schedule and execute work on an updated worker.

Observed result: the command returned `worker-1`.


## Release Notes

Removed `skip_for_reservation_prefixes` flag.
