### PR TITLE
SCHED-2105: Pin kube-state-metrics to system nodes and make its resources tunable

### DIFF
--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -76,6 +76,18 @@ spec:
           datasources:
             searchNamespace: {{- toYaml .Values.observability.vmStack.values.dashboardNamespaces | nindent 12 }}
       kube-state-metrics:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: slurm.nebius.ai/nodeset
+                      operator: In
+                      values:
+                        - system
+        {{- with $kubeStateMetrics.resources }}
+        resources: {{- toYaml . | nindent 10 }}
+        {{- end }}
         extraArgs:
           - '--metric-allowlist=kube_pod_info'
           - '--metric-allowlist=kube_pod_created'

--- a/helm/soperator-fluxcd/tests/kube_state_metrics_test.yaml
+++ b/helm/soperator-fluxcd/tests/kube_state_metrics_test.yaml
@@ -29,3 +29,42 @@ tests:
       - equal:
           path: spec.values.kube-state-metrics.vmScrape.spec.endpoints[0].max_scrape_size
           value: "150554432"
+
+  - it: should not set kube-state-metrics resources by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.values.kube-state-metrics.resources
+
+  - it: should pin kube-state-metrics to system nodes
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.kube-state-metrics.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: slurm.nebius.ai/nodeset
+      - equal:
+          path: spec.values.kube-state-metrics.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+          value: system
+
+  - it: should pass kube-state-metrics resources through
+    set:
+      observability.vmStack.values.kubeStateMetrics.resources:
+        requests:
+          cpu: 200m
+          memory: 1024Mi
+        limits:
+          memory: 2048Mi
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.values.kube-state-metrics.resources.requests.cpu
+          value: 200m
+      - equal:
+          path: spec.values.kube-state-metrics.resources.requests.memory
+          value: 1024Mi
+      - equal:
+          path: spec.values.kube-state-metrics.resources.limits.memory
+          value: 2048Mi


### PR DESCRIPTION
## Problem

Two problems with the kube-state-metrics pod:

1. Nothing tells the scheduler where to put it. It usually lands on a system node by luck, but it can also land on a worker node, where infra pods compete for the ~1 CPU left after the Slurm worker takes the rest (SCHED-1519).
2. There is no way to set its resource requests/limits through our chart values. Today it runs with no requests at all, so the scheduler reserves no room for it and it's the first pod to be evicted under memory pressure - while its memory use grows with the cluster.

## Solution

- Pin kube-state-metrics to system nodes (required node affinity on `slurm.nebius.ai/nodeset=system`). If system nodes are full, it waits instead of degrading a worker node.
- Pass `observability.vmStack.values.kubeStateMetrics.resources` through to the kube-state-metrics chart. Terraform will supply per-cluster-size values.

## Related PRs

- nebius/nebius-solutions-library#1093 - the terraform side that fills in the resources values. Those values do nothing until this PR ships, so this one goes first (or in the same release).
- Covers the kube-state-metrics part of SCHED-1519; placement for the other infra Deployments stays in that ticket.

## Testing

Added helm unit tests for the node affinity and the resources passthrough. `helm unittest` passes (120 tests).

e2e test run covering this PR together with nebius/nebius-solutions-library#1093: https://github.com/nebius/soperator/actions/runs/29948551520

## Release Notes

Feature: kube-state-metrics is pinned to system nodes and its resources can be tuned via `observability.vmStack.values.kubeStateMetrics.resources`.
