### PR TITLE
Run Python unit tests in CI

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -204,6 +204,20 @@ jobs:
           fi
           go build "${packages[@]}"
 
+  test-python:
+    needs: [changes, authorize]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Test Python
+        run: make test-python
+
   build-soperator-images:
     needs:
       - changes
@@ -846,6 +860,7 @@ jobs:
       - pre-build
       - lint
       - build-e2e
+      - test-python
       - build-slurm-images
       - build-soperator-images
       - manifest-populate-jail

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,28 @@ test: manifests generate fmt vet envtest ## Run tests.
 	go test ./...
 
 .PHONY: test-python
-test-python: ## Temporarily retained while removing Python unit tests from CI.
-	@echo "Python unit tests are disabled in CI."
+test-python: ## Run all Python unit tests.
+	@found=false; \
+	while IFS= read -r -d '' test_file; do \
+		found=true; \
+		test_dir=$$(dirname "$$test_file"); \
+		test_pattern=$$(basename "$$test_file"); \
+		echo "Running Python unit tests in $$test_file"; \
+		PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
+			-s "$$test_dir" \
+			-p "$$test_pattern" \
+			-v; \
+	done < <(find . \
+		-type d \( \
+			-name .git -o \
+			-name .venv -o \
+			-name venv -o \
+			-name __pycache__ \
+		\) -prune -o \
+		-type f \( -name '*_test.py' -o -name 'test_*.py' \) -print0); \
+	if [ "$$found" = false ]; then \
+		echo "No Python unit tests found; skipping."; \
+	fi
 
 .PHONY: test-coverage
 test-coverage: manifests generate fmt vet envtest ## Run tests and generate test coverage.

--- a/images/worker/worker_init_test.py
+++ b/images/worker/worker_init_test.py
@@ -895,7 +895,9 @@ class TestWaitForTopologyNonGpu(unittest.TestCase):
             worker_init.wait_for_topology()
 
         mock_apply.assert_called_once_with(
-            "worker-0", "topology=default:fab-a:fab-a.unknown"
+            "worker-0",
+            "topology=default:fab-a:fab-a.unknown",
+            worker_init.TOPOLOGY_PLUGIN_TREE,
         )
 
     @mock.patch("worker_init.wait_for_hostname_in_topology_conf")
@@ -915,7 +917,9 @@ class TestWaitForTopologyNonGpu(unittest.TestCase):
             worker_init.wait_for_topology()
 
         mock_apply.assert_called_once_with(
-            "worker-0", "topology=default:fab-a.unknown"
+            "worker-0",
+            "topology=default:fab-a.unknown",
+            worker_init.TOPOLOGY_PLUGIN_BLOCK,
         )
 
     @mock.patch("worker_init.wait_for_hostname_in_topology_conf")


### PR DESCRIPTION
## Blocked by

Do not merge this pull request while #2752 is open.

This pull request is intentionally a draft. Once #2752 has an accepted and validated backward-compatible rollout approach, this branch should be updated to use it before being marked ready for review.

## Summary

- restore the repository-wide `test-python` Makefile target from #2744
- restore the change-gated `test-python` GitHub Actions job
- include the job in the `ci-success` dependency set
- update two worker-test assertions to match the topology-plugin argument now passed on `main`

## Why

This recreates #2744 after its revert in #2750 so Python unit tests can again run consistently in CI. The rollout must first address #2752: workflows triggered by `pull_request_target` need a backward-compatible way to run against existing pull-request heads and maintained release branches that may not contain newly introduced repository tooling.

The test runner discovers `*_test.py` and `test_*.py` files throughout the repository while pruning Git metadata, virtual environments, and Python cache directories. Each discovered test file runs in its own directory to preserve its local import behavior.

## Validation

- `env PYTHONDONTWRITEBYTECODE=1 make test-python`: 108 tests passed (104 worker tests and 4 Slurm-script tests)
- parsed `.github/workflows/one_job.yml` with PyYAML
- `git diff --check`
