### PR TITLE
Run Slurm script unit tests in CI

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -204,6 +204,20 @@ jobs:
           fi
           go build "${packages[@]}"
 
+  test-slurm-scripts:
+    needs: [changes, authorize]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Test Slurm scripts
+        run: make test-slurm-scripts
+
   build-soperator-images:
     needs:
       - changes
@@ -846,6 +860,7 @@ jobs:
       - pre-build
       - lint
       - build-e2e
+      - test-slurm-scripts
       - build-slurm-images
       - build-soperator-images
       - manifest-populate-jail

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,13 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	go test ./...
 
+.PHONY: test-slurm-scripts
+test-slurm-scripts: ## Run Python unit tests for Slurm scripts.
+	python3 -m unittest discover \
+		-s helm/slurm-cluster/slurm_scripts \
+		-p '*_test.py' \
+		-v
+
 .PHONY: test-coverage
 test-coverage: manifests generate fmt vet envtest ## Run tests and generate test coverage.
 	go test ./... -coverprofile cover.out


### PR DESCRIPTION
## Summary

- add a `test-slurm-scripts` Makefile target using Python unittest discovery
- add a dedicated, change-gated GitHub Actions job that checks out the PR head and runs the target
- include the job in the existing `ci-success` dependency set

## Why

`check_runner_test.py` can currently be run only through a manual Python command. This makes all `*_test.py` files under `helm/slurm-cluster/slurm_scripts` run automatically for the same non-documentation changes as the existing CI jobs.

This is a stacked PR targeting the branch for #2719 so the review remains limited to the CI integration.

## Validation

- `env PYTHONDONTWRITEBYTECODE=1 make test-slurm-scripts` (4 tests passed)
- `yq '.' .github/workflows/one_job.yml` (workflow YAML parsed successfully)
- `git diff --check`
