### PR TITLE
 SCHED-2157: Token from IMDS for Otel Collectors

### DIFF
--- a/docs/logs-pipeline.md
+++ b/docs/logs-pipeline.md
@@ -44,6 +44,13 @@ The public logging endpoint defaults to `dns:///write.logging.eu-north1.nebius.c
 `observability.region` does not change the log write region. Set
 `observability.opentelemetry.publicEndpoint` only when an explicit endpoint override is needed.
 
+By default, the o11y TSA token writer fetches the write token from IMDS and
+maintains it in a Kubernetes Secret. The OpenTelemetry log collectors mount that
+Secret and use it through the `bearertokenauth` extension. This avoids requiring
+a pre-existing `/mnt/cloud-metadata` token directory on every collector host.
+`observability.publicEndpointTokenKind: hostPath` remains available for
+installations that intentionally provide the token file from the host.
+
 ## Components
 
 ### Log Collection
@@ -166,8 +173,15 @@ The logging system automatically extracts metadata from filenames and creates th
 observability:
   # Cloud delivery
   publicEndpointEnabled: true  # Enable/disable cloud export
+  publicEndpointTokenKind: secret
   logsProjectId: "your-nebius-project-id"
   region: "eu-north1"
+  tsaToken:
+    secretName: o11y-writer-sa-token
+    secretKey: accessToken
+    writer:
+      source: imds
+      namespaces: []  # Defaults to enabled metrics/log collector namespaces
   opentelemetry:
     # Optional. Defaults to dns:///write.logging.eu-north1.nebius.cloud.:443
     publicEndpoint: "dns:///write.logging.eu-north1.nebius.cloud.:443"

--- a/docs/metrics-pipeline.md
+++ b/docs/metrics-pipeline.md
@@ -176,8 +176,12 @@ curl "http://localhost:8429/api/v1/query?query=up"
 
 #### Remote Write to Nebius Cloud
 - Endpoint: `https://write.monitoring.{region}.nebius.cloud/projects/{projectId}/buckets/soperator/prometheus`
-- Authentication: Bearer token from `/mnt/imds/tsa-token`, populated and refreshed by the vmagent IMDS token sidecar
+- Authentication: Bearer token from the `o11y-writer-sa-token` Secret, populated and refreshed by the shared TSA token writer
 - When: Enabled with `publicEndpointEnabled: true`
+
+The default token writer source is IMDS (`observability.tsaToken.writer.source: imds`).
+Set `observability.publicEndpointTokenKind: hostPath` only when the token should be
+read directly from a host-mounted file such as `/mnt/cloud-metadata/tsa-token`.
 
 ### Visualization
 

