### PR TITLE
[DO NOT MERGE] Testing SPANK plugin in prolog

### DIFF
--- a/images/common/scripts/complement_jail.sh
+++ b/images/common/scripts/complement_jail.sh
@@ -376,6 +376,10 @@ pushd "${jaildir}"
     touch usr/lib/slurm/spanknccldebug.so
     mount --bind "/${SLURM_LIB_PATH}/spanknccldebug.so" "usr/lib/slurm/spanknccldebug.so"
 
+    log "[slurm] Bind-mount allocated-memory diagnostic SPANK plugin from container to the jail"
+    touch usr/lib/slurm/spank_alloc_mem_diagnostic.so
+    mount --bind "/${SLURM_LIB_PATH}/spank_alloc_mem_diagnostic.so" "usr/lib/slurm/spank_alloc_mem_diagnostic.so"
+
     log "[slurm] Bind-mount NCCL Inspector PreConf SPANK plugin from container to the jail"
     touch usr/lib/slurm/spank_nccl_inspector_preconf.so
     mount --bind "/${SLURM_LIB_PATH}/spank_nccl_inspector_preconf.so" "usr/lib/slurm/spank_nccl_inspector_preconf.so"

--- a/images/common/scripts/install_alloc_mem_diagnostic_plugin.sh
+++ b/images/common/scripts/install_alloc_mem_diagnostic_plugin.sh
@@ -23,3 +23,6 @@ gcc \
   -shared \
   -o /usr/lib/"${ALT_ARCH}"-linux-gnu/slurm/spank_alloc_mem_diagnostic.so \
   ${ALLOC_MEM_DIAGNOSTIC_SRC_DIR}/*.c
+
+# Create the per-worker output file used by the diagnostic callback.
+install -o root -g root -m 0644 /dev/null /var/log/spank_alloc_mem_diagnostic.log

--- a/images/common/scripts/install_alloc_mem_diagnostic_plugin.sh
+++ b/images/common/scripts/install_alloc_mem_diagnostic_plugin.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -u
+
+# ALT_ARCH has the extended form like: x86_64, aarch64
+ALT_ARCH="$(uname -m)"
+
+ALLOC_MEM_DIAGNOSTIC_SRC_DIR=/usr/src/soperator/spank/alloc-mem-diagnostic
+
+# Compile and install the allocated-memory diagnostic SPANK plugin.
+gcc \
+  -std=gnu99 \
+  -fPIC \
+  -flto \
+  -O3 \
+  -s \
+  -DNDEBUG \
+  -I/usr/local/include/slurm \
+  -I${ALLOC_MEM_DIAGNOSTIC_SRC_DIR} \
+  -L/usr/local/lib \
+  -lslurm \
+  -shared \
+  -o /usr/lib/"${ALT_ARCH}"-linux-gnu/slurm/spank_alloc_mem_diagnostic.so \
+  ${ALLOC_MEM_DIAGNOSTIC_SRC_DIR}/*.c

--- a/images/common/spank-alloc-mem-diagnostic/README.md
+++ b/images/common/spank-alloc-mem-diagnostic/README.md
@@ -2,11 +2,12 @@
 
 This plugin records the values exposed to `slurm_spank_init()` by a remote
 `slurmstepd`. It is diagnostic only: it does not change the job environment,
-write files, drain nodes, or return an error. The only intentional delay is the
-optional `sleep=<seconds>` argument.
+drain nodes, or return an error. Its only outputs are an append-only diagnostic
+file and the optional delay requested with `sleep=<seconds>`.
 
 The plugin ignores every context except `S_CTX_REMOTE`. In remote context it
-logs one `event=init` record containing:
+appends one `event=init` record to the worker-local file
+`/var/log/spank_alloc_mem_diagnostic.log`. Each record contains:
 
 - an explicit UTC timestamp and PID;
 - the SPANK context;
@@ -15,9 +16,10 @@ logs one `event=init` record containing:
 - the numeric and textual return code from every `spank_get_item()` call; and
 - the configured sleep value.
 
-An unavailable item is logged as `unavailable`, alongside its non-success
+An unavailable item is recorded as `unavailable`, alongside its non-success
 return code. If sleep is enabled, a second `event=sleep_complete` record is
-written after the delay.
+written after the delay. File creation and write errors are ignored so
+diagnostic output can never fail a job.
 
 ## Build and enable
 
@@ -25,7 +27,9 @@ The worker, login, and Slurm check-job images build
 `spank_alloc_mem_diagnostic.so` using the same GNU99, PIC, LTO, optimization,
 Slurm include/library paths, and shared-library layout as the existing
 Soperator NCCL debug SPANK plugin. Rebuild and deploy those images before
-enabling the plugin.
+enabling the plugin. The image build pre-creates the output file as
+root-owned mode `0644`; remote initialization runs before Slurm drops
+privileges.
 
 Append the plugin to the SlurmCluster's custom SPANK plugins:
 
@@ -49,13 +53,17 @@ The shared library is installed under
 search location. It is also made available inside the Soperator jail so an
 `srun` launched from a job can load the same plugstack.
 
-To watch diagnostic records on a development cluster, use the worker pod logs
-(adjust the pod name if needed):
+The file is local to each worker pod. To watch diagnostic records on a
+development cluster, read it from the worker's `slurmd` container (adjust the
+pod name if needed):
 
 ```bash
-kubectl -n soperator logs worker-0 --all-containers=true -f |
-  grep --line-buffered alloc_mem_diagnostic
+kubectl -n soperator exec worker-0 -c slurmd -- \
+  tail -f /var/log/spank_alloc_mem_diagnostic.log
 ```
+
+For jobs that can run on multiple nodes, inspect the file on every participating
+worker and filter records using `job_id=<id>`.
 
 The important fields look like:
 
@@ -76,7 +84,8 @@ With the plugin enabled without a sleep argument, submit:
 sbatch --mem=4G --wrap='hostname; sleep 30'
 ```
 
-Find the `event=init` record for the returned job ID. Verify:
+Find the `event=init` record for the returned job ID in the participating
+worker's diagnostic file. Verify:
 
 1. `context=remote` proves the plugin ran in `slurmstepd`.
 2. `job_alloc_mem_rc=0(Success)` proves `S_JOB_ALLOC_MEM` was available.
@@ -85,7 +94,7 @@ Find the `event=init` record for the returned job ID. Verify:
    point in job launch.
 
 For a multi-node allocation, expect a record from every participating
-`slurmstepd`; compare `node_id` across worker logs.
+`slurmstepd`; compare `node_id` across worker files.
 
 ## Experiment 2: callback timing
 
@@ -113,8 +122,8 @@ Then submit:
 sbatch --mem=4G --wrap='date; hostname'
 ```
 
-Compare the plugin's `event=init` and `event=sleep_complete` timestamps with
-the timestamp in the job output. The two plugin timestamps should be about ten
+Compare the `event=init` and `event=sleep_complete` file records with the
+timestamp in the job output. The two plugin timestamps should be about ten
 seconds apart, and the payload should start roughly ten seconds after
 `event=init`, immediately after `event=sleep_complete`. Comparing these
 timestamps avoids confusing scheduler queue time with the plugin delay.
@@ -125,7 +134,7 @@ intentional.
 
 ## Experiment 3: multiple `srun` steps
 
-Submit a one-node script so one log line corresponds to one remote
+Submit a one-node script so one file record corresponds to one remote
 `slurmstepd` invocation:
 
 ```bash
@@ -142,7 +151,7 @@ EOF
 sbatch /tmp/spank-steps.sbatch
 ```
 
-Filter worker logs by the returned job ID. Count distinct PIDs and
+Filter worker diagnostic files by the returned job ID. Count distinct PIDs and
 `step_id` values. Record whether there is one callback for the batch step plus
 one for each `srun` step, and compare the numeric IDs with
 `SLURM_STEP_ID` printed by the two payloads. On a multi-node step, group by
@@ -160,11 +169,13 @@ srun --nodes=1 --ntasks=1 sh -c 'echo second interactive step: ${SLURM_STEP_ID};
 exit
 ```
 
-Compare these worker records with Experiment 3. In particular, note whether
+Compare these worker file records with Experiment 3. In particular, note whether
 creating the allocation itself produces a remote record and which records are
 produced by each `srun`. The plugin intentionally ignores the allocator and
 local contexts, so every diagnostic record should still say
 `context=remote`.
 
 When testing is complete, remove the custom plugin entry from
-`spec.plugStackConfig.customPlugins`.
+`spec.plugStackConfig.customPlugins`. Preserve the relevant records, then
+truncate the worker-local diagnostic files if the test data is no longer
+needed.

--- a/images/common/spank-alloc-mem-diagnostic/README.md
+++ b/images/common/spank-alloc-mem-diagnostic/README.md
@@ -1,0 +1,170 @@
+# Allocated-memory SPANK diagnostic
+
+This plugin records the values exposed to `slurm_spank_init()` by a remote
+`slurmstepd`. It is diagnostic only: it does not change the job environment,
+write files, drain nodes, or return an error. The only intentional delay is the
+optional `sleep=<seconds>` argument.
+
+The plugin ignores every context except `S_CTX_REMOTE`. In remote context it
+logs one `event=init` record containing:
+
+- an explicit UTC timestamp and PID;
+- the SPANK context;
+- job, step, and relative node IDs;
+- job- and step-allocated memory in MB;
+- the numeric and textual return code from every `spank_get_item()` call; and
+- the configured sleep value.
+
+An unavailable item is logged as `unavailable`, alongside its non-success
+return code. If sleep is enabled, a second `event=sleep_complete` record is
+written after the delay.
+
+## Build and enable
+
+The worker, login, and Slurm check-job images build
+`spank_alloc_mem_diagnostic.so` using the same GNU99, PIC, LTO, optimization,
+Slurm include/library paths, and shared-library layout as the existing
+Soperator NCCL debug SPANK plugin. Rebuild and deploy those images before
+enabling the plugin.
+
+Append the plugin to the SlurmCluster's custom SPANK plugins:
+
+```yaml
+spec:
+  plugStackConfig:
+    customPlugins:
+      - required: false
+        path: spank_alloc_mem_diagnostic.so
+```
+
+Keep it `optional` so a packaging or loading problem cannot block a job. After
+Soperator regenerates `plugstack.conf`, confirm that it contains:
+
+```text
+optional spank_alloc_mem_diagnostic.so
+```
+
+The shared library is installed under
+`/usr/lib/<architecture>-linux-gnu/slurm/`, which is already a Slurm plugin
+search location. It is also made available inside the Soperator jail so an
+`srun` launched from a job can load the same plugstack.
+
+To watch diagnostic records on a development cluster, use the worker pod logs
+(adjust the pod name if needed):
+
+```bash
+kubectl -n soperator logs worker-0 --all-containers=true -f |
+  grep --line-buffered alloc_mem_diagnostic
+```
+
+The important fields look like:
+
+```text
+event=init ... context=remote ... job_id=123 job_id_rc=0(Success) step_id=4294967294 step_id_rc=0(Success) node_id=0 node_id_rc=0(Success) job_alloc_mem_mb=4096 job_alloc_mem_rc=0(Success) step_alloc_mem_mb=4096 step_alloc_mem_rc=0(Success)
+```
+
+Only values whose return code is `ESPANK_SUCCESS` are usable. Slurm reports
+`S_JOB_ALLOC_MEM` and `S_STEP_ALLOC_MEM` in MB. Slurm represents special
+steps such as the batch script with reserved unsigned 32-bit values, so a batch
+`step_id` can appear as a large integer.
+
+## Experiment 1: allocated job memory
+
+With the plugin enabled without a sleep argument, submit:
+
+```bash
+sbatch --mem=4G --wrap='hostname; sleep 30'
+```
+
+Find the `event=init` record for the returned job ID. Verify:
+
+1. `context=remote` proves the plugin ran in `slurmstepd`.
+2. `job_alloc_mem_rc=0(Success)` proves `S_JOB_ALLOC_MEM` was available.
+3. `job_alloc_mem_mb=4096` matches `--mem=4G`.
+4. The other item return codes and values show what else is available at this
+   point in job launch.
+
+For a multi-node allocation, expect a record from every participating
+`slurmstepd`; compare `node_id` across worker logs.
+
+## Experiment 2: callback timing
+
+Temporarily configure the custom plugin argument:
+
+```yaml
+spec:
+  plugStackConfig:
+    customPlugins:
+      - required: false
+        path: spank_alloc_mem_diagnostic.so
+        arguments:
+          sleep: "10"
+```
+
+This renders the plugstack entry:
+
+```text
+optional spank_alloc_mem_diagnostic.so sleep=10
+```
+
+Then submit:
+
+```bash
+sbatch --mem=4G --wrap='date; hostname'
+```
+
+Compare the plugin's `event=init` and `event=sleep_complete` timestamps with
+the timestamp in the job output. The two plugin timestamps should be about ten
+seconds apart, and the payload should start roughly ten seconds after
+`event=init`, immediately after `event=sleep_complete`. Comparing these
+timestamps avoids confusing scheduler queue time with the plugin delay.
+
+The argument applies to every remote step that loads the plugin. Remove it
+before running the other experiments unless repeated ten-second delays are
+intentional.
+
+## Experiment 3: multiple `srun` steps
+
+Submit a one-node script so one log line corresponds to one remote
+`slurmstepd` invocation:
+
+```bash
+cat > /tmp/spank-steps.sbatch <<'EOF'
+#!/bin/bash
+#SBATCH --nodes=1
+#SBATCH --mem=4G
+
+echo "batch job: ${SLURM_JOB_ID}"
+srun --nodes=1 --ntasks=1 sh -c 'echo first step: ${SLURM_STEP_ID}; hostname'
+srun --nodes=1 --ntasks=1 sh -c 'echo second step: ${SLURM_STEP_ID}; hostname'
+EOF
+
+sbatch /tmp/spank-steps.sbatch
+```
+
+Filter worker logs by the returned job ID. Count distinct PIDs and
+`step_id` values. Record whether there is one callback for the batch step plus
+one for each `srun` step, and compare the numeric IDs with
+`SLURM_STEP_ID` printed by the two payloads. On a multi-node step, group by
+`step_id` and `node_id`: remote initialization is performed by each
+participating node's `slurmstepd`.
+
+## Experiment 4: interactive allocation
+
+Start an allocation from a login node and launch two steps:
+
+```bash
+salloc --nodes=1 --mem=4G
+srun --nodes=1 --ntasks=1 sh -c 'echo interactive step: ${SLURM_STEP_ID}; hostname'
+srun --nodes=1 --ntasks=1 sh -c 'echo second interactive step: ${SLURM_STEP_ID}; hostname'
+exit
+```
+
+Compare these worker records with Experiment 3. In particular, note whether
+creating the allocation itself produces a remote record and which records are
+produced by each `srun`. The plugin intentionally ignores the allocator and
+local contexts, so every diagnostic record should still say
+`context=remote`.
+
+When testing is complete, remove the custom plugin entry from
+`spec.plugStackConfig.customPlugins`.

--- a/images/common/spank-alloc-mem-diagnostic/src/alloc_mem_diagnostic.c
+++ b/images/common/spank-alloc-mem-diagnostic/src/alloc_mem_diagnostic.c
@@ -1,6 +1,8 @@
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -9,17 +11,23 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <slurm/slurm.h>
+#include <sys/file.h>
+
 #include <slurm/spank.h>
 
 SPANK_PLUGIN("alloc_mem_diagnostic", 1);
 
 #define PLUGIN_TAG "alloc_mem_diagnostic"
+#ifndef OUTPUT_FILE
+#define OUTPUT_FILE "/var/log/spank_alloc_mem_diagnostic.log"
+#endif
+#define RECORD_SIZE 2048
 #define TIMESTAMP_SIZE 32
 #define VALUE_SIZE 32
 
 struct sleep_config {
     bool         requested;
+    bool         valid;
     unsigned int seconds;
 };
 
@@ -83,8 +91,59 @@ static const char *error_name(spank_err_t rc) {
     return name == NULL ? "unknown" : name;
 }
 
+static void append_record(const char *format, ...) {
+    char    record[RECORD_SIZE];
+    va_list arguments;
+
+    va_start(arguments, format);
+    int formatted =
+        vsnprintf(record, sizeof(record) - 1, format, arguments);
+    va_end(arguments);
+
+    if (formatted < 0) {
+        return;
+    }
+
+    size_t length = (size_t)formatted;
+    if (length >= sizeof(record) - 1) {
+        length = sizeof(record) - 2;
+    }
+    record[length++] = '\n';
+    record[length]   = '\0';
+
+    int fd = open(
+        OUTPUT_FILE,
+        O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC | O_NOFOLLOW,
+        0644
+    );
+    if (fd < 0) {
+        return;
+    }
+
+    bool locked = flock(fd, LOCK_EX) == 0;
+    size_t offset = 0;
+    while (offset < length) {
+        ssize_t written = write(fd, record + offset, length - offset);
+        if (written > 0) {
+            offset += (size_t)written;
+            continue;
+        }
+        if (written < 0 && errno == EINTR) {
+            continue;
+        }
+        break;
+    }
+
+    if (locked) {
+        (void)flock(fd, LOCK_UN);
+    }
+    (void)close(fd);
+}
+
 static struct sleep_config parse_sleep_config(int argc, char **argv) {
-    struct sleep_config config = {0};
+    struct sleep_config config = {
+        .valid = true,
+    };
 
     for (int i = 0; i < argc; ++i) {
         char          *end = NULL;
@@ -100,22 +159,19 @@ static struct sleep_config parse_sleep_config(int argc, char **argv) {
         value            = strtoul(argv[i] + strlen("sleep="), &end, 10);
         if (errno != 0 || end == argv[i] + strlen("sleep=") || *end != '\0' ||
             value > UINT_MAX) {
-            slurm_error(
-                PLUGIN_TAG
-                " invalid argument '%s'; sleep disabled and plugin will continue",
-                argv[i]
-            );
             config.seconds = 0;
+            config.valid   = false;
             continue;
         }
 
         config.seconds = (unsigned int)value;
+        config.valid   = true;
     }
 
     return config;
 }
 
-static void sleep_without_failing(unsigned int seconds) {
+static int sleep_without_failing(unsigned int seconds) {
     struct timespec requested = {
         .tv_sec  = seconds,
         .tv_nsec = 0,
@@ -128,13 +184,10 @@ static void sleep_without_failing(unsigned int seconds) {
             continue;
         }
 
-        slurm_error(
-            PLUGIN_TAG " nanosleep failed: errno=%d (%s); plugin will continue",
-            errno,
-            strerror(errno)
-        );
-        return;
+        return errno;
     }
+
+    return 0;
 }
 
 int slurm_spank_init(spank_t spank, int argc, char **argv) {
@@ -184,7 +237,7 @@ int slurm_spank_init(spank_t spank, int argc, char **argv) {
 
     struct sleep_config sleep_config = parse_sleep_config(argc, argv);
 
-    slurm_info(
+    append_record(
         PLUGIN_TAG
         " event=init timestamp=%s pid=%ld context=%s context_id=%d "
         "job_id=%s job_id_rc=%d(%s) "
@@ -192,7 +245,7 @@ int slurm_spank_init(spank_t spank, int argc, char **argv) {
         "node_id=%s node_id_rc=%d(%s) "
         "job_alloc_mem_mb=%s job_alloc_mem_rc=%d(%s) "
         "step_alloc_mem_mb=%s step_alloc_mem_rc=%d(%s) "
-        "sleep_requested=%s sleep_seconds=%u",
+        "sleep_requested=%s sleep_valid=%s sleep_seconds=%u",
         timestamp,
         (long)getpid(),
         context_name(context),
@@ -213,23 +266,40 @@ int slurm_spank_init(spank_t spank, int argc, char **argv) {
         (int)step_mem_rc,
         error_name(step_mem_rc),
         sleep_config.requested ? "true" : "false",
+        sleep_config.valid ? "true" : "false",
         sleep_config.seconds
     );
 
     if (sleep_config.seconds > 0) {
-        sleep_without_failing(sleep_config.seconds);
+        int sleep_errno = sleep_without_failing(sleep_config.seconds);
         format_timestamp(timestamp, sizeof(timestamp));
-        slurm_info(
-            PLUGIN_TAG
-            " event=sleep_complete timestamp=%s pid=%ld context=%s "
-            "job_id=%s step_id=%s sleep_seconds=%u",
-            timestamp,
-            (long)getpid(),
-            context_name(context),
-            job_id_value,
-            step_id_value,
-            sleep_config.seconds
-        );
+        if (sleep_errno == 0) {
+            append_record(
+                PLUGIN_TAG
+                " event=sleep_complete timestamp=%s pid=%ld context=%s "
+                "job_id=%s step_id=%s sleep_seconds=%u",
+                timestamp,
+                (long)getpid(),
+                context_name(context),
+                job_id_value,
+                step_id_value,
+                sleep_config.seconds
+            );
+        } else {
+            append_record(
+                PLUGIN_TAG
+                " event=sleep_error timestamp=%s pid=%ld context=%s "
+                "job_id=%s step_id=%s sleep_seconds=%u errno=%d(%s)",
+                timestamp,
+                (long)getpid(),
+                context_name(context),
+                job_id_value,
+                step_id_value,
+                sleep_config.seconds,
+                sleep_errno,
+                strerror(sleep_errno)
+            );
+        }
     }
 
     return ESPANK_SUCCESS;

--- a/images/common/spank-alloc-mem-diagnostic/src/alloc_mem_diagnostic.c
+++ b/images/common/spank-alloc-mem-diagnostic/src/alloc_mem_diagnostic.c
@@ -1,0 +1,236 @@
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <slurm/slurm.h>
+#include <slurm/spank.h>
+
+SPANK_PLUGIN("alloc_mem_diagnostic", 1);
+
+#define PLUGIN_TAG "alloc_mem_diagnostic"
+#define TIMESTAMP_SIZE 32
+#define VALUE_SIZE 32
+
+struct sleep_config {
+    bool         requested;
+    unsigned int seconds;
+};
+
+static const char *context_name(spank_context_t context) {
+    switch (context) {
+        case S_CTX_ERROR:
+            return "error";
+        case S_CTX_LOCAL:
+            return "local";
+        case S_CTX_REMOTE:
+            return "remote";
+        case S_CTX_ALLOCATOR:
+            return "allocator";
+        case S_CTX_SLURMD:
+            return "slurmd";
+        case S_CTX_JOB_SCRIPT:
+            return "job_script";
+        default:
+            return "unknown";
+    }
+}
+
+static void format_timestamp(char *buffer, size_t size) {
+    struct timespec now;
+    struct tm       utc;
+    char            seconds[24];
+
+    if (clock_gettime(CLOCK_REALTIME, &now) != 0 ||
+        gmtime_r(&now.tv_sec, &utc) == NULL ||
+        strftime(seconds, sizeof(seconds), "%Y-%m-%dT%H:%M:%S", &utc) == 0) {
+        snprintf(buffer, size, "unavailable");
+        return;
+    }
+
+    snprintf(buffer, size, "%s.%03ldZ", seconds, now.tv_nsec / 1000000L);
+}
+
+static void format_uint32_item(
+    char *buffer, size_t size, spank_err_t rc, uint32_t value
+) {
+    if (rc == ESPANK_SUCCESS) {
+        snprintf(buffer, size, "%" PRIu32, value);
+    } else {
+        snprintf(buffer, size, "unavailable");
+    }
+}
+
+static void format_uint64_item(
+    char *buffer, size_t size, spank_err_t rc, uint64_t value
+) {
+    if (rc == ESPANK_SUCCESS) {
+        snprintf(buffer, size, "%" PRIu64, value);
+    } else {
+        snprintf(buffer, size, "unavailable");
+    }
+}
+
+static const char *error_name(spank_err_t rc) {
+    const char *name = spank_strerror(rc);
+
+    return name == NULL ? "unknown" : name;
+}
+
+static struct sleep_config parse_sleep_config(int argc, char **argv) {
+    struct sleep_config config = {0};
+
+    for (int i = 0; i < argc; ++i) {
+        char          *end = NULL;
+        unsigned long value;
+
+        if (argv == NULL || argv[i] == NULL ||
+            strncmp(argv[i], "sleep=", strlen("sleep=")) != 0) {
+            continue;
+        }
+
+        config.requested = true;
+        errno            = 0;
+        value            = strtoul(argv[i] + strlen("sleep="), &end, 10);
+        if (errno != 0 || end == argv[i] + strlen("sleep=") || *end != '\0' ||
+            value > UINT_MAX) {
+            slurm_error(
+                PLUGIN_TAG
+                " invalid argument '%s'; sleep disabled and plugin will continue",
+                argv[i]
+            );
+            config.seconds = 0;
+            continue;
+        }
+
+        config.seconds = (unsigned int)value;
+    }
+
+    return config;
+}
+
+static void sleep_without_failing(unsigned int seconds) {
+    struct timespec requested = {
+        .tv_sec  = seconds,
+        .tv_nsec = 0,
+    };
+    struct timespec remaining;
+
+    while (nanosleep(&requested, &remaining) != 0) {
+        if (errno == EINTR) {
+            requested = remaining;
+            continue;
+        }
+
+        slurm_error(
+            PLUGIN_TAG " nanosleep failed: errno=%d (%s); plugin will continue",
+            errno,
+            strerror(errno)
+        );
+        return;
+    }
+}
+
+int slurm_spank_init(spank_t spank, int argc, char **argv) {
+    spank_context_t context = spank_context();
+
+    if (context != S_CTX_REMOTE) {
+        return ESPANK_SUCCESS;
+    }
+
+    uint32_t job_id      = 0;
+    uint32_t step_id     = 0;
+    uint32_t node_id     = 0;
+    uint64_t job_mem_mb  = 0;
+    uint64_t step_mem_mb = 0;
+
+    spank_err_t job_id_rc = spank_get_item(spank, S_JOB_ID, &job_id);
+    spank_err_t step_id_rc =
+        spank_get_item(spank, S_JOB_STEPID, &step_id);
+    spank_err_t node_id_rc =
+        spank_get_item(spank, S_JOB_NODEID, &node_id);
+    spank_err_t job_mem_rc =
+        spank_get_item(spank, S_JOB_ALLOC_MEM, &job_mem_mb);
+    spank_err_t step_mem_rc =
+        spank_get_item(spank, S_STEP_ALLOC_MEM, &step_mem_mb);
+
+    char job_id_value[VALUE_SIZE];
+    char step_id_value[VALUE_SIZE];
+    char node_id_value[VALUE_SIZE];
+    char job_mem_value[VALUE_SIZE];
+    char step_mem_value[VALUE_SIZE];
+    char timestamp[TIMESTAMP_SIZE];
+
+    format_uint32_item(job_id_value, sizeof(job_id_value), job_id_rc, job_id);
+    format_uint32_item(
+        step_id_value, sizeof(step_id_value), step_id_rc, step_id
+    );
+    format_uint32_item(
+        node_id_value, sizeof(node_id_value), node_id_rc, node_id
+    );
+    format_uint64_item(
+        job_mem_value, sizeof(job_mem_value), job_mem_rc, job_mem_mb
+    );
+    format_uint64_item(
+        step_mem_value, sizeof(step_mem_value), step_mem_rc, step_mem_mb
+    );
+    format_timestamp(timestamp, sizeof(timestamp));
+
+    struct sleep_config sleep_config = parse_sleep_config(argc, argv);
+
+    slurm_info(
+        PLUGIN_TAG
+        " event=init timestamp=%s pid=%ld context=%s context_id=%d "
+        "job_id=%s job_id_rc=%d(%s) "
+        "step_id=%s step_id_rc=%d(%s) "
+        "node_id=%s node_id_rc=%d(%s) "
+        "job_alloc_mem_mb=%s job_alloc_mem_rc=%d(%s) "
+        "step_alloc_mem_mb=%s step_alloc_mem_rc=%d(%s) "
+        "sleep_requested=%s sleep_seconds=%u",
+        timestamp,
+        (long)getpid(),
+        context_name(context),
+        (int)context,
+        job_id_value,
+        (int)job_id_rc,
+        error_name(job_id_rc),
+        step_id_value,
+        (int)step_id_rc,
+        error_name(step_id_rc),
+        node_id_value,
+        (int)node_id_rc,
+        error_name(node_id_rc),
+        job_mem_value,
+        (int)job_mem_rc,
+        error_name(job_mem_rc),
+        step_mem_value,
+        (int)step_mem_rc,
+        error_name(step_mem_rc),
+        sleep_config.requested ? "true" : "false",
+        sleep_config.seconds
+    );
+
+    if (sleep_config.seconds > 0) {
+        sleep_without_failing(sleep_config.seconds);
+        format_timestamp(timestamp, sizeof(timestamp));
+        slurm_info(
+            PLUGIN_TAG
+            " event=sleep_complete timestamp=%s pid=%ld context=%s "
+            "job_id=%s step_id=%s sleep_seconds=%u",
+            timestamp,
+            (long)getpid(),
+            context_name(context),
+            job_id_value,
+            step_id_value,
+            sleep_config.seconds
+        );
+    }
+
+    return ESPANK_SUCCESS;
+}

--- a/images/login/sshd.dockerfile
+++ b/images/login/sshd.dockerfile
@@ -43,6 +43,13 @@ RUN chmod +x /opt/bin/install_nccld_debug_plugin.sh && \
     /opt/bin/install_nccld_debug_plugin.sh && \
     rm /opt/bin/install_nccld_debug_plugin.sh
 
+# Install allocated-memory diagnostic SPANK plugin
+COPY images/common/spank-alloc-mem-diagnostic/src /usr/src/soperator/spank/alloc-mem-diagnostic
+COPY images/common/scripts/install_alloc_mem_diagnostic_plugin.sh /opt/bin/
+RUN chmod +x /opt/bin/install_alloc_mem_diagnostic_plugin.sh && \
+    /opt/bin/install_alloc_mem_diagnostic_plugin.sh && \
+    rm /opt/bin/install_alloc_mem_diagnostic_plugin.sh
+
 # Install NCCL Inspector PreConf SPANK plugin
 COPY ansible/spank-nccl-inspector-preconf.yml /opt/ansible/spank-nccl-inspector-preconf.yml
 COPY ansible/roles/spank-nccl-inspector-preconf /opt/ansible/roles/spank-nccl-inspector-preconf

--- a/images/slurm_check_job/slurm_check_job.dockerfile
+++ b/images/slurm_check_job/slurm_check_job.dockerfile
@@ -41,6 +41,13 @@ RUN chmod +x /opt/bin/install_nccld_debug_plugin.sh && \
     /opt/bin/install_nccld_debug_plugin.sh && \
     rm /opt/bin/install_nccld_debug_plugin.sh
 
+# Install allocated-memory diagnostic SPANK plugin
+COPY images/common/spank-alloc-mem-diagnostic/src /usr/src/soperator/spank/alloc-mem-diagnostic
+COPY images/common/scripts/install_alloc_mem_diagnostic_plugin.sh /opt/bin/
+RUN chmod +x /opt/bin/install_alloc_mem_diagnostic_plugin.sh && \
+    /opt/bin/install_alloc_mem_diagnostic_plugin.sh && \
+    rm /opt/bin/install_alloc_mem_diagnostic_plugin.sh
+
 # Install NCCL Inspector PreConf SPANK plugin
 COPY ansible/spank-nccl-inspector-preconf.yml /opt/ansible/spank-nccl-inspector-preconf.yml
 COPY ansible/roles/spank-nccl-inspector-preconf /opt/ansible/roles/spank-nccl-inspector-preconf
@@ -67,6 +74,7 @@ RUN ARCH="$(uname -m)" && \
     ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/chroot.so" /usr/lib/slurm/chroot.so && \
     ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/spank_pyxis.so" /usr/lib/slurm/spank_pyxis.so && \
     ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/spanknccldebug.so" /usr/lib/slurm/spanknccldebug.so && \
+    ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/spank_alloc_mem_diagnostic.so" /usr/lib/slurm/spank_alloc_mem_diagnostic.so && \
     ln -s "/usr/lib/${ARCH}-linux-gnu/slurm/spank_nccl_inspector_preconf.so" /usr/lib/slurm/spank_nccl_inspector_preconf.so
 
 # Disable NCCL Debug SPANK plugin by default for Slurm jobs

--- a/images/worker/slurmd.dockerfile
+++ b/images/worker/slurmd.dockerfile
@@ -72,6 +72,13 @@ RUN chmod +x /opt/bin/install_nccld_debug_plugin.sh && \
     /opt/bin/install_nccld_debug_plugin.sh && \
     rm /opt/bin/install_nccld_debug_plugin.sh
 
+# Install allocated-memory diagnostic SPANK plugin
+COPY images/common/spank-alloc-mem-diagnostic/src /usr/src/soperator/spank/alloc-mem-diagnostic
+COPY images/common/scripts/install_alloc_mem_diagnostic_plugin.sh /opt/bin/
+RUN chmod +x /opt/bin/install_alloc_mem_diagnostic_plugin.sh && \
+    /opt/bin/install_alloc_mem_diagnostic_plugin.sh && \
+    rm /opt/bin/install_alloc_mem_diagnostic_plugin.sh
+
 # Install NCCL Inspector PreConf SPANK plugin
 COPY ansible/spank-nccl-inspector-preconf.yml /opt/ansible/spank-nccl-inspector-preconf.yml
 COPY ansible/roles/spank-nccl-inspector-preconf /opt/ansible/roles/spank-nccl-inspector-preconf


### PR DESCRIPTION
## Summary

- add an opt-in diagnostic SPANK plugin that inspects job and step allocation data from remote `slurm_spank_init()`
- log the SPANK context, IDs, allocated memory values, and every `spank_get_item()` return code
- support an optional `sleep=<seconds>` timing experiment while always returning success
- package the separate plugin in the worker, login, and Slurm check-job images and expose it inside the jail
- document four cluster experiments for batch, timing, multi-step, and interactive behavior

## Why

This tests whether `S_JOB_ALLOC_MEM` is available from the remote `slurmstepd`
context early enough to replace the current Prolog memory lookup without issuing
one `scontrol show job` RPC per allocated node.

This PR is intentionally marked **DO NOT MERGE**. It is being opened to trigger
the GitHub image compilation workflow and validate the plugin against the real
Slurm build environment.

## Impact

The plugin is installed as a separate shared library but is not enabled by
default. It ignores non-remote contexts, never drains a node, never changes the
job environment, and always returns `ESPANK_SUCCESS`. The only intentional job
delay is the explicitly configured optional sleep.

## Validation

- GNU99 compilation with `-Wall -Wextra -Werror` against a contract-compatible SPANK stub
- mock callback execution confirming zero lookups outside remote context and exactly five remote lookups
- `bash -n` for the installer and modified jail script
- `git diff --check`
- production image compilation: pending GitHub Actions
