### PR TITLE
Make tests selectable for manual runs

### DIFF
--- a/docs/acceptance-tests.md
+++ b/docs/acceptance-tests.md
@@ -30,10 +30,22 @@ All flags:
 - `--slurm-cluster-name`: optional, defaults to `soperator`.
 - `--run-unstable`: optional, defaults to `false`; when false, scenarios tagged
   `@unstable` are excluded.
+- `--selected`: optional, defaults to `false`; when true, only scenarios tagged
+  `@selected` are included.
 - `--report-dir`: optional. When set, the runner writes Cucumber and JUnit
   reports into that directory.
 
 GPU scenarios are selected automatically. If no GPU workers are discovered,
 scenarios tagged `@gpu` are excluded.
+
+For focused manual runs on a dev cluster, temporarily add `@selected` to the
+scenario under investigation and run:
+
+```bash
+bin/acceptance --kubectl-context <dev-context> --selected
+```
+
+The `@selected` tag is for local/manual investigation only. The GitHub Actions
+e2e workflow does not pass `--selected`.
 
 Note: The node replacement scenario uses the local `nebius` CLI to check instance removal.

--- a/internal/e2e/acceptance/options.go
+++ b/internal/e2e/acceptance/options.go
@@ -17,6 +17,7 @@ type options struct {
 	KubectlContext   string
 	SlurmClusterName string
 	RunUnstableTests bool
+	SelectedOnly     bool
 	ReportDir        string
 }
 
@@ -34,7 +35,7 @@ func Run(ctx context.Context, args []string) error {
 		WorkersByNodeSet: make(map[string][]framework.WorkerPodRef),
 	}
 
-	runner := NewRunner(state, opts.RunUnstableTests, opts.KubectlContext, opts.ReportDir)
+	runner := NewRunner(state, opts.RunUnstableTests, opts.SelectedOnly, opts.KubectlContext, opts.ReportDir)
 	return runner.Run(ctx)
 }
 
@@ -48,6 +49,7 @@ func parseOptions(args []string) (options, error) {
 	fs.StringVar(&opts.KubectlContext, "kubectl-context", "", "kubectl context to use for acceptance tests")
 	fs.StringVar(&opts.SlurmClusterName, "slurm-cluster-name", opts.SlurmClusterName, "SlurmCluster resource name")
 	fs.BoolVar(&opts.RunUnstableTests, "run-unstable", false, "run scenarios tagged @unstable")
+	fs.BoolVar(&opts.SelectedOnly, "selected", false, "run only scenarios tagged @selected")
 	fs.StringVar(&opts.ReportDir, "report-dir", "", "optional directory for Cucumber and JUnit reports")
 
 	if err := fs.Parse(args); err != nil {

--- a/internal/e2e/acceptance/runner.go
+++ b/internal/e2e/acceptance/runner.go
@@ -34,11 +34,12 @@ const (
 type Runner struct {
 	state            *framework.ClusterState
 	runUnstableTests bool
+	selectedOnly     bool
 	kubectlContext   string
 	reportDir        string
 }
 
-func NewRunner(state *framework.ClusterState, runUnstableTests bool, kubectlContext, reportDir string) *Runner {
+func NewRunner(state *framework.ClusterState, runUnstableTests, selectedOnly bool, kubectlContext, reportDir string) *Runner {
 	if state == nil {
 		state = &framework.ClusterState{
 			WorkersByNodeSet: make(map[string][]framework.WorkerPodRef),
@@ -50,6 +51,7 @@ func NewRunner(state *framework.ClusterState, runUnstableTests bool, kubectlCont
 	return &Runner{
 		state:            state,
 		runUnstableTests: runUnstableTests,
+		selectedOnly:     selectedOnly,
 		kubectlContext:   kubectlContext,
 		reportDir:        reportDir,
 	}
@@ -100,6 +102,10 @@ func (r *Runner) Run(ctx context.Context) error {
 func (r *Runner) tagFilter() string {
 	var filters []string
 
+	if r.selectedOnly {
+		log.Printf("acceptance: selected=true, running only @selected scenarios")
+		filters = append(filters, "@selected")
+	}
 	if !r.runUnstableTests {
 		log.Printf("acceptance: run-unstable=false, excluding @unstable scenarios")
 		filters = append(filters, "~@unstable")

--- a/internal/e2e/acceptance/runner_test.go
+++ b/internal/e2e/acceptance/runner_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
+	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
 )
 
 func TestParseOptionsDefaults(t *testing.T) {
@@ -18,6 +19,7 @@ func TestParseOptionsDefaults(t *testing.T) {
 	assert.Equal(t, "dev-context", opts.KubectlContext)
 	assert.Equal(t, "soperator", opts.SlurmClusterName)
 	assert.False(t, opts.RunUnstableTests)
+	assert.False(t, opts.SelectedOnly)
 	assert.Empty(t, opts.ReportDir)
 }
 
@@ -26,6 +28,7 @@ func TestParseOptionsExplicitValues(t *testing.T) {
 		"--kubectl-context", "dev-context",
 		"--slurm-cluster-name", "custom",
 		"--run-unstable=true",
+		"--selected=true",
 		"--report-dir", "reports",
 	})
 	require.NoError(t, err)
@@ -33,7 +36,55 @@ func TestParseOptionsExplicitValues(t *testing.T) {
 	assert.Equal(t, "dev-context", opts.KubectlContext)
 	assert.Equal(t, "custom", opts.SlurmClusterName)
 	assert.True(t, opts.RunUnstableTests)
+	assert.True(t, opts.SelectedOnly)
 	assert.Equal(t, "reports", opts.ReportDir)
+}
+
+func TestRunnerTagFilter(t *testing.T) {
+	gpuState := &framework.ClusterState{
+		GPUWorkers: []framework.WorkerPodRef{{Name: "worker-gpu-0"}},
+	}
+	noGPUState := &framework.ClusterState{}
+
+	tests := []struct {
+		name             string
+		state            *framework.ClusterState
+		runUnstableTests bool
+		selectedOnly     bool
+		want             string
+	}{
+		{
+			name:  "default excludes unstable",
+			state: gpuState,
+			want:  "~@unstable",
+		},
+		{
+			name:         "selected includes selected tag and excludes unstable",
+			state:        gpuState,
+			selectedOnly: true,
+			want:         "@selected && ~@unstable",
+		},
+		{
+			name:             "selected and unstable only includes selected tag",
+			state:            gpuState,
+			runUnstableTests: true,
+			selectedOnly:     true,
+			want:             "@selected",
+		},
+		{
+			name:         "selected without GPU workers also excludes GPU",
+			state:        noGPUState,
+			selectedOnly: true,
+			want:         "@selected && ~@unstable && ~@gpu",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewRunner(tt.state, tt.runUnstableTests, tt.selectedOnly, "", "")
+			assert.Equal(t, tt.want, runner.tagFilter())
+		})
+	}
 }
 
 func TestParseOptionsRequiresKubectlContext(t *testing.T) {


### PR DESCRIPTION
## Problem

Developers could not easily run only a hand-picked subset of acceptance scenarios against a dev cluster. Manual investigation required either running the full acceptance suite or editing feature files in a more invasive way.

## Solution

Added a standalone acceptance runner flag, --selected, that filters Godog execution to scenarios tagged @selected.

This is intended for temporary/manual dev-cluster runs. The managed GitHub Actions e2e path is unchanged and does not pass --selected.

Updated the acceptance test documentation with the new flag and manual workflow.

## Testing

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