--- a/helm/soperator-fluxcd/templates/_helpers.tpl
+++ b/helm/soperator-fluxcd/templates/_helpers.tpl
@@ -64,6 +64,81 @@ Validate observability.publicEndpointTokenKind is one of: secret, hostPath
 {{- end -}}
 
 {{/*
+Resolve o11y TSA token settings. observability.vmStack.tsaToken is kept as a
+legacy override path for existing installations.
+*/}}
+{{- define "soperator-fluxcd.o11yTsaToken" -}}
+{{- $global := .Values.observability.tsaToken | default dict -}}
+{{- $legacy := .Values.observability.vmStack.tsaToken | default dict -}}
+{{- mergeOverwrite (deepCopy $global) $legacy | toYaml -}}
+{{- end -}}
+
+{{- define "soperator-fluxcd.o11yTsaTokenSecretName" -}}
+{{- $token := include "soperator-fluxcd.o11yTsaToken" . | fromYaml -}}
+{{- $token.secretName | default "o11y-writer-sa-token" -}}
+{{- end -}}
+
+{{- define "soperator-fluxcd.o11yTsaTokenSecretKey" -}}
+{{- $token := include "soperator-fluxcd.o11yTsaToken" . | fromYaml -}}
+{{- $token.secretKey | default "accessToken" -}}
+{{- end -}}
+
+{{- define "soperator-fluxcd.o11yTsaTokenMountPath" -}}
+{{- $token := include "soperator-fluxcd.o11yTsaToken" . | fromYaml -}}
+{{- $token.mountPath | default "/o11ytoken" -}}
+{{- end -}}
+
+{{- define "soperator-fluxcd.o11yTsaTokenHostPath" -}}
+{{- $token := include "soperator-fluxcd.o11yTsaToken" . | fromYaml -}}
+{{- $token.hostPath | default "/mnt/cloud-metadata" -}}
+{{- end -}}
+
+{{- define "soperator-fluxcd.o11yTsaTokenHostPathFilename" -}}
+{{- $token := include "soperator-fluxcd.o11yTsaToken" . | fromYaml -}}
+{{- $token.hostPathFilename | default "tsa-token" -}}
+{{- end -}}
+
+{{- define "soperator-fluxcd.o11yTsaTokenWriterName" -}}
+{{- printf "%s-tsa-token-writer" (include "soperator-fluxcd.fullname" .) -}}
+{{- end -}}
+
+{{- define "soperator-fluxcd.o11yTsaTokenWriterNamespace" -}}
+{{- if .Values.observability.vmStack.enabled -}}
+{{- .Values.observability.vmStack.namespace | default "monitoring-system" -}}
+{{- else -}}
+{{- .Values.observability.opentelemetry.namespace | default "logs-system" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "soperator-fluxcd.o11yTsaTokenWriterEnabled" -}}
+{{- $token := include "soperator-fluxcd.o11yTsaToken" . | fromYaml -}}
+{{- $writer := $token.writer | default dict -}}
+{{- $enabled := true -}}
+{{- if hasKey $writer "enabled" -}}
+{{- $enabled = $writer.enabled -}}
+{{- end -}}
+{{- if $enabled -}}true{{- end -}}
+{{- end -}}
+
+{{- define "soperator-fluxcd.o11yTsaTokenWriterNamespaces" -}}
+{{- $token := include "soperator-fluxcd.o11yTsaToken" . | fromYaml -}}
+{{- $writer := $token.writer | default dict -}}
+{{- $configured := $writer.namespaces | default list -}}
+{{- if gt (len $configured) 0 -}}
+{{- $configured | uniq | toYaml -}}
+{{- else -}}
+{{- $namespaces := list -}}
+{{- if .Values.observability.vmStack.enabled -}}
+{{- $namespaces = append $namespaces (.Values.observability.vmStack.namespace | default "monitoring-system") -}}
+{{- end -}}
+{{- if .Values.observability.opentelemetry.enabled -}}
+{{- $namespaces = append $namespaces (.Values.observability.opentelemetry.namespace | default "logs-system") -}}
+{{- end -}}
+{{- $namespaces | uniq | toYaml -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Convert a Kubernetes CPU quantity to a positive GOMAXPROCS value.
 */}}
 {{- define "soperator-fluxcd.cpuQuantityToGOMAXPROCS" -}}

--- a/helm/soperator-fluxcd/templates/o11y-tsa-token-writer.yaml
+++ b/helm/soperator-fluxcd/templates/o11y-tsa-token-writer.yaml
@@ -1,27 +1,27 @@
-{{- if and .Values.observability.enabled .Values.observability.vmStack.enabled .Values.observability.publicEndpointEnabled }}
+{{- if and .Values.observability.enabled .Values.observability.publicEndpointEnabled }}
 {{- $tokenKind := .Values.observability.publicEndpointTokenKind }}
-{{- $tsaToken := .Values.observability.vmStack.tsaToken | default dict }}
+{{- $tsaToken := include "soperator-fluxcd.o11yTsaToken" . | fromYaml }}
 {{- $writer := $tsaToken.writer | default dict }}
 {{- $writerEnabled := true }}
 {{- if hasKey $writer "enabled" }}
 {{- $writerEnabled = $writer.enabled }}
 {{- end }}
