### PR TITLE
SCHED-2184 Redesign enroot and docker acceptance tests

### DIFF
--- a/internal/e2e/acceptance/features/docker_containers.feature
+++ b/internal/e2e/acceptance/features/docker_containers.feature
@@ -1,13 +1,14 @@
 Feature: Docker containers
-  # Skipped: Docker NCCL job hangs in this scenario (SCHED-1562); needs deeper triage.
-  @skip
+  Scenario: Docker container lifecycle uses local storage
+    Given a long-running Docker container job is submitted on two workers
+    When the Docker container job is running
+    Then Docker image and runtime storage is populated on a worker
+    And Docker containers from the job are running on selected workers
+    When the Docker container job is cancelled
+    And Docker containers from the job are stopped explicitly
+    Then Docker containers from the job are no longer running
+
   @gpu
-  Scenario: A long-running Docker NCCL job uses local storage and cleans up containers
-    Given a long-running Docker NCCL job is submitted on two GPU workers
-    When the Docker NCCL job is running
-    Then Docker overlayfs storage is populated on a worker
-    And Docker container content blobs are populated on a worker
-    And a Docker container from the job is running on workers
-    And the Docker NCCL job is still running
-    When the Docker NCCL job is cancelled
-    Then Docker containers from that job are no longer running
+  Scenario: Docker containers can access GPUs
+    Given a Docker GPU smoke job is submitted on one GPU worker
+    Then the Docker GPU smoke job succeeds and reports visible GPUs

--- a/internal/e2e/acceptance/features/enroot_containers.feature
+++ b/internal/e2e/acceptance/features/enroot_containers.feature
@@ -1,38 +1,17 @@
 Feature: Enroot containers
-  @skip
-  @gpu
-  Scenario: Enroot and Pyxis cache images and clean up runtime data
-    Given Enroot materialized runtime storage is enabled
-    Given a long-running Enroot NCCL job is submitted on two GPU workers
-    When the Enroot NCCL job is running
-    Then Enroot cache is populated on local storage on a worker
-    And Enroot squashfs image is present on a worker
-    And Enroot runtime container data is visible while the job is running
-    And the Enroot NCCL job is still running
-    When the Enroot NCCL job is cancelled
-    Then Enroot runtime data is cleaned up and squashfs cache remains
-    When the same Enroot NCCL job is submitted again
-    Then Enroot runtime data is repopulated without changing the squashfs artifact
-    And the repeated Enroot NCCL job is still running
-    When the repeated Enroot NCCL job is cancelled
-    When a named Enroot container job is submitted
-    Then the named Enroot runtime directory remains after cancellation
-    When the named Enroot runtime directory is cleaned up
-    Then the named Enroot runtime directory is removed
+  Scenario: Enroot and Pyxis cache images and clean up runtime state
+    Given a long-running Enroot container job is submitted on two workers
+    When the Enroot container job is running
+    Then an Enroot image artifact is present on a worker
+    And Enroot runtime state is visible while the job is running
+    When the Enroot container job is cancelled
+    Then Enroot runtime state is cleaned up and the image artifact remains
+    When the same Enroot container job is submitted again
+    Then the existing Enroot image artifact is reused
+    When the repeated Enroot container job is cancelled
+    Then Enroot runtime state is cleaned up
 
-  @skip
   @gpu
-  Scenario: Enroot and Pyxis mount cached SquashFS directly
-    Given Enroot direct SquashFS startup is enabled
-    Given a long-running Enroot NCCL job is submitted on two GPU workers
-    When the Enroot NCCL job is running
-    Then Enroot cache is populated on local storage on a worker
-    And Enroot squashfs image is present on a worker
-    And Enroot squashfs image is mounted directly while the job is running
-    And the Enroot NCCL job is still running
-    When the Enroot NCCL job is cancelled
-    Then Enroot direct runtime is cleaned up and squashfs cache remains
-    When the same Enroot NCCL job is submitted again
-    Then Enroot squashfs artifact is reused without materializing runtime data
-    And the repeated Enroot NCCL job is still running
-    When the repeated Enroot NCCL job is cancelled
+  Scenario: Enroot containers can access GPUs
+    Given an Enroot GPU smoke job is submitted on one GPU worker
+    Then the Enroot GPU smoke job succeeds and reports visible GPUs

--- a/internal/e2e/acceptance/framework/helpers.go
+++ b/internal/e2e/acceptance/framework/helpers.go
@@ -33,41 +33,6 @@ func ParseSbatchJobID(output string) (string, error) {
 	return jobID, nil
 }
 
-func TreeOutputHasEntries(output string) bool {
-	lines := make([]string, 0)
-	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		lines = append(lines, line)
-	}
-	if len(lines) < 3 {
-		return false
-	}
-
-	for _, line := range lines[1 : len(lines)-1] {
-		if strings.TrimSpace(line) != "" {
-			return true
-		}
-	}
-	return false
-}
-
-func WaitForTreeEntriesOnWorker(ctx context.Context, exec Exec, worker, storagePath, description string, timeout time.Duration) error {
-	trimmedWorker := strings.TrimSpace(worker)
-	if trimmedWorker == "" {
-		return fmt.Errorf("%s: worker is not selected", description)
-	}
-
-	return exec.WaitFor(ctx, description, timeout, DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
-		out, err := exec.Worker(trimmedWorker).RunWithDefaultRetry(waitCtx, fmt.Sprintf("sudo tree -L 2 -a %s", ShellQuote(storagePath)))
-		if err != nil {
-			return false, err
-		}
-		return TreeOutputHasEntries(out), nil
-	})
-}
-
 // WaitForWithJobAlive is Exec.WaitFor with an added short‑circuit on job death. On each tick:
 //   - if Slurm still considers the job alive (PENDING / RUNNING / COMPLETING / …), probe runs exactly
 //     as it would under a plain Exec.WaitFor; the tick result — ready / not‑ready / error — is passed through;

--- a/internal/e2e/acceptance/steps/container_image.go
+++ b/internal/e2e/acceptance/steps/container_image.go
@@ -1,6 +1,0 @@
-package steps
-
-const (
-	e2eNCCLContainerImageDocker = "cr.eu-north1.nebius.cloud/ml-containers/training_diag:13.0.2-ubuntu24.04-20260709140028"
-	e2eNCCLContainerImageEnroot = "docker://cr.eu-north1.nebius.cloud#ml-containers/training_diag:13.0.2-ubuntu24.04-20260709140028"
-)

--- a/internal/e2e/acceptance/steps/container_smoke.go
+++ b/internal/e2e/acceptance/steps/container_smoke.go
@@ -9,7 +9,14 @@ import (
 	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
 )
 
-const containerSmokeSacctTimeout = 2 * time.Minute
+const (
+	containerSmokeSacctTimeout = 2 * time.Minute
+
+	// Cluster-supported GPU diagnostic image; includes nvidia-smi for container GPU visibility.
+	gpuSmokeImageRef    = "ml-containers/training_diag:13.0.2-ubuntu24.04-20260709140028"
+	gpuSmokeDockerImage = "cr.eu-north1.nebius.cloud/" + gpuSmokeImageRef
+	gpuSmokeEnrootImage = "docker://cr.eu-north1.nebius.cloud#" + gpuSmokeImageRef
+)
 
 func waitForJobSucceeded(ctx context.Context, exec framework.Exec, slurm *framework.SlurmClient, job framework.SbatchJob, timeout time.Duration) error {
 	if err := framework.AnnotateWithJobLog(ctx, exec, slurm, job, slurm.WaitForJobGone(ctx, job.ID, timeout)); err != nil {

--- a/internal/e2e/acceptance/steps/container_smoke.go
+++ b/internal/e2e/acceptance/steps/container_smoke.go
@@ -1,0 +1,88 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
+)
+
+const containerSmokeSacctTimeout = 2 * time.Minute
+
+func waitForJobSucceeded(ctx context.Context, exec framework.Exec, slurm *framework.SlurmClient, job framework.SbatchJob, timeout time.Duration) error {
+	if err := framework.AnnotateWithJobLog(ctx, exec, slurm, job, slurm.WaitForJobGone(ctx, job.ID, timeout)); err != nil {
+		return err
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, containerSmokeSacctTimeout)
+	defer cancel()
+
+	for {
+		if err := waitCtx.Err(); err != nil {
+			return framework.AnnotateWithJobLog(ctx, exec, slurm, job,
+				fmt.Errorf("wait for job %s completed successfully: %w", job.ID, err))
+		}
+
+		_, dump, err := slurm.JobState(waitCtx, job.ID)
+		if err != nil {
+			return framework.AnnotateWithJobLog(ctx, exec, slurm, job, err)
+		}
+		state, exitCode, found := parseSacctOutcome(dump, job.ID)
+		if found {
+			if state == "COMPLETED" && exitCode == "0:0" {
+				return nil
+			}
+			if !framework.IsJobAliveState(state) {
+				return framework.AnnotateWithJobLog(ctx, exec, slurm, job,
+					fmt.Errorf("job %s finished with state=%s exit_code=%s", job.ID, state, exitCode))
+			}
+		}
+
+		select {
+		case <-waitCtx.Done():
+		case <-time.After(framework.DefaultPollInterval):
+		}
+	}
+}
+
+func assertJobStdoutReportsVisibleGPUs(ctx context.Context, exec framework.Exec, job framework.SbatchJob) error {
+	stdout, err := readJobFile(ctx, exec, job.StdoutPath)
+	if err != nil {
+		return err
+	}
+	return assertGPUListing(stdout, fmt.Sprintf("job stdout %s", job.StdoutPath))
+}
+
+func assertGPUListing(output, source string) error {
+	if strings.Contains(output, "GPU ") {
+		return nil
+	}
+	return fmt.Errorf("expected nvidia-smi GPU listing in %s, got output:\n%s", source, strings.TrimSpace(output))
+}
+
+func readJobFile(ctx context.Context, exec framework.Exec, path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("job output path is empty")
+	}
+	output, err := exec.Jail().RunWithDefaultRetry(ctx, fmt.Sprintf("cat %s", framework.ShellQuote(path)))
+	if err != nil {
+		return "", fmt.Errorf("read job output %s: %w", path, err)
+	}
+	return output, nil
+}
+
+func parseSacctOutcome(dump, jobID string) (string, string, bool) {
+	for _, line := range strings.Split(dump, "\n") {
+		fields := strings.Split(line, "|")
+		if len(fields) < 3 {
+			continue
+		}
+		if strings.TrimSpace(fields[0]) != jobID {
+			continue
+		}
+		return strings.TrimSpace(fields[1]), strings.TrimSpace(fields[2]), true
+	}
+	return "", "", false
+}

