### PR TITLE
SCHED-1967: Add Slurm-cluster soperatorchecks user initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,7 @@ sync-version: yq ## Sync versions from file
 	@$(YQ) -i ".images.populateJailTag = \"$(IMAGE_VERSION)\"" "helm/slurm-cluster/values.yaml"
 	@$(YQ) -i ".images.soperatorExporter = \"$(IMAGE_REPO)/soperator-exporter:$(IMAGE_VERSION)\"" "helm/slurm-cluster/values.yaml"
 	@$(YQ) -i ".images.sConfigController = \"$(IMAGE_REPO)/sconfigcontroller:$(OPERATOR_IMAGE_TAG)\"" "helm/slurm-cluster/values.yaml"
+	@$(YQ) -i ".images.k8sJob = \"$(IMAGE_REPO)/k8s_check_job:$(IMAGE_VERSION)\"" "helm/slurm-cluster/values.yaml"
 	@$(YQ) -i ".images.mariaDB = \"docker-registry1.mariadb.com/library/mariadb:12.1.2\"" "helm/slurm-cluster/values.yaml"
 	@# endregion helm/slurm-cluster/values.yaml
 

--- a/helm/slurm-cluster/scripts/create-user-soperatorchecks.sh
+++ b/helm/slurm-cluster/scripts/create-user-soperatorchecks.sh
@@ -1,0 +1,21 @@
+set -ex
+
+echo "Creating soperatorchecks user..."
+chroot /mnt/jail /bin/bash -s <<'EOF'
+
+id "soperatorchecks" || echo "" | soperator-createuser soperatorchecks --home /opt/soperator-home/soperatorchecks --gecos ""
+
+if [ ! -f /opt/soperator-home/soperatorchecks/.ssh/soperatorchecks_id_ecdsa ]; then
+  echo "Generating ssh key..."
+  ssh-keygen -t ecdsa -f /opt/soperator-home/soperatorchecks/.ssh/soperatorchecks_id_ecdsa -N '' -C soperatorchecks
+  cat /opt/soperator-home/soperatorchecks/.ssh/soperatorchecks_id_ecdsa.pub >> /opt/soperator-home/soperatorchecks/.ssh/authorized_keys
+fi
+
+mkdir -p /etc/soperatorchecks
+chown soperatorchecks:soperatorchecks /etc/soperatorchecks
+
+EOF
+
+# Because of the bug in filestore ssh is unavailable for ~15 sec after new user creation.
+echo "Wait for ssh availability 20 sec..."
+sleep 20

