### PR TITLE
SCHED-2105: Rename kube-state-metrics scrape key to vmScrape

### DIFF
--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -208,7 +208,10 @@ spec:
         collectors:
           - pods
           - nodes
-        vmServiceScrape:
+        # The victoria-metrics-k8s-stack chart reads this scrape config from the `vmScrape` key,
+        # see https://github.com/VictoriaMetrics/helm-charts/blob/victoria-metrics-k8s-stack-0.80.0/charts/victoria-metrics-k8s-stack/templates/servicemonitors.yaml
+        # Endpoints here fully replace the chart's default list.
+        vmScrape:
           spec:
             endpoints:
               - honorLabels: true

--- a/helm/soperator-fluxcd/tests/kube_state_metrics_test.yaml
+++ b/helm/soperator-fluxcd/tests/kube_state_metrics_test.yaml
@@ -10,15 +10,15 @@ tests:
           path: spec.values.vmagent.spec.extraArgs["promscrape.maxScrapeSize"]
           value: "33554432"
       - equal:
-          path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[0].port
+          path: spec.values.kube-state-metrics.vmScrape.spec.endpoints[0].port
           value: http
       - notExists:
-          path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[0].max_scrape_size
+          path: spec.values.kube-state-metrics.vmScrape.spec.endpoints[0].max_scrape_size
       - equal:
-          path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[1].port
+          path: spec.values.kube-state-metrics.vmScrape.spec.endpoints[1].port
           value: metrics
       - notExists:
-          path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[1].max_scrape_size
+          path: spec.values.kube-state-metrics.vmScrape.spec.endpoints[1].max_scrape_size
 
   - it: should allow overriding kube-state-metrics scrape size
     set:
@@ -27,5 +27,5 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: spec.values.kube-state-metrics.vmServiceScrape.spec.endpoints[0].max_scrape_size
+          path: spec.values.kube-state-metrics.vmScrape.spec.endpoints[0].max_scrape_size
           value: "150554432"

--- a/internal/e2e/acceptance/features/observability.feature
+++ b/internal/e2e/acceptance/features/observability.feature
@@ -1,0 +1,3 @@
+Feature: Observability stack
+  Scenario: kube-state-metrics scrape config is consumed by the vm-stack chart
+    Then the kube-state-metrics VMServiceScrape carries the soperator scrape endpoints