--- a/internal/e2e/acceptance/steps/docker_containers.go
+++ b/internal/e2e/acceptance/steps/docker_containers.go
@@ -19,8 +19,7 @@ const (
 	dockerLifecycleImage   = "cr.eu-north1.nebius.cloud/soperator/busybox"
 	dockerLifecycleCommand = "echo ready; sleep 3600"
 
-	// Cluster-supported GPU diagnostic image; includes nvidia-smi for container GPU visibility.
-	dockerGPUImage = "cr.eu-north1.nebius.cloud/ml-containers/training_diag:13.0.2-ubuntu24.04-20260709140028"
+	dockerLocalStorageRoot = "/mnt/image-storage/docker"
 
 	dockerJobStartTimeout      = 20 * time.Minute
 	dockerProbeTimeout         = 10 * time.Minute
@@ -112,10 +111,48 @@ func (s *DockerContainers) theDockerContainerJobIsRunning(ctx context.Context) e
 }
 
 func (s *DockerContainers) dockerImageAndRuntimeStorageIsPopulatedOnAWorker(ctx context.Context) error {
-	if err := framework.WaitForTreeEntriesOnWorker(ctx, s.exec, s.connectionWorker, "/mnt/image-storage/docker/overlay2/", "Docker overlay2 storage", dockerProbeTimeout); err != nil {
-		return err
+	if s.connectionWorker == "" {
+		return fmt.Errorf("Docker connection worker is not selected")
 	}
-	return framework.WaitForTreeEntriesOnWorker(ctx, s.exec, s.connectionWorker, "/mnt/image-storage/docker/containerd/daemon/io.containerd.content.v1.content/blobs/sha256/", "Docker container content blobs", dockerProbeTimeout)
+
+	err := framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "Docker image and runtime storage on local disk",
+		dockerProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
+			rootDir, err := s.dockerRootDir(waitCtx, s.connectionWorker)
+			if err != nil {
+				return false, err
+			}
+			if !pathIsUnder(rootDir, dockerLocalStorageRoot) {
+				return false, fmt.Errorf("expected Docker root dir under %s, got %q", dockerLocalStorageRoot, rootDir)
+			}
+
+			imageID, err := s.dockerImageID(waitCtx, s.connectionWorker, dockerLifecycleImage)
+			if err != nil {
+				return false, err
+			}
+			if imageID == "" {
+				return false, nil
+			}
+
+			containerIDs, err := s.dockerContainerIDsByNamePrefix(waitCtx, s.connectionWorker)
+			if err != nil {
+				return false, err
+			}
+			for containerID := range containerIDs {
+				paths, err := s.dockerContainerGraphDriverPaths(waitCtx, s.connectionWorker, containerID)
+				if err != nil {
+					return false, err
+				}
+				if paths == "" {
+					return false, nil
+				}
+				if !graphDriverPathsUnder(paths, dockerLocalStorageRoot) {
+					return false, fmt.Errorf("expected Docker graph-driver paths under %s, got:\n%s", dockerLocalStorageRoot, paths)
+				}
+				return true, nil
+			}
+			return false, nil
+		})
+	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job, err)
 }
 
 func (s *DockerContainers) dockerContainersFromTheJobAreRunningOnSelectedWorkers(ctx context.Context) error {
@@ -140,16 +177,6 @@ func (s *DockerContainers) theDockerContainerJobIsCancelled(ctx context.Context)
 }
 
 func (s *DockerContainers) dockerContainersFromTheJobAreStoppedExplicitly(ctx context.Context) error {
-	running, err := s.trackedDockerContainerCount(ctx)
-	if err != nil {
-		return err
-	}
-	if running == 0 {
-		s.exec.Logf("Docker containers: no matching containers found after scancel; explicit stop was a no-op")
-		return nil
-	}
-
-	s.exec.Logf("Docker containers: %d matching container(s) still running after scancel; stopping explicitly", running)
 	s.stopContainersByNamePrefix(ctx)
 	return nil
 }