-{{- if and $writerEnabled (eq $tokenKind "secret") }}
+{{- if and $writerEnabled (eq $tokenKind "secret") (or .Values.observability.vmStack.enabled .Values.observability.opentelemetry.enabled) }}
 {{- include "soperator-fluxcd.validatePublicEndpointTokenKind" . -}}
-{{- $ns := .Values.observability.vmStack.namespace }}
-{{- $secretName := $tsaToken.secretName | default "o11y-writer-sa-token" }}
-{{- $secretKey := $tsaToken.secretKey | default "accessToken" }}
+{{- $ns := include "soperator-fluxcd.o11yTsaTokenWriterNamespace" . }}
+{{- $secretName := include "soperator-fluxcd.o11yTsaTokenSecretName" . }}
+{{- $secretKey := include "soperator-fluxcd.o11yTsaTokenSecretKey" . }}
 {{- $source := $writer.source | default "imds" }}
-{{- $namespaces := $writer.namespaces | default (list $ns) }}
+{{- $namespaces := include "soperator-fluxcd.o11yTsaTokenWriterNamespaces" . | fromYamlArray }}
 {{- $image := $writer.image | default dict }}
-{{- $repo := required "observability.vmStack.tsaToken.writer.image.repository is required" $image.repository }}
-{{- $tag := required "observability.vmStack.tsaToken.writer.image.tag is required" $image.tag }}
+{{- $repo := required "observability.tsaToken.writer.image.repository is required" $image.repository }}
+{{- $tag := required "observability.tsaToken.writer.image.tag is required" $image.tag }}
 {{- $pullPolicy := $image.pullPolicy | default "IfNotPresent" }}
-{{- $hostPath := $tsaToken.hostPath | default "/mnt/cloud-metadata" }}
-{{- $mountPath := $tsaToken.mountPath | default "/o11ytoken" }}
-{{- $tokenFilename := $tsaToken.hostPathFilename | default "tsa-token" }}
+{{- $hostPath := include "soperator-fluxcd.o11yTsaTokenHostPath" . }}
+{{- $mountPath := include "soperator-fluxcd.o11yTsaTokenMountPath" . }}
+{{- $tokenFilename := include "soperator-fluxcd.o11yTsaTokenHostPathFilename" . }}
 {{- $hostNetwork := and (eq $source "imds") (ne (toString ($writer.hostNetwork | default true)) "false") }}
