### PR TITLE
SCHED-1893: Render exporter resources with camelCase values key

### DIFF
--- a/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
+++ b/helm/slurm-cluster/templates/slurm-cluster-cr.yaml
@@ -475,7 +475,9 @@ spec:
         {{- with (default dict .Values.slurmNodes.exporter.exporterContainer) }}
         {{- with .resources }}
         resources:
-          {{- toYaml . | nindent 10 }}
+          cpu: {{ required ".Values.slurmNodes.exporter.exporterContainer.resources.cpu must be provided." .cpu | quote }}
+          memory: {{ required ".Values.slurmNodes.exporter.exporterContainer.resources.memory must be provided." .memory | quote }}
+          ephemeral-storage: {{ required ".Values.slurmNodes.exporter.exporterContainer.resources.ephemeralStorage must be provided." .ephemeralStorage | quote }}
         {{- end }}
         {{- with .livenessProbe }}
         livenessProbe:

--- a/helm/slurm-cluster/tests/exporter-resources_test.yaml
+++ b/helm/slurm-cluster/tests/exporter-resources_test.yaml
@@ -18,7 +18,7 @@ tests:
             resources:
               cpu: "250m"
               memory: "256Mi"
-              ephemeral-storage: "500Mi"
+              ephemeralStorage: "500Mi"
     asserts:
       - equal:
           path: spec.slurmNodes.exporter.exporterContainer.resources.cpu

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -609,11 +609,10 @@ slurmNodes:
         memory: "256Mi"
         ephemeralStorage: "500Mi"
     exporterContainer:
-    # Rendered into the CR verbatim: use k8s resource names (ephemeral-storage, not ephemeralStorage).
     # resources:
     #   cpu: "250m"
     #   memory: "256Mi"
-    #   ephemeral-storage: "500Mi"
+    #   ephemeralStorage: "500Mi"
     # livenessProbe:
     #   httpGet:
     #     path: /healthz


### PR DESCRIPTION
## Problem
`exporterContainer.resources` was rendered into the CR verbatim via `toYaml`, so values had to use the k8s `ephemeral-storage` key. Every other `slurmNodes.*.resources` block uses `ephemeralStorage`, and the verbatim rendering was not backward-compatible.

## Solution
- Values keep the usual `ephemeralStorage` key; the template translates it to the `ephemeral-storage` CR key
- All three resource keys are validated with `required`

Rolls back the verbatim `toYaml` variant from the previous SCHED-1893 PR (unreleased).
Companion terraform change: nebius/nebius-solutions-library#1081.

## Testing
`helm unittest` for `exporter-resources_test.yaml` passes.

## Release Notes
None