@@ -172,7 +199,7 @@ func (s *DockerContainers) aDockerGPUSmokeJobIsSubmittedOnOneGPUWorker(ctx conte
 	s.connectionWorker = workers[0]
 
 	wrap := fmt.Sprintf("srun docker run --name e2e-docker-gpu-${SLURM_JOB_ID}-${SLURM_NODEID} --gpus=all -e NVIDIA_DRIVER_CAPABILITIES=utility %s nvidia-smi -L",
-		framework.ShellQuote(dockerGPUImage),
+		framework.ShellQuote(gpuSmokeDockerImage),
 	)
 	job, err := s.slurm.SubmitBatch(ctx, framework.SbatchOptions{
 		JobName:      "e2e-docker-gpu-smoke",
@@ -255,22 +282,6 @@ func (s *DockerContainers) waitForCurrentJobGone(ctx context.Context) error {
 	return nil
 }
 
-func (s *DockerContainers) trackedDockerContainerCount(ctx context.Context) (int, error) {
-	if len(s.workers) == 0 {
-		return 0, fmt.Errorf("Docker workers are not selected")
-	}
-
-	count := 0
-	for _, worker := range s.workers {
-		currentIDs, err := s.dockerContainerIDsByNamePrefix(ctx, worker)
-		if err != nil {
-			return 0, err
-		}
-		count += len(currentIDs)
-	}
-	return count, nil
-}
-
 func (s *DockerContainers) dockerContainerIDsByNamePrefix(ctx context.Context, worker string) (map[string]struct{}, error) {
 	if s.containerNamePrefix == "" {
 		return nil, fmt.Errorf("Docker container name prefix is empty")
@@ -282,6 +293,32 @@ func (s *DockerContainers) dockerContainerIDsByNamePrefix(ctx context.Context, w
 		return nil, err
 	}
 	return parseIDSet(out), nil
+}
+
+func (s *DockerContainers) dockerRootDir(ctx context.Context, worker string) (string, error) {
+	out, err := s.exec.Worker(worker).RunWithDefaultRetry(ctx, "sudo docker info --format '{{.DockerRootDir}}'")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func (s *DockerContainers) dockerImageID(ctx context.Context, worker, image string) (string, error) {
+	out, err := s.exec.Worker(worker).RunWithDefaultRetry(ctx,
+		fmt.Sprintf("sudo docker image inspect --format '{{.Id}}' %s", framework.ShellQuote(image)))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func (s *DockerContainers) dockerContainerGraphDriverPaths(ctx context.Context, worker, containerID string) (string, error) {
+	out, err := s.exec.Worker(worker).RunWithDefaultRetry(ctx,
+		fmt.Sprintf("sudo docker inspect --format '{{range $key, $value := .GraphDriver.Data}}{{println $value}}{{end}}' %s", framework.ShellQuote(containerID)))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
 }
 
 func (s *DockerContainers) dockerContainerIDsByNamePrefixAll(ctx context.Context, worker string) (map[string]struct{}, error) {
@@ -328,6 +365,33 @@ func parseIDSet(output string) map[string]struct{} {
 		result[id] = struct{}{}
 	}
 	return result
+}
+
+func graphDriverPathsUnder(output, root string) bool {
+	foundPath := false
+	for _, line := range strings.Split(output, "\n") {
+		value := strings.TrimSpace(line)
+		if value == "" {
+			continue
+		}
+		for _, field := range strings.Split(value, ":") {
+			candidate := strings.TrimSpace(field)
+			if candidate == "" || !strings.HasPrefix(candidate, "/") {
+				continue
+			}
+			foundPath = true
+			if !pathIsUnder(candidate, root) {
+				return false
+			}
+		}
+	}
+	return foundPath
+}
+
+func pathIsUnder(value, root string) bool {
+	cleanValue := path.Clean(strings.TrimSpace(value))
+	cleanRoot := path.Clean(strings.TrimSpace(root))
+	return cleanValue == cleanRoot || strings.HasPrefix(cleanValue, cleanRoot+"/")
 }
 
 func (s *DockerContainers) stopContainersByNamePrefix(ctx context.Context) {

--- a/internal/e2e/acceptance/steps/docker_containers.go
+++ b/internal/e2e/acceptance/steps/docker_containers.go
@@ -15,12 +15,18 @@ import (
 const (
 	dockerContainersFeatureFile = "docker_containers.feature"
 
-	dockerARP = "NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1 NCCL_ALGO=Ring all_reduce_perf -b 8G -e 8G -f 2 -g 8 -N 0"
+	// Small mirrored image; Docker lifecycle only needs sh/sleep and storage population.
+	dockerLifecycleImage   = "cr.eu-north1.nebius.cloud/soperator/busybox"
+	dockerLifecycleCommand = "echo ready; sleep 3600"
+
+	// Cluster-supported GPU diagnostic image; includes nvidia-smi for container GPU visibility.
+	dockerGPUImage = "cr.eu-north1.nebius.cloud/ml-containers/training_diag:13.0.2-ubuntu24.04-20260709140028"
 
 	dockerJobStartTimeout      = 20 * time.Minute
 	dockerProbeTimeout         = 10 * time.Minute
 	dockerJobCancelTimeout     = 5 * time.Minute
 	dockerContainerStopTimeout = 5 * time.Minute
+	dockerGPUSmokeTimeout      = 10 * time.Minute
 )
 
 type DockerContainers struct {
@@ -46,41 +52,46 @@ func (s *DockerContainers) Register(sc *godog.ScenarioContext) {
 			return ctx, nil
 		}
 
-		if cleanupErr := s.cancelCurrentJob(context.Background()); cleanupErr != nil {
+		if cleanupErr := s.requestCurrentJobCancellation(context.Background()); cleanupErr != nil {
 			s.exec.Logf("cleanup: cancel Docker job: %v", cleanupErr)
 		}
 		s.stopContainersByNamePrefix(context.Background())
+		s.removeContainersByNamePrefix(context.Background())
+		if cleanupErr := s.waitForCurrentJobGone(context.Background()); cleanupErr != nil {
+			s.exec.Logf("cleanup: wait for Docker job to finish: %v", cleanupErr)
+		}
 		return ctx, nil
 	})
 
-	sc.Step(`^a long-running Docker NCCL job is submitted on two GPU workers$`, s.aLongRunningDockerNCCLJobIsSubmittedOnTwoGPUWorkers)
-	sc.Step(`^the Docker NCCL job is running$`, s.theDockerNCCLJobIsRunning)
-	sc.Step(`^Docker overlayfs storage is populated on a worker$`, s.dockerOverlayfsStorageIsPopulatedOnAWorker)
-	sc.Step(`^Docker container content blobs are populated on a worker$`, s.dockerContainerContentBlobsArePopulatedOnAWorker)
-	sc.Step(`^a Docker container from the job is running on workers$`, s.aDockerContainerFromTheJobIsRunningOnWorkers)
-	sc.Step(`^the Docker NCCL job is still running$`, s.theDockerNCCLJobIsStillRunning)
-	sc.Step(`^the Docker NCCL job is cancelled$`, s.theDockerNCCLJobIsCancelled)
-	sc.Step(`^Docker containers from that job are no longer running$`, s.dockerContainersFromThatJobAreNoLongerRunning)
+	sc.Step(`^a long-running Docker container job is submitted on two workers$`, s.aLongRunningDockerContainerJobIsSubmittedOnTwoWorkers)
+	sc.Step(`^the Docker container job is running$`, s.theDockerContainerJobIsRunning)
+	sc.Step(`^Docker image and runtime storage is populated on a worker$`, s.dockerImageAndRuntimeStorageIsPopulatedOnAWorker)
+	sc.Step(`^Docker containers from the job are running on selected workers$`, s.dockerContainersFromTheJobAreRunningOnSelectedWorkers)
+	sc.Step(`^the Docker container job is cancelled$`, s.theDockerContainerJobIsCancelled)
+	sc.Step(`^Docker containers from the job are stopped explicitly$`, s.dockerContainersFromTheJobAreStoppedExplicitly)
+	sc.Step(`^Docker containers from the job are no longer running$`, s.dockerContainersFromTheJobAreNoLongerRunning)
+	sc.Step(`^a Docker GPU smoke job is submitted on one GPU worker$`, s.aDockerGPUSmokeJobIsSubmittedOnOneGPUWorker)
+	sc.Step(`^the Docker GPU smoke job succeeds and reports visible GPUs$`, s.theDockerGPUSmokeJobSucceedsAndReportsVisibleGPUs)
 }
 
-func (s *DockerContainers) aLongRunningDockerNCCLJobIsSubmittedOnTwoGPUWorkers(ctx context.Context) error {
-	workers, err := s.slurm.AnyGPUWorkers(2)
+func (s *DockerContainers) aLongRunningDockerContainerJobIsSubmittedOnTwoWorkers(ctx context.Context) error {
+	workers, err := s.slurm.AnyWorkers(2)
 	if err != nil {
 		return err
 	}
 	s.workers = workers
-	s.connectionWorker = s.workers[0]
+	s.connectionWorker = workers[0]
 
-	wrap := fmt.Sprintf("srun docker run --rm --name e2e-docker-${SLURM_JOB_ID}-${SLURM_NODEID} --gpus=all --device=/dev/infiniband %s bash -lc %s",
-		framework.ShellQuote(e2eNCCLContainerImageDocker),
-		framework.ShellQuote(dockerARP),
+	wrap := fmt.Sprintf("srun docker run --rm --name e2e-docker-${SLURM_JOB_ID}-${SLURM_NODEID} %s sh -c %s",
+		framework.ShellQuote(dockerLifecycleImage),
+		framework.ShellQuote(dockerLifecycleCommand),
 	)
 	job, err := s.slurm.SubmitBatch(ctx, framework.SbatchOptions{
-		JobName:     "e2e-docker-containers",
-		Nodes:       2,
-		Nodelist:    s.workers,
-		GPUsPerNode: 8,
-		Wrap:        wrap,
+		JobName:      "e2e-docker-containers",
+		Nodes:        2,
+		Nodelist:     s.workers,
+		TasksPerNode: 1,
+		Wrap:         wrap,
 	})
 	if err != nil {
 		return err
@@ -92,7 +103,7 @@ func (s *DockerContainers) aLongRunningDockerNCCLJobIsSubmittedOnTwoGPUWorkers(c
 	return nil
 }
 
-func (s *DockerContainers) theDockerNCCLJobIsRunning(ctx context.Context) error {
+func (s *DockerContainers) theDockerContainerJobIsRunning(ctx context.Context) error {
 	if s.job.IsZero() {
 		return fmt.Errorf("Docker job ID is empty")
 	}
@@ -100,25 +111,14 @@ func (s *DockerContainers) theDockerNCCLJobIsRunning(ctx context.Context) error 
 		s.slurm.WaitForJobRunning(ctx, s.job.ID, dockerJobStartTimeout))
 }
 
-func (s *DockerContainers) theDockerNCCLJobIsStillRunning(ctx context.Context) error {
-	if s.job.IsZero() {
-		return fmt.Errorf("Docker job ID is empty")
+func (s *DockerContainers) dockerImageAndRuntimeStorageIsPopulatedOnAWorker(ctx context.Context) error {
+	if err := framework.WaitForTreeEntriesOnWorker(ctx, s.exec, s.connectionWorker, "/mnt/image-storage/docker/overlay2/", "Docker overlay2 storage", dockerProbeTimeout); err != nil {
+		return err
 	}
-	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job,
-		s.slurm.AssertJobRunning(ctx, s.job.ID))
-}
-
-func (s *DockerContainers) dockerOverlayfsStorageIsPopulatedOnAWorker(ctx context.Context) error {
-	return framework.WaitForTreeEntriesOnWorker(ctx, s.exec, s.connectionWorker, "/mnt/image-storage/docker/rootfs/overlayfs/", "Docker overlayfs storage", dockerProbeTimeout)
-}
-
-func (s *DockerContainers) dockerContainerContentBlobsArePopulatedOnAWorker(ctx context.Context) error {
-	// This scenario checks storage population/cleanup only.
-	// It does not currently assert strict blob-by-blob identity across repeated runs.
 	return framework.WaitForTreeEntriesOnWorker(ctx, s.exec, s.connectionWorker, "/mnt/image-storage/docker/containerd/daemon/io.containerd.content.v1.content/blobs/sha256/", "Docker container content blobs", dockerProbeTimeout)
 }
 
-func (s *DockerContainers) aDockerContainerFromTheJobIsRunningOnWorkers(ctx context.Context) error {
+func (s *DockerContainers) dockerContainersFromTheJobAreRunningOnSelectedWorkers(ctx context.Context) error {
 	err := framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "Docker containers running on selected workers",
 		dockerProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
 			for _, worker := range s.workers {
@@ -135,19 +135,89 @@ func (s *DockerContainers) aDockerContainerFromTheJobIsRunningOnWorkers(ctx cont
 	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job, err)
 }
 
-func (s *DockerContainers) theDockerNCCLJobIsCancelled(ctx context.Context) error {
-	return s.cancelCurrentJob(ctx)
+func (s *DockerContainers) theDockerContainerJobIsCancelled(ctx context.Context) error {
+	return s.requestCurrentJobCancellation(ctx)
 }
 
-func (s *DockerContainers) dockerContainersFromThatJobAreNoLongerRunning(ctx context.Context) error {
-	// Expected behavior is that containers stop after `scancel`, but currently this is unreliable.
-	// TODO(SCHED-1497): remove explicit Docker stop workaround once cancellation cleanup is fixed.
-	s.exec.Logf("Docker containers: applying SCHED-1497 workaround (explicit docker stop before assertion)")
+func (s *DockerContainers) dockerContainersFromTheJobAreStoppedExplicitly(ctx context.Context) error {
+	running, err := s.trackedDockerContainerCount(ctx)
+	if err != nil {
+		return err
+	}
+	if running == 0 {
+		s.exec.Logf("Docker containers: no matching containers found after scancel; explicit stop was a no-op")
+		return nil
+	}
+
+	s.exec.Logf("Docker containers: %d matching container(s) still running after scancel; stopping explicitly", running)
 	s.stopContainersByNamePrefix(ctx)
-	return s.waitForTrackedContainersGone(ctx, dockerContainerStopTimeout)
+	return nil
+}
+
+func (s *DockerContainers) dockerContainersFromTheJobAreNoLongerRunning(ctx context.Context) error {
+	if err := s.waitForTrackedContainersGone(ctx, dockerContainerStopTimeout); err != nil {
+		return err
+	}
+	return s.waitForCurrentJobGone(ctx)
+}
+
+func (s *DockerContainers) aDockerGPUSmokeJobIsSubmittedOnOneGPUWorker(ctx context.Context) error {
+	// Future option: omit --nodelist and discover the allocated worker after
+	// submission, letting Slurm avoid busy nodes before Docker log collection.
+	workers, err := s.slurm.AnyGPUWorkers(1)
+	if err != nil {
+		return err
+	}
+	s.workers = workers
+	s.connectionWorker = workers[0]
+
+	wrap := fmt.Sprintf("srun docker run --name e2e-docker-gpu-${SLURM_JOB_ID}-${SLURM_NODEID} --gpus=all -e NVIDIA_DRIVER_CAPABILITIES=utility %s nvidia-smi -L",
+		framework.ShellQuote(dockerGPUImage),
+	)
+	job, err := s.slurm.SubmitBatch(ctx, framework.SbatchOptions{
+		JobName:      "e2e-docker-gpu-smoke",
+		Nodes:        1,
+		Nodelist:     s.workers,
+		GPUsPerNode:  1,
+		TasksPerNode: 1,
+		Wrap:         wrap,
+	})
+	if err != nil {
+		return err
+	}
+	s.job = job
+	s.containerNamePrefix = fmt.Sprintf("e2e-docker-gpu-%s-", job.ID)
+	s.exec.Logf("Docker GPU smoke: selected worker=%s job_id=%s stdout=%s stderr=%s",
+		s.connectionWorker, job.ID, job.StdoutPath, job.StderrPath)
+	return nil
+}
+
+func (s *DockerContainers) theDockerGPUSmokeJobSucceedsAndReportsVisibleGPUs(ctx context.Context) error {
+	if s.job.IsZero() {
+		return fmt.Errorf("Docker GPU smoke job ID is empty")
+	}
+	job := s.job
+	// A sacct-only wait would let us read Docker logs earlier, but it can hide
+	// Slurm cleanup time and transfer resource-release waits to later scenarios.
+	if err := waitForJobSucceeded(ctx, s.exec, s.slurm, job, dockerGPUSmokeTimeout); err != nil {
+		return err
+	}
+	logs, err := s.dockerContainerLogsByNamePrefix(ctx, s.connectionWorker)
+	if err != nil {
+		return err
+	}
+	if err := assertGPUListing(logs, fmt.Sprintf("Docker container logs on %s", s.connectionWorker)); err != nil {
+		return err
+	}
+	s.removeContainersByNamePrefix(ctx)
+	s.job = framework.SbatchJob{}
+	return nil
 }
 
 func (s *DockerContainers) waitForTrackedContainersGone(ctx context.Context, timeout time.Duration) error {
+	if len(s.workers) == 0 {
+		return fmt.Errorf("Docker workers are not selected")
+	}
 	return s.exec.WaitFor(ctx, "Docker containers stopped on selected workers", timeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
 		for _, worker := range s.workers {
 			currentIDs, err := s.dockerContainerIDsByNamePrefix(waitCtx, worker)
@@ -162,16 +232,43 @@ func (s *DockerContainers) waitForTrackedContainersGone(ctx context.Context, tim
 	})
 }
 
-func (s *DockerContainers) cancelCurrentJob(ctx context.Context) error {
+func (s *DockerContainers) requestCurrentJobCancellation(ctx context.Context) error {
 	if s.job.IsZero() {
 		return nil
 	}
 
-	if err := s.slurm.CancelJob(ctx, s.job.ID, dockerJobCancelTimeout); err != nil {
+	if err := s.slurm.CancelJob(ctx, s.job.ID, 0); err != nil {
 		return fmt.Errorf("cancel Docker job %s: %w", s.job.ID, err)
+	}
+	return nil
+}
+
+func (s *DockerContainers) waitForCurrentJobGone(ctx context.Context) error {
+	if s.job.IsZero() {
+		return nil
+	}
+
+	if err := s.slurm.WaitForJobGone(ctx, s.job.ID, dockerJobCancelTimeout); err != nil {
+		return fmt.Errorf("wait for Docker job %s to finish: %w", s.job.ID, err)
 	}
 	s.job = framework.SbatchJob{}
 	return nil
+}
+
+func (s *DockerContainers) trackedDockerContainerCount(ctx context.Context) (int, error) {
+	if len(s.workers) == 0 {
+		return 0, fmt.Errorf("Docker workers are not selected")
+	}
+
+	count := 0
+	for _, worker := range s.workers {
+		currentIDs, err := s.dockerContainerIDsByNamePrefix(ctx, worker)
+		if err != nil {
+			return 0, err
+		}
+		count += len(currentIDs)
+	}
+	return count, nil
 }
 
 func (s *DockerContainers) dockerContainerIDsByNamePrefix(ctx context.Context, worker string) (map[string]struct{}, error) {
@@ -185,6 +282,40 @@ func (s *DockerContainers) dockerContainerIDsByNamePrefix(ctx context.Context, w
 		return nil, err
 	}
 	return parseIDSet(out), nil
+}
+
+func (s *DockerContainers) dockerContainerIDsByNamePrefixAll(ctx context.Context, worker string) (map[string]struct{}, error) {
+	if s.containerNamePrefix == "" {
+		return nil, fmt.Errorf("Docker container name prefix is empty")
+	}
+
+	out, err := s.exec.Worker(worker).RunWithDefaultRetry(ctx,
+		fmt.Sprintf("sudo docker ps -a --filter name=%s --format '{{.ID}}'", framework.ShellQuote(s.containerNamePrefix)))
+	if err != nil {
+		return nil, err
+	}
+	return parseIDSet(out), nil
+}
+
+func (s *DockerContainers) dockerContainerLogsByNamePrefix(ctx context.Context, worker string) (string, error) {
+	ids, err := s.dockerContainerIDsByNamePrefixAll(ctx, worker)
+	if err != nil {
+		return "", err
+	}
+	if len(ids) == 0 {
+		return "", fmt.Errorf("no Docker containers found with prefix %s on worker %s", s.containerNamePrefix, worker)
+	}
+
+	logs := make([]string, 0, len(ids))
+	for id := range ids {
+		out, err := s.exec.Worker(worker).RunWithDefaultRetry(ctx,
+			fmt.Sprintf("sudo docker logs %s 2>&1", framework.ShellQuote(id)))
+		if err != nil {
+			return "", err
+		}
+		logs = append(logs, out)
+	}
+	return strings.Join(logs, "\n"), nil
 }
 
 func parseIDSet(output string) map[string]struct{} {
@@ -214,6 +345,25 @@ func (s *DockerContainers) stopContainersByNamePrefix(ctx context.Context) {
 		for id := range parseIDSet(out) {
 			if _, err := s.exec.Worker(worker).Run(ctx, fmt.Sprintf("sudo docker stop %s >/dev/null 2>&1 || true", framework.ShellQuote(id))); err != nil {
 				s.exec.Logf("Docker cleanup: stop container %s on worker %s failed: %v", id, worker, err)
+			}
+		}
+	}
+}
+
+func (s *DockerContainers) removeContainersByNamePrefix(ctx context.Context) {
+	if s.containerNamePrefix == "" {
+		return
+	}
+
+	for _, worker := range s.workers {
+		ids, err := s.dockerContainerIDsByNamePrefixAll(ctx, worker)
+		if err != nil {
+			s.exec.Logf("Docker cleanup: list all containers on worker %s failed: %v", worker, err)
+			continue
+		}
+		for id := range ids {
+			if _, err := s.exec.Worker(worker).Run(ctx, fmt.Sprintf("sudo docker rm -f %s >/dev/null 2>&1 || true", framework.ShellQuote(id))); err != nil {
+				s.exec.Logf("Docker cleanup: remove container %s on worker %s failed: %v", id, worker, err)
 			}
 		}
 	}

--- a/internal/e2e/acceptance/steps/docker_containers_test.go
+++ b/internal/e2e/acceptance/steps/docker_containers_test.go
@@ -1,0 +1,79 @@
+package steps
+
+import "testing"
+
+func TestGraphDriverPathsUnderAcceptsDockerOverlayInspectData(t *testing.T) {
+	const root = "/mnt/image-storage/docker"
+	output := `
+7a233c2a9c9881f79238b610bcfbe8b7bcd014a43b8c1dc17fcab60fa3e61c4c
+/mnt/image-storage/docker/overlay2/init/diff:/mnt/image-storage/docker/overlay2/base/diff
+/mnt/image-storage/docker/overlay2/container/merged
+/mnt/image-storage/docker/overlay2/container/diff
+/mnt/image-storage/docker/overlay2/container/work
+`
+
+	if !graphDriverPathsUnder(output, root) {
+		t.Fatalf("graphDriverPathsUnder() = false, want true")
+	}
+}
+
+func TestGraphDriverPathsUnderRejectsUnexpectedPaths(t *testing.T) {
+	const root = "/mnt/image-storage/docker"
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "metadata without paths",
+			output: "7a233c2a9c9881f79238b610bcfbe8b7bcd014a43b8c1dc17fcab60fa3e61c4c",
+			want:   false,
+		},
+		{
+			name:   "path outside root",
+			output: "/var/lib/docker/overlay2/container/merged",
+			want:   false,
+		},
+		{
+			name:   "one lowerdir outside root",
+			output: "/mnt/image-storage/docker/overlay2/base/diff:/var/lib/docker/overlay2/base/diff",
+			want:   false,
+		},
+		{
+			name:   "path under root",
+			output: "/mnt/image-storage/docker/overlay2/container/merged",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := graphDriverPathsUnder(tt.output, root); got != tt.want {
+				t.Fatalf("graphDriverPathsUnder() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPathIsUnder(t *testing.T) {
+	const root = "/mnt/image-storage/docker"
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "root", value: "/mnt/image-storage/docker", want: true},
+		{name: "child", value: "/mnt/image-storage/docker/overlay2/container/merged", want: true},
+		{name: "sibling with common prefix", value: "/mnt/image-storage/docker-other", want: false},
+		{name: "outside root", value: "/var/lib/docker", want: false},
+		{name: "cleaned outside root", value: "/mnt/image-storage/docker/../containerd", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pathIsUnder(tt.value, root); got != tt.want {
+				t.Fatalf("pathIsUnder(%q, %q) = %t, want %t", tt.value, root, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/e2e/acceptance/steps/enroot_containers.go
+++ b/internal/e2e/acceptance/steps/enroot_containers.go
@@ -2,7 +2,6 @@ package steps
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -16,19 +15,22 @@ import (
 const (
 	enrootContainersFeatureFile = "enroot_containers.feature"
 
-	enrootDockerMount   = "/usr/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu,/usr/lib64:/usr/lib64"
-	enrootARP           = "NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1 NCCL_ALGO=Ring all_reduce_perf -b 8G -e 8G -f 2 -g 8 -N 0"
-	enrootNamedJobName  = "kek"
+	// Mirrored Ubuntu has /bin/bash required by the Slurm task prolog under Pyxis.
+	enrootLifecycleImage   = "docker://cr.eu-north1.nebius.cloud#soperator/ubuntu:noble"
+	enrootLifecycleCommand = "echo ready; sleep 3600"
+
+	// Cluster-supported GPU diagnostic image; includes nvidia-smi for container GPU visibility.
+	enrootGPUImage = "docker://cr.eu-north1.nebius.cloud#ml-containers/training_diag:13.0.2-ubuntu24.04-20260709140028"
+
 	enrootSquashPattern = ".sqsh"
 	enrootSquashRoot    = "/var/cache/enroot-container-images"
-	enrootTasksPerNode  = 8
 
-	enrootDedicatedCachePath = "/mnt/image-storage/enroot/cache"
-	enrootDedicatedDataPath  = "/mnt/image-storage/enroot/data"
+	enrootDedicatedDataPath = "/mnt/image-storage/enroot/data"
 
 	enrootJobStartTimeout = 25 * time.Minute
 	enrootProbeTimeout    = 10 * time.Minute
 	enrootStopTimeout     = 5 * time.Minute
+	enrootGPUSmokeTimeout = 10 * time.Minute
 )
 
 type EnrootContainers struct {
@@ -39,8 +41,10 @@ type EnrootContainers struct {
 	connectionWorker string
 	job              framework.SbatchJob
 
-	squashPath       string
-	squashStatBefore string
+	squashPath               string
+	expectedSquashPath       string
+	squashStatBefore         string
+	squashArtifactsBeforeJob map[string]enrootSquashArtifact
 
 	directSquashFS *bool
 }
@@ -61,64 +65,53 @@ func (s *EnrootContainers) Register(sc *godog.ScenarioContext) {
 		if cleanupErr := s.cancelCurrentJob(context.Background()); cleanupErr != nil {
 			s.exec.Logf("cleanup: cancel enroot job: %v", cleanupErr)
 		}
-		if cleanupErr := s.removeNamedRuntimeDir(context.Background()); cleanupErr != nil {
-			s.exec.Logf("cleanup: remove named enroot runtime directory: %v", cleanupErr)
-		}
 		return ctx, nil
 	})
 
-	sc.Step(`^Enroot direct SquashFS startup is enabled$`, s.enrootDirectSquashFSStartupIsEnabled)
-	sc.Step(`^Enroot materialized runtime storage is enabled$`, s.enrootMaterializedRuntimeStorageIsEnabled)
-	sc.Step(`^a long-running Enroot NCCL job is submitted on two GPU workers$`, s.aLongRunningEnrootNCCLJobIsSubmittedOnTwoGPUWorkers)
-	sc.Step(`^the Enroot NCCL job is running$`, s.theEnrootNCCLJobIsRunning)
-	sc.Step(`^Enroot cache is populated on local storage on a worker$`, s.enrootCacheIsPopulatedOnLocalStorageOnAWorker)
-	sc.Step(`^Enroot squashfs image is present on a worker$`, s.enrootSquashfsImageIsPresentOnAWorker)
-	sc.Step(`^Enroot runtime container data is visible while the job is running$`, s.enrootRuntimeContainerDataIsVisibleWhileTheJobIsRunning)
-	sc.Step(`^Enroot squashfs image is mounted directly while the job is running$`, s.enrootSquashfsImageIsMountedDirectlyWhileTheJobIsRunning)
-	sc.Step(`^the Enroot NCCL job is still running$`, s.theEnrootNCCLJobIsStillRunning)
-	sc.Step(`^the Enroot NCCL job is cancelled$`, s.theEnrootNCCLJobIsCancelled)
-	sc.Step(`^Enroot runtime data is cleaned up and squashfs cache remains$`, s.enrootRuntimeDataIsCleanedUpAndSquashfsCacheRemains)
-	sc.Step(`^Enroot direct runtime is cleaned up and squashfs cache remains$`, s.enrootDirectRuntimeIsCleanedUpAndSquashfsCacheRemains)
-	sc.Step(`^the same Enroot NCCL job is submitted again$`, s.theSameEnrootNCCLJobIsSubmittedAgain)
-	sc.Step(`^Enroot runtime data is repopulated without changing the squashfs artifact$`, s.enrootRuntimeDataIsRepopulatedWithoutChangingTheSquashfsArtifact)
-	sc.Step(`^Enroot squashfs artifact is reused without materializing runtime data$`, s.enrootSquashfsArtifactIsReusedWithoutMaterializingRuntimeData)
-	sc.Step(`^the repeated Enroot NCCL job is still running$`, s.theEnrootNCCLJobIsStillRunning)
-	sc.Step(`^the repeated Enroot NCCL job is cancelled$`, s.theRepeatedEnrootNCCLJobIsCancelled)
-	sc.Step(`^a named Enroot container job is submitted$`, s.aNamedEnrootContainerJobIsSubmitted)
-	sc.Step(`^the named Enroot runtime directory remains after cancellation$`, s.theNamedEnrootRuntimeDirectoryRemainsAfterCancellation)
-	sc.Step(`^the named Enroot runtime directory is cleaned up$`, s.theNamedEnrootRuntimeDirectoryIsCleanedUp)
-	sc.Step(`^the named Enroot runtime directory is removed$`, s.theNamedEnrootRuntimeDirectoryIsRemoved)
+	sc.Step(`^a long-running Enroot container job is submitted on two workers$`, s.aLongRunningEnrootContainerJobIsSubmittedOnTwoWorkers)
+	sc.Step(`^the Enroot container job is running$`, s.theEnrootContainerJobIsRunning)
+	sc.Step(`^an Enroot image artifact is present on a worker$`, s.anEnrootImageArtifactIsPresentOnAWorker)
+	sc.Step(`^Enroot runtime state is visible while the job is running$`, s.enrootRuntimeStateIsVisibleWhileTheJobIsRunning)
+	sc.Step(`^the Enroot container job is cancelled$`, s.theEnrootContainerJobIsCancelled)
+	sc.Step(`^Enroot runtime state is cleaned up and the image artifact remains$`, s.enrootRuntimeStateIsCleanedUpAndTheImageArtifactRemains)
+	sc.Step(`^the same Enroot container job is submitted again$`, s.theSameEnrootContainerJobIsSubmittedAgain)
+	sc.Step(`^the existing Enroot image artifact is reused$`, s.theExistingEnrootImageArtifactIsReused)
+	sc.Step(`^the repeated Enroot container job is cancelled$`, s.theRepeatedEnrootContainerJobIsCancelled)
+	sc.Step(`^Enroot runtime state is cleaned up$`, s.enrootRuntimeStateIsCleanedUp)
+	sc.Step(`^an Enroot GPU smoke job is submitted on one GPU worker$`, s.anEnrootGPUSmokeJobIsSubmittedOnOneGPUWorker)
+	sc.Step(`^the Enroot GPU smoke job succeeds and reports visible GPUs$`, s.theEnrootGPUSmokeJobSucceedsAndReportsVisibleGPUs)
 }
 
-func (s *EnrootContainers) enrootDirectSquashFSStartupIsEnabled(ctx context.Context) error {
-	enabled, err := s.enrootDirectSquashFSEnabled(ctx)
+func (s *EnrootContainers) aLongRunningEnrootContainerJobIsSubmittedOnTwoWorkers(ctx context.Context) error {
+	if len(s.workers) == 0 {
+		workers, err := s.slurm.AnyWorkers(2)
+		if err != nil {
+			return err
+		}
+		s.workers = workers
+		s.connectionWorker = workers[0]
+		s.exec.Logf("enroot containers: selected workers=%s", strings.Join(s.workers, ","))
+	}
+	s.squashPath = ""
+	s.expectedSquashPath = ""
+	s.squashStatBefore = ""
+
+	expectedSquashPath, err := s.expectedLifecycleSquashPath(ctx)
 	if err != nil {
 		return err
 	}
-	if !enabled {
-		s.exec.Logf("enroot containers: direct SquashFS startup is disabled, skipping scenario")
-		return godog.ErrSkip
-	}
-	return nil
-}
+	s.expectedSquashPath = expectedSquashPath
 
-func (s *EnrootContainers) enrootMaterializedRuntimeStorageIsEnabled(ctx context.Context) error {
-	enabled, err := s.enrootDirectSquashFSEnabled(ctx)
+	artifacts, err := s.squashArtifacts(ctx)
 	if err != nil {
 		return err
 	}
-	if enabled {
-		s.exec.Logf("enroot containers: direct SquashFS startup is enabled, skipping materialized runtime scenario")
-		return godog.ErrSkip
-	}
-	return nil
+	s.squashArtifactsBeforeJob = artifacts
+
+	return s.submitEnrootLifecycleJob(ctx, "e2e-enroot-initial")
 }
 
-func (s *EnrootContainers) aLongRunningEnrootNCCLJobIsSubmittedOnTwoGPUWorkers(ctx context.Context) error {
-	return s.submitEnrootJob(ctx, "", "e2e-enroot-initial")
-}
-
-func (s *EnrootContainers) theEnrootNCCLJobIsRunning(ctx context.Context) error {
+func (s *EnrootContainers) theEnrootContainerJobIsRunning(ctx context.Context) error {
 	if s.job.IsZero() {
 		return fmt.Errorf("enroot job id is empty")
 	}
@@ -126,48 +119,216 @@ func (s *EnrootContainers) theEnrootNCCLJobIsRunning(ctx context.Context) error 
 		s.slurm.WaitForJobRunning(ctx, s.job.ID, enrootJobStartTimeout))
 }
 
-func (s *EnrootContainers) theEnrootNCCLJobIsStillRunning(ctx context.Context) error {
-	if s.job.IsZero() {
-		return fmt.Errorf("enroot job id is empty")
-	}
-	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job,
-		s.slurm.AssertJobRunning(ctx, s.job.ID))
-}
-
-func (s *EnrootContainers) enrootCacheIsPopulatedOnLocalStorageOnAWorker(ctx context.Context) error {
-	directSquashFS, err := s.enrootDirectSquashFSEnabled(ctx)
-	if err != nil {
-		return err
-	}
-
-	if directSquashFS {
-		return framework.WaitForTreeEntriesOnWorker(ctx, s.exec, s.connectionWorker, enrootSquashRoot, "enroot squashfs cache is populated", enrootProbeTimeout)
-	}
-	return framework.WaitForTreeEntriesOnWorker(ctx, s.exec, s.connectionWorker, enrootDedicatedCachePath, "enroot cache is populated", enrootProbeTimeout)
-}
-
-func (s *EnrootContainers) enrootSquashfsImageIsPresentOnAWorker(ctx context.Context) error {
+func (s *EnrootContainers) anEnrootImageArtifactIsPresentOnAWorker(ctx context.Context) error {
 	if s.connectionWorker == "" {
 		return fmt.Errorf("enroot connection worker is not selected")
 	}
 
-	if err := s.exec.WaitFor(ctx, "enroot squashfs image present", enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
-		findOutput, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(waitCtx,
-			fmt.Sprintf("sudo find %s -type f -name '*%s' 2>/dev/null | sort", framework.ShellQuote(enrootSquashRoot), enrootSquashPattern))
+	err := framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "enroot image artifact present",
+		enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
+			squashPath, _, found, err := s.pickTrackedSquashArtifact(waitCtx)
+			if err != nil {
+				return false, err
+			}
+			if !found {
+				return false, nil
+			}
+			s.squashPath = squashPath
+			s.exec.Logf("enroot containers: tracked squashfs path=%s", squashPath)
+			return true, nil
+		})
+	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job, err)
+}
+
+func (s *EnrootContainers) enrootRuntimeStateIsVisibleWhileTheJobIsRunning(ctx context.Context) error {
+	directSquashFS, err := s.enrootDirectSquashFSEnabled(ctx)
+	if err != nil {
+		return err
+	}
+	if directSquashFS {
+		return s.enrootSquashfsImageIsMountedDirectlyWhileTheJobIsRunning(ctx)
+	}
+	return s.enrootRuntimeContainerDataIsVisibleWhileTheJobIsRunning(ctx)
+}
+
+func (s *EnrootContainers) theEnrootContainerJobIsCancelled(ctx context.Context) error {
+	return s.cancelCurrentJob(ctx)
+}
+
+func (s *EnrootContainers) enrootRuntimeStateIsCleanedUpAndTheImageArtifactRemains(ctx context.Context) error {
+	if err := s.waitForRuntimeStateCleanedUpAndArtifactRemains(ctx); err != nil {
+		return err
+	}
+	statValue, err := s.squashStat(ctx)
+	if err != nil {
+		return err
+	}
+	if statValue == "" {
+		return fmt.Errorf("tracked squashfs stat is empty")
+	}
+	s.squashStatBefore = statValue
+	return nil
+}
+
+func (s *EnrootContainers) theSameEnrootContainerJobIsSubmittedAgain(ctx context.Context) error {
+	if s.squashPath == "" {
+		return fmt.Errorf("squashfs path is not captured")
+	}
+	if err := s.submitEnrootLifecycleJob(ctx, "e2e-enroot-repeated"); err != nil {
+		return err
+	}
+	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job,
+		s.slurm.WaitForJobRunning(ctx, s.job.ID, enrootJobStartTimeout))
+}
+
+func (s *EnrootContainers) theExistingEnrootImageArtifactIsReused(ctx context.Context) error {
+	if s.squashPath == "" {
+		return fmt.Errorf("squashfs path is not captured")
+	}
+	if s.squashStatBefore == "" {
+		return fmt.Errorf("baseline squashfs stat is not captured")
+	}
+
+	directSquashFS, err := s.enrootDirectSquashFSEnabled(ctx)
+	if err != nil {
+		return err
+	}
+	if directSquashFS {
+		return s.enrootSquashfsArtifactIsReusedWithDirectMount(ctx)
+	}
+	return s.enrootSquashfsArtifactIsReusedWithMaterializedRuntime(ctx)
+}
+
+func (s *EnrootContainers) theRepeatedEnrootContainerJobIsCancelled(ctx context.Context) error {
+	return s.cancelCurrentJob(ctx)
+}
+
+func (s *EnrootContainers) enrootRuntimeStateIsCleanedUp(ctx context.Context) error {
+	return s.waitForRuntimeStateCleanedUpAndArtifactRemains(ctx)
+}
+
+func (s *EnrootContainers) anEnrootGPUSmokeJobIsSubmittedOnOneGPUWorker(ctx context.Context) error {
+	// Future option: omit --nodelist and let Slurm choose the GPU worker.
+	workers, err := s.slurm.AnyGPUWorkers(1)
+	if err != nil {
+		return err
+	}
+	s.workers = workers
+	s.connectionWorker = workers[0]
+
+	wrap := fmt.Sprintf("NVIDIA_DRIVER_CAPABILITIES=utility srun --container-image=%s nvidia-smi -L",
+		framework.ShellQuote(enrootGPUImage),
+	)
+	job, err := s.slurm.SubmitBatch(ctx, framework.SbatchOptions{
+		JobName:      "e2e-enroot-gpu-smoke",
+		Nodes:        1,
+		Nodelist:     s.workers,
+		GPUsPerNode:  1,
+		TasksPerNode: 1,
+		Wrap:         wrap,
+	})
+	if err != nil {
+		return err
+	}
+	s.job = job
+	s.exec.Logf("enroot GPU smoke: selected worker=%s job_id=%s stdout=%s stderr=%s",
+		s.connectionWorker, job.ID, job.StdoutPath, job.StderrPath)
+	return nil
+}
+
+func (s *EnrootContainers) theEnrootGPUSmokeJobSucceedsAndReportsVisibleGPUs(ctx context.Context) error {
+	if s.job.IsZero() {
+		return fmt.Errorf("enroot GPU smoke job ID is empty")
+	}
+	job := s.job
+	if err := waitForJobSucceeded(ctx, s.exec, s.slurm, job, enrootGPUSmokeTimeout); err != nil {
+		return err
+	}
+	if err := assertJobStdoutReportsVisibleGPUs(ctx, s.exec, job); err != nil {
+		return err
+	}
+	s.job = framework.SbatchJob{}
+	return nil
+}
+
+func (s *EnrootContainers) submitEnrootLifecycleJob(ctx context.Context, jobName string) error {
+	if len(s.workers) == 0 {
+		return fmt.Errorf("enroot workers are not selected")
+	}
+	if s.connectionWorker == "" {
+		s.connectionWorker = s.workers[0]
+	}
+
+	wrap := fmt.Sprintf("srun --container-image=%s bash -lc %s",
+		framework.ShellQuote(enrootLifecycleImage),
+		framework.ShellQuote(enrootLifecycleCommand),
+	)
+	job, err := s.slurm.SubmitBatch(ctx, framework.SbatchOptions{
+		JobName:      jobName,
+		Nodes:        2,
+		Nodelist:     s.workers,
+		TasksPerNode: 1,
+		Wrap:         wrap,
+	})
+	if err != nil {
+		return err
+	}
+	s.job = job
+	s.exec.Logf("enroot containers: submitted job=%s id=%s stdout=%s stderr=%s",
+		job.JobName, job.ID, job.StdoutPath, job.StderrPath)
+	return nil
+}
+
+func (s *EnrootContainers) waitForRuntimeStateCleanedUpAndArtifactRemains(ctx context.Context) error {
+	if s.squashPath == "" {
+		return fmt.Errorf("squashfs path is not captured")
+	}
+	if s.connectionWorker == "" {
+		return fmt.Errorf("enroot connection worker is not selected")
+	}
+
+	directSquashFS, err := s.enrootDirectSquashFSEnabled(ctx)
+	if err != nil {
+		return err
+	}
+	if directSquashFS {
+		return s.waitForDirectRuntimeCleanedUpAndArtifactRemains(ctx)
+	}
+	return s.waitForMaterializedRuntimeCleanedUpAndArtifactRemains(ctx)
+}
+
+func (s *EnrootContainers) waitForMaterializedRuntimeCleanedUpAndArtifactRemains(ctx context.Context) error {
+	return s.exec.WaitFor(ctx, "enroot runtime data cleaned and image artifact remains", enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
+		treeOutput, err := s.legacyEnrootDataTree(waitCtx, s.connectionWorker)
 		if err != nil {
 			return false, err
 		}
-		squashPath := pickSquashPath(findOutput)
-		if squashPath == "" {
+		if strings.Contains(treeOutput, "pyxis_") {
 			return false, nil
 		}
-		s.squashPath = squashPath
-		s.exec.Logf("enroot containers: tracked squashfs path=%s", squashPath)
-		return true, nil
-	}); err != nil {
-		return err
-	}
-	return nil
+		statValue, err := s.squashStat(waitCtx)
+		if err != nil {
+			return false, err
+		}
+		return statValue != "", nil
+	})
+}
+
+func (s *EnrootContainers) waitForDirectRuntimeCleanedUpAndArtifactRemains(ctx context.Context) error {
+	return s.exec.WaitFor(ctx, "enroot direct squashfs unmounted and image artifact remains", enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
+		mounted, err := s.squashfsMountProcessExists(waitCtx)
+		if err != nil {
+			return false, err
+		}
+		if mounted {
+			return false, nil
+		}
+		statValue, err := s.squashStat(waitCtx)
+		if err != nil {
+			return false, err
+		}
+		return statValue != "", nil
+	})
 }
 
 func (s *EnrootContainers) enrootRuntimeContainerDataIsVisibleWhileTheJobIsRunning(ctx context.Context) error {
@@ -210,102 +371,14 @@ func (s *EnrootContainers) enrootSquashfsImageIsMountedDirectlyWhileTheJobIsRunn
 			if err != nil {
 				return false, err
 			}
-			if !mounted {
-				return false, nil
-			}
-			return true, nil
+			return mounted, nil
 		})
 	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job, err)
 }
 
-func (s *EnrootContainers) theEnrootNCCLJobIsCancelled(ctx context.Context) error {
-	return s.cancelCurrentJob(ctx)
-}
-
-func (s *EnrootContainers) enrootRuntimeDataIsCleanedUpAndSquashfsCacheRemains(ctx context.Context) error {
-	if s.squashPath == "" {
-		return fmt.Errorf("squashfs path is not captured")
-	}
-	if s.connectionWorker == "" {
-		return fmt.Errorf("enroot connection worker is not selected")
-	}
-
-	err := s.exec.WaitFor(ctx, "enroot runtime data cleaned and squashfs cache remains", enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
-		treeOutput, err := s.legacyEnrootDataTree(waitCtx, s.connectionWorker)
-		if err != nil {
-			return false, err
-		}
-		if strings.Contains(treeOutput, "pyxis_") {
-			return false, nil
-		}
-		if _, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(waitCtx, fmt.Sprintf("sudo test -f %s", framework.ShellQuote(s.squashPath))); err != nil {
-			return false, err
-		}
-		statOutput, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(waitCtx, fmt.Sprintf("sudo stat -c '%%Y:%%s' %s", framework.ShellQuote(s.squashPath)))
-		if err != nil {
-			return false, err
-		}
-		statValue := strings.TrimSpace(statOutput)
-		if statValue == "" {
-			return false, nil
-		}
-		s.squashStatBefore = statValue
-		return true, nil
-	})
-	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job, err)
-}
-
-func (s *EnrootContainers) enrootDirectRuntimeIsCleanedUpAndSquashfsCacheRemains(ctx context.Context) error {
-	if s.squashPath == "" {
-		return fmt.Errorf("squashfs path is not captured")
-	}
-	if s.connectionWorker == "" {
-		return fmt.Errorf("enroot connection worker is not selected")
-	}
-
-	return s.exec.WaitFor(ctx, "enroot direct squashfs unmounted and cache remains", enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
-		mounted, err := s.squashfsMountProcessExists(waitCtx)
-		if err != nil {
-			return false, err
-		}
-		if mounted {
-			return false, nil
-		}
-		statValue, err := s.squashStat(waitCtx)
-		if err != nil {
-			return false, err
-		}
-		if statValue == "" {
-			return false, nil
-		}
-		s.squashStatBefore = statValue
-		return true, nil
-	})
-}
-
-func (s *EnrootContainers) theSameEnrootNCCLJobIsSubmittedAgain(ctx context.Context) error {
-	if err := s.submitEnrootJob(ctx, "", "e2e-enroot-repeated"); err != nil {
-		return err
-	}
-	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job,
-		s.slurm.WaitForJobRunning(ctx, s.job.ID, enrootJobStartTimeout))
-}
-
-func (s *EnrootContainers) enrootRuntimeDataIsRepopulatedWithoutChangingTheSquashfsArtifact(ctx context.Context) error {
-	if s.squashPath == "" {
-		return fmt.Errorf("squashfs path is not captured")
-	}
-	if s.squashStatBefore == "" {
-		return fmt.Errorf("baseline squashfs stat is not captured")
-	}
-	if s.connectionWorker == "" {
-		return fmt.Errorf("enroot connection worker is not selected")
-	}
-
-	err := framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "enroot data repopulated from cache",
+func (s *EnrootContainers) enrootSquashfsArtifactIsReusedWithMaterializedRuntime(ctx context.Context) error {
+	err := framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "enroot image artifact reused with materialized runtime",
 		enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
-			// We validate cache reuse by checking the tracked squashfs stat is unchanged
-			// while runtime data is recreated. We do not compare full directory trees.
 			treeOutput, err := s.legacyEnrootDataTree(waitCtx, s.connectionWorker)
 			if err != nil {
 				return false, err
@@ -313,28 +386,17 @@ func (s *EnrootContainers) enrootRuntimeDataIsRepopulatedWithoutChangingTheSquas
 			if !strings.Contains(treeOutput, "pyxis_") {
 				return false, nil
 			}
-
-			statOutput, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(waitCtx, fmt.Sprintf("sudo stat -c '%%Y:%%s' %s", framework.ShellQuote(s.squashPath)))
+			statOutput, err := s.squashStat(waitCtx)
 			if err != nil {
 				return false, err
 			}
-			return strings.TrimSpace(statOutput) == s.squashStatBefore, nil
+			return statOutput == s.squashStatBefore, nil
 		})
 	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job, err)
 }
 
-func (s *EnrootContainers) enrootSquashfsArtifactIsReusedWithoutMaterializingRuntimeData(ctx context.Context) error {
-	if s.squashPath == "" {
-		return fmt.Errorf("squashfs path is not captured")
-	}
-	if s.squashStatBefore == "" {
-		return fmt.Errorf("baseline squashfs stat is not captured")
-	}
-	if s.connectionWorker == "" {
-		return fmt.Errorf("enroot connection worker is not selected")
-	}
-
-	err := framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "enroot direct squashfs reused from cache",
+func (s *EnrootContainers) enrootSquashfsArtifactIsReusedWithDirectMount(ctx context.Context) error {
+	err := framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "enroot image artifact reused with direct squashfs mount",
 		enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
 			mounted, err := s.squashfsMountProcessExists(waitCtx)
 			if err != nil {
@@ -352,147 +414,6 @@ func (s *EnrootContainers) enrootSquashfsArtifactIsReusedWithoutMaterializingRun
 	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job, err)
 }
 
-func (s *EnrootContainers) theRepeatedEnrootNCCLJobIsCancelled(ctx context.Context) error {
-	return s.cancelCurrentJob(ctx)
-}
-
-func (s *EnrootContainers) aNamedEnrootContainerJobIsSubmitted(ctx context.Context) error {
-	if err := s.submitEnrootJob(ctx, enrootNamedJobName, "e2e-enroot-named"); err != nil {
-		return err
-	}
-	if err := framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job,
-		s.slurm.WaitForJobRunning(ctx, s.job.ID, enrootJobStartTimeout)); err != nil {
-		return err
-	}
-	namedDir := namedEnrootDir(enrootNamedJobName)
-	err := framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "named enroot runtime directory created",
-		enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
-			for _, worker := range s.workers {
-				treeOutput, err := s.legacyEnrootDataTree(waitCtx, worker)
-				if err != nil {
-					return false, err
-				}
-				if !strings.Contains(treeOutput, namedDir) {
-					return false, nil
-				}
-			}
-			return true, nil
-		})
-	if err := framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job, err); err != nil {
-		return err
-	}
-	// Mirror the explicit "still running" Gherkin step from the other cancellations:
-	// catch the case where the named job died between dir‑creation and our cancel.
-	if err := framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job,
-		s.slurm.AssertJobRunning(ctx, s.job.ID)); err != nil {
-		return err
-	}
-	return s.cancelCurrentJob(ctx)
-}
-
-func (s *EnrootContainers) theNamedEnrootRuntimeDirectoryRemainsAfterCancellation(ctx context.Context) error {
-	namedDir := namedEnrootDir(enrootNamedJobName)
-
-	return s.exec.WaitFor(ctx, "named enroot runtime directory remains", enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
-		for _, worker := range s.workers {
-			treeOutput, err := s.legacyEnrootDataTree(waitCtx, worker)
-			if err != nil {
-				return false, err
-			}
-			if !strings.Contains(treeOutput, namedDir) {
-				return false, nil
-			}
-		}
-		return true, nil
-	})
-}
-
-func (s *EnrootContainers) theNamedEnrootRuntimeDirectoryIsCleanedUp(ctx context.Context) error {
-	if len(s.workers) == 0 {
-		return fmt.Errorf("enroot workers are not selected")
-	}
-
-	cleanupWrap := fmt.Sprintf("srun rm -rf %s", framework.ShellQuote(namedEnrootDirPath(enrootNamedJobName)))
-	cleanup, err := s.slurm.SubmitBatch(ctx, framework.SbatchOptions{
-		JobName:      "e2e-enroot-cleanup",
-		Nodes:        2,
-		Nodelist:     s.workers,
-		TasksPerNode: 1,
-		Wrap:         cleanupWrap,
-	})
-	if err != nil {
-		return err
-	}
-	s.exec.Logf("enroot containers: submitted cleanup job id=%s stdout=%s stderr=%s",
-		cleanup.ID, cleanup.StdoutPath, cleanup.StderrPath)
-	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, cleanup,
-		s.slurm.WaitForJobGone(ctx, cleanup.ID, enrootStopTimeout))
-}
-
-func (s *EnrootContainers) theNamedEnrootRuntimeDirectoryIsRemoved(ctx context.Context) error {
-	namedDir := namedEnrootDir(enrootNamedJobName)
-	return s.exec.WaitFor(ctx, "named enroot runtime directory removed", enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
-		for _, worker := range s.workers {
-			treeOutput, err := s.legacyEnrootDataTree(waitCtx, worker)
-			if err != nil {
-				return false, err
-			}
-			if strings.Contains(treeOutput, namedDir) {
-				return false, nil
-			}
-		}
-		return true, nil
-	})
-}
-
-func (s *EnrootContainers) submitEnrootJob(ctx context.Context, containerName, jobName string) error {
-	if len(s.workers) == 0 {
-		workers, err := s.slurm.AnyGPUWorkers(2)
-		if err != nil {
-			return err
-		}
-		s.workers = workers
-		s.connectionWorker = s.workers[0]
-		s.exec.Logf("enroot containers: selected workers=%s", strings.Join(s.workers, ","))
-	} else if s.connectionWorker == "" {
-		s.connectionWorker = s.workers[0]
-	}
-
-	// Wrap the NCCL body in `bash -lc` so env assignments (NCCL_*=…) are
-	// shell‑parsed inside the container instead of being passed as positional
-	// args to srun / pyxis, where execve() treats them as the program name and
-	// fails with "No such file or directory". Mirrors docker_containers.go.
-	wrap := fmt.Sprintf("srun --mpi=pmix --container-image=%s --container-mounts=%s bash -lc %s",
-		framework.ShellQuote(e2eNCCLContainerImageEnroot),
-		framework.ShellQuote(enrootDockerMount),
-		framework.ShellQuote(enrootARP),
-	)
-	if containerName != "" {
-		wrap = fmt.Sprintf("srun --mpi=pmix --container-image=%s --container-name=%s --container-mounts=%s bash -lc %s",
-			framework.ShellQuote(e2eNCCLContainerImageEnroot),
-			framework.ShellQuote(containerName),
-			framework.ShellQuote(enrootDockerMount),
-			framework.ShellQuote(enrootARP),
-		)
-	}
-
-	job, err := s.slurm.SubmitBatch(ctx, framework.SbatchOptions{
-		JobName:      jobName,
-		Nodes:        2,
-		Nodelist:     s.workers,
-		GPUsPerNode:  8,
-		TasksPerNode: enrootTasksPerNode,
-		Wrap:         wrap,
-	})
-	if err != nil {
-		return err
-	}
-	s.job = job
-	s.exec.Logf("enroot containers: submitted job=%s id=%s stdout=%s stderr=%s",
-		job.JobName, job.ID, job.StdoutPath, job.StderrPath)
-	return nil
-}
-
 func (s *EnrootContainers) cancelCurrentJob(ctx context.Context) error {
 	if s.job.IsZero() {
 		return nil
@@ -506,46 +427,118 @@ func (s *EnrootContainers) cancelCurrentJob(ctx context.Context) error {
 	return nil
 }
 
-func (s *EnrootContainers) removeNamedRuntimeDir(ctx context.Context) error {
-	if len(s.workers) == 0 {
-		return nil
-	}
-	var failures []string
-	for _, worker := range s.workers {
-		_, err := s.exec.Worker(worker).Run(ctx, fmt.Sprintf("sudo rm -rf %s", framework.ShellQuote(namedEnrootDirPath(enrootNamedJobName))))
-		if err != nil {
-			failures = append(failures, fmt.Sprintf("%s: %v", worker, err))
-		}
-	}
-	if len(failures) > 0 {
-		return errors.New(strings.Join(failures, "; "))
-	}
-	return nil
+type enrootSquashArtifact struct {
+	stat     string
+	imageURI string
 }
 
-func pickSquashPath(findOutput string) string {
-	var fallback string
-	for _, line := range strings.Split(findOutput, "\n") {
+func (s *EnrootContainers) pickTrackedSquashArtifact(ctx context.Context) (string, string, bool, error) {
+	if s.expectedSquashPath == "" {
+		expectedSquashPath, err := s.expectedLifecycleSquashPath(ctx)
+		if err != nil {
+			return "", "", false, err
+		}
+		s.expectedSquashPath = expectedSquashPath
+	}
+
+	exists, err := s.pathExists(ctx, s.expectedSquashPath)
+	if err != nil {
+		return "", "", false, err
+	}
+	if exists {
+		statValue, err := s.squashStatForPath(ctx, s.expectedSquashPath)
+		if err != nil {
+			return "", "", false, err
+		}
+		return s.expectedSquashPath, statValue, true, nil
+	}
+
+	current, err := s.squashArtifacts(ctx)
+	if err != nil {
+		return "", "", false, err
+	}
+
+	for squashPath, artifact := range current {
+		if artifact.imageURI == enrootLifecycleImage {
+			return squashPath, artifact.stat, true, nil
+		}
+	}
+	for squashPath, artifact := range current {
+		if s.squashArtifactsBeforeJob[squashPath].stat != artifact.stat {
+			return squashPath, artifact.stat, true, nil
+		}
+	}
+
+	return "", "", false, nil
+}
+
+func (s *EnrootContainers) expectedLifecycleSquashPath(ctx context.Context) (string, error) {
+	digest, err := s.enrootImageDigest(ctx, enrootLifecycleImage)
+	if err != nil {
+		return "", err
+	}
+	return path.Join(enrootSquashRoot, digest+".sqsh"), nil
+}
+
+func (s *EnrootContainers) enrootImageDigest(ctx context.Context, image string) (string, error) {
+	if s.connectionWorker == "" {
+		return "", fmt.Errorf("enroot connection worker is not selected")
+	}
+
+	output, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(ctx,
+		fmt.Sprintf("enroot digest %s", framework.ShellQuote(image)))
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(output, "\n") {
 		candidate := strings.TrimSpace(line)
-		if candidate == "" {
+		if strings.HasPrefix(candidate, "sha256:") {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("digest for enroot image %s not found in output:\n%s", image, strings.TrimSpace(output))
+}
+
+func (s *EnrootContainers) pathExists(ctx context.Context, targetPath string) (bool, error) {
+	output, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(ctx,
+		fmt.Sprintf("sudo test -f %s && echo exists || true", framework.ShellQuote(targetPath)))
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(output) == "exists", nil
+}
+
+func (s *EnrootContainers) squashArtifacts(ctx context.Context) (map[string]enrootSquashArtifact, error) {
+	if s.connectionWorker == "" {
+		return nil, fmt.Errorf("enroot connection worker is not selected")
+	}
+
+	output, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(ctx,
+		fmt.Sprintf("sudo find %s -type f -name '*%s' 2>/dev/null | sort", framework.ShellQuote(enrootSquashRoot), enrootSquashPattern))
+	if err != nil {
+		return nil, err
+	}
+
+	artifacts := make(map[string]enrootSquashArtifact)
+	for _, line := range strings.Split(output, "\n") {
+		squashPath := strings.TrimSpace(line)
+		if squashPath == "" {
 			continue
 		}
-		if fallback == "" {
-			fallback = candidate
+		statValue, err := s.squashStatForPath(ctx, squashPath)
+		if err != nil {
+			return nil, err
 		}
-		if strings.Contains(candidate, enrootSquashPattern) {
-			return candidate
+		imageURI, err := s.squashImageURI(ctx, squashPath)
+		if err != nil {
+			return nil, err
+		}
+		artifacts[squashPath] = enrootSquashArtifact{
+			stat:     statValue,
+			imageURI: imageURI,
 		}
 	}
-	return fallback
-}
-
-func namedEnrootDir(containerName string) string {
-	return "pyxis_" + containerName
-}
-
-func namedEnrootDirPath(containerName string) string {
-	return path.Join(enrootDedicatedDataPath, namedEnrootDir(containerName))
+	return artifacts, nil
 }
 
 func (s *EnrootContainers) squashfsMountProcessExists(ctx context.Context) (bool, error) {
@@ -572,11 +565,24 @@ func (s *EnrootContainers) enrootDirectSquashFSEnabled(ctx context.Context) (boo
 }
 
 func (s *EnrootContainers) squashStat(ctx context.Context) (string, error) {
-	statOutput, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(ctx, fmt.Sprintf("sudo stat -c '%%Y:%%s' %s", framework.ShellQuote(s.squashPath)))
+	return s.squashStatForPath(ctx, s.squashPath)
+}
+
+func (s *EnrootContainers) squashStatForPath(ctx context.Context, squashPath string) (string, error) {
+	statOutput, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(ctx, fmt.Sprintf("sudo stat -c '%%Y:%%s' %s", framework.ShellQuote(squashPath)))
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(statOutput), nil
+}
+
+func (s *EnrootContainers) squashImageURI(ctx context.Context, squashPath string) (string, error) {
+	output, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(ctx,
+		fmt.Sprintf("sudo getfattr --only-values -n user.image_uri %s 2>/dev/null || true", framework.ShellQuote(squashPath)))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
 }
 
 func (s *EnrootContainers) legacyEnrootDataTree(ctx context.Context, worker string) (string, error) {

--- a/internal/e2e/acceptance/steps/enroot_containers.go
+++ b/internal/e2e/acceptance/steps/enroot_containers.go
@@ -19,11 +19,7 @@ const (
 	enrootLifecycleImage   = "docker://cr.eu-north1.nebius.cloud#soperator/ubuntu:noble"
 	enrootLifecycleCommand = "echo ready; sleep 3600"
 
-	// Cluster-supported GPU diagnostic image; includes nvidia-smi for container GPU visibility.
-	enrootGPUImage = "docker://cr.eu-north1.nebius.cloud#ml-containers/training_diag:13.0.2-ubuntu24.04-20260709140028"
-
-	enrootSquashPattern = ".sqsh"
-	enrootSquashRoot    = "/var/cache/enroot-container-images"
+	enrootSquashRoot = "/var/cache/enroot-container-images"
 
 	enrootDedicatedDataPath = "/mnt/image-storage/enroot/data"
 
@@ -41,10 +37,9 @@ type EnrootContainers struct {
 	connectionWorker string
 	job              framework.SbatchJob
 
-	squashPath               string
-	expectedSquashPath       string
-	squashStatBefore         string
-	squashArtifactsBeforeJob map[string]enrootSquashArtifact
+	squashPath         string
+	expectedSquashPath string
+	squashStatBefore   string
 
 	directSquashFS *bool
 }
@@ -102,12 +97,6 @@ func (s *EnrootContainers) aLongRunningEnrootContainerJobIsSubmittedOnTwoWorkers
 	}
 	s.expectedSquashPath = expectedSquashPath
 
-	artifacts, err := s.squashArtifacts(ctx)
-	if err != nil {
-		return err
-	}
-	s.squashArtifactsBeforeJob = artifacts
-
 	return s.submitEnrootLifecycleJob(ctx, "e2e-enroot-initial")
 }
 
@@ -126,15 +115,15 @@ func (s *EnrootContainers) anEnrootImageArtifactIsPresentOnAWorker(ctx context.C
 
 	err := framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "enroot image artifact present",
 		enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
-			squashPath, _, found, err := s.pickTrackedSquashArtifact(waitCtx)
+			found, err := s.expectedSquashArtifactExists(waitCtx)
 			if err != nil {
 				return false, err
 			}
 			if !found {
 				return false, nil
 			}
-			s.squashPath = squashPath
-			s.exec.Logf("enroot containers: tracked squashfs path=%s", squashPath)
+			s.squashPath = s.expectedSquashPath
+			s.exec.Logf("enroot containers: tracked squashfs path=%s", s.squashPath)
 			return true, nil
 		})
 	return framework.AnnotateWithJobLog(ctx, s.exec, s.slurm, s.job, err)
@@ -217,7 +206,7 @@ func (s *EnrootContainers) anEnrootGPUSmokeJobIsSubmittedOnOneGPUWorker(ctx cont
 	s.connectionWorker = workers[0]
 
 	wrap := fmt.Sprintf("NVIDIA_DRIVER_CAPABILITIES=utility srun --container-image=%s nvidia-smi -L",
-		framework.ShellQuote(enrootGPUImage),
+		framework.ShellQuote(gpuSmokeEnrootImage),
 	)
 	job, err := s.slurm.SubmitBatch(ctx, framework.SbatchOptions{
 		JobName:      "e2e-enroot-gpu-smoke",
@@ -298,12 +287,16 @@ func (s *EnrootContainers) waitForRuntimeStateCleanedUpAndArtifactRemains(ctx co
 }
 
 func (s *EnrootContainers) waitForMaterializedRuntimeCleanedUpAndArtifactRemains(ctx context.Context) error {
+	runtimePrefix, err := s.enrootRuntimeNamePrefix()
+	if err != nil {
+		return err
+	}
 	return s.exec.WaitFor(ctx, "enroot runtime data cleaned and image artifact remains", enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
 		treeOutput, err := s.legacyEnrootDataTree(waitCtx, s.connectionWorker)
 		if err != nil {
 			return false, err
 		}
-		if strings.Contains(treeOutput, "pyxis_") {
+		if strings.Contains(treeOutput, runtimePrefix) {
 			return false, nil
 		}
 		statValue, err := s.squashStat(waitCtx)
@@ -335,8 +328,12 @@ func (s *EnrootContainers) enrootRuntimeContainerDataIsVisibleWhileTheJobIsRunni
 	if s.connectionWorker == "" {
 		return fmt.Errorf("enroot connection worker is not selected")
 	}
+	runtimePrefix, err := s.enrootRuntimeNamePrefix()
+	if err != nil {
+		return err
+	}
 
-	err := framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "enroot runtime container visible",
+	err = framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "enroot runtime container visible",
 		enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
 			listOutput, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(waitCtx, "sudo enroot list || true")
 			if err != nil {
@@ -346,10 +343,10 @@ func (s *EnrootContainers) enrootRuntimeContainerDataIsVisibleWhileTheJobIsRunni
 			if err != nil {
 				return false, err
 			}
-			if !strings.Contains(listOutput, "pyxis_") {
+			if !strings.Contains(listOutput, runtimePrefix) {
 				return false, nil
 			}
-			if !strings.Contains(treeOutput, "pyxis_") {
+			if !strings.Contains(treeOutput, runtimePrefix) {
 				return false, nil
 			}
 			return true, nil
@@ -377,13 +374,17 @@ func (s *EnrootContainers) enrootSquashfsImageIsMountedDirectlyWhileTheJobIsRunn
 }
 
 func (s *EnrootContainers) enrootSquashfsArtifactIsReusedWithMaterializedRuntime(ctx context.Context) error {
-	err := framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "enroot image artifact reused with materialized runtime",
+	runtimePrefix, err := s.enrootRuntimeNamePrefix()
+	if err != nil {
+		return err
+	}
+	err = framework.WaitForWithJobAlive(ctx, s.exec, s.slurm, s.job, "enroot image artifact reused with materialized runtime",
 		enrootProbeTimeout, framework.DefaultPollInterval, func(waitCtx context.Context) (bool, error) {
 			treeOutput, err := s.legacyEnrootDataTree(waitCtx, s.connectionWorker)
 			if err != nil {
 				return false, err
 			}
-			if !strings.Contains(treeOutput, "pyxis_") {
+			if !strings.Contains(treeOutput, runtimePrefix) {
 				return false, nil
 			}
 			statOutput, err := s.squashStat(waitCtx)
@@ -427,49 +428,20 @@ func (s *EnrootContainers) cancelCurrentJob(ctx context.Context) error {
 	return nil
 }
 
-type enrootSquashArtifact struct {
-	stat     string
-	imageURI string
-}
-
-func (s *EnrootContainers) pickTrackedSquashArtifact(ctx context.Context) (string, string, bool, error) {
+func (s *EnrootContainers) expectedSquashArtifactExists(ctx context.Context) (bool, error) {
 	if s.expectedSquashPath == "" {
 		expectedSquashPath, err := s.expectedLifecycleSquashPath(ctx)
 		if err != nil {
-			return "", "", false, err
+			return false, err
 		}
 		s.expectedSquashPath = expectedSquashPath
 	}
 
 	exists, err := s.pathExists(ctx, s.expectedSquashPath)
 	if err != nil {
-		return "", "", false, err
+		return false, err
 	}
-	if exists {
-		statValue, err := s.squashStatForPath(ctx, s.expectedSquashPath)
-		if err != nil {
-			return "", "", false, err
-		}
-		return s.expectedSquashPath, statValue, true, nil
-	}
-
-	current, err := s.squashArtifacts(ctx)
-	if err != nil {
-		return "", "", false, err
-	}
-
-	for squashPath, artifact := range current {
-		if artifact.imageURI == enrootLifecycleImage {
-			return squashPath, artifact.stat, true, nil
-		}
-	}
-	for squashPath, artifact := range current {
-		if s.squashArtifactsBeforeJob[squashPath].stat != artifact.stat {
-			return squashPath, artifact.stat, true, nil
-		}
-	}
-
-	return "", "", false, nil
+	return exists, nil
 }
 
 func (s *EnrootContainers) expectedLifecycleSquashPath(ctx context.Context) (string, error) {
@@ -508,39 +480,6 @@ func (s *EnrootContainers) pathExists(ctx context.Context, targetPath string) (b
 	return strings.TrimSpace(output) == "exists", nil
 }
 
-func (s *EnrootContainers) squashArtifacts(ctx context.Context) (map[string]enrootSquashArtifact, error) {
-	if s.connectionWorker == "" {
-		return nil, fmt.Errorf("enroot connection worker is not selected")
-	}
-
-	output, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(ctx,
-		fmt.Sprintf("sudo find %s -type f -name '*%s' 2>/dev/null | sort", framework.ShellQuote(enrootSquashRoot), enrootSquashPattern))
-	if err != nil {
-		return nil, err
-	}
-
-	artifacts := make(map[string]enrootSquashArtifact)
-	for _, line := range strings.Split(output, "\n") {
-		squashPath := strings.TrimSpace(line)
-		if squashPath == "" {
-			continue
-		}
-		statValue, err := s.squashStatForPath(ctx, squashPath)
-		if err != nil {
-			return nil, err
-		}
-		imageURI, err := s.squashImageURI(ctx, squashPath)
-		if err != nil {
-			return nil, err
-		}
-		artifacts[squashPath] = enrootSquashArtifact{
-			stat:     statValue,
-			imageURI: imageURI,
-		}
-	}
-	return artifacts, nil
-}
-
 func (s *EnrootContainers) squashfsMountProcessExists(ctx context.Context) (bool, error) {
 	output, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(ctx,
 		fmt.Sprintf("sudo ps -eww -o args= | grep -F -- %s | grep -F -- squashfuse | grep -v grep || true", framework.ShellQuote(s.squashPath)))
@@ -576,15 +515,13 @@ func (s *EnrootContainers) squashStatForPath(ctx context.Context, squashPath str
 	return strings.TrimSpace(statOutput), nil
 }
 
-func (s *EnrootContainers) squashImageURI(ctx context.Context, squashPath string) (string, error) {
-	output, err := s.exec.Worker(s.connectionWorker).RunWithDefaultRetry(ctx,
-		fmt.Sprintf("sudo getfattr --only-values -n user.image_uri %s 2>/dev/null || true", framework.ShellQuote(squashPath)))
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(output), nil
-}
-
 func (s *EnrootContainers) legacyEnrootDataTree(ctx context.Context, worker string) (string, error) {
 	return s.exec.Worker(worker).RunWithDefaultRetry(ctx, fmt.Sprintf("sudo tree -L 1 %s", framework.ShellQuote(enrootDedicatedDataPath)))
+}
+
+func (s *EnrootContainers) enrootRuntimeNamePrefix() (string, error) {
+	if s.job.IsZero() {
+		return "", fmt.Errorf("enroot job id is empty")
+	}
+	return fmt.Sprintf("pyxis_%s.", s.job.ID), nil
 }

--- a/internal/e2e/acceptance/steps/enroot_containers.go
+++ b/internal/e2e/acceptance/steps/enroot_containers.go
@@ -40,6 +40,7 @@ type EnrootContainers struct {
 	squashPath         string
 	expectedSquashPath string
 	squashStatBefore   string
+	runtimeNamePrefix  string
 
 	directSquashFS *bool
 }
@@ -90,6 +91,7 @@ func (s *EnrootContainers) aLongRunningEnrootContainerJobIsSubmittedOnTwoWorkers
 	s.squashPath = ""
 	s.expectedSquashPath = ""
 	s.squashStatBefore = ""
+	s.runtimeNamePrefix = ""
 
 	expectedSquashPath, err := s.expectedLifecycleSquashPath(ctx)
 	if err != nil {
@@ -263,6 +265,7 @@ func (s *EnrootContainers) submitEnrootLifecycleJob(ctx context.Context, jobName
 		return err
 	}
 	s.job = job
+	s.runtimeNamePrefix = fmt.Sprintf("pyxis_%s.", job.ID)
 	s.exec.Logf("enroot containers: submitted job=%s id=%s stdout=%s stderr=%s",
 		job.JobName, job.ID, job.StdoutPath, job.StderrPath)
 	return nil
@@ -520,8 +523,8 @@ func (s *EnrootContainers) legacyEnrootDataTree(ctx context.Context, worker stri
 }
 
 func (s *EnrootContainers) enrootRuntimeNamePrefix() (string, error) {
-	if s.job.IsZero() {
-		return "", fmt.Errorf("enroot job id is empty")
+	if s.runtimeNamePrefix == "" {
+		return "", fmt.Errorf("enroot runtime name prefix is not captured")
 	}
-	return fmt.Sprintf("pyxis_%s.", s.job.ID), nil
+	return s.runtimeNamePrefix, nil
 }


### PR DESCRIPTION
## Problem

Docker and Enroot acceptance scenarios were based on long NCCL workloads and manual cache/runtime inspection flows. They were slow, fragile, hard to debug, and mixed several concerns together: container runtime lifecycle, image cache behavior, Slurm cancellation behavior, and GPU visibility.

## Solution

Simplified the container acceptance coverage into focused scenarios:

- Docker lifecycle now uses a small mirrored BusyBox image to verify Docker containers run under Slurm, populate local Docker storage, and are explicitly stopped after cancellation.
- 
- Enroot/Pyxis lifecycle now uses a mirrored Ubuntu image because Pyxis runs the Slurm task prolog inside the container and requires /bin/bash; the scenario verifies image artifact persistence, runtime cleanup, and cache reuse.

- GPU visibility is covered by separate Docker and Enroot smoke scenarios using the cluster-supported training_diag image and nvidia-smi -L.
- Removed the old shared hardcoded NCCL image constants and the obsolete NCCL-based scenario flow.
- Kept explicit Docker cleanup because dev-cluster testing confirmed Docker containers can remain running after scancel.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

E2E run - https://github.com/nebius/soperator/actions/runs/29919869911

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
