### PR TITLE
SCHED-1867: CPU + GPU cluster node replacement e2e scenario

### DIFF
--- a/docs/acceptance-tests.md
+++ b/docs/acceptance-tests.md
@@ -38,6 +38,9 @@ All flags:
 GPU scenarios are selected automatically. If no GPU workers are discovered,
 scenarios tagged `@gpu` are excluded.
 
+CPU scenarios are selected automatically. If no CPU workers are discovered,
+scenarios tagged `@cpu` are excluded.
+
 For focused manual runs on a dev cluster, pass the scenario location:
 
 ```bash

--- a/internal/e2e/acceptance/features/node_replacement.feature
+++ b/internal/e2e/acceptance/features/node_replacement.feature
@@ -2,10 +2,22 @@ Feature: Node replacement
   @gpu
   @unstable
   Scenario: A maintenance event replaces the selected worker node
-    Given a test job is submitted and running on a worker node
+    Given a test job is submitted and running on a GPU worker node
     When a maintenance event is triggered for that node
     Then the node is drained with a maintenance reason
     When the test job is cancelled
     Then the old instance is removed
     And a replacement node joins the cluster
     And the replacement node passes GPU validation
+
+  @cpu
+  @gpu
+  @unstable
+  Scenario: A maintenance event replaces a CPU worker node in a heterogeneous cluster
+    Given a test job is submitted and running on a CPU worker node
+    When a maintenance event is triggered for that node
+    Then the node is drained with a maintenance reason
+    When the test job is cancelled
+    Then the old instance is removed
+    And a replacement node joins the cluster
+    And all pre-existing worker nodes are operational

--- a/internal/e2e/acceptance/framework/exec.go
+++ b/internal/e2e/acceptance/framework/exec.go
@@ -24,6 +24,7 @@ type ArgsScope interface {
 
 type Exec interface {
 	AvailableWorkers() []WorkerPodRef
+	AvailableCPUWorkers() []WorkerPodRef
 	AvailableGPUWorkers() []WorkerPodRef
 	Kubectl() ArgsScope
 	// Local returns a local process scope. Do not use it for kubectl commands;

--- a/internal/e2e/acceptance/framework/model.go
+++ b/internal/e2e/acceptance/framework/model.go
@@ -14,6 +14,7 @@ type DiscoveredNodeSet struct {
 type ClusterState struct {
 	SlurmClusterName   string
 	Workers            []WorkerPodRef
+	CPUWorkers         []WorkerPodRef
 	GPUWorkers         []WorkerPodRef
 	WorkersByNodeSet   map[string][]WorkerPodRef
 	DiscoveredNodeSets []DiscoveredNodeSet
@@ -33,4 +34,12 @@ func (s *ClusterState) DesiredWorkerCount() int {
 
 func (s *ClusterState) HasGPUWorkers() bool {
 	return len(s.GPUWorkers) > 0
+}
+
+func (s *ClusterState) HasCPUWorkers() bool {
+	return len(s.CPUWorkers) > 0
+}
+
+func (s *ClusterState) IsHeterogeneousCluster() bool {
+	return s.HasCPUWorkers() && s.HasGPUWorkers()
 }

--- a/internal/e2e/acceptance/framework/slurm_client.go
+++ b/internal/e2e/acceptance/framework/slurm_client.go
@@ -164,6 +164,10 @@ func (s *SlurmClient) AnyWorkers(count int) ([]string, error) {
 	return pickAnyWorkerNames(s.exec.AvailableWorkers(), count, "workers")
 }
 
+func (s *SlurmClient) AnyCPUWorkers(count int) ([]string, error) {
+	return pickAnyWorkerNames(s.exec.AvailableCPUWorkers(), count, "CPU workers")
+}
+
 func (s *SlurmClient) AnyGPUWorkers(count int) ([]string, error) {
 	return pickAnyWorkerNames(s.exec.AvailableGPUWorkers(), count, "GPU workers")
 }

--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -110,6 +110,14 @@ func (r *Runner) tagFilter() string {
 		log.Printf("acceptance: no GPU workers found, excluding @gpu scenarios")
 		filters = append(filters, "~@gpu")
 	}
+	if !r.state.HasCPUWorkers() {
+		log.Printf("acceptance: no CPU workers found, excluding @cpu scenarios")
+		filters = append(filters, "~@cpu")
+	}
+	if !r.state.IsHeterogeneousCluster() {
+		log.Printf("acceptance: no heterogeneous CPU+GPU worker set found, excluding @heterogeneous scenarios")
+		filters = append(filters, "~@heterogeneous")
+	}
 
 	return strings.Join(filters, " && ")
 }
@@ -174,6 +182,7 @@ func discoverCluster(ctx context.Context, w *world, state *framework.ClusterStat
 	}
 
 	log.Printf("acceptance: discovered workers: %s", workerNames(state.Workers))
+	log.Printf("acceptance: discovered CPU workers: %s", workerNames(state.CPUWorkers))
 	log.Printf("acceptance: discovered GPU workers: %s", workerNames(state.GPUWorkers))
 	log.Printf("acceptance: discovered workers by nodeset: %s", workersByNodeSetSummary(state.WorkersByNodeSet))
 	return nil
@@ -213,7 +222,7 @@ func discoverNodeSets(ctx context.Context, w *world, clusterName string) ([]fram
 func discoveredNodeSetsFromLiveList(nodeSets slurmv1alpha1.NodeSetList, clusterName string) []framework.DiscoveredNodeSet {
 	discovered := make([]framework.DiscoveredNodeSet, 0, len(nodeSets.Items))
 	for _, nodeSet := range nodeSets.Items {
-		if nodeSet.Spec.ClusterName != "" && nodeSet.Spec.ClusterName != clusterName {
+		if clusterName != "" && nodeSet.Spec.ClusterName != "" && nodeSet.Spec.ClusterName != clusterName {
 			continue
 		}
 		discovered = append(discovered, framework.DiscoveredNodeSet{
@@ -389,6 +398,7 @@ func verifyPodReady(ctx context.Context, w *world, namespace, name string) error
 
 func classifyWorkers(state *framework.ClusterState) {
 	state.WorkersByNodeSet = make(map[string][]framework.WorkerPodRef, len(state.DiscoveredNodeSets))
+	state.CPUWorkers = nil
 	state.GPUWorkers = nil
 
 	if len(state.DiscoveredNodeSets) == 0 {
@@ -414,6 +424,8 @@ func classifyWorkers(state *framework.ClusterState) {
 			state.WorkersByNodeSet[nodeSet.Name] = append(state.WorkersByNodeSet[nodeSet.Name], worker)
 			if gpuByName[nodeSet.Name] {
 				state.GPUWorkers = append(state.GPUWorkers, worker)
+			} else {
+				state.CPUWorkers = append(state.CPUWorkers, worker)
 			}
 			break
 		}

--- a/internal/e2e/acceptance/runner_test.go
+++ b/internal/e2e/acceptance/runner_test.go
@@ -42,10 +42,14 @@ func TestParseOptionsExplicitValues(t *testing.T) {
 }
 
 func TestRunnerTagFilter(t *testing.T) {
-	gpuState := &framework.ClusterState{
+	heterogeneousState := &framework.ClusterState{
+		CPUWorkers: []framework.WorkerPodRef{{Name: "worker-cpu-0"}},
 		GPUWorkers: []framework.WorkerPodRef{{Name: "worker-gpu-0"}},
 	}
 	noGPUState := &framework.ClusterState{}
+	gpuOnlyState := &framework.ClusterState{
+		GPUWorkers: []framework.WorkerPodRef{{Name: "worker-gpu-0"}},
+	}
 
 	tests := []struct {
 		name             string
@@ -55,19 +59,25 @@ func TestRunnerTagFilter(t *testing.T) {
 	}{
 		{
 			name:  "default excludes unstable",
-			state: gpuState,
+			state: heterogeneousState,
 			want:  "~@unstable",
 		},
 		{
-			name:             "run unstable has no tag filter when GPU workers exist",
-			state:            gpuState,
+			name:             "run unstable has no tag filter when CPU and GPU workers exist",
+			state:            heterogeneousState,
 			runUnstableTests: true,
 			want:             "",
 		},
 		{
 			name:  "without GPU workers also excludes GPU",
 			state: noGPUState,
-			want:  "~@unstable && ~@gpu",
+			want:  "~@unstable && ~@gpu && ~@cpu && ~@heterogeneous",
+		},
+		{
+			name:             "without CPU workers excludes CPU and heterogeneous",
+			state:            gpuOnlyState,
+			runUnstableTests: true,
+			want:             "~@cpu && ~@heterogeneous",
 		},
 	}
 
@@ -145,6 +155,73 @@ func TestDiscoveredNodeSetsFromLiveList(t *testing.T) {
 	assert.Equal(t, "worker-gpu", discovered[1].Name)
 	assert.Equal(t, 2, discovered[1].Size)
 	assert.True(t, discovered[1].HasGPU)
+}
+
+func TestDiscoveredNodeSetsFromLiveListDoesNotFilterWhenClusterNameIsEmpty(t *testing.T) {
+	nodeSets := slurmv1alpha1.NodeSetList{
+		Items: []slurmv1alpha1.NodeSet{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "worker-gpu"},
+				Spec: slurmv1alpha1.NodeSetSpec{
+					ClusterName: "soperator",
+					Replicas:    2,
+					GPU:         slurmv1alpha1.GPUSpec{Enabled: true},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "worker-cpu"},
+				Spec: slurmv1alpha1.NodeSetSpec{
+					ClusterName: "soperator",
+					Replicas:    3,
+				},
+			},
+		},
+	}
+
+	discovered := discoveredNodeSetsFromLiveList(nodeSets, "")
+	require.Len(t, discovered, 2)
+
+	assert.Equal(t, "worker-cpu", discovered[0].Name)
+	assert.Equal(t, "worker-gpu", discovered[1].Name)
+}
+
+func TestClassifyWorkersSeparatesCPUAndGPU(t *testing.T) {
+	state := &framework.ClusterState{
+		Workers: []framework.WorkerPodRef{
+			{Name: "worker-gpu-0"},
+			{Name: "worker-cpu-0"},
+			{Name: "worker-gpu-1"},
+		},
+		DiscoveredNodeSets: []framework.DiscoveredNodeSet{
+			{Name: "worker-gpu", Size: 2, HasGPU: true},
+			{Name: "worker-cpu", Size: 1, HasGPU: false},
+		},
+	}
+
+	classifyWorkers(state)
+
+	assert.ElementsMatch(t, []framework.WorkerPodRef{{Name: "worker-cpu-0"}}, state.CPUWorkers)
+	assert.ElementsMatch(t, []framework.WorkerPodRef{{Name: "worker-gpu-0"}, {Name: "worker-gpu-1"}}, state.GPUWorkers)
+	assert.ElementsMatch(t, []framework.WorkerPodRef{{Name: "worker-cpu-0"}}, state.WorkersByNodeSet["worker-cpu"])
+	assert.ElementsMatch(t, []framework.WorkerPodRef{{Name: "worker-gpu-0"}, {Name: "worker-gpu-1"}}, state.WorkersByNodeSet["worker-gpu"])
+	assert.True(t, state.IsHeterogeneousCluster())
+}
+
+func TestTagFilterExcludesHeterogeneousScenariosWithoutCPUAndGPUWorkers(t *testing.T) {
+	runner := NewRunner(&framework.ClusterState{
+		GPUWorkers: []framework.WorkerPodRef{{Name: "worker-gpu-0"}},
+	}, true, nil, "dev-context", "")
+
+	assert.Equal(t, "~@cpu && ~@heterogeneous", runner.tagFilter())
+}
+
+func TestTagFilterAllowsHeterogeneousScenariosWithCPUAndGPUWorkers(t *testing.T) {
+	runner := NewRunner(&framework.ClusterState{
+		CPUWorkers: []framework.WorkerPodRef{{Name: "worker-cpu-0"}},
+		GPUWorkers: []framework.WorkerPodRef{{Name: "worker-gpu-0"}},
+	}, true, nil, "dev-context", "")
+
+	assert.Empty(t, runner.tagFilter())
 }
 
 func TestReportFormat(t *testing.T) {

--- a/internal/e2e/acceptance/steps/node_replacement.go
+++ b/internal/e2e/acceptance/steps/node_replacement.go
@@ -36,6 +36,8 @@ type NodeReplacement struct {
 	replacementWorker  string
 	originalInstanceID string
 	maintenanceJob     framework.SbatchJob
+	preExistingWorkers []string
+	gpuWorkers         map[string]struct{}
 }
 
 func NewNodeReplacement(exec framework.Exec, slurm *framework.SlurmClient) *NodeReplacement {
@@ -56,22 +58,39 @@ func (s *NodeReplacement) Register(sc *godog.ScenarioContext) {
 		return ctx, nil
 	})
 
-	sc.Step(`^a test job is submitted and running on a worker node$`, s.aTestJobIsSubmittedAndRunningOnAWorkerNode)
+	sc.Step(`^a test job is submitted and running on a (CPU|GPU) worker node$`, s.aTestJobIsSubmittedAndRunningOnWorkerNode)
 	sc.Step(`^a maintenance event is triggered for that node$`, s.aMaintenanceEventIsTriggeredForThatNode)
 	sc.Step(`^the node is drained with a maintenance reason$`, s.theNodeIsDrainedWithAMaintenanceReason)
 	sc.Step(`^the test job is cancelled$`, s.theTestJobIsCancelled)
 	sc.Step(`^the old instance is removed$`, s.theOldInstanceIsRemoved)
 	sc.Step(`^a replacement node joins the cluster$`, s.aReplacementNodeJoinsTheCluster)
 	sc.Step(`^the replacement node passes GPU validation$`, s.theReplacementNodePassesGPUValidation)
+	sc.Step(`^all pre-existing worker nodes are operational$`, s.allPreExistingWorkerNodesAreOperational)
 }
 
-func (s *NodeReplacement) aTestJobIsSubmittedAndRunningOnAWorkerNode(ctx context.Context) error {
-	workers, err := s.slurm.AnyGPUWorkers(1)
+func (s *NodeReplacement) aTestJobIsSubmittedAndRunningOnWorkerNode(ctx context.Context, workerType string) error {
+	workers, err := s.anyWorkersByType(workerType, 1)
 	if err != nil {
 		return err
 	}
-	s.replacementWorker = workers[0]
+	return s.submitTestJobOnWorker(ctx, workers[0])
+}
 
+func (s *NodeReplacement) anyWorkersByType(workerType string, count int) ([]string, error) {
+	switch strings.ToUpper(workerType) {
+	case "CPU":
+		return s.slurm.AnyCPUWorkers(count)
+	case "GPU":
+		return s.slurm.AnyGPUWorkers(count)
+	default:
+		return nil, fmt.Errorf("unsupported worker type %q", workerType)
+	}
+}
+
+func (s *NodeReplacement) submitTestJobOnWorker(ctx context.Context, worker string) error {
+	s.replacementWorker = worker
+	s.preExistingWorkers = workerNamesFromRefs(s.exec.AvailableWorkers())
+	s.gpuWorkers = workerNameSet(s.exec.AvailableGPUWorkers())
 	nodeState, err := s.exec.Controller().RunWithDefaultRetry(ctx, fmt.Sprintf("scontrol show node %s", framework.ShellQuote(s.replacementWorker)))
 	if err != nil {
 		return fmt.Errorf("read original node state: %w", err)
@@ -189,6 +208,59 @@ func (s *NodeReplacement) theReplacementNodePassesGPUValidation(ctx context.Cont
 	return nil
 }
 
+func (s *NodeReplacement) allPreExistingWorkerNodesAreOperational(ctx context.Context) error {
+	if len(s.preExistingWorkers) == 0 {
+		return fmt.Errorf("no pre-existing workers were recorded before replacement")
+	}
+
+	for _, workerName := range s.preExistingWorkers {
+		if err := s.validateWorkerNodeState(ctx, workerName); err != nil {
+			return err
+		}
+		if _, isGPU := s.gpuWorkers[workerName]; isGPU {
+			if err := s.validateGPUWorker(ctx, workerName); err != nil {
+				return fmt.Errorf("validate pre-existing GPU worker %s: %w", workerName, err)
+			}
+			continue
+		}
+		if err := s.validateCPUWorker(ctx, workerName); err != nil {
+			return fmt.Errorf("validate pre-existing CPU worker %s: %w", workerName, err)
+		}
+	}
+	return nil
+}
+
+func (s *NodeReplacement) validateWorkerNodeState(ctx context.Context, workerName string) error {
+	state, err := s.exec.Controller().Run(ctx, fmt.Sprintf("scontrol show node %s", framework.ShellQuote(workerName)))
+	if err != nil {
+		return fmt.Errorf("read worker node state %s: %w", workerName, err)
+	}
+	nodeState := parseNodeState(state)
+	if nodeState == "" {
+		return fmt.Errorf("parse worker node state %s: no State field in %q", workerName, state)
+	}
+	for _, bad := range []string{"DRAIN", "DOWN", "NOT_RESPONDING", "FAIL", "INVALID_REG"} {
+		if strings.Contains(nodeState, bad) {
+			return fmt.Errorf("worker node %s has bad state %q", workerName, nodeState)
+		}
+	}
+	return nil
+}
+
+func (s *NodeReplacement) validateCPUWorker(ctx context.Context, workerName string) error {
+	if _, err := s.exec.Jail().Run(ctx, fmt.Sprintf("srun -w %s true", framework.ShellQuote(workerName))); err != nil {
+		return fmt.Errorf("validate worker accepts a targeted Slurm job: %w", err)
+	}
+	return nil
+}
+
+func (s *NodeReplacement) validateGPUWorker(ctx context.Context, workerName string) error {
+	if _, err := s.exec.Jail().Run(ctx, fmt.Sprintf("srun -w %s --gpus-per-node=1 nvidia-smi -L >/dev/null", framework.ShellQuote(workerName))); err != nil {
+		return fmt.Errorf("validate worker GPU from login node: %w", err)
+	}
+	return nil
+}
+
 func (s *NodeReplacement) cancelJob(ctx context.Context, maintenanceJobID string) error {
 	if maintenanceJobID == "" {
 		return nil
@@ -222,4 +294,26 @@ func parseNodeState(state string) string {
 		return ""
 	}
 	return strings.TrimSpace(match[1])
+}
+
+func workerNamesFromRefs(workers []framework.WorkerPodRef) []string {
+	names := make([]string, 0, len(workers))
+	for _, worker := range workers {
+		if strings.TrimSpace(worker.Name) == "" {
+			continue
+		}
+		names = append(names, worker.Name)
+	}
+	return names
+}
+
+func workerNameSet(workers []framework.WorkerPodRef) map[string]struct{} {
+	names := make(map[string]struct{}, len(workers))
+	for _, worker := range workers {
+		if strings.TrimSpace(worker.Name) == "" {
+			continue
+		}
+		names[worker.Name] = struct{}{}
+	}
+	return names
 }

--- a/internal/e2e/acceptance/world.go
+++ b/internal/e2e/acceptance/world.go
@@ -29,6 +29,10 @@ func (w *world) AvailableWorkers() []framework.WorkerPodRef {
 	return append([]framework.WorkerPodRef(nil), w.state.Workers...)
 }
 
+func (w *world) AvailableCPUWorkers() []framework.WorkerPodRef {
+	return append([]framework.WorkerPodRef(nil), w.state.CPUWorkers...)
+}
+
 func (w *world) AvailableGPUWorkers() []framework.WorkerPodRef {
 	return append([]framework.WorkerPodRef(nil), w.state.GPUWorkers...)
 }


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

CPU and GPU nodes share images and init scripts, bugs such shared resources can cause issue in heterogeneous clusters where CPU nodes may corrupt the GPU related setup (e.g. drivers, services, etc).

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
This e2e test covers node replacement in clusters with both CPU and GPU nodes to make sure after CPU node replacement GPU nodes are usable.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

Tested by manually runing this scenario on a test cluster: first with both CPU and GPU nodes, and then on GPU only cluster (it gets skipped)

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