--- a/helm/slurm-cluster/templates/create-user-soperatorchecks-job.yaml
+++ b/helm/slurm-cluster/templates/create-user-soperatorchecks-job.yaml
@@ -1,0 +1,59 @@
+{{- $config := .Values.clusterInitialization.createUserSoperatorchecks -}}
+{{- if $config.enabled -}}
+{{- $jailVolumeSourceName := required "clusterInitialization.jailVolumeSourceName must be provided" .Values.clusterInitialization.jailVolumeSourceName -}}
+{{- $jailVolumeSource := dict -}}
+{{- range $source := .Values.volumeSources -}}
+  {{- if eq $source.name $jailVolumeSourceName -}}
+    {{- $jailVolumeSource = omit $source "name" "createPVC" "storageClassName" "size" -}}
+  {{- end -}}
+{{- end -}}
+{{- if empty $jailVolumeSource -}}
+  {{- fail (printf "volume source %q configured by clusterInitialization.jailVolumeSourceName was not found" $jailVolumeSourceName) -}}
+{{- end -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-create-user-soperatorchecks" (include "slurm-cluster.name" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "slurm-cluster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-initialization
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  activeDeadlineSeconds: {{ $config.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "slurm-cluster.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: cluster-initialization
+    spec:
+      restartPolicy: Never
+      {{- if not (kindIs "invalid" .Values.clusterInitialization.hostUsers) }}
+      hostUsers: {{ .Values.clusterInitialization.hostUsers }}
+      {{- else if semverCompare ">=1.33.0" .Capabilities.KubeVersion.Version }}
+      hostUsers: true
+      {{- else }}
+      hostUsers: false
+      {{- end }}
+      containers:
+        - name: create-user-soperatorchecks
+          image: {{ required "images.k8sJob must be provided" .Values.images.k8sJob | quote }}
+          imagePullPolicy: {{ $config.imagePullPolicy | quote }}
+          command:
+            - bash
+            - -c
+            - |
+{{ .Files.Get "scripts/create-user-soperatorchecks.sh" | indent 14 }}
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+          volumeMounts:
+            - name: jail
+              mountPath: /mnt/jail
+      volumes:
+        - name: jail
+{{ toYaml $jailVolumeSource | indent 10 }}
+{{- end }}

--- a/helm/slurm-cluster/tests/cluster_initialization_hostusers_k8s_new_test.yaml
+++ b/helm/slurm-cluster/tests/cluster_initialization_hostusers_k8s_new_test.yaml
@@ -1,0 +1,14 @@
+suite: test cluster initialization hostUsers on Kubernetes >= 1.33
+capabilities:
+  majorVersion: "1"
+  minorVersion: "33"
+templates:
+  - templates/create-user-soperatorchecks-job.yaml
+tests:
+  - it: should set hostUsers true on Kubernetes >= 1.33
+    set:
+      clusterInitialization.createUserSoperatorchecks.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: true

--- a/helm/slurm-cluster/tests/cluster_initialization_hostusers_k8s_old_test.yaml
+++ b/helm/slurm-cluster/tests/cluster_initialization_hostusers_k8s_old_test.yaml
@@ -1,0 +1,14 @@
+suite: test cluster initialization hostUsers on Kubernetes < 1.33
+capabilities:
+  majorVersion: "1"
+  minorVersion: "32"
+templates:
+  - templates/create-user-soperatorchecks-job.yaml
+tests:
+  - it: should set hostUsers false on Kubernetes < 1.33
+    set:
+      clusterInitialization.createUserSoperatorchecks.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: false

--- a/helm/slurm-cluster/tests/cluster_initialization_test.yaml
+++ b/helm/slurm-cluster/tests/cluster_initialization_test.yaml
@@ -29,9 +29,6 @@ tests:
           path: spec.template.spec.restartPolicy
           value: Never
       - equal:
-          path: spec.template.spec.containers[0].image
-          value: cr.eu-north1.nebius.cloud/soperator/k8s_check_job:4.1.5-slurm25.11.5
-      - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
       - equal:

--- a/helm/slurm-cluster/tests/cluster_initialization_test.yaml
+++ b/helm/slurm-cluster/tests/cluster_initialization_test.yaml
@@ -1,0 +1,119 @@
+suite: test cluster initialization
+templates:
+  - templates/create-user-soperatorchecks-job.yaml
+tests:
+  - it: should not render create-user-soperatorchecks by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render create-user-soperatorchecks as a Helm hook when enabled
+    set:
+      clusterInitialization.createUserSoperatorchecks.enabled: true
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: slurm1-create-user-soperatorchecks
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 1800
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: cr.eu-north1.nebius.cloud/soperator/k8s_check_job:4.1.5-slurm25.11.5
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: bash
+      - equal:
+          path: spec.template.spec.containers[0].command[1]
+          value: -c
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'id "soperatorchecks" \|\| echo "" \| soperator-createuser soperatorchecks --home /opt/soperator-home/soperatorchecks --gecos ""'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'soperatorchecks_id_ecdsa'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'mkdir -p /etc/soperatorchecks'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'sleep 20'
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: SYS_ADMIN
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: jail
+            mountPath: /mnt/jail
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: jail
+            persistentVolumeClaim:
+              claimName: jail-pvc
+              readOnly: false
+
+  - it: should allow initialization runtime settings to be overridden
+    set:
+      clusterInitialization.hostUsers: true
+      clusterInitialization.createUserSoperatorchecks.enabled: true
+      clusterInitialization.createUserSoperatorchecks.activeDeadlineSeconds: 240
+      clusterInitialization.createUserSoperatorchecks.imagePullPolicy: Always
+      images.k8sJob: example.invalid/k8s-job:test
+    asserts:
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 240
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example.invalid/k8s-job:test
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: should use the configured jail volume source
+    set:
+      clusterInitialization.createUserSoperatorchecks.enabled: true
+      clusterInitialization.jailVolumeSourceName: custom-jail
+      volumeSources:
+        - name: custom-jail
+          createPVC: false
+          storageClassName: ""
+          size: ""
+          persistentVolumeClaim:
+            claimName: custom-jail-pvc
+            readOnly: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: jail
+            persistentVolumeClaim:
+              claimName: custom-jail-pvc
+              readOnly: false
+
+  - it: should fail when the configured jail volume source is missing
+    set:
+      clusterInitialization.createUserSoperatorchecks.enabled: true
+      clusterInitialization.jailVolumeSourceName: missing
+    asserts:
+      - failedTemplate:
+          errorMessage: 'volume source "missing" configured by clusterInitialization.jailVolumeSourceName was not found'

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -1,4 +1,15 @@
 clusterName: "slurm1"
+# Cluster initialization operations owned by the slurm-cluster Helm release.
+clusterInitialization:
+  # Name of the volume source containing the Slurm jail.
+  jailVolumeSourceName: "jail"
+  # Controls whether initialization pods share the host user namespace.
+  # When unset, this follows the compatibility behavior used by ActiveChecks.
+  hostUsers: null
+  createUserSoperatorchecks:
+    enabled: false
+    activeDeadlineSeconds: 1800
+    imagePullPolicy: "IfNotPresent"
 # Additional annotations for the cluster
 annotations: {}
 # Add appArmor profile to the cluster
@@ -716,6 +727,7 @@ images:
   slurmdbd: "cr.eu-north1.nebius.cloud/soperator/controller_slurmdbd:4.1.5-slurm25.11.5"
   soperatorExporter: "cr.eu-north1.nebius.cloud/soperator/soperator-exporter:4.1.5-slurm25.11.5"
   sConfigController: "cr.eu-north1.nebius.cloud/soperator/sconfigcontroller:4.1.5"
+  k8sJob: "cr.eu-north1.nebius.cloud/soperator/k8s_check_job:4.1.5-slurm25.11.5"
   nodeExporter: "cr.eu-north1.nebius.cloud/soperator-proxy-docker-io/prom/node-exporter:v1.10.2"
   mariaDB: "docker-registry1.mariadb.com/library/mariadb:12.1.2"
 # Configuration for slurm scripts.


### PR DESCRIPTION
## Context

[SCHED-1967](https://nebius.atlassian.net/browse/SCHED-1967) separates mandatory cluster initialization from long-running ActiveChecks so diagnostic completion can eventually stop blocking Terraform apply.

This is PR 2 in the compatibility-first migration and should merge after #2757. It adds the new path disabled by default, so existing ActiveChecks behavior remains unchanged.

## Changes

- add a post-install/post-upgrade Slurm-cluster hook for `create-user-soperatorchecks`
- reuse the existing idempotent user/bootstrap script and jail mount behavior
- add image/version synchronization and configurable timeout/runtime values
- cover disabled/enabled rendering, jail volumes, and Kubernetes `hostUsers` behavior

## Validation

- `helm lint helm/slurm-cluster` (default and enabled)
- `helm unittest helm/slurm-cluster` (106 tests passed)
- `helm unittest helm/*/` (354 tests passed)
- default Slurm-cluster manifests unchanged
- copied script matches the legacy script and passes `bash -n`
- `git diff --check`


[SCHED-1967]: https://nebius.atlassian.net/browse/SCHED-1967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