### PR TITLE
Run Slurm script unit tests in CI

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -204,7 +204,7 @@ jobs:
           fi
           go build "${packages[@]}"
 
-  test-slurm-scripts:
+  test-python:
     needs: [changes, authorize]
     if: needs.changes.outputs.should_build == 'true'
     runs-on: ubuntu-24.04
@@ -215,8 +215,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Test Slurm scripts
-        run: make test-slurm-scripts
+      - name: Test Python
+        run: make test-python
 
   build-soperator-images:
     needs:
@@ -860,7 +860,7 @@ jobs:
       - pre-build
       - lint
       - build-e2e
-      - test-slurm-scripts
+      - test-python
       - build-slurm-images
       - build-soperator-images
       - manifest-populate-jail

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -204,6 +204,20 @@ jobs:
           fi
           go build "${packages[@]}"
 
+  test-slurm-scripts:
+    needs: [changes, authorize]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Test Slurm scripts
+        run: make test-slurm-scripts
+
   build-soperator-images:
     needs:
       - changes
@@ -846,6 +860,7 @@ jobs:
       - pre-build
       - lint
       - build-e2e
+      - test-slurm-scripts
       - build-slurm-images
       - build-soperator-images
       - manifest-populate-jail

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,17 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	go test ./...
 
+.PHONY: test-slurm-scripts
+test-slurm-scripts: ## Run Python unit tests for Slurm scripts.
+	@if find helm/slurm-cluster/slurm_scripts -type f -name '*_test.py' -print -quit | grep -q .; then \
+		python3 -m unittest discover \
+			-s helm/slurm-cluster/slurm_scripts \
+			-p '*_test.py' \
+			-v; \
+	else \
+		echo "No Slurm script unit tests found; skipping."; \
+	fi
+
 .PHONY: test-coverage
 test-coverage: manifests generate fmt vet envtest ## Run tests and generate test coverage.
 	go test ./... -coverprofile cover.out

--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,18 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: test-slurm-scripts
 test-slurm-scripts: ## Run Python unit tests for Slurm scripts.
-	@if find helm/slurm-cluster/slurm_scripts -type f -name '*_test.py' -print -quit | grep -q .; then \
-		python3 -m unittest discover \
-			-s helm/slurm-cluster/slurm_scripts \
-			-p '*_test.py' \
-			-v; \
-	else \
+	@found=false; \
+	for test_dir in helm/slurm-cluster/slurm_scripts images/worker; do \
+		if find "$$test_dir" -type f -name '*_test.py' -print -quit | grep -q .; then \
+			found=true; \
+			echo "Running Python unit tests in $$test_dir"; \
+			python3 -m unittest discover \
+				-s "$$test_dir" \
+				-p '*_test.py' \
+				-v || exit $$?; \
+		fi; \
+	done; \
+	if [ "$$found" = false ]; then \
 		echo "No Slurm script unit tests found; skipping."; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -119,21 +119,28 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	go test ./...
 
-.PHONY: test-slurm-scripts
-test-slurm-scripts: ## Run Python unit tests for Slurm scripts.
+.PHONY: test-python
+test-python: ## Run all Python unit tests.
 	@found=false; \
-	for test_dir in helm/slurm-cluster/slurm_scripts images/worker; do \
-		if find "$$test_dir" -type f -name '*_test.py' -print -quit | grep -q .; then \
-			found=true; \
-			echo "Running Python unit tests in $$test_dir"; \
-			python3 -m unittest discover \
-				-s "$$test_dir" \
-				-p '*_test.py' \
-				-v || exit $$?; \
-		fi; \
-	done; \
+	while IFS= read -r -d '' test_file; do \
+		found=true; \
+		test_dir=$$(dirname "$$test_file"); \
+		test_pattern=$$(basename "$$test_file"); \
+		echo "Running Python unit tests in $$test_file"; \
+		PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
+			-s "$$test_dir" \
+			-p "$$test_pattern" \
+			-v; \
+	done < <(find . \
+		-type d \( \
+			-name .git -o \
+			-name .venv -o \
+			-name venv -o \
+			-name __pycache__ \
+		\) -prune -o \
+		-type f \( -name '*_test.py' -o -name 'test_*.py' \) -print0); \
 	if [ "$$found" = false ]; then \
-		echo "No Slurm script unit tests found; skipping."; \
+		echo "No Python unit tests found; skipping."; \
 	fi
 
 .PHONY: test-coverage


### PR DESCRIPTION
## Summary

- add a `test-python` Makefile target using Python unittest discovery
- discover `*_test.py` suites in all the repo
- add a dedicated, change-gated GitHub Actions job that runs the target
- include the job in the existing `ci-success` dependency set
- skip cleanly only when neither test root contains tests

## Why

This extracts the reusable unit-test runner from #2719 into a standalone change based on `main`. Keeping the runner independent lets Python tests in #2719, #2742, #2743, and future pull requests use the same CI job without depending on a health-check behavior change.

The discovery root cover all the Python scripts. In particular, this ensures #2743 runs its `check_runner_test.py` and `write_soperator_metadata_test.py` suites, as well as the existing worker tests.

PR #2743 is stacked on this branch so its checked-out head contains the Make target; #2742 remains stacked on #2743. Because the repository uses `pull_request_target`, the new job becomes available after this PR merges into `main`. Synchronizing #2743 after that merge will trigger the 109-test suite.

## Validation

- `env PYTHONDONTWRITEBYTECODE=1 make test-python` on this branch: 102 tests passed
- the same target on the stacked #2743 branch: 109 tests passed (4 Slurm-script tests and 105 worker tests)
- parsed `.github/workflows/one_job.yml` with PyYAML
- `git diff --check origin/main...HEAD`
