### PR TITLE
SCHED-1909: serve rebooter node reads from a node-restricted cache

### DIFF
--- a/cmd/rebooter/main.go
+++ b/cmd/rebooter/main.go
@@ -30,10 +30,14 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/klog/v2"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -154,7 +158,19 @@ func main() {
 	})
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
+		Scheme: scheme,
+		// The rebooter runs on every node, so an unrestricted cache would hold the whole cluster in every pod.
+		// The field selectors below are server-side: any informer this manager ever starts LISTs and WATCHes
+		// only this pod's own node and the pods running on it.
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Node{}: {Field: fields.OneTermEqualSelector("metadata.name", nodeName)},
+				// Guardrail: nothing caches pods today (pod reads go through the kubelet via nodes/proxy),
+				// but a single cached pod read added in the future would silently start an informer over
+				// every pod in the cluster. This selector caps such an informer to this node's own pods.
+				&corev1.Pod{}: {Field: fields.OneTermEqualSelector("spec.nodeName", nodeName)},
+			},
+		},
 		Metrics:                metricsopts.ServerOptions(metricsAddr, secureMetrics, tlsOpts),
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,

--- a/internal/rebooter/reconcile.go
+++ b/internal/rebooter/reconcile.go
@@ -119,11 +119,13 @@ func (r *RebooterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{RequeueAfter: r.reconcileTimeout}, nil
 }
 
-// getNode returns the node with the given name directly from the API server,
-// bypassing the informer cache.
+// getNode returns the rebooter's own node from the manager cache.
+// The cache is restricted (in cmd/rebooter/main.go) to this single node via a server-side field selector,
+// so the informer started lazily by the first read LISTs and WATCHes one object
+// instead of issuing a direct API request per reconcile.
 func (r *RebooterReconciler) getNode(ctx context.Context) (*corev1.Node, error) {
 	node := &corev1.Node{}
-	if err := r.APIReader.Get(ctx, client.ObjectKey{Name: r.nodeName}, node); err != nil {
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: r.nodeName}, node); err != nil {
 		return nil, fmt.Errorf("failed to get node %s: %w", r.nodeName, err)
 	}
 	return node, nil
@@ -606,9 +608,9 @@ func (r *RebooterReconciler) RebootNode(ctx context.Context, node *corev1.Node) 
 }
 
 // SetupWithManager sets up the controller with the Manager.
-// No node informer is registered — this avoids a LIST+WATCH against the API server
-// at startup. Instead, one GenericEvent is sent on startCh to kick off the first
-// reconcile; subsequent cycles are driven by ctrl.Result{RequeueAfter: ...}.
+// No typed watch is registered: one GenericEvent is sent on startCh to kick off the first reconcile,
+// and subsequent cycles are driven by ctrl.Result{RequeueAfter: ...}.
+// Node reads are served by the manager cache, whose field selectors restrict it to this pod's own node.
 func (r *RebooterReconciler) SetupWithManager(
 	mgr ctrl.Manager, maxConcurrency int, cacheSyncTimeout time.Duration, nodeName string,
 ) error {


### PR DESCRIPTION
## Problem

The rebooter runs on every node. To keep memory low it registers no informer and `getNode` reads the node directly from the API server, which means one GET per node per reconcile interval — constant API server load that grows with cluster size.

## Solution

- Restrict the manager cache with server-side field selectors: `Node` to `metadata.name == <own node>`, `Pod` to `spec.nodeName == <own node>`.
- `getNode` now reads from the cached client; the informer started by the first read LISTs and WATCHes a single object instead of issuing a GET per reconcile.
- `APIReader` stays in the conflict-retry patch helpers, which need a fresh read.

## Testing

- `go test ./internal/rebooter/...` passes.
- E2E run: https://github.com/nebius/soperator/actions/runs/30285117707

## Release Notes

Fix: rebooter serves node reads from a cache restricted to its own node instead of querying the API server every reconcile.