--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -222,6 +222,7 @@ func discoveredNodeSetsFromLiveList(nodeSets slurmv1alpha1.NodeSetList, clusterN
 func featurePaths() []string {
 	return []string{
 		"features/cluster_creation.feature",
+		"features/observability.feature",
 		"features/internal_ssh.feature",
 		"features/package_installation.feature",
 		"features/node_replacement.feature",
@@ -244,6 +245,7 @@ func (r *Runner) initializeScenario(sc *godog.ScenarioContext) {
 	steps.NewDockerContainers(w, slurm, r.state.SlurmClusterName).Register(sc)
 	steps.NewEnrootContainers(w, slurm, r.state.SlurmClusterName).Register(sc)
 	steps.NewTopology(r.state, w).Register(sc)
+	steps.NewObservability(w).Register(sc)
 
 	registerSkipHook(sc)
 }

--- a/internal/e2e/acceptance/steps/observability.go
+++ b/internal/e2e/acceptance/steps/observability.go
@@ -1,0 +1,109 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cucumber/godog"
+
+	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
+)
+
+const observabilityNamespace = "monitoring-system"
+
+type Observability struct {
+	exec framework.Exec
+}
+
+func NewObservability(exec framework.Exec) *Observability {
+	return &Observability{exec: exec}
+}
+
+func (s *Observability) Register(sc *godog.ScenarioContext) {
+	sc.Step(`^the kube-state-metrics VMServiceScrape carries the soperator scrape endpoints$`, s.checkKubeStateMetricsScrape)
+}
+
+// The soperator-fluxcd chart passes the kube-state-metrics scrape config to the
+// victoria-metrics-k8s-stack chart under the `vmScrape` values key. Keys the
+// upstream chart does not read are silently dropped, and the generated
+// VMServiceScrape falls back to the chart's built-in default - a single http
+// endpoint (see SCHED-2105, where exactly that hid the maxScrapeSize override).
+// The soperator-defined config has two endpoints, so their presence proves the
+// values reached the rendered object.
+func (s *Observability) checkKubeStateMetricsScrape(ctx context.Context) error {
+	var scrapes vmServiceScrapeList
+	if err := kubectlJSON(ctx, s.exec, &scrapes, "get", "vmservicescrapes", "-n", observabilityNamespace, "-o", "json"); err != nil {
+		return fmt.Errorf("list VMServiceScrapes: %w", err)
+	}
+	if len(scrapes.Items) == 0 {
+		return fmt.Errorf("no VMServiceScrapes found in namespace %s - is observability enabled on this cluster?", observabilityNamespace)
+	}
+
+	var ksm []vmServiceScrape
+	for _, scrape := range scrapes.Items {
+		if strings.Contains(scrape.Metadata.Name, "kube-state-metrics") {
+			ksm = append(ksm, scrape)
+		}
+	}
+	if len(ksm) != 1 {
+		names := make([]string, 0, len(ksm))
+		for _, scrape := range ksm {
+			names = append(names, scrape.Metadata.Name)
+		}
+		return fmt.Errorf("expected exactly one kube-state-metrics VMServiceScrape in %s, got %d [%s]",
+			observabilityNamespace, len(ksm), strings.Join(names, ", "))
+	}
+
+	endpoints := ksm[0].Spec.Endpoints
+	if len(endpoints) != 2 {
+		return fmt.Errorf("%s has %d endpoints, expected 2 (http + metrics): the soperator scrape config is being ignored by the vm-stack chart",
+			ksm[0].Metadata.Name, len(endpoints))
+	}
+	var problems []string
+	if endpoints[0].Port != "http" {
+		problems = append(problems, fmt.Sprintf("endpoints[0].port=%q, expected \"http\"", endpoints[0].Port))
+	}
+	if endpoints[1].Port != "metrics" {
+		problems = append(problems, fmt.Sprintf("endpoints[1].port=%q, expected \"metrics\"", endpoints[1].Port))
+	}
+	for i, endpoint := range endpoints {
+		if !hasLabeldrop(endpoint) {
+			problems = append(problems, fmt.Sprintf("endpoints[%d] lost the labeldrop relabel config", i))
+		}
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("%s: %s", ksm[0].Metadata.Name, strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+func hasLabeldrop(endpoint vmScrapeEndpoint) bool {
+	for _, relabel := range endpoint.MetricRelabelConfigs {
+		if relabel.Action == "labeldrop" {
+			return true
+		}
+	}
+	return false
+}
+
+type vmServiceScrapeList struct {
+	Items []vmServiceScrape `json:"items"`
+}
+
+type vmServiceScrape struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		Endpoints []vmScrapeEndpoint `json:"endpoints"`
+	} `json:"spec"`
+}
+
+type vmScrapeEndpoint struct {
+	Port                 string `json:"port"`
+	MaxScrapeSize        string `json:"max_scrape_size"`
+	MetricRelabelConfigs []struct {
+		Action string `json:"action"`
+	} `json:"metricRelabelConfigs"`
+}


### PR DESCRIPTION
## Problem

The kube-state-metrics scrape config in `soperator-fluxcd` was defined under `vmServiceScrape`, but the victoria-metrics-k8s-stack chart reads it from the `vmScrape` key and silently ignores anything else. Our custom endpoints, the `maxScrapeSize` override, and the `uid`/`container_id`/`image_id` label drops never applied; the chart deployed its default scrape config instead.

Verified on a live cluster: the HelmRelease values contain our two-endpoint block, but the rendered `VMServiceScrape` has only the chart's default single endpoint.

## Solution

- rename the key to `vmScrape` in `vm-stack.yaml`, with a comment explaining why the key matters and that the endpoints list replaces the chart's default
- update the helm unit tests to the new path
- add an e2e acceptance scenario (`observability.feature`) asserting the in-cluster `VMServiceScrape` carries the soperator-defined endpoints. helm unittest only checks what we put into the HelmRelease, not what the upstream chart consumes, so a wrong values key is invisible to it - the e2e check closes that gap

## Testing

- `helm unittest` passes
- E2E tests: https://github.com/nebius/soperator/actions/runs/29823521287


## Release Notes

Fix: kube-state-metrics scrape settings (custom endpoints, max scrape size, label drops) are now applied; they were previously ignored due to a wrong values key.


## Related PRs

- nebius/nebius-solutions-library#1093 - terraform side: the per-tier `kubeStateMetrics.maxScrapeSize` values that reach the cluster only with this key fix
- nebius/soperator#2772 - same kube-state-metrics section: system-node pinning and resources passthrough
