### PR TITLE
SCHED-1901: Disable autoscaling of worker nodes in E2E

### DIFF
--- a/internal/e2e/values.go
+++ b/internal/e2e/values.go
@@ -84,6 +84,9 @@ func overrideTestValues(tfVars map[string]interface{}, cfg Config) map[string]in
 		entry := map[string]interface{}{
 			"name": ns.Name,
 			"size": ns.Size,
+			"autoscaling": map[string]interface{}{
+				"enabled": false,
+			},
 			"resource": map[string]interface{}{
 				"platform": ns.Platform,
 				"preset":   ns.Preset,


### PR DESCRIPTION
## Problem
Using autoscaler for small clusters doesn't provide a boost in cluster deployment. E2Es need to stay fast.

## Solution
Disable autoscaling of worker node groups in E2E.

## Testing
E2E.

## Release Notes
