### PR TITLE
SCHED-1897: Add guard to avoid calling get_node_info out of hc_program for undrain…

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/check_runner.py
+++ b/helm/slurm-cluster/slurm_scripts/check_runner.py
@@ -328,6 +328,11 @@ def run_check(check: Check, in_jail=False):
 
     logging.info(f"Check {check.name}: OK")
 
+    # Please note that "undrain" and "uncomment" actions can be issues only from "hc_program" context.
+    if check.on_ok in ("undrain", "uncomment") and CHECKS_CONTEXT != "hc_program":
+        logging.info(f"Skipping on_ok={check.on_ok} in unsupported context {CHECKS_CONTEXT}")
+        return
+
     # Undrain / uncomment the Slurm node, if it was marked with the same reason
     if check.on_ok == "undrain" and "DRAIN" in get_node_info().state_flags:
         if get_node_info().reason and get_node_info().reason.startswith(reason_base):

--- a/helm/slurm-cluster/slurm_scripts/check_runner_test.py
+++ b/helm/slurm-cluster/slurm_scripts/check_runner_test.py
@@ -1,0 +1,120 @@
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+CHECK_RUNNER_PATH = Path(__file__).with_name("check_runner.py")
+
+
+class CheckRunnerOnOkContextTest(unittest.TestCase):
+    def load_runner(self, context: str, tmpdir: str):
+        env = {
+            "SLURMD_NODENAME": "worker-1",
+            "CHECKS_OUTPUTS_BASE_DIR": tmpdir,
+            "CHECKS_CONTEXT": context,
+            "CHECKS_CONFIG": str(Path(tmpdir) / "checks.json"),
+            "CHECKS_RUNNER_OUTPUT": "/dev/null",
+        }
+        patcher = mock.patch.dict(os.environ, env, clear=False)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        module_name = f"check_runner_under_test_{context}_{id(self)}"
+        spec = importlib.util.spec_from_file_location(module_name, CHECK_RUNNER_PATH)
+        runner = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(runner)
+        return runner
+
+    def test_undrain_on_ok_is_ignored_outside_hc_program(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = self.load_runner("prolog", tmpdir)
+            check = runner.Check(
+                name="boot_disk_full",
+                command="/usr/bin/true",
+                on_ok="undrain",
+                reason_base="[user_problem] $name",
+                log="check.out",
+            )
+
+            def get_node_info():
+                raise AssertionError("prolog on_ok=undrain must not read Slurm node info")
+
+            def undrain_node():
+                raise AssertionError("prolog on_ok=undrain must not undrain Slurm nodes")
+
+            runner.get_node_info = get_node_info
+            runner.undrain_node = undrain_node
+
+            runner.run_check(check, in_jail=True)
+
+    def test_undrain_on_ok_still_runs_in_hc_program(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = self.load_runner("hc_program", tmpdir)
+            check = runner.Check(
+                name="boot_disk_full",
+                command="/usr/bin/true",
+                on_ok="undrain",
+                reason_base="[user_problem] $name",
+                log="check.out",
+            )
+            calls = []
+
+            runner.get_node_info = lambda: runner.NodeInfo(
+                state_flags=["DRAIN"],
+                reason="[user_problem] boot_disk_full: disk ok [hc_program]",
+            )
+            runner.undrain_node = lambda: calls.append("undrain")
+
+            runner.run_check(check, in_jail=True)
+
+            self.assertEqual(["undrain"], calls)
+
+    def test_uncomment_on_ok_is_ignored_outside_hc_program(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = self.load_runner("epilog", tmpdir)
+            check = runner.Check(
+                name="some_check",
+                command="/usr/bin/true",
+                on_ok="uncomment",
+                reason_base="[node_problem] $name",
+                log="check.out",
+            )
+
+            def get_node_info():
+                raise AssertionError("epilog on_ok=uncomment must not read Slurm node info")
+
+            def uncomment_node():
+                raise AssertionError("epilog on_ok=uncomment must not uncomment Slurm nodes")
+
+            runner.get_node_info = get_node_info
+            runner.uncomment_node = uncomment_node
+
+            runner.run_check(check, in_jail=True)
+
+    def test_uncomment_on_ok_still_runs_in_hc_program(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = self.load_runner("hc_program", tmpdir)
+            check = runner.Check(
+                name="some_check",
+                command="/usr/bin/true",
+                on_ok="uncomment",
+                reason_base="[node_problem] $name",
+                log="check.out",
+            )
+            calls = []
+
+            runner.get_node_info = lambda: runner.NodeInfo(
+                comment="[node_problem] some_check: recovered [hc_program]",
+            )
+            runner.uncomment_node = lambda: calls.append("uncomment")
+
+            runner.run_check(check, in_jail=True)
+
+            self.assertEqual(["uncomment"], calls)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

Passive checks can generate unnecessary Slurm RPCs from job-coupled contexts.

In particular, `boot_disk_full` is configured with `on_ok: undrain` and runs in both `prolog` and `hc_program`. Although the check itself only performs a local disk-usage check, `check_runner.py` evaluates the `on_ok: undrain` path after a successful `prolog` run. This calls `get_node_info()`, which executes `scontrol show node ... --json`.

As a result, every successful `boot_disk_full` execution in `prolog` can produce an unnecessary `scontrol show node` call. This adds per-job/per-node RPC load to Slurm and was identified as one of the main contributors in SCHED-1897.

## Solution

Restrict `on_ok` recovery actions to the `hc_program` context.

`undrain` and `uncomment` are intended to be issued only by periodic health checks, not by `prolog` or `epilog`. With this change, successful checks in `prolog`/`epilog` no longer evaluate the `undrain`/`uncomment` path and therefore no longer call `get_node_info()` just to decide whether a node should be resumed or uncommented.

Failure handling remains unchanged: checks can still drain or comment nodes on failure according to their configuration.

## Testing

Tested with local `check_runner_test.py`.
 
## Release Notes

Fix: Reduced Slurm RPC load from passive checks by preventing `prolog`/`epilog` success paths from evaluating `undrain`/`uncomment` actions.

The intended auto-recovery behavior remains available from `hc_program`; no user-facing configuration changes or migrations are required.