### PR TITLE
Validate enabled built-in Slurm scripts

### DIFF
--- a/helm/slurm-cluster/templates/slurm-scripts-cm.yaml
+++ b/helm/slurm-cluster/templates/slurm-scripts-cm.yaml
@@ -24,7 +24,11 @@ data:
   {{- if $conf.customContent }}
 {{ tpl ($conf.customContent) $ | indent 4 }}
   {{- else }}
-{{ tpl (printf "slurm_scripts/%s" $name | $.Files.Get) $ | indent 4 }}
+    {{- $content := printf "slurm_scripts/%s" $name | $.Files.Get }}
+    {{- if not $content }}
+      {{- fail (printf "slurmScripts.builtIn.%s is enabled but no bundled script exists; remove this obsolete entry or set customContent" $name) }}
+    {{- end }}
+{{ tpl $content $ | indent 4 }}
   {{- end }}
 {{- end }}
 {{- end }}
@@ -41,7 +45,11 @@ data:
     {{- if $conf.customConfig }}
       {{- $checks = append $checks (fromJson (tpl ($conf.customConfig) $)) }}
     {{- else }}
-      {{- $checks = append $checks (fromJson (tpl (printf "slurm_scripts/%s.json" $name | $.Files.Get) $)) }}
+      {{- $config := printf "slurm_scripts/%s.json" $name | $.Files.Get }}
+      {{- if not $config }}
+        {{- fail (printf "slurmScripts.builtIn.%s is enabled but no bundled check configuration exists; remove this obsolete entry or set customConfig" $name) }}
+      {{- end }}
+      {{- $checks = append $checks (fromJson (tpl $config $)) }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/slurm-cluster/tests/slurm_scripts_test.yaml
+++ b/helm/slurm-cluster/tests/slurm_scripts_test.yaml
@@ -1,0 +1,26 @@
+suite: test Slurm scripts configuration
+templates:
+  - slurm-scripts-cm.yaml
+tests:
+  - it: should reject an enabled built-in without a bundled script
+    set:
+      slurmScripts:
+        builtIn:
+          removed_check.sh:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "slurmScripts.builtIn.removed_check.sh is enabled but no bundled script exists; remove this obsolete entry or set customContent"
+
+  - it: should reject an enabled built-in without a bundled check configuration
+    set:
+      slurmScripts:
+        builtIn:
+          removed_check.sh:
+            enabled: true
+            customContent: |-
+              #!/bin/bash
+              exit 0
+    asserts:
+      - failedTemplate:
+          errorMessage: "slurmScripts.builtIn.removed_check.sh is enabled but no bundled check configuration exists; remove this obsolete entry or set customConfig"


### PR DESCRIPTION
## Summary

- verify that every enabled `slurmScripts.builtIn` entry has bundled script content when `customContent` is not provided
- verify that every enabled built-in has a bundled JSON check specification when `customConfig` is not provided
- fail Helm rendering with an actionable migration error when either asset is missing
- add Helm coverage for both missing-script and missing-configuration cases

## Why

Helm values can retain an enabled built-in entry after that check has been removed from a newer chart version. The template previously accepted the unknown key, rendered an empty script, and attempted to parse an empty check specification. The resulting malformed `checks.json` could cause `check_runner.py` to reject the complete configuration and run no health checks.

This issue was identified while preparing #2778. It is implemented separately from `main` so #2778 can remain focused on removing the obsolete `alloc_mem_used` check.

## Impact

Upgrades with stale or misspelled enabled built-in keys now fail during Helm rendering with instructions to remove the obsolete entry or provide the corresponding custom content/configuration.

Valid bundled checks and built-ins with explicit `customContent` or `customConfig` continue to render unchanged.

## Validation

- `helm unittest -f 'tests/slurm_scripts_test.yaml' helm/slurm-cluster` — 2 tests passed
- `helm unittest helm/slurm-cluster` — 101 tests passed across 18 suites
- default `helm template` rendering passed
- `git diff --check` passed
