### PR TITLE
[Superseded by #2774] Expose node RealMemory without controller RPC

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -204,6 +204,20 @@ jobs:
           fi
           go build "${packages[@]}"
 
+  test-slurm-scripts:
+    needs: [changes, authorize]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Test Slurm scripts
+        run: make test-slurm-scripts
+
   build-soperator-images:
     needs:
       - changes
@@ -846,6 +860,7 @@ jobs:
       - pre-build
       - lint
       - build-e2e
+      - test-slurm-scripts
       - build-slurm-images
       - build-soperator-images
       - manifest-populate-jail

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,17 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	go test ./...
 
+.PHONY: test-slurm-scripts
+test-slurm-scripts: ## Run Python unit tests for Slurm scripts.
+	@if find helm/slurm-cluster/slurm_scripts -type f -name '*_test.py' -print -quit | grep -q .; then \
+		python3 -m unittest discover \
+			-s helm/slurm-cluster/slurm_scripts \
+			-p '*_test.py' \
+			-v; \
+	else \
+		echo "No Slurm script unit tests found; skipping."; \
+	fi
+
 .PHONY: test-coverage
 test-coverage: manifests generate fmt vet envtest ## Run tests and generate test coverage.
 	go test ./... -coverprofile cover.out

--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,18 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: test-slurm-scripts
 test-slurm-scripts: ## Run Python unit tests for Slurm scripts.
-	@if find helm/slurm-cluster/slurm_scripts -type f -name '*_test.py' -print -quit | grep -q .; then \
-		python3 -m unittest discover \
-			-s helm/slurm-cluster/slurm_scripts \
-			-p '*_test.py' \
-			-v; \
-	else \
+	@found=false; \
+	for test_dir in helm/slurm-cluster/slurm_scripts images/worker; do \
+		if find "$$test_dir" -type f -name '*_test.py' -print -quit | grep -q .; then \
+			found=true; \
+			echo "Running Python unit tests in $$test_dir"; \
+			python3 -m unittest discover \
+				-s "$$test_dir" \
+				-p '*_test.py' \
+				-v || exit $$?; \
+		fi; \
+	done; \
+	if [ "$$found" = false ]; then \
 		echo "No Slurm script unit tests found; skipping."; \
 	fi
 

--- a/helm/slurm-cluster/slurm_scripts/check_runner.py
+++ b/helm/slurm-cluster/slurm_scripts/check_runner.py
@@ -8,6 +8,9 @@ import sys
 import time
 import typing
 
+SOPERATOR_NODE_METADATA_FILE = "/run/soperator/node_metadata.env"
+SOPERATOR_NODE_REAL_MEMORY_BYTES = "SOPERATOR_NODE_REAL_MEMORY_BYTES"
+
 # Set up logging
 try:
     log_stdout = "/dev/stdout"
@@ -114,7 +117,7 @@ class Check(typing.NamedTuple):
     # - CHECKS_NODE_COMMENT - comment field of the Slurm node
     # - CHECKS_NODE_REAL_MEM_BYTES - total allocatable memory in bytes for the Slurm node
     # - CHECKS_JOB_ALLOC_MEM_BYTES - memory in bytes, allocated for this Slurm job on this node
-    # These values are extracted from long-running commands, that's why they aren't exported by default
+    # Some values are extracted from long-running commands, so they aren't exported by default.
     need_env: list[str] = []
 
 class NodeInfo(typing.NamedTuple):
@@ -351,9 +354,38 @@ def export_needed_env(check: Check):
         if env == "CHECKS_NODE_COMMENT":
             os.environ["CHECKS_NODE_COMMENT"] = get_node_info().comment
         if env == "CHECKS_NODE_REAL_MEM_BYTES":
-            os.environ["CHECKS_NODE_REAL_MEM_BYTES"] = str(get_node_info().real_memory_bytes)
+            os.environ["CHECKS_NODE_REAL_MEM_BYTES"] = str(get_node_real_memory_bytes())
         if env == "CHECKS_JOB_ALLOC_MEM_BYTES":
             os.environ["CHECKS_JOB_ALLOC_MEM_BYTES"] = str(get_job_info().allocated_memory_bytes)
+
+# Get node RealMemory from node-local metadata, avoiding a controller RPC in the normal path.
+# Fall back to Slurm node info for compatibility with workers that have not yet been restarted
+# with an image and pod specification that publish the metadata file.
+@functools.lru_cache(maxsize=1)
+def get_node_real_memory_bytes() -> int:
+    try:
+        with open(SOPERATOR_NODE_METADATA_FILE, encoding="utf-8") as metadata_file:
+            for raw_line in metadata_file:
+                key, separator, value = raw_line.rstrip("\n").partition("=")
+                if key != SOPERATOR_NODE_REAL_MEMORY_BYTES:
+                    continue
+                if separator == "" or not value.isdecimal() or int(value) <= 0:
+                    raise ValueError(f"Invalid {SOPERATOR_NODE_REAL_MEMORY_BYTES} value")
+
+                real_memory_bytes = int(value)
+                logging.info(
+                    f"Node RealMemory from {SOPERATOR_NODE_METADATA_FILE}: "
+                    f"{real_memory_bytes} bytes"
+                )
+                return real_memory_bytes
+
+        raise ValueError(f"Missing {SOPERATOR_NODE_REAL_MEMORY_BYTES} value")
+    except Exception as e:
+        logging.warning(
+            f"Failed to get node RealMemory from {SOPERATOR_NODE_METADATA_FILE}: {e}; "
+            "falling back to Slurm node info"
+        )
+        return get_node_info().real_memory_bytes
 
 # Get GPU platform tags, e.g. ["8xH200", "8xGPU] from "nvidia-smi"
 # Please note, this command can be executed from both jail or host rootfs

--- a/helm/slurm-cluster/slurm_scripts/check_runner_test.py
+++ b/helm/slurm-cluster/slurm_scripts/check_runner_test.py
@@ -1,0 +1,119 @@
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("check_runner.py")
+
+
+def load_check_runner():
+    required_env = {
+        "SLURMD_NODENAME": "worker-1",
+        "CHECKS_OUTPUTS_BASE_DIR": "/opt/soperator-outputs",
+        "CHECKS_CONTEXT": "hc_program",
+        "CHECKS_CONFIG": "/opt/slurm_scripts/checks.json",
+    }
+    with mock.patch.dict(os.environ, required_env):
+        spec = importlib.util.spec_from_file_location(
+            "check_runner_under_test", MODULE_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+
+check_runner = load_check_runner()
+
+
+class NodeRealMemoryMetadataTest(unittest.TestCase):
+    def setUp(self):
+        check_runner.get_node_real_memory_bytes.cache_clear()
+
+    def test_reads_real_memory_from_local_metadata_without_node_rpc(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata_file = Path(tmpdir) / "node_metadata.env"
+            metadata_file.write_text(
+                "IGNORED=value\n"
+                "SOPERATOR_NODE_REAL_MEMORY_BYTES=999292928\n",
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(
+                    check_runner, "SOPERATOR_NODE_METADATA_FILE", str(metadata_file)
+                ),
+                mock.patch.object(check_runner, "get_node_info") as get_node_info,
+            ):
+                result = check_runner.get_node_real_memory_bytes()
+
+            self.assertEqual(999292928, result)
+            get_node_info.assert_not_called()
+
+    def test_exports_local_real_memory_for_checks(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata_file = Path(tmpdir) / "node_metadata.env"
+            metadata_file.write_text(
+                "SOPERATOR_NODE_REAL_MEMORY_BYTES=999292928\n",
+                encoding="utf-8",
+            )
+            check = check_runner.Check(need_env=["CHECKS_NODE_REAL_MEM_BYTES"])
+
+            with (
+                mock.patch.object(
+                    check_runner, "SOPERATOR_NODE_METADATA_FILE", str(metadata_file)
+                ),
+                mock.patch.object(check_runner, "get_node_info") as get_node_info,
+                mock.patch.dict(os.environ, {}, clear=False),
+            ):
+                check_runner.export_needed_env(check)
+                exported_value = os.environ["CHECKS_NODE_REAL_MEM_BYTES"]
+
+            self.assertEqual("999292928", exported_value)
+            get_node_info.assert_not_called()
+
+    def test_falls_back_to_slurm_when_metadata_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_file = Path(tmpdir) / "missing.env"
+            node_info = check_runner.NodeInfo(real_memory_bytes=2147483648)
+
+            with (
+                mock.patch.object(
+                    check_runner, "SOPERATOR_NODE_METADATA_FILE", str(missing_file)
+                ),
+                mock.patch.object(
+                    check_runner, "get_node_info", return_value=node_info
+                ) as get_node_info,
+            ):
+                result = check_runner.get_node_real_memory_bytes()
+
+            self.assertEqual(2147483648, result)
+            get_node_info.assert_called_once_with()
+
+    def test_falls_back_to_slurm_when_metadata_is_invalid(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata_file = Path(tmpdir) / "node_metadata.env"
+            metadata_file.write_text(
+                "SOPERATOR_NODE_REAL_MEMORY_BYTES=invalid\n", encoding="utf-8"
+            )
+            node_info = check_runner.NodeInfo(real_memory_bytes=1073741824)
+
+            with (
+                mock.patch.object(
+                    check_runner, "SOPERATOR_NODE_METADATA_FILE", str(metadata_file)
+                ),
+                mock.patch.object(
+                    check_runner, "get_node_info", return_value=node_info
+                ) as get_node_info,
+            ):
+                result = check_runner.get_node_real_memory_bytes()
+
+            self.assertEqual(1073741824, result)
+            get_node_info.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+max_used_gb="${IDLE_MEM_USED_MAX_USED_GB:-}"
+meminfo_path="${IDLE_MEM_USED_MEMINFO_PATH:-/proc/meminfo}"
+node_state_flags="${CHECKS_NODE_STATE_FLAGS:-}"
+node_name="${SLURMD_NODENAME:-unknown}"
+
+echo "[$(date)] Check memory usage when node ${node_name} is idle"
+echo "Configured maximum used memory: ${max_used_gb:-<unset>} GB"
+echo "Node state source: CHECKS_NODE_STATE_FLAGS, populated by check_runner.py from 'scontrol show node ${node_name} --json'"
+echo "Slurm node state flags: ${node_state_flags:-<unavailable>}"
+
+node_is_idle=false
+IFS='+' read -r -a state_flags <<< "${node_state_flags}"
+for state_flag in "${state_flags[@]}"; do
+    if [[ "${state_flag}" == "IDLE" ]]; then
+        node_is_idle=true
+        break
+    fi
+done
+
+echo "Node is idle: ${node_is_idle}"
+if [[ "${node_is_idle}" != "true" ]]; then
+    echo "Node is not IDLE; skipping memory validation"
+    exit 0
+fi
+
+if ! [[ "${max_used_gb}" =~ ^[0-9]+$ ]] || [[ "${max_used_gb}" == "0" ]]; then
+    echo "Invalid idle memory threshold '${max_used_gb:-<unset>}'; expected a positive GB count, skipping memory validation" >&2
+    exit 0
+fi
+
+max_used_bytes=$((max_used_gb * 1000000000))
+
+meminfo_values="$(
+    awk '
+        /^MemTotal:/ { total = $2 }
+        /^MemAvailable:/ { available = $2 }
+        END { if (total != "" && available != "") print total, available }
+    ' "${meminfo_path}" 2>/dev/null || true
+)"
+read -r mem_total_kib mem_available_kib <<< "${meminfo_values}"
+
+if ! [[ "${mem_total_kib:-}" =~ ^[0-9]+$ ]] ||
+   ! [[ "${mem_available_kib:-}" =~ ^[0-9]+$ ]] ||
+   (( mem_available_kib > mem_total_kib )); then
+    echo "Could not determine valid MemTotal and MemAvailable values from ${meminfo_path}; skipping memory validation" >&2
+    exit 0
+fi
+
+mem_total_bytes=$((mem_total_kib * 1024))
+mem_available_bytes=$((mem_available_kib * 1024))
+mem_used_bytes=$((mem_total_bytes - mem_available_bytes))
+
+mem_total_gb="$(awk -v bytes="${mem_total_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+mem_available_gb="$(awk -v bytes="${mem_available_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+mem_used_gb="$(awk -v bytes="${mem_used_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+
+echo "Memory source: ${meminfo_path}"
+echo "Memory measurements: total=${mem_total_gb} GB (${mem_total_bytes} bytes), available=${mem_available_gb} GB (${mem_available_bytes} bytes), used=total-available=${mem_used_gb} GB (${mem_used_bytes} bytes)"
+echo "Maximum allowed used memory: ${max_used_gb} GB (${max_used_bytes} bytes)"
+
+if (( mem_used_bytes > max_used_bytes )); then
+    echo "Node ${node_name} is IDLE but uses ${mem_used_gb} GB of memory (threshold: ${max_used_gb} GB; MemTotal: ${mem_total_gb} GB; MemAvailable: ${mem_available_gb} GB). This may indicate leftover or spurious processes consuming memory." >&3
+    exit 1
+fi
+
+echo "Idle node memory usage is within the configured threshold"
+exit 0

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
@@ -4,26 +4,36 @@ set -euo pipefail
 
 max_used_gb="${IDLE_MEM_USED_MAX_USED_GB:-}"
 meminfo_path="${IDLE_MEM_USED_MEMINFO_PATH:-/proc/meminfo}"
-node_state_flags="${CHECKS_NODE_STATE_FLAGS:-}"
 node_name="${SLURMD_NODENAME:-unknown}"
 
 echo "[$(date)] Check memory usage when node ${node_name} is idle"
 echo "Configured maximum used memory: ${max_used_gb:-<unset>} GB"
-echo "Node state source: CHECKS_NODE_STATE_FLAGS, populated by check_runner.py from 'scontrol show node ${node_name} --json'"
-echo "Slurm node state flags: ${node_state_flags:-<unavailable>}"
+echo "Idle state source: local 'scontrol listjobs' (no controller RPC)"
+echo "Idle state rule: exit code 1 with \"No slurmstepd's found on this node\" means the node has no local jobs"
 
-node_is_idle=false
-IFS='+' read -r -a state_flags <<< "${node_state_flags}"
-for state_flag in "${state_flags[@]}"; do
-    if [[ "${state_flag}" == "IDLE" ]]; then
-        node_is_idle=true
-        break
-    fi
-done
+if listjobs_output="$(scontrol listjobs 2>&1)"; then
+    listjobs_rc=0
+else
+    listjobs_rc=$?
+fi
+
+echo "scontrol listjobs exit code: ${listjobs_rc}"
+echo "scontrol listjobs output: ${listjobs_output:-<empty>}"
+
+if (( listjobs_rc == 0 )); then
+    node_is_idle=false
+    echo "Local Slurm jobs are present; treating the node as non-idle"
+elif (( listjobs_rc == 1 )) && [[ "${listjobs_output}" == *"No slurmstepd's found on this node"* ]]; then
+    node_is_idle=true
+    echo "No local slurmstepd was found; treating the node as idle"
+else
+    echo "Could not determine whether the node is idle from 'scontrol listjobs'; skipping memory validation" >&2
+    exit 0
+fi
 
 echo "Node is idle: ${node_is_idle}"
 if [[ "${node_is_idle}" != "true" ]]; then
-    echo "Node is not IDLE; skipping memory validation"
+    echo "Node has local jobs; skipping memory validation"
     exit 0
 fi
 

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-max_used_gb="${IDLE_MEM_USED_MAX_USED_GB:-}"
 meminfo_path="${IDLE_MEM_USED_MEMINFO_PATH:-/proc/meminfo}"
 node_name="${SLURMD_NODENAME:-unknown}"
+node_real_memory_bytes="${CHECKS_NODE_REAL_MEM_BYTES:-}"
 
 echo "[$(date)] Check memory usage when node ${node_name} is idle"
-echo "Configured maximum used memory: ${max_used_gb:-<unset>} GB"
+echo "Slurm RealMemory input: ${node_real_memory_bytes:-<unavailable>} bytes"
 echo "Idle state source: local 'scontrol listjobs' (no controller RPC)"
 echo "Idle state rule: exit code 1 with \"No slurmstepd's found on this node\" means the node has no local jobs"
 
@@ -37,12 +37,10 @@ if [[ "${node_is_idle}" != "true" ]]; then
     exit 0
 fi
 
-if ! [[ "${max_used_gb}" =~ ^[0-9]+$ ]] || [[ "${max_used_gb}" == "0" ]]; then
-    echo "Invalid idle memory threshold '${max_used_gb:-<unset>}'; expected a positive GB count, skipping memory validation" >&2
+if ! [[ "${node_real_memory_bytes}" =~ ^[0-9]+$ ]] || [[ "${node_real_memory_bytes}" == "0" ]]; then
+    echo "Invalid or unavailable Slurm RealMemory '${node_real_memory_bytes:-<unavailable>}'; expected a positive byte count, skipping memory validation" >&2
     exit 0
 fi
-
-max_used_bytes=$((max_used_gb * 1000000000))
 
 meminfo_values="$(
     awk '
@@ -64,18 +62,30 @@ mem_total_bytes=$((mem_total_kib * 1024))
 mem_available_bytes=$((mem_available_kib * 1024))
 mem_used_bytes=$((mem_total_bytes - mem_available_bytes))
 
+if (( node_real_memory_bytes > mem_total_bytes )); then
+    echo "Slurm RealMemory ${node_real_memory_bytes} bytes exceeds MemTotal ${mem_total_bytes} bytes; skipping memory validation" >&2
+    exit 0
+fi
+
+max_idle_used_bytes=$((mem_total_bytes - node_real_memory_bytes))
+
 mem_total_gb="$(awk -v bytes="${mem_total_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
 mem_available_gb="$(awk -v bytes="${mem_available_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
 mem_used_gb="$(awk -v bytes="${mem_used_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+node_real_memory_gb="$(awk -v bytes="${node_real_memory_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+max_idle_used_gb="$(awk -v bytes="${max_idle_used_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
 
 echo "Memory source: ${meminfo_path}"
 echo "Memory measurements: total=${mem_total_gb} GB (${mem_total_bytes} bytes), available=${mem_available_gb} GB (${mem_available_bytes} bytes), used=total-available=${mem_used_gb} GB (${mem_used_bytes} bytes)"
-echo "Maximum allowed used memory: ${max_used_gb} GB (${max_used_bytes} bytes)"
+echo "Slurm RealMemory: ${node_real_memory_gb} GB (${node_real_memory_bytes} bytes)"
+echo "Derived maximum idle used memory: MemTotal-RealMemory=${max_idle_used_gb} GB (${max_idle_used_bytes} bytes)"
 
-if (( mem_used_bytes > max_used_bytes )); then
-    echo "Node ${node_name} is IDLE but uses ${mem_used_gb} GB of memory (threshold: ${max_used_gb} GB; MemTotal: ${mem_total_gb} GB; MemAvailable: ${mem_available_gb} GB). This may indicate leftover or spurious processes consuming memory." >&3
+if (( mem_available_bytes < node_real_memory_bytes )); then
+    memory_deficit_bytes=$((node_real_memory_bytes - mem_available_bytes))
+    memory_deficit_gb="$(awk -v bytes="${memory_deficit_bytes}" 'BEGIN { printf "%.2f", bytes / 1000000000 }')"
+    echo "Node ${node_name} is IDLE but has only ${mem_available_gb} GB of memory available, below Slurm RealMemory ${node_real_memory_gb} GB by ${memory_deficit_gb} GB (used: ${mem_used_gb} GB; derived maximum idle usage: ${max_idle_used_gb} GB; MemTotal: ${mem_total_gb} GB). This may indicate leftover or spurious processes consuming memory." >&3
     exit 1
 fi
 
-echo "Idle node memory usage is within the configured threshold"
+echo "Idle node leaves enough memory available for Slurm RealMemory"
 exit 0

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
@@ -12,5 +12,5 @@
   "reason_append_details": true,
   "run_in_jail": false,
   "log": "slurm_scripts/$worker.$name.$context.out",
-  "need_env": ["CHECKS_NODE_STATE_FLAGS"]
+  "need_env": []
 }

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
@@ -1,0 +1,16 @@
+{
+  "name": "idle_mem_used",
+  "command": "IDLE_MEM_USED_MAX_USED_GB={{ required `Idle memory maximum used GB must be provided.` (index .Values.slurmScripts.builtIn `idle_mem_used.sh`).maxUsedGB }} ./idle_mem_used.sh",
+  "platforms": ["any"],
+  "skip_for_cpu_jobs": false,
+  "skip_for_partial_gpu_jobs": false,
+  "contexts": ["hc_program"],
+  "node_states": ["any"],
+  "on_fail": "drain",
+  "on_ok": "none",
+  "reason_base": "[node_problem] $name",
+  "reason_append_details": true,
+  "run_in_jail": false,
+  "log": "slurm_scripts/$worker.$name.$context.out",
+  "need_env": ["CHECKS_NODE_STATE_FLAGS"]
+}

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used.sh.json
@@ -1,6 +1,6 @@
 {
   "name": "idle_mem_used",
-  "command": "IDLE_MEM_USED_MAX_USED_GB={{ required `Idle memory maximum used GB must be provided.` (index .Values.slurmScripts.builtIn `idle_mem_used.sh`).maxUsedGB }} ./idle_mem_used.sh",
+  "command": "./idle_mem_used.sh",
   "platforms": ["any"],
   "skip_for_cpu_jobs": false,
   "skip_for_partial_gpu_jobs": false,
@@ -12,5 +12,5 @@
   "reason_append_details": true,
   "run_in_jail": false,
   "log": "slurm_scripts/$worker.$name.$context.out",
-  "need_env": []
+  "need_env": ["CHECKS_NODE_REAL_MEM_BYTES"]
 }

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
@@ -1,0 +1,105 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("idle_mem_used.sh")
+GIB = 1024 * 1024 * 1024
+
+
+class IdleMemUsedTest(unittest.TestCase):
+    def run_check(
+        self,
+        *,
+        node_states: str,
+        total_bytes: int | None,
+        available_bytes: int | None,
+        max_used_gb: int = 32,
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            meminfo_path = Path(tmpdir) / "meminfo"
+            if total_bytes is not None and available_bytes is not None:
+                meminfo_path.write_text(
+                    f"MemTotal:       {total_bytes // 1024} kB\n"
+                    f"MemAvailable:   {available_bytes // 1024} kB\n",
+                    encoding="utf-8",
+                )
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "SLURMD_NODENAME": "worker-1",
+                    "CHECKS_NODE_STATE_FLAGS": node_states,
+                    "IDLE_MEM_USED_MAX_USED_GB": str(max_used_gb),
+                    "IDLE_MEM_USED_MEMINFO_PATH": str(meminfo_path),
+                }
+            )
+
+            return subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'exec 3>&1; exec bash "$1"',
+                    "idle-mem-used-test",
+                    str(SCRIPT_PATH),
+                ],
+                check=False,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+    def test_non_idle_node_skips_memory_validation(self):
+        result = self.run_check(
+            node_states="ALLOCATED",
+            total_bytes=None,
+            available_bytes=None,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("Node is idle: false", result.stdout)
+        self.assertIn("Node is not IDLE; skipping memory validation", result.stdout)
+        self.assertNotIn("Memory measurements:", result.stdout)
+
+    def test_idle_node_below_threshold_passes(self):
+        result = self.run_check(
+            node_states="IDLE",
+            total_bytes=64 * GIB,
+            available_bytes=60 * GIB,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("Node is idle: true", result.stdout)
+        self.assertIn(f"used=total-available=4.29 GB ({4 * GIB} bytes)", result.stdout)
+        self.assertIn("Maximum allowed used memory: 32 GB (32000000000 bytes)", result.stdout)
+
+    def test_idle_node_above_threshold_fails_with_actionable_reason(self):
+        result = self.run_check(
+            node_states="IDLE+CLOUD",
+            total_bytes=64 * GIB,
+            available_bytes=22 * GIB,
+        )
+
+        self.assertEqual(1, result.returncode)
+        self.assertIn("Node is idle: true", result.stdout)
+        self.assertIn("Node worker-1 is IDLE but uses", result.stdout)
+        self.assertIn("45.10 GB", result.stdout)
+        self.assertIn("threshold: 32 GB", result.stdout)
+        self.assertIn("leftover or spurious processes", result.stdout)
+
+    def test_unavailable_memory_data_does_not_drain_node(self):
+        result = self.run_check(
+            node_states="IDLE",
+            total_bytes=None,
+            available_bytes=None,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("Could not determine valid MemTotal and MemAvailable", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
@@ -17,7 +17,7 @@ class IdleMemUsedTest(unittest.TestCase):
         listjobs_output: str,
         total_bytes: int | None,
         available_bytes: int | None,
-        max_used_gb: int = 32,
+        node_real_memory_bytes: int | None = 56 * GIB,
     ) -> subprocess.CompletedProcess[str]:
         with tempfile.TemporaryDirectory() as tmpdir:
             scontrol_path = Path(tmpdir) / "scontrol"
@@ -38,11 +38,14 @@ class IdleMemUsedTest(unittest.TestCase):
                 )
 
             env = os.environ.copy()
+            if node_real_memory_bytes is None:
+                env.pop("CHECKS_NODE_REAL_MEM_BYTES", None)
+            else:
+                env["CHECKS_NODE_REAL_MEM_BYTES"] = str(node_real_memory_bytes)
             env.update(
                 {
                     "PATH": f"{tmpdir}:{env['PATH']}",
                     "SLURMD_NODENAME": "worker-1",
-                    "IDLE_MEM_USED_MAX_USED_GB": str(max_used_gb),
                     "IDLE_MEM_USED_MEMINFO_PATH": str(meminfo_path),
                     "MOCK_SCONTROL_LISTJOBS_RC": str(listjobs_rc),
                     "MOCK_SCONTROL_LISTJOBS_OUTPUT": listjobs_output,
@@ -78,7 +81,7 @@ class IdleMemUsedTest(unittest.TestCase):
         self.assertIn("Node has local jobs; skipping memory validation", result.stdout)
         self.assertNotIn("Memory measurements:", result.stdout)
 
-    def test_idle_node_below_threshold_passes(self):
+    def test_idle_node_with_enough_available_memory_passes(self):
         result = self.run_check(
             listjobs_rc=1,
             listjobs_output="No slurmstepd's found on this node",
@@ -90,9 +93,15 @@ class IdleMemUsedTest(unittest.TestCase):
         self.assertIn("Node is idle: true", result.stdout)
         self.assertIn("No local slurmstepd was found", result.stdout)
         self.assertIn(f"used=total-available=4.29 GB ({4 * GIB} bytes)", result.stdout)
-        self.assertIn("Maximum allowed used memory: 32 GB (32000000000 bytes)", result.stdout)
+        self.assertIn(
+            f"Slurm RealMemory: 60.13 GB ({56 * GIB} bytes)", result.stdout
+        )
+        self.assertIn(
+            f"Derived maximum idle used memory: MemTotal-RealMemory=8.59 GB ({8 * GIB} bytes)",
+            result.stdout,
+        )
 
-    def test_idle_node_above_threshold_fails_with_actionable_reason(self):
+    def test_idle_node_with_insufficient_available_memory_fails(self):
         result = self.run_check(
             listjobs_rc=1,
             listjobs_output="No slurmstepd's found on this node",
@@ -102,9 +111,9 @@ class IdleMemUsedTest(unittest.TestCase):
 
         self.assertEqual(1, result.returncode)
         self.assertIn("Node is idle: true", result.stdout)
-        self.assertIn("Node worker-1 is IDLE but uses", result.stdout)
-        self.assertIn("45.10 GB", result.stdout)
-        self.assertIn("threshold: 32 GB", result.stdout)
+        self.assertIn("Node worker-1 is IDLE but has only 23.62 GB", result.stdout)
+        self.assertIn("below Slurm RealMemory 60.13 GB by 36.51 GB", result.stdout)
+        self.assertIn("derived maximum idle usage: 8.59 GB", result.stdout)
         self.assertIn("leftover or spurious processes", result.stdout)
 
     def test_unavailable_memory_data_does_not_drain_node(self):
@@ -117,6 +126,32 @@ class IdleMemUsedTest(unittest.TestCase):
 
         self.assertEqual(0, result.returncode)
         self.assertIn("Could not determine valid MemTotal and MemAvailable", result.stderr)
+
+    def test_unavailable_real_memory_does_not_drain_node(self):
+        result = self.run_check(
+            listjobs_rc=1,
+            listjobs_output="No slurmstepd's found on this node",
+            total_bytes=None,
+            available_bytes=None,
+            node_real_memory_bytes=None,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("Invalid or unavailable Slurm RealMemory", result.stderr)
+        self.assertNotIn("Memory measurements:", result.stdout)
+
+    def test_real_memory_larger_than_memtotal_does_not_drain_node(self):
+        result = self.run_check(
+            listjobs_rc=1,
+            listjobs_output="No slurmstepd's found on this node",
+            total_bytes=64 * GIB,
+            available_bytes=60 * GIB,
+            node_real_memory_bytes=72 * GIB,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("exceeds MemTotal", result.stderr)
+        self.assertNotIn("Derived maximum idle used memory", result.stdout)
 
     def test_unexpected_listjobs_failure_does_not_validate_memory(self):
         result = self.run_check(

--- a/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
+++ b/helm/slurm-cluster/slurm_scripts/idle_mem_used_test.py
@@ -13,12 +13,22 @@ class IdleMemUsedTest(unittest.TestCase):
     def run_check(
         self,
         *,
-        node_states: str,
+        listjobs_rc: int,
+        listjobs_output: str,
         total_bytes: int | None,
         available_bytes: int | None,
         max_used_gb: int = 32,
     ) -> subprocess.CompletedProcess[str]:
         with tempfile.TemporaryDirectory() as tmpdir:
+            scontrol_path = Path(tmpdir) / "scontrol"
+            scontrol_path.write_text(
+                "#!/bin/bash\n"
+                "printf '%s\\n' \"${MOCK_SCONTROL_LISTJOBS_OUTPUT}\"\n"
+                "exit \"${MOCK_SCONTROL_LISTJOBS_RC}\"\n",
+                encoding="utf-8",
+            )
+            scontrol_path.chmod(0o755)
+
             meminfo_path = Path(tmpdir) / "meminfo"
             if total_bytes is not None and available_bytes is not None:
                 meminfo_path.write_text(
@@ -30,10 +40,12 @@ class IdleMemUsedTest(unittest.TestCase):
             env = os.environ.copy()
             env.update(
                 {
+                    "PATH": f"{tmpdir}:{env['PATH']}",
                     "SLURMD_NODENAME": "worker-1",
-                    "CHECKS_NODE_STATE_FLAGS": node_states,
                     "IDLE_MEM_USED_MAX_USED_GB": str(max_used_gb),
                     "IDLE_MEM_USED_MEMINFO_PATH": str(meminfo_path),
+                    "MOCK_SCONTROL_LISTJOBS_RC": str(listjobs_rc),
+                    "MOCK_SCONTROL_LISTJOBS_OUTPUT": listjobs_output,
                 }
             )
 
@@ -54,31 +66,36 @@ class IdleMemUsedTest(unittest.TestCase):
 
     def test_non_idle_node_skips_memory_validation(self):
         result = self.run_check(
-            node_states="ALLOCATED",
+            listjobs_rc=0,
+            listjobs_output="JOBID\n1011",
             total_bytes=None,
             available_bytes=None,
         )
 
         self.assertEqual(0, result.returncode)
         self.assertIn("Node is idle: false", result.stdout)
-        self.assertIn("Node is not IDLE; skipping memory validation", result.stdout)
+        self.assertIn("Local Slurm jobs are present", result.stdout)
+        self.assertIn("Node has local jobs; skipping memory validation", result.stdout)
         self.assertNotIn("Memory measurements:", result.stdout)
 
     def test_idle_node_below_threshold_passes(self):
         result = self.run_check(
-            node_states="IDLE",
+            listjobs_rc=1,
+            listjobs_output="No slurmstepd's found on this node",
             total_bytes=64 * GIB,
             available_bytes=60 * GIB,
         )
 
         self.assertEqual(0, result.returncode)
         self.assertIn("Node is idle: true", result.stdout)
+        self.assertIn("No local slurmstepd was found", result.stdout)
         self.assertIn(f"used=total-available=4.29 GB ({4 * GIB} bytes)", result.stdout)
         self.assertIn("Maximum allowed used memory: 32 GB (32000000000 bytes)", result.stdout)
 
     def test_idle_node_above_threshold_fails_with_actionable_reason(self):
         result = self.run_check(
-            node_states="IDLE+CLOUD",
+            listjobs_rc=1,
+            listjobs_output="No slurmstepd's found on this node",
             total_bytes=64 * GIB,
             available_bytes=22 * GIB,
         )
@@ -92,13 +109,27 @@ class IdleMemUsedTest(unittest.TestCase):
 
     def test_unavailable_memory_data_does_not_drain_node(self):
         result = self.run_check(
-            node_states="IDLE",
+            listjobs_rc=1,
+            listjobs_output="No slurmstepd's found on this node",
             total_bytes=None,
             available_bytes=None,
         )
 
         self.assertEqual(0, result.returncode)
         self.assertIn("Could not determine valid MemTotal and MemAvailable", result.stderr)
+
+    def test_unexpected_listjobs_failure_does_not_validate_memory(self):
+        result = self.run_check(
+            listjobs_rc=2,
+            listjobs_output="Unable to inspect local jobs",
+            total_bytes=None,
+            available_bytes=None,
+        )
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("scontrol listjobs exit code: 2", result.stdout)
+        self.assertIn("Could not determine whether the node is idle", result.stderr)
+        self.assertNotIn("Memory measurements:", result.stdout)
 
 
 if __name__ == "__main__":

--- a/helm/slurm-cluster/tests/idle_mem_used_test.yaml
+++ b/helm/slurm-cluster/tests/idle_mem_used_test.yaml
@@ -1,0 +1,44 @@
+suite: test idle memory health check
+templates:
+  - slurm-scripts-cm.yaml
+tests:
+  - it: should enable the idle memory check with the default threshold
+    asserts:
+      - isNotNull:
+          path: data["idle_mem_used.sh"]
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"name": "idle_mem_used"'
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"command": "IDLE_MEM_USED_MAX_USED_GB=32 ./idle_mem_used.sh"'
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"contexts": \[\s*"hc_program"\s*\]'
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"on_fail": "drain"'
+
+  - it: should render a configured maximum used memory threshold
+    set:
+      slurmScripts:
+        builtIn:
+          idle_mem_used.sh:
+            maxUsedGB: 16
+    asserts:
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"command": "IDLE_MEM_USED_MAX_USED_GB=16 ./idle_mem_used.sh"'
+
+  - it: should allow the idle memory check to be disabled
+    set:
+      slurmScripts:
+        builtIn:
+          idle_mem_used.sh:
+            enabled: false
+    asserts:
+      - isNull:
+          path: data["idle_mem_used.sh"]
+      - notMatchRegex:
+          path: data["checks.json"]
+          pattern: '"name": "idle_mem_used"'

--- a/helm/slurm-cluster/tests/idle_mem_used_test.yaml
+++ b/helm/slurm-cluster/tests/idle_mem_used_test.yaml
@@ -18,6 +18,9 @@ tests:
       - matchRegex:
           path: data["checks.json"]
           pattern: '"on_fail": "drain"'
+      - matchRegex:
+          path: data["checks.json"]
+          pattern: '"need_env": \[\s*\]'
 
   - it: should render a configured maximum used memory threshold
     set:

--- a/helm/slurm-cluster/tests/idle_mem_used_test.yaml
+++ b/helm/slurm-cluster/tests/idle_mem_used_test.yaml
@@ -2,7 +2,7 @@ suite: test idle memory health check
 templates:
   - slurm-scripts-cm.yaml
 tests:
-  - it: should enable the idle memory check with the default threshold
+  - it: should enable the idle memory check with node RealMemory
     asserts:
       - isNotNull:
           path: data["idle_mem_used.sh"]
@@ -11,7 +11,7 @@ tests:
           pattern: '"name": "idle_mem_used"'
       - matchRegex:
           path: data["checks.json"]
-          pattern: '"command": "IDLE_MEM_USED_MAX_USED_GB=32 ./idle_mem_used.sh"'
+          pattern: '"command": "./idle_mem_used.sh"'
       - matchRegex:
           path: data["checks.json"]
           pattern: '"contexts": \[\s*"hc_program"\s*\]'
@@ -20,18 +20,7 @@ tests:
           pattern: '"on_fail": "drain"'
       - matchRegex:
           path: data["checks.json"]
-          pattern: '"need_env": \[\s*\]'
-
-  - it: should render a configured maximum used memory threshold
-    set:
-      slurmScripts:
-        builtIn:
-          idle_mem_used.sh:
-            maxUsedGB: 16
-    asserts:
-      - matchRegex:
-          path: data["checks.json"]
-          pattern: '"command": "IDLE_MEM_USED_MAX_USED_GB=16 ./idle_mem_used.sh"'
+          pattern: '"need_env": \[\s*"CHECKS_NODE_REAL_MEM_BYTES"\s*\]'
 
   - it: should allow the idle memory check to be disabled
     set:

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -773,6 +773,12 @@ slurmScripts:
       enabled: true
       customContent: null
       customConfig: null
+    idle_mem_used.sh:
+      enabled: true
+      # Drain an idle node when MemTotal - MemAvailable exceeds 32 GB.
+      maxUsedGB: 32
+      customContent: null
+      customConfig: null
     job_tmpfs_delete.sh:
       enabled: true
       customContent: null

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -775,8 +775,6 @@ slurmScripts:
       customConfig: null
     idle_mem_used.sh:
       enabled: true
-      # Drain an idle node when MemTotal - MemAvailable exceeds 32 GB.
-      maxUsedGB: 32
       customContent: null
       customConfig: null
     job_tmpfs_delete.sh:

--- a/images/worker/slurmd.dockerfile
+++ b/images/worker/slurmd.dockerfile
@@ -157,6 +157,7 @@ RUN mkdir -p /var/log/slurm/multilog && \
 
 # Copy slurmd entrypoint script
 COPY images/worker/slurmd_entrypoint.sh /opt/bin/slurm/
+COPY images/worker/write_soperator_metadata.sh /opt/bin/slurm/
 
 # Copy worker init script (controller readiness + topology for ephemeral nodes)
 COPY images/worker/worker_init.py /opt/bin/slurm/
@@ -167,6 +168,7 @@ COPY images/worker/docker_proxy_nginx_entrypoint.sh /opt/bin/slurm/
 COPY images/worker/dockerd_entrypoint.sh /opt/bin/slurm/
 
 RUN chmod +x /opt/bin/slurm/slurmd_entrypoint.sh && \
+    chmod +x /opt/bin/slurm/write_soperator_metadata.sh && \
     chmod +x /opt/bin/slurm/supervisord_entrypoint.sh && \
     chmod +x /opt/bin/slurm/worker_init.py && \
     chmod +x /opt/bin/slurm/docker_proxy_nginx_entrypoint.sh && \

--- a/images/worker/slurmd_entrypoint.sh
+++ b/images/worker/slurmd_entrypoint.sh
@@ -42,6 +42,9 @@ else
     export TOPO_SWITCH_TIER2="unknown"
 fi
 
+echo "Export Soperator node metadata"
+/opt/bin/slurm/write_soperator_metadata.sh
+
 echo "Evaluate variables in the Slurm node 'Extra' field"
 evaluated_extra=$(eval echo "$SLURM_NODE_EXTRA")
 

--- a/images/worker/write_soperator_metadata.sh
+++ b/images/worker/write_soperator_metadata.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+metadata_file="${1:-/run/soperator/node_metadata.env}"
+node_real_memory_bytes="${SOPERATOR_NODE_REAL_MEMORY_BYTES:-}"
+
+if ! [[ "${node_real_memory_bytes}" =~ ^[0-9]+$ ]] || [[ "${node_real_memory_bytes}" == "0" ]]; then
+    rm -f -- "${metadata_file}"
+    echo "SOPERATOR_NODE_REAL_MEMORY_BYTES is unavailable or invalid; skipping node metadata export" >&2
+    exit 0
+fi
+
+metadata_dir="$(dirname -- "${metadata_file}")"
+install -d -m 0755 "${metadata_dir}"
+
+temporary_file="$(mktemp "${metadata_file}.tmp.XXXXXX")"
+trap 'rm -f -- "${temporary_file}"' EXIT
+
+printf 'SOPERATOR_NODE_REAL_MEMORY_BYTES=%s\n' "${node_real_memory_bytes}" > "${temporary_file}"
+chmod 0644 "${temporary_file}"
+mv -f -- "${temporary_file}" "${metadata_file}"
+trap - EXIT
+
+echo "Exported node metadata to ${metadata_file}"

--- a/images/worker/write_soperator_metadata_test.py
+++ b/images/worker/write_soperator_metadata_test.py
@@ -1,0 +1,76 @@
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("write_soperator_metadata.sh")
+
+
+class WriteSoperatorMetadataTest(unittest.TestCase):
+    def run_writer(
+        self, metadata_file: Path, real_memory_bytes: str | None
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        if real_memory_bytes is None:
+            env.pop("SOPERATOR_NODE_REAL_MEMORY_BYTES", None)
+        else:
+            env["SOPERATOR_NODE_REAL_MEMORY_BYTES"] = real_memory_bytes
+
+        return subprocess.run(
+            ["bash", str(SCRIPT_PATH), str(metadata_file)],
+            check=False,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def test_writes_real_memory_metadata_atomically(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata_file = Path(tmpdir) / "nested" / "node_metadata.env"
+
+            result = self.run_writer(metadata_file, "999292928")
+
+            self.assertEqual(0, result.returncode)
+            self.assertEqual(
+                "SOPERATOR_NODE_REAL_MEMORY_BYTES=999292928\n",
+                metadata_file.read_text(encoding="utf-8"),
+            )
+            self.assertEqual(0o644, stat.S_IMODE(metadata_file.stat().st_mode))
+            self.assertEqual([], list(metadata_file.parent.glob("*.tmp.*")))
+
+    def test_replaces_existing_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata_file = Path(tmpdir) / "node_metadata.env"
+            metadata_file.write_text(
+                "SOPERATOR_NODE_REAL_MEMORY_BYTES=1\n", encoding="utf-8"
+            )
+
+            result = self.run_writer(metadata_file, "2147483648")
+
+            self.assertEqual(0, result.returncode)
+            self.assertEqual(
+                "SOPERATOR_NODE_REAL_MEMORY_BYTES=2147483648\n",
+                metadata_file.read_text(encoding="utf-8"),
+            )
+
+    def test_missing_or_invalid_metadata_is_skipped(self):
+        for value in (None, "", "0", "-1", "1.5", "invalid"):
+            with self.subTest(value=value), tempfile.TemporaryDirectory() as tmpdir:
+                metadata_file = Path(tmpdir) / "node_metadata.env"
+                metadata_file.write_text(
+                    "SOPERATOR_NODE_REAL_MEMORY_BYTES=1\n", encoding="utf-8"
+                )
+
+                result = self.run_writer(metadata_file, value)
+
+                self.assertEqual(0, result.returncode)
+                self.assertFalse(metadata_file.exists())
+                self.assertIn("skipping node metadata export", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/internal/consts/node_metadata.go
+++ b/internal/consts/node_metadata.go
@@ -1,0 +1,5 @@
+package consts
+
+// EnvNodeRealMemoryBytes carries the byte representation of the RealMemory value
+// rendered into slurm.conf for a worker node.
+const EnvNodeRealMemoryBytes = "SOPERATOR_NODE_REAL_MEMORY_BYTES"

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -243,6 +243,14 @@ func renderContainerNodeSetSlurmd(
 		return corev1.Container{}, fmt.Errorf("checking resource requests: %w", err)
 	}
 
+	for _, env := range nodeSet.ContainerSlurmd.CustomEnv {
+		if env.Name == consts.EnvNodeRealMemoryBytes {
+			return corev1.Container{}, fmt.Errorf("environment variable %q is managed by Soperator", consts.EnvNodeRealMemoryBytes)
+		}
+	}
+
+	realMemoryBytes := common.RenderRealMemorySlurmd(resources) * 1024 * 1024
+
 	appArmorProfile := nodeSet.ContainerSlurmd.AppArmorProfile
 	if nodeSet.AppArmorProfileUseDefault {
 		appArmorProfile = fmt.Sprintf("%s/%s", "localhost", naming.BuildAppArmorProfileName(nodeSet.ParentalCluster.Name, nodeSet.ParentalCluster.Namespace))
@@ -265,6 +273,7 @@ func renderContainerNodeSetSlurmd(
 				nodeSet.GPU.Nvidia.GDRCopyEnabled,
 				nodeSet.DockerEnabled,
 				nodeSet.NodeExtra,
+				realMemoryBytes,
 			),
 			nodeSet.ContainerSlurmd.CustomEnv...,
 		),
@@ -337,6 +346,7 @@ func renderNodeSetSlurmdEnv(
 	enableGDRCopy bool,
 	dockerEnabled bool,
 	slurmNodeExtra string,
+	realMemoryBytes int64,
 ) []corev1.EnvVar {
 	envVar := []corev1.EnvVar{
 		{
@@ -359,6 +369,10 @@ func renderNodeSetSlurmdEnv(
 		{
 			Name:  consts.EnvDockerEnabled,
 			Value: strconv.FormatBool(dockerEnabled),
+		},
+		{
+			Name:  consts.EnvNodeRealMemoryBytes,
+			Value: strconv.FormatInt(realMemoryBytes, 10),
 		},
 	}
 

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -664,6 +664,81 @@ func TestRenderNodeSetStatefulSet_DockerEnabled(t *testing.T) {
 	}
 }
 
+func TestRenderNodeSetStatefulSet_NodeRealMemoryMetadata(t *testing.T) {
+	createNodeSet := func() *values.SlurmNodeSet {
+		return &values.SlurmNodeSet{
+			Name: "test-nodeset",
+			ParentalCluster: client.ObjectKey{
+				Namespace: "test-namespace",
+				Name:      "test-cluster",
+			},
+			ContainerSlurmd: values.Container{
+				NodeContainer: slurmv1.NodeContainer{
+					Image: "test-image",
+					Resources: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1G"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+					},
+				},
+			},
+			ContainerMunge: values.Container{
+				NodeContainer: slurmv1.NodeContainer{Image: "munge-image"},
+			},
+			VolumeSpool: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/spool"},
+			},
+			VolumeJail: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/jail"},
+			},
+			StatefulSet:              values.StatefulSet{Replicas: 1},
+			SupervisorDConfigMapName: "supervisord-config",
+			SSHDConfigMapName:        "sshd-config",
+			GPU:                      &slurmv1alpha1.GPUSpec{Enabled: false},
+		}
+	}
+
+	t.Run("exports the rendered Slurm RealMemory in bytes", func(t *testing.T) {
+		result, err := worker.RenderNodeSetStatefulSet(
+			"test-cluster",
+			createNodeSet(),
+			&slurmv1.Secrets{},
+			consts.CGroupV2,
+			false,
+			false,
+			"",
+		)
+		assert.NoError(t, err)
+
+		for _, container := range result.Spec.Template.Spec.Containers {
+			if container.Name == consts.ContainerNameSlurmd {
+				// Slurm RealMemory is expressed in whole MiB: 1G becomes 953 MiB.
+				assertEnvValue(t, container.Env, consts.EnvNodeRealMemoryBytes, "999292928")
+				return
+			}
+		}
+		t.Fatal("slurmd container not found")
+	})
+
+	t.Run("rejects a custom override of Soperator metadata", func(t *testing.T) {
+		nodeSet := createNodeSet()
+		nodeSet.ContainerSlurmd.CustomEnv = []corev1.EnvVar{{
+			Name:  consts.EnvNodeRealMemoryBytes,
+			Value: "1",
+		}}
+
+		_, err := worker.RenderNodeSetStatefulSet(
+			"test-cluster",
+			nodeSet,
+			&slurmv1.Secrets{},
+			consts.CGroupV2,
+			false,
+			false,
+			"",
+		)
+		assert.ErrorContains(t, err, "is managed by Soperator")
+	})
+}
+
 func TestRenderNodeSetStatefulSet_PersistentVolumeClaimRetentionPolicy(t *testing.T) {
 	createNodeSet := func(ephemeralNodes *bool, jailSubMounts []slurmv1alpha1.NodeVolumeMount, customVolumeMounts []slurmv1alpha1.NodeVolumeMount) *values.SlurmNodeSet {
 		return &values.SlurmNodeSet{


### PR DESCRIPTION
## Superseded

This PR is superseded by #2774 and is retained only for its existing discussion and review history.

The branch was rebuilt on current `main` to remove the accidentally merged #2742 changes. GitHub kept this PR's pull ref pinned to the old combined history and would not reopen it after the force-push, so a replacement PR was required.

The active stack is:

1. #2774 — the independent RPC-free node `RealMemory` feature, based on `main`
2. #2773 — the idle-memory health check, stacked on the #2774 branch

Please review the replacement PRs instead of this stale diff.
