### PR TITLE
SCHED-1897: Add idle node memory health check

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+max_used_gb="${IDLE_MEM_USED_MAX_USED_GB:-}"
+meminfo_path="${IDLE_MEM_USED_MEMINFO_PATH:-/proc/meminfo}"
+node_state_flags="${CHECKS_NODE_STATE_FLAGS:-}"
+node_name="${SLURMD_NODENAME:-unknown}"
+
+echo "[$(date)] Check memory usage when node ${node_name} is idle"
+echo "Configured maximum used memory: ${max_used_gb:-<unset>} GB"
+echo "Node state source: CHECKS_NODE_STATE_FLAGS, populated by check_runner.py from 'scontrol show node ${node_name} --json'"
+echo "Slurm node state flags: ${node_state_flags:-<unavailable>}"
+
+node_is_idle=false
+IFS='+' read -r -a state_flags <<< "${node_state_flags}"
+for state_flag in "${state_flags[@]}"; do
+    if [[ "${state_flag}" == "IDLE" ]]; then
+        node_is_idle=true
+        break
+    fi
+done
+
+echo "Node is idle: ${node_is_idle}"
+if [[ "${node_is_idle}" != "true" ]]; then
+    echo "Node is not IDLE; skipping memory validation"
+    exit 0
+fi
+
+if ! [[ "${max_used_gb}" =~ ^[0-9]+$ ]] || [[ "${max_used_gb}" == "0" ]]; then
+    echo "Invalid idle memory threshold '${max_used_gb:-<unset>}'; expected a positive GB count, skipping memory validation" >&2
+    exit 0
+fi
+
+max_used_bytes=$((max_used_gb * 1000000000))
+
+meminfo_values="$(
+    awk '
+        /^MemTotal:/ { total = $2 }
+        /^MemAvailable:/ { available = $2 }
+        END { if (total != "" && available != "") print total, available }
+    ' "${meminfo_path}" 2>/dev/null || true
+)"
+read -r mem_total_kib mem_available_kib <<< "${meminfo_values}"
+
+if ! [[ "${mem_total_kib:-}" =~ ^[0-9]+$ ]] ||
+   ! [[ "${mem_available_kib:-}" =~ ^[0-9]+$ ]] ||
+   (( mem_available_kib > mem_total_kib )); then
+    echo "Could not determine valid MemTotal and MemAvailable values from ${meminfo_path}; skipping memory validation" >&2
+    exit 0
+fi
+
+mem_total_bytes=$((mem_total_kib * 1024))
+mem_available_bytes=$((mem_available_kib * 1024))
+mem_used_bytes=$((mem_total_bytes - mem_available_bytes))
+
+mem_total_gb="$(awk -v bytes="${mem_total_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+mem_available_gb="$(awk -v bytes="${mem_available_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+mem_used_gb="$(awk -v bytes="${mem_used_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+
+echo "Memory source: ${meminfo_path}"
+echo "Memory measurements: total=${mem_total_gb} GB (${mem_total_bytes} bytes), available=${mem_available_gb} GB (${mem_available_bytes} bytes), used=total-available=${mem_used_gb} GB (${mem_used_bytes} bytes)"
+echo "Maximum allowed used memory: ${max_used_gb} GB (${max_used_bytes} bytes)"
+
+if (( mem_used_bytes > max_used_bytes )); then
+    echo "Node ${node_name} is IDLE but uses ${mem_used_gb} GB of memory (threshold: ${max_used_gb} GB; MemTotal: ${mem_total_gb} GB; MemAvailable: ${mem_available_gb} GB). This may indicate leftover or spurious processes consuming memory." >&3
+    exit 1
+fi
+
+echo "Idle node memory usage is within the configured threshold"
+exit 0

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
@@ -4,26 +4,36 @@ set -euo pipefail
 
 max_used_gb="${IDLE_MEM_USED_MAX_USED_GB:-}"
 meminfo_path="${IDLE_MEM_USED_MEMINFO_PATH:-/proc/meminfo}"
-node_state_flags="${CHECKS_NODE_STATE_FLAGS:-}"
 node_name="${SLURMD_NODENAME:-unknown}"
 
 echo "[$(date)] Check memory usage when node ${node_name} is idle"
 echo "Configured maximum used memory: ${max_used_gb:-<unset>} GB"
-echo "Node state source: CHECKS_NODE_STATE_FLAGS, populated by check_runner.py from 'scontrol show node ${node_name} --json'"
-echo "Slurm node state flags: ${node_state_flags:-<unavailable>}"
+echo "Idle state source: local 'scontrol listjobs' (no controller RPC)"
+echo "Idle state rule: exit code 1 with \"No slurmstepd's found on this node\" means the node has no local jobs"
 
-node_is_idle=false
-IFS='+' read -r -a state_flags <<< "${node_state_flags}"
-for state_flag in "${state_flags[@]}"; do
-    if [[ "${state_flag}" == "IDLE" ]]; then
-        node_is_idle=true
-        break
-    fi
-done
+if listjobs_output="$(scontrol listjobs 2>&1)"; then
+    listjobs_rc=0
+else
+    listjobs_rc=$?
+fi
+
+echo "scontrol listjobs exit code: ${listjobs_rc}"
+echo "scontrol listjobs output: ${listjobs_output:-<empty>}"
+
+if (( listjobs_rc == 0 )); then
+    node_is_idle=false
+    echo "Local Slurm jobs are present; treating the node as non-idle"
+elif (( listjobs_rc == 1 )) && [[ "${listjobs_output}" == *"No slurmstepd's found on this node"* ]]; then
+    node_is_idle=true
+    echo "No local slurmstepd was found; treating the node as idle"
+else
+    echo "Could not determine whether the node is idle from 'scontrol listjobs'; skipping memory validation" >&2
+    exit 0
+fi
 
 echo "Node is idle: ${node_is_idle}"
 if [[ "${node_is_idle}" != "true" ]]; then
-    echo "Node is not IDLE; skipping memory validation"
+    echo "Node has local jobs; skipping memory validation"
     exit 0
 fi
 

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-max_used_gb="${IDLE_MEM_USED_MAX_USED_GB:-}"
 meminfo_path="${IDLE_MEM_USED_MEMINFO_PATH:-/proc/meminfo}"
 node_name="${SLURMD_NODENAME:-unknown}"
+node_real_memory_bytes="${CHECKS_NODE_REAL_MEM_BYTES:-}"
 
 echo "[$(date)] Check memory usage when node ${node_name} is idle"
-echo "Configured maximum used memory: ${max_used_gb:-<unset>} GB"
+echo "Slurm RealMemory input: ${node_real_memory_bytes:-<unavailable>} bytes"
 echo "Idle state source: local 'scontrol listjobs' (no controller RPC)"
 echo "Idle state rule: exit code 1 with \"No slurmstepd's found on this node\" means the node has no local jobs"
 
@@ -37,12 +37,10 @@ if [[ "${node_is_idle}" != "true" ]]; then
     exit 0
 fi
 
-if ! [[ "${max_used_gb}" =~ ^[0-9]+$ ]] || [[ "${max_used_gb}" == "0" ]]; then
-    echo "Invalid idle memory threshold '${max_used_gb:-<unset>}'; expected a positive GB count, skipping memory validation" >&2
+if ! [[ "${node_real_memory_bytes}" =~ ^[0-9]+$ ]] || [[ "${node_real_memory_bytes}" == "0" ]]; then
+    echo "Invalid or unavailable Slurm RealMemory '${node_real_memory_bytes:-<unavailable>}'; expected a positive byte count, skipping memory validation" >&2
     exit 0
 fi
-
-max_used_bytes=$((max_used_gb * 1000000000))
 
 meminfo_values="$(
     awk '
@@ -64,18 +62,30 @@ mem_total_bytes=$((mem_total_kib * 1024))
 mem_available_bytes=$((mem_available_kib * 1024))
 mem_used_bytes=$((mem_total_bytes - mem_available_bytes))
 
+if (( node_real_memory_bytes > mem_total_bytes )); then
+    echo "Slurm RealMemory ${node_real_memory_bytes} bytes exceeds MemTotal ${mem_total_bytes} bytes; skipping memory validation" >&2
+    exit 0
+fi
+
+max_idle_used_bytes=$((mem_total_bytes - node_real_memory_bytes))
+
 mem_total_gb="$(awk -v bytes="${mem_total_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
 mem_available_gb="$(awk -v bytes="${mem_available_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
 mem_used_gb="$(awk -v bytes="${mem_used_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+node_real_memory_gb="$(awk -v bytes="${node_real_memory_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+max_idle_used_gb="$(awk -v bytes="${max_idle_used_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
 
 echo "Memory source: ${meminfo_path}"
 echo "Memory measurements: total=${mem_total_gb} GB (${mem_total_bytes} bytes), available=${mem_available_gb} GB (${mem_available_bytes} bytes), used=total-available=${mem_used_gb} GB (${mem_used_bytes} bytes)"
-echo "Maximum allowed used memory: ${max_used_gb} GB (${max_used_bytes} bytes)"
+echo "Slurm RealMemory: ${node_real_memory_gb} GB (${node_real_memory_bytes} bytes)"
+echo "Derived maximum idle used memory: MemTotal-RealMemory=${max_idle_used_gb} GB (${max_idle_used_bytes} bytes)"
 
-if (( mem_used_bytes > max_used_bytes )); then
-    echo "Node ${node_name} is IDLE but uses ${mem_used_gb} GB of memory (threshold: ${max_used_gb} GB; MemTotal: ${mem_total_gb} GB; MemAvailable: ${mem_available_gb} GB). This may indicate leftover or spurious processes consuming memory." >&3
+if (( mem_available_bytes < node_real_memory_bytes )); then
+    memory_deficit_bytes=$((node_real_memory_bytes - mem_available_bytes))
+    memory_deficit_gb="$(awk -v bytes="${memory_deficit_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+    echo "Node ${node_name} is IDLE but has only ${mem_available_gb} GB of memory available, below Slurm RealMemory ${node_real_memory_gb} GB by ${memory_deficit_gb} GB (used: ${mem_used_gb} GB; derived maximum idle usage: ${max_idle_used_gb} GB; MemTotal: ${mem_total_gb} GB). This may indicate leftover or spurious processes consuming memory." >&3
     exit 1
 fi
 
-echo "Idle node memory usage is within the configured threshold"
+echo "Idle node leaves enough memory available for Slurm RealMemory"
 exit 0

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
@@ -12,5 +12,5 @@
   "reason_append_details": true,
   "run_in_jail": false,
   "log": "slurm_scripts/$worker.$name.$context.out",
-  "need_env": ["CHECKS_NODE_STATE_FLAGS"]
+  "need_env": []
 }

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
@@ -1,0 +1,16 @@
+{
+  "name": "idle_mem_used",
+  "command": "IDLE_MEM_USED_MAX_USED_GB={{ required `Idle memory maximum used GB must be provided.` (index .Values.slurmScripts.builtIn `idle_mem_used.sh`).maxUsedGB }} ./idle_mem_used.sh",
+  "platforms": ["any"],
+  "skip_for_cpu_jobs": false,
+  "skip_for_partial_gpu_jobs": false,
+  "contexts": ["hc_program"],
+  "node_states": ["any"],
+  "on_fail": "drain",
+  "on_ok": "none",
+  "reason_base": "[node_problem] $name",
+  "reason_append_details": true,
+  "run_in_jail": false,
+  "log": "slurm_scripts/$worker.$name.$context.out",
+  "need_env": ["CHECKS_NODE_STATE_FLAGS"]
+}

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
@@ -1,6 +1,6 @@
 {
   "name": "idle_mem_used",
-  "command": "IDLE_MEM_USED_MAX_USED_GB={{ required `Idle memory maximum used GB must be provided.` (index .Values.slurmScripts.builtIn `idle_mem_used.sh`).maxUsedGB }} ./idle_mem_used.sh",
+  "command": "./idle_mem_used.sh",
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
@@ -12,5 +12,5 @@
   "reason_append_details": true,
   "run_in_jail": false,
   "log": "slurm_scripts/$worker.$name.$context.out",
-  "need_env": []
+  "need_env": ["CHECKS_NODE_REAL_MEM_BYTES"]
 }

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
@@ -1,0 +1,105 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("idle_mem_used.sh")
+GIB = 1024 * 1024 * 1024
+
+
+class IdleMemUsedTest(unittest.TestCase):
+    def run_check(
+        self,
+        *,
+        node_states: str,
+        total_bytes: int | None,
+        available_bytes: int | None,
+        max_used_gb: int = 32,
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            meminfo_path = Path(tmpdir) / "meminfo"
+            if total_bytes is not None and available_bytes is not None:
+                meminfo_path.write_text(
+                    f"MemTotal:       {total_bytes // 1024} kB\n"
+                    f"MemAvailable:   {available_bytes // 1024} kB\n",
+                    encoding="utf-8",
+                )
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "SLURMD_NODENAME": "worker-1",
+                    "CHECKS_NODE_STATE_FLAGS": node_states,
+                    "IDLE_MEM_USED_MAX_USED_GB": str(max_used_gb),
+                    "IDLE_MEM_USED_MEMINFO_PATH": str(meminfo_path),
+                }
+            )
+
+            return subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'exec 3>&1; exec bash "$1"',
+                    "idle-mem-used-test",
+                    str(SCRIPT_PATH),
+                ],
+                check=False,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+    def test_non_idle_node_skips_memory_validation(self):
+        result = self.run_check(
+            node_states="ALLOCATED",
+            total_bytes=None,
+            available_bytes=None,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("Node is idle: false", result.stdout)
+        self.assertIn("Node is not IDLE; skipping memory validation", result.stdout)
+        self.assertNotIn("Memory measurements:", result.stdout)
+
+    def test_idle_node_below_threshold_passes(self):
+        result = self.run_check(
+            node_states="IDLE",
+            total_bytes=64 * GIB,
+            available_bytes=60 * GIB,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("Node is idle: true", result.stdout)
+        self.assertIn(f"used=total-available=4.29 GB ({4 * GIB} bytes)", result.stdout)
+        self.assertIn("Maximum allowed used memory: 32 GB (32000000000 bytes)", result.stdout)
+
+    def test_idle_node_above_threshold_fails_with_actionable_reason(self):
+        result = self.run_check(
+            node_states="IDLE+CLOUD",
+            total_bytes=64 * GIB,
+            available_bytes=22 * GIB,
+        )
+
+        self.assertEqual(1, result.returncode)
+        self.assertIn("Node is idle: true", result.stdout)
+        self.assertIn("Node worker-1 is IDLE but uses", result.stdout)
+        self.assertIn("45.10 GB", result.stdout)
+        self.assertIn("threshold: 32 GB", result.stdout)
+        self.assertIn("leftover or spurious processes", result.stdout)
+
+    def test_unavailable_memory_data_does_not_drain_node(self):
+        result = self.run_check(
+            node_states="IDLE",
+            total_bytes=None,
+            available_bytes=None,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("Could not determine valid MemTotal and MemAvailable", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
@@ -17,7 +17,7 @@ class IdleMemUsedTest(unittest.TestCase):
         listjobs_output: str,
         total_bytes: int | None,
         available_bytes: int | None,
-        max_used_gb: int = 32,
+        node_real_memory_bytes: int | None = 56 * GIB,
     ) -> subprocess.CompletedProcess[str]:
         with tempfile.TemporaryDirectory() as tmpdir:
             scontrol_path = Path(tmpdir) / "scontrol"
@@ -38,11 +38,14 @@ class IdleMemUsedTest(unittest.TestCase):
                 )
 
             env = os.environ.copy()
+            if node_real_memory_bytes is None:
+                env.pop("CHECKS_NODE_REAL_MEM_BYTES", None)
+            else:
+                env["CHECKS_NODE_REAL_MEM_BYTES"] = str(node_real_memory_bytes)
             env.update(
                 {
                     "PATH": f"{tmpdir}:{env['PATH']}",
                     "SLURMD_NODENAME": "worker-1",
-                    "IDLE_MEM_USED_MAX_USED_GB": str(max_used_gb),
                     "IDLE_MEM_USED_MEMINFO_PATH": str(meminfo_path),
                     "MOCK_SCONTROL_LISTJOBS_RC": str(listjobs_rc),
                     "MOCK_SCONTROL_LISTJOBS_OUTPUT": listjobs_output,
@@ -78,7 +81,7 @@ class IdleMemUsedTest(unittest.TestCase):
         self.assertIn("Node has local jobs; skipping memory validation", result.stdout)
         self.assertNotIn("Memory measurements:", result.stdout)
 
-    def test_idle_node_below_threshold_passes(self):
+    def test_idle_node_with_enough_available_memory_passes(self):
         result = self.run_check(
             listjobs_rc=1,
             listjobs_output="No slurmstepd's found on this node",
@@ -90,9 +93,15 @@ class IdleMemUsedTest(unittest.TestCase):
         self.assertIn("Node is idle: true", result.stdout)
         self.assertIn("No local slurmstepd was found", result.stdout)
         self.assertIn(f"used=total-available=4.29 GB ({4 * GIB} bytes)", result.stdout)
-        self.assertIn("Maximum allowed used memory: 32 GB (32000000000 bytes)", result.stdout)
+        self.assertIn(
+            f"Slurm RealMemory: 60.13 GB ({56 * GIB} bytes)", result.stdout
+        )
+        self.assertIn(
+            f"Derived maximum idle used memory: MemTotal-RealMemory=8.59 GB ({8 * GIB} bytes)",
+            result.stdout,
+        )
 
-    def test_idle_node_above_threshold_fails_with_actionable_reason(self):
+    def test_idle_node_with_insufficient_available_memory_fails(self):
         result = self.run_check(
             listjobs_rc=1,
             listjobs_output="No slurmstepd's found on this node",
@@ -102,9 +111,9 @@ class IdleMemUsedTest(unittest.TestCase):
 
         self.assertEqual(1, result.returncode)
         self.assertIn("Node is idle: true", result.stdout)
-        self.assertIn("Node worker-1 is IDLE but uses", result.stdout)
-        self.assertIn("45.10 GB", result.stdout)
-        self.assertIn("threshold: 32 GB", result.stdout)
+        self.assertIn("Node worker-1 is IDLE but has only 23.62 GB", result.stdout)
+        self.assertIn("below Slurm RealMemory 60.13 GB by 36.51 GB", result.stdout)
+        self.assertIn("derived maximum idle usage: 8.59 GB", result.stdout)
         self.assertIn("leftover or spurious processes", result.stdout)
 
     def test_unavailable_memory_data_does_not_drain_node(self):
@@ -117,6 +126,32 @@ class IdleMemUsedTest(unittest.TestCase):
 
         self.assertEqual(0, result.returncode)
         self.assertIn("Could not determine valid MemTotal and MemAvailable", result.stderr)
+
+    def test_unavailable_real_memory_does_not_drain_node(self):
+        result = self.run_check(
+            listjobs_rc=1,
+            listjobs_output="No slurmstepd's found on this node",
+            total_bytes=None,
+            available_bytes=None,
+            node_real_memory_bytes=None,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("Invalid or unavailable Slurm RealMemory", result.stderr)
+        self.assertNotIn("Memory measurements:", result.stdout)
+
+    def test_real_memory_larger_than_memtotal_does_not_drain_node(self):
+        result = self.run_check(
+            listjobs_rc=1,
+            listjobs_output="No slurmstepd's found on this node",
+            total_bytes=64 * GIB,
+            available_bytes=60 * GIB,
+            node_real_memory_bytes=72 * GIB,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("exceeds MemTotal", result.stderr)
+        self.assertNotIn("Derived maximum idle used memory", result.stdout)
 
     def test_unexpected_listjobs_failure_does_not_validate_memory(self):
         result = self.run_check(

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
@@ -13,12 +13,22 @@ class IdleMemUsedTest(unittest.TestCase):
     def run_check(
         self,
         *,
-        node_states: str,
+        listjobs_rc: int,
+        listjobs_output: str,
         total_bytes: int | None,
         available_bytes: int | None,
         max_used_gb: int = 32,
     ) -> subprocess.CompletedProcess[str]:
         with tempfile.TemporaryDirectory() as tmpdir:
+            scontrol_path = Path(tmpdir) / "scontrol"
+            scontrol_path.write_text(
+                "#!/bin/bash\n"
+                "printf '%s\\n' \"${MOCK_SCONTROL_LISTJOBS_OUTPUT}\"\n"
+                "exit \"${MOCK_SCONTROL_LISTJOBS_RC}\"\n",
+                encoding="utf-8",
+            )
+            scontrol_path.chmod(0o755)
+
             meminfo_path = Path(tmpdir) / "meminfo"
             if total_bytes is not None and available_bytes is not None:
                 meminfo_path.write_text(
@@ -30,10 +40,12 @@ class IdleMemUsedTest(unittest.TestCase):
             env = os.environ.copy()
             env.update(
                 {
+                    "PATH": f"{tmpdir}:{env['PATH']}",
                     "SLURMD_NODENAME": "worker-1",
-                    "CHECKS_NODE_STATE_FLAGS": node_states,
                     "IDLE_MEM_USED_MAX_USED_GB": str(max_used_gb),
                     "IDLE_MEM_USED_MEMINFO_PATH": str(meminfo_path),
+                    "MOCK_SCONTROL_LISTJOBS_RC": str(listjobs_rc),
+                    "MOCK_SCONTROL_LISTJOBS_OUTPUT": listjobs_output,
                 }
             )
 
@@ -54,31 +66,36 @@ class IdleMemUsedTest(unittest.TestCase):
 
     def test_non_idle_node_skips_memory_validation(self):
         result = self.run_check(
-            node_states="ALLOCATED",
+            listjobs_rc=0,
+            listjobs_output="JOBID\n1011",
             total_bytes=None,
             available_bytes=None,
         )
 
         self.assertEqual(0, result.returncode)
         self.assertIn("Node is idle: false", result.stdout)
-        self.assertIn("Node is not IDLE; skipping memory validation", result.stdout)
+        self.assertIn("Local Slurm jobs are present", result.stdout)
+        self.assertIn("Node has local jobs; skipping memory validation", result.stdout)
         self.assertNotIn("Memory measurements:", result.stdout)
 
     def test_idle_node_below_threshold_passes(self):
         result = self.run_check(
-            node_states="IDLE",
+            listjobs_rc=1,
+            listjobs_output="No slurmstepd's found on this node",
             total_bytes=64 * GIB,
             available_bytes=60 * GIB,
         )
 
         self.assertEqual(0, result.returncode)
         self.assertIn("Node is idle: true", result.stdout)
+        self.assertIn("No local slurmstepd was found", result.stdout)
         self.assertIn(f"used=total-available=4.29 GB ({4 * GIB} bytes)", result.stdout)
         self.assertIn("Maximum allowed used memory: 32 GB (32000000000 bytes)", result.stdout)
 
     def test_idle_node_above_threshold_fails_with_actionable_reason(self):
         result = self.run_check(
-            node_states="IDLE+CLOUD",
+            listjobs_rc=1,
+            listjobs_output="No slurmstepd's found on this node",
             total_bytes=64 * GIB,
             available_bytes=22 * GIB,
         )
@@ -92,13 +109,27 @@ class IdleMemUsedTest(unittest.TestCase):
 
     def test_unavailable_memory_data_does_not_drain_node(self):
         result = self.run_check(
-            node_states="IDLE",
+            listjobs_rc=1,
+            listjobs_output="No slurmstepd's found on this node",
             total_bytes=None,
             available_bytes=None,
         )
 
         self.assertEqual(0, result.returncode)
         self.assertIn("Could not determine valid MemTotal and MemAvailable", result.stderr)
+
+    def test_unexpected_listjobs_failure_does_not_validate_memory(self):
+        result = self.run_check(
+            listjobs_rc=2,
+            listjobs_output="Unable to inspect local jobs",
+            total_bytes=None,
+            available_bytes=None,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("scontrol listjobs exit code: 2", result.stdout)
+        self.assertIn("Could not determine whether the node is idle", result.stderr)
+        self.assertNotIn("Memory measurements:", result.stdout)
 
 
 if __name__ == "__main__":

--- a/helm/slurm-cluster/tests/idle_mem_used_test.yaml
+++ b/helm/slurm-cluster/tests/idle_mem_used_test.yaml
@@ -1,0 +1,44 @@
+suite: test idle memory health check
+templates:
+  - slurm-scripts-cm.yaml
+tests:
+  - it: should enable the idle memory check with the default threshold
+    asserts:
+      - isNotNull:
+          path: data["idle_mem_used.sh"]
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"name": "idle_mem_used"'
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"command": "IDLE_MEM_USED_MAX_USED_GB=32 ./idle_mem_used.sh"'
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"contexts": \[\s*"hc_program"\s*\]'
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"on_fail": "drain"'
+
+  - it: should render a configured maximum used memory threshold
+    set:
+      slurmScripts:
+        builtIn:
+          idle_mem_used.sh:
+            maxUsedGB: 16
+    asserts:
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"command": "IDLE_MEM_USED_MAX_USED_GB=16 ./idle_mem_used.sh"'
+
+  - it: should allow the idle memory check to be disabled
+    set:
+      slurmScripts:
+        builtIn:
+          idle_mem_used.sh:
+            enabled: false
+    asserts:
+      - isNull:
+          path: data["idle_mem_used.sh"]
+      - notMatchRegex:
+          path: data["checks.json"]
+          pattern: '"name": "idle_mem_used"'

--- a/helm/slurm-cluster/tests/idle_mem_used_test.yaml
+++ b/helm/slurm-cluster/tests/idle_mem_used_test.yaml
@@ -18,6 +18,9 @@ tests:
       - matchRegex:
           path: data["checks.json"]
           pattern: '"on_fail": "drain"'
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"need_env": \[\s*\]'
 
   - it: should render a configured maximum used memory threshold
     set:

--- a/helm/slurm-cluster/tests/idle_mem_used_test.yaml
+++ b/helm/slurm-cluster/tests/idle_mem_used_test.yaml
@@ -2,7 +2,7 @@ suite: test idle memory health check
 templates:
   - slurm-scripts-cm.yaml
 tests:
-  - it: should enable the idle memory check with the default threshold
+  - it: should enable the idle memory check with node RealMemory
     asserts:
       - isNotNull:
           path: data["idle_mem_used.sh"]
@@ -11,7 +11,7 @@ tests:
           pattern: '"name": "idle_mem_used"'
       - matchRegex:
           path: data["checks.json"]
-          pattern: '"command": "IDLE_MEM_USED_MAX_USED_GB=32 ./idle_mem_used.sh"'
+          pattern: '"command": "./idle_mem_used.sh"'
       - matchRegex:
           path: data["checks.json"]
           pattern: '"contexts": \[\s*"hc_program"\s*\]'
@@ -20,18 +20,7 @@ tests:
           pattern: '"on_fail": "drain"'
       - matchRegex:
           path: data["checks.json"]
-          pattern: '"need_env": \[\s*\]'
-
-  - it: should render a configured maximum used memory threshold
-    set:
-      slurmScripts:
-        builtIn:
-          idle_mem_used.sh:
-            maxUsedGB: 16
-    asserts:
-      - matchRegex:
-          path: data["checks.json"]
-          pattern: '"command": "IDLE_MEM_USED_MAX_USED_GB=16 ./idle_mem_used.sh"'
+          pattern: '"need_env": \[\s*"CHECKS_NODE_REAL_MEM_BYTES"\s*\]'
 
   - it: should allow the idle memory check to be disabled
     set:

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -773,6 +773,12 @@ slurmScripts:
       enabled: true
       customContent: null
       customConfig: null
+    idle_mem_used.sh:
+      enabled: true
+      # Drain an idle node when MemTotal - MemAvailable exceeds 32 GB.
+      maxUsedGB: 32
+      customContent: null
+      customConfig: null
     job_tmpfs_delete.sh:
       enabled: true
       customContent: null

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -775,8 +775,6 @@ slurmScripts:
       customConfig: null
     idle_mem_used.sh:
       enabled: true
-      # Drain an idle node when MemTotal - MemAvailable exceeds 32 GB.
-      maxUsedGB: 32
       customContent: null
       customConfig: null
     job_tmpfs_delete.sh:


### PR DESCRIPTION
## Historical status

This PR was accidentally merged into the #2743 feature branch. It is retained as the historical review record and should not be used as the active dependency stack.

The clean replacement stack is:

1. #2774 — expose node `RealMemory` without a controller RPC
2. #2773 — add the dependent idle-memory health check

## Original scope

This PR introduced the SCHED-1897 `idle_mem_used` periodic health check. It uses local `scontrol listjobs` for RPC-free idle detection, consumes authoritative Slurm `RealMemory`, derives the idle-memory threshold from `MemTotal - RealMemory`, and drains idle nodes with an actionable diagnostic when available memory is unexpectedly low.

See #2773 for the complete replacement description, validation, and isolated five-file feature diff.
