### PR TITLE
ActiveChecks: Fix chroot for create-user check

### DIFF
--- a/internal/consts/container.go
+++ b/internal/consts/container.go
@@ -18,8 +18,9 @@ const (
 	ContainerNameCustom            = "custom-container"
 	ContainerNameSConfigController = SConfigControllerName
 
-	ContainerSecurityContextCapabilitySysAdmin = "SYS_ADMIN"
-	ContainerSecurityContextCapabilitySetFcap  = "SETFCAP"
+	ContainerSecurityContextCapabilitySysAdmin  = "SYS_ADMIN"
+	ContainerSecurityContextCapabilitySetFcap   = "SETFCAP"
+	ContainerSecurityContextCapabilitySysChroot = "SYS_CHROOT"
 
 	ContainerPortNameExporter = "metrics"
 	ContainerPortExporter     = 8080

--- a/internal/render/soperatorchecks/container.go
+++ b/internal/render/soperatorchecks/container.go
@@ -34,7 +34,10 @@ func renderContainerK8sCronjob(check *slurmv1alpha1.ActiveCheck) corev1.Containe
 			Env:             check.Spec.K8sJobSpec.JobContainer.Env,
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
-					Add: []corev1.Capability{consts.ContainerSecurityContextCapabilitySysAdmin},
+					Add: []corev1.Capability{
+						consts.ContainerSecurityContextCapabilitySysAdmin,
+						consts.ContainerSecurityContextCapabilitySysChroot,
+					},
 				},
 				AppArmorProfile: common.ParseAppArmorProfile(
 					check.Spec.K8sJobSpec.JobContainer.AppArmorProfile),
@@ -99,7 +102,10 @@ func renderContainerK8sCronjob(check *slurmv1alpha1.ActiveCheck) corev1.Containe
 		Env:             slurmEnvVars,
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{consts.ContainerSecurityContextCapabilitySysAdmin},
+				Add: []corev1.Capability{
+					consts.ContainerSecurityContextCapabilitySysAdmin,
+					consts.ContainerSecurityContextCapabilitySysChroot,
+				},
 			},
 			AppArmorProfile: common.ParseAppArmorProfile(
 				check.Spec.K8sJobSpec.JobContainer.AppArmorProfile),


### PR DESCRIPTION
SYS_CHROOT is required in ActiveChecks to allow chroot to jail and create user