### PR TITLE
SCHED-1893: Fix exporterContainer resources.

### DIFF
--- a/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
+++ b/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
@@ -473,6 +473,10 @@ spec:
         imagePullPolicy: {{ default "IfNotPresent" .Values.slurmNodes.exporter.imagePullPolicy | quote }}
         appArmorProfile: {{ default "unconfined" .Values.slurmNodes.exporter.appArmorProfile | quote }}
         {{- with (default dict .Values.slurmNodes.exporter.exporterContainer) }}
+        {{- with .resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- with .livenessProbe }}
         livenessProbe:
           {{- toYaml . | nindent 10 }}

--- a/helm/slurm-cluster/tests/exporter-resources_test.yaml
+++ b/helm/slurm-cluster/tests/exporter-resources_test.yaml
@@ -1,0 +1,31 @@
+suite: test exporter container resources
+templates:
+  - templates/slurm-cluster-cr.yaml
+tests:
+  - it: should not render exporter container resources by default
+    set:
+      clusterName: test-cluster
+    asserts:
+      - notExists:
+          path: spec.slurmNodes.exporter.exporterContainer.resources
+
+  - it: should render exporter container resources when provided
+    set:
+      clusterName: test-cluster
+      slurmNodes:
+        exporter:
+          exporterContainer:
+            resources:
+              cpu: "250m"
+              memory: "256Mi"
+              ephemeral-storage: "500Mi"
+    asserts:
+      - equal:
+          path: spec.slurmNodes.exporter.exporterContainer.resources.cpu
+          value: 250m
+      - equal:
+          path: spec.slurmNodes.exporter.exporterContainer.resources.memory
+          value: 256Mi
+      - equal:
+          path: spec.slurmNodes.exporter.exporterContainer.resources["ephemeral-storage"]
+          value: 500Mi

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -609,6 +609,11 @@ slurmNodes:
         memory: "256Mi"
         ephemeralStorage: "500Mi"
     exporterContainer:
+    # Rendered into the CR verbatim: use k8s resource names (ephemeral-storage, not ephemeralStorage).
+    # resources:
+    #   cpu: "250m"
+    #   memory: "256Mi"
+    #   ephemeral-storage: "500Mi"
     # livenessProbe:
     #   httpGet:
     #     path: /healthz


### PR DESCRIPTION
Considered together with nebius/nebius-solutions-library#1073 (sizing tiers): that PR's terraform sends `exporterContainer.resources`, which this chart dropped until now.

## Problem

`exporterContainer` resources are not used in the Helm chart.

## Solution

Use them! The value is rendered into the CR verbatim, so keys are k8s resource names (`ephemeral-storage`, not `ephemeralStorage`).

## Testing

Add a Helm test.

## Release Notes

Fix: Exporter container resources were ignored
