### PR TITLE
Add SETFCAP to populate-jail

### DIFF
--- a/internal/consts/container.go
+++ b/internal/consts/container.go
@@ -19,6 +19,7 @@ const (
 	ContainerNameSConfigController = SConfigControllerName
 
 	ContainerSecurityContextCapabilitySysAdmin = "SYS_ADMIN"
+	ContainerSecurityContextCapabilitySetFcap  = "SETFCAP"
 
 	ContainerPortNameExporter = "metrics"
 	ContainerPortExporter     = 8080

--- a/internal/render/populate_jail/container.go
+++ b/internal/render/populate_jail/container.go
@@ -34,6 +34,7 @@ func renderContainerPopulateJail(populateJail *values.PopulateJail) corev1.Conta
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{
 					consts.ContainerSecurityContextCapabilitySysAdmin,
+					consts.ContainerSecurityContextCapabilitySetFcap,
 				},
 			},
 			AppArmorProfile: common.ParseAppArmorProfile(populateJail.ContainerPopulateJail.AppArmorProfile),


### PR DESCRIPTION
Allows to set xattrs on target fs.

## Problem
Populate jail fails with:
`xattr.LSet /mnt/jail/usr/bin/ping security.capability: operation not permitted`

## Solution
Add SETFCAP to populate jail job