-{{- $name := printf "%s-tsa-token-writer" (include "soperator-fluxcd.fullname" .) }}
+{{- $name := include "soperator-fluxcd.o11yTsaTokenWriterName" . }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -47,7 +47,7 @@ spec:
     remediation:
       retries: 3
   interval: {{ $writer.interval }}
-  targetNamespace: {{ .Values.observability.vmStack.namespace }}
+  targetNamespace: {{ $ns }}
   releaseName: tsa-token-writer
   values:
     resources:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -29,6 +29,9 @@ spec:
 
   dependsOn:
     - name: {{ include "soperator-fluxcd.fullname" . }}-ns
+    {{- if and .Values.observability.publicEndpointEnabled (eq .Values.observability.publicEndpointTokenKind "secret") (include "soperator-fluxcd.o11yTsaTokenWriterEnabled" .) }}
+    - name: {{ include "soperator-fluxcd.o11yTsaTokenWriterName" . }}
+    {{- end }}
     - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
 
   install:
@@ -38,10 +41,15 @@ spec:
   interval: {{ .Values.observability.opentelemetry.events.interval }}
   timeout: {{ .Values.observability.opentelemetry.events.timeout }}
   releaseName: opentelemetry-collector-events
-  targetNamespace: logs-system
+  targetNamespace: {{ .Values.observability.opentelemetry.namespace }}
 
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
+  {{- $tokenSecretName := include "soperator-fluxcd.o11yTsaTokenSecretName" . }}
+  {{- $tokenSecretKey := include "soperator-fluxcd.o11yTsaTokenSecretKey" . }}
+  {{- $tokenHostPath := include "soperator-fluxcd.o11yTsaTokenHostPath" . }}
+  {{- $tokenMountPath := include "soperator-fluxcd.o11yTsaTokenMountPath" . }}
+  {{- $tokenHostPathFilename := include "soperator-fluxcd.o11yTsaTokenHostPathFilename" . }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
   {{- $sendingQueue := .Values.observability.opentelemetry.sendingQueue | default dict }}
   {{- $eventsValues := .Values.observability.opentelemetry.events.values | default dict }}
@@ -109,10 +117,10 @@ spec:
       - name: o11ytoken
         {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
         secret:
-          secretName: o11y-writer-sa-token
+          secretName: {{ $tokenSecretName | quote }}
         {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
         hostPath:
-          path: /mnt/cloud-metadata
+          path: {{ $tokenHostPath | quote }}
           type: Directory
         {{- end }}
       {{- end }}
@@ -127,7 +135,7 @@ spec:
       {{- end }}
 
       {{- if $hasPublicEndpoint }}
-      - mountPath: /o11ytoken
+      - mountPath: {{ $tokenMountPath | quote }}
         name: o11ytoken
         readOnly: true
       {{- end }}
@@ -307,10 +315,10 @@ spec:
         {{- if $hasPublicEndpoint }}
         bearertokenauth:
           {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
-          filename: "/o11ytoken/accessToken"
+          filename: {{ printf "%s/%s" $tokenMountPath $tokenSecretKey | quote }}
           {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
-          filename: "/o11ytoken/tsa-token"
-          {{- end }}
+          filename: {{ printf "%s/%s" $tokenMountPath $tokenHostPathFilename | quote }}
+        {{- end }}
         {{- end }}
 
 

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -30,6 +30,9 @@ spec:
 
   dependsOn:
     - name: {{ include "soperator-fluxcd.fullname" . }}-ns
+    {{- if and .Values.observability.publicEndpointEnabled (eq .Values.observability.publicEndpointTokenKind "secret") (include "soperator-fluxcd.o11yTsaTokenWriterEnabled" .) }}
+    - name: {{ include "soperator-fluxcd.o11yTsaTokenWriterName" . }}
+    {{- end }}
     - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
     # nodesets itself reaches Ready very quickly (it just creates NodeSet CRs), so this is
     # not sufficient on its own — the init container below waits for actual worker output.
@@ -43,10 +46,15 @@ spec:
   interval: {{ .Values.observability.opentelemetry.logs.interval }}
   timeout: {{ .Values.observability.opentelemetry.logs.timeout }}
   releaseName: opentelemetry-collector-jail-logs
-  targetNamespace: logs-system
+  targetNamespace: {{ .Values.observability.opentelemetry.namespace }}
 
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
+  {{- $tokenSecretName := include "soperator-fluxcd.o11yTsaTokenSecretName" . }}
+  {{- $tokenSecretKey := include "soperator-fluxcd.o11yTsaTokenSecretKey" . }}
+  {{- $tokenHostPath := include "soperator-fluxcd.o11yTsaTokenHostPath" . }}
+  {{- $tokenMountPath := include "soperator-fluxcd.o11yTsaTokenMountPath" . }}
+  {{- $tokenHostPathFilename := include "soperator-fluxcd.o11yTsaTokenHostPathFilename" . }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
   {{- $sendingQueue := .Values.observability.opentelemetry.sendingQueue | default dict }}
   {{- $logsValues := .Values.observability.opentelemetry.logs.values | default dict }}
@@ -122,10 +130,10 @@ spec:
       - name: o11ytoken
         {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
         secret:
-          secretName: o11y-writer-sa-token
+          secretName: {{ $tokenSecretName | quote }}
         {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
         hostPath:
-          path: /mnt/cloud-metadata
+          path: {{ $tokenHostPath | quote }}
           type: Directory
         {{- end }}
       {{- end }}
@@ -142,7 +150,7 @@ spec:
 
     {{- if $hasPublicEndpoint }}
       - name: o11ytoken
-        mountPath: /o11ytoken
+        mountPath: {{ $tokenMountPath | quote }}
         readOnly: true
     {{- end }}
 
@@ -553,10 +561,10 @@ spec:
         {{- if $hasPublicEndpoint }}
         bearertokenauth:
           {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
-          filename: "/o11ytoken/accessToken"
+          filename: {{ printf "%s/%s" $tokenMountPath $tokenSecretKey | quote }}
           {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
-          filename: "/o11ytoken/tsa-token"
-          {{- end }}
+          filename: {{ printf "%s/%s" $tokenMountPath $tokenHostPathFilename | quote }}
+        {{- end }}
         {{- end }}
 
       service:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -29,6 +29,9 @@ spec:
 
   dependsOn:
     - name: {{ include "soperator-fluxcd.fullname" . }}-ns
+    {{- if and .Values.observability.publicEndpointEnabled (eq .Values.observability.publicEndpointTokenKind "secret") (include "soperator-fluxcd.o11yTsaTokenWriterEnabled" .) }}
+    - name: {{ include "soperator-fluxcd.o11yTsaTokenWriterName" . }}
+    {{- end }}
     - name: {{ include "soperator-fluxcd.fullname" . }}-vm-logs
 
   install:
@@ -38,10 +41,15 @@ spec:
   interval: {{ .Values.observability.opentelemetry.logs.interval }}
   timeout: {{ .Values.observability.opentelemetry.logs.timeout }}
   releaseName: opentelemetry-collector-logs
-  targetNamespace: logs-system
+  targetNamespace: {{ .Values.observability.opentelemetry.namespace }}
 
   values:
   {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
+  {{- $tokenSecretName := include "soperator-fluxcd.o11yTsaTokenSecretName" . }}
+  {{- $tokenSecretKey := include "soperator-fluxcd.o11yTsaTokenSecretKey" . }}
+  {{- $tokenHostPath := include "soperator-fluxcd.o11yTsaTokenHostPath" . }}
+  {{- $tokenMountPath := include "soperator-fluxcd.o11yTsaTokenMountPath" . }}
+  {{- $tokenHostPathFilename := include "soperator-fluxcd.o11yTsaTokenHostPathFilename" . }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
   {{- $sendingQueue := .Values.observability.opentelemetry.sendingQueue | default dict }}
   {{- $logsValues := .Values.observability.opentelemetry.logs.values | default dict }}
@@ -140,10 +148,10 @@ spec:
       - name: o11ytoken
         {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
         secret:
-          secretName: o11y-writer-sa-token
+          secretName: {{ $tokenSecretName | quote }}
         {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
         hostPath:
-          path: /mnt/cloud-metadata
+          path: {{ $tokenHostPath | quote }}
           type: Directory
         {{- end }}
       {{- end }}
@@ -170,7 +178,7 @@ spec:
 
       {{- if $hasPublicEndpoint }}
       - name: o11ytoken
-        mountPath: /o11ytoken
+        mountPath: {{ $tokenMountPath | quote }}
         readOnly: true
       {{- end }}
 
@@ -571,9 +579,9 @@ spec:
         {{- if $hasPublicEndpoint }}
         bearertokenauth:
           {{- if eq .Values.observability.publicEndpointTokenKind "secret" }}
-          filename: "/o11ytoken/accessToken"
+          filename: {{ printf "%s/%s" $tokenMountPath $tokenSecretKey | quote }}
           {{- else if eq .Values.observability.publicEndpointTokenKind "hostPath" }}
-          filename: "/o11ytoken/tsa-token"
+          filename: {{ printf "%s/%s" $tokenMountPath $tokenHostPathFilename | quote }}
         {{- end }}
 
         {{- end }}

--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -23,6 +23,9 @@ spec:
       version: {{ .Values.observability.vmStack.version }}
   dependsOn:
   - name: {{ include "soperator-fluxcd.fullname" . }}-ns
+  {{- if and .Values.observability.publicEndpointEnabled (eq .Values.observability.publicEndpointTokenKind "secret") (include "soperator-fluxcd.o11yTsaTokenWriterEnabled" .) }}
+  - name: {{ include "soperator-fluxcd.o11yTsaTokenWriterName" . }}
+  {{- end }}
   {{- if .Values.certManager.enabled }}
   - name: {{ include "soperator-fluxcd.fullname" . }}-cert-manager
   {{- end }}
@@ -410,12 +413,11 @@ spec:
           {{- $hasPublicEndpoint := .Values.observability.publicEndpointEnabled }}
           {{- $tokenKind := .Values.observability.publicEndpointTokenKind }}
           {{- $hasVmagentSpec := .Values.observability.vmStack.values.vmagent.spec }}
-          {{- $tsaToken := .Values.observability.vmStack.tsaToken | default dict }}
-          {{- $tokenSecretName := $tsaToken.secretName | default "o11y-writer-sa-token" }}
-          {{- $tokenSecretKey := $tsaToken.secretKey | default "accessToken" }}
-          {{- $tokenHostPath := $tsaToken.hostPath | default "/mnt/cloud-metadata" }}
-          {{- $tokenMountPath := $tsaToken.mountPath | default "/o11ytoken" }}
-          {{- $tokenHostPathFilename := $tsaToken.hostPathFilename | default "tsa-token" }}
+          {{- $tokenSecretName := include "soperator-fluxcd.o11yTsaTokenSecretName" . }}
+          {{- $tokenSecretKey := include "soperator-fluxcd.o11yTsaTokenSecretKey" . }}
+          {{- $tokenHostPath := include "soperator-fluxcd.o11yTsaTokenHostPath" . }}
+          {{- $tokenMountPath := include "soperator-fluxcd.o11yTsaTokenMountPath" . }}
+          {{- $tokenHostPathFilename := include "soperator-fluxcd.o11yTsaTokenHostPathFilename" . }}
           {{- $useHostPathToken := and $hasPublicEndpoint (eq $tokenKind "hostPath") }}
           {{- $hasHostNetwork := and $hasVmagentSpec (hasKey $hasVmagentSpec "hostNetwork") }}
           {{- $hasDnsPolicy := and $hasVmagentSpec (hasKey $hasVmagentSpec "dnsPolicy") }}

--- a/helm/soperator-fluxcd/tests/o11y_tsa_token_writer_test.yaml
+++ b/helm/soperator-fluxcd/tests/o11y_tsa_token_writer_test.yaml
@@ -1,6 +1,6 @@
 suite: test vmagent tsa-token writer
 templates:
-  - templates/vm-tsa-token-writer.yaml
+  - templates/o11y-tsa-token-writer.yaml
 
 tests:
   - it: should render a HelmRelease using the bedag raw chart
@@ -43,10 +43,10 @@ tests:
             writer:
               source: imds
     asserts:
-      # resources: ServiceAccount + Role + RoleBinding + Deployment
+      # resources: ServiceAccount + (Role + RoleBinding) for monitoring/logs + Deployment
       - lengthEqual:
           path: spec.values.resources
-          count: 4
+          count: 6
       - equal:
           path: spec.values.resources[0].kind
           value: ServiceAccount
@@ -54,17 +54,17 @@ tests:
           path: spec.values.resources[0].metadata.namespace
           value: monitoring-system
       - equal:
-          path: spec.values.resources[3].kind
+          path: spec.values.resources[5].kind
           value: Deployment
       - equal:
-          path: spec.values.resources[3].spec.template.spec.hostNetwork
+          path: spec.values.resources[5].spec.template.spec.hostNetwork
           value: true
       - equal:
-          path: spec.values.resources[3].spec.template.spec.containers[0].env[0].value
+          path: spec.values.resources[5].spec.template.spec.containers[0].env[0].value
           value: "imds"
       - equal:
-          path: spec.values.resources[3].spec.template.spec.containers[0].env[3].value
-          value: "monitoring-system"
+          path: spec.values.resources[5].spec.template.spec.containers[0].env[3].value
+          value: "monitoring-system logs-system"
 
   - it: should restrict secret access by resourceName but allow create
     set:
@@ -109,15 +109,15 @@ tests:
               source: file
     asserts:
       - notExists:
-          path: spec.values.resources[3].spec.template.spec.hostNetwork
+          path: spec.values.resources[5].spec.template.spec.hostNetwork
       - equal:
-          path: spec.values.resources[3].spec.template.spec.containers[0].env[0].value
+          path: spec.values.resources[5].spec.template.spec.containers[0].env[0].value
           value: "file"
       - equal:
-          path: spec.values.resources[3].spec.template.spec.volumes[0].hostPath.path
+          path: spec.values.resources[5].spec.template.spec.volumes[0].hostPath.path
           value: "/mnt/cloud-metadata"
       - equal:
-          path: spec.values.resources[3].spec.template.spec.containers[0].volumeMounts[0].mountPath
+          path: spec.values.resources[5].spec.template.spec.containers[0].volumeMounts[0].mountPath
           value: "/o11ytoken"
 
   - it: should maintain the secret in every configured namespace

--- a/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
+++ b/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
@@ -52,6 +52,31 @@ tests:
           path: spec.values.config.exporters.otlp.endpoint
           value: dns:///write.logging.custom.nebius.cloud.:443
 
+  - it: should mount the shared token secret with custom name key and namespace
+    set:
+      observability.opentelemetry.namespace: custom-logs
+      observability.tsaToken.secretName: custom-o11y-token
+      observability.tsaToken.secretKey: token
+      observability.tsaToken.mountPath: /var/run/o11y-token
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.dependsOn[1].name
+          value: RELEASE-NAME-tsa-token-writer
+      - equal:
+          path: spec.targetNamespace
+          value: custom-logs
+      - equal:
+          path: spec.values.extraVolumes[4].secret.secretName
+          value: custom-o11y-token
+      - equal:
+          path: spec.values.extraVolumeMounts[4].mountPath
+          value: /var/run/o11y-token
+      - equal:
+          path: spec.values.config.extensions.bearertokenauth.filename
+          value: /var/run/o11y-token/token
+
   - it: should fall back to default batch settings when batch config is empty
     set:
       observability.opentelemetry.batch: null
@@ -143,6 +168,31 @@ tests:
           path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.batch.max_size
           value: 7000
 
+  - it: should mount the shared token secret with custom name key and namespace
+    set:
+      observability.opentelemetry.namespace: custom-logs
+      observability.tsaToken.secretName: custom-o11y-token
+      observability.tsaToken.secretKey: token
+      observability.tsaToken.mountPath: /var/run/o11y-token
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.dependsOn[1].name
+          value: RELEASE-NAME-tsa-token-writer
+      - equal:
+          path: spec.targetNamespace
+          value: custom-logs
+      - equal:
+          path: spec.values.extraVolumes[1].secret.secretName
+          value: custom-o11y-token
+      - equal:
+          path: spec.values.extraVolumeMounts[1].mountPath
+          value: /var/run/o11y-token
+      - equal:
+          path: spec.values.config.extensions.bearertokenauth.filename
+          value: /var/run/o11y-token/token
+
   - it: should omit file storage when events file storage is disabled
     set:
       observability.opentelemetry.events.values.enableFileStorage: false
@@ -209,6 +259,31 @@ tests:
       - equal:
           path: spec.values.extraVolumeMounts[0].readOnly
           value: false
+
+  - it: should mount the shared token secret with custom name key and namespace
+    set:
+      observability.opentelemetry.namespace: custom-logs
+      observability.tsaToken.secretName: custom-o11y-token
+      observability.tsaToken.secretKey: token
+      observability.tsaToken.mountPath: /var/run/o11y-token
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.dependsOn[1].name
+          value: RELEASE-NAME-tsa-token-writer
+      - equal:
+          path: spec.targetNamespace
+          value: custom-logs
+      - equal:
+          path: spec.values.extraVolumes[2].secret.secretName
+          value: custom-o11y-token
+      - equal:
+          path: spec.values.extraVolumeMounts[2].mountPath
+          value: /var/run/o11y-token
+      - equal:
+          path: spec.values.config.extensions.bearertokenauth.filename
+          value: /var/run/o11y-token/token
 
   - it: should omit file storage when jail log file storage is disabled
     set:

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -150,6 +150,35 @@ observability:
   logsProjectId: default-project-id
   metricsProjectId: default-project-id
   region: eu-north1
+  # Source of the o11y write bearer token, consumed per `observability.publicEndpointTokenKind`:
+  #   secret   - collectors reference a token Secret (e.g. maintained by the token writer, or created in Terraform)
+  #   hostPath - collectors mount a host-provided token file directly
+  tsaToken:
+    secretName: o11y-writer-sa-token
+    secretKey: accessToken
+    hostPath: /mnt/cloud-metadata
+    mountPath: /o11ytoken
+    hostPathFilename: tsa-token
+    writer:
+      enabled: true
+      interval: 5m
+      version: 2.0.0
+      driftDetection:
+        mode: warn
+      # Token source: `imds` fetches from IMDS_BASE_URL; `file` reads a mounted host token.
+      source: imds
+      # Namespaces to maintain the Secret in. Empty means enabled o11y consumer namespaces.
+      namespaces: []
+      image:
+        repository: cr.eu-north1.nebius.cloud/soperator-proxy-docker-io/alpine/curl
+        tag: "8.19.0"
+        pullPolicy: IfNotPresent
+      imdsBaseUrl: http://169.254.169.254
+      hostNetwork: true
+      tokenExpiryFile: ""
+      refreshSafetyMarginSeconds: 900
+      pollIntervalSeconds: 300
+      resources: {}
   opentelemetry:
     enabled: true
     publicEndpoint: dns:///write.logging.eu-north1.nebius.cloud.:443
@@ -281,40 +310,6 @@ observability:
       remediation:
         retries: 6
         remediateLastFailure: true
-    # Source of the o11y remote-write bearer token, consumed per `observability.publicEndpointTokenKind`:
-    #   secret   - vmagent references the token via remoteWrite[].bearerTokenSecret (operator-managed),
-    #              so extra remote-write destinations can carry their own auth without conflict
-    #   hostPath - the token file is mounted from the host and passed via -remoteWrite.bearerTokenFile,
-    #              scoped to the o11y endpoint only
-    tsaToken:
-      secretName: o11y-writer-sa-token
-      secretKey: accessToken
-      hostPath: /mnt/cloud-metadata
-      mountPath: /o11ytoken
-      hostPathFilename: tsa-token
-      writer:
-        enabled: true
-        interval: 5m
-        version: 2.0.0
-        driftDetection:
-          mode: warn
-        # Token source: `imds` (fetch from IMDS_BASE_URL, may be a proxy) or
-        # `file` (read a host-provided token file mounted from `hostPath`).
-        source: file
-        # Namespaces to maintain the Secret in. Empty means the vmStack namespace.
-        namespaces: []
-        image:
-          repository: cr.eu-north1.nebius.cloud/soperator-proxy-docker-io/alpine/curl
-          tag: "8.19.0"
-          pullPolicy: IfNotPresent
-        imdsBaseUrl: http://169.254.169.254
-        # hostNetwork is needed only to reach link-local IMDS directly; set false
-        # when IMDS_BASE_URL points at a routable proxy.
-        hostNetwork: true
-        tokenExpiryFile: ""
-        refreshSafetyMarginSeconds: 900
-        pollIntervalSeconds: 300
-        resources: {}
     values:
       dashboardNamespaces:
         - soperator


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

Sharing solution for TSA token from IMDS service between vmstack and otel collectors.
Configurable through values.
Terraform provisioned Soperator will still use the current way for logs.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Support TSA token from IMDS for otel collectors by reusing tsa-writer 