### PR TITLE
SCHED-2205 Fix e2e build workflow outputs

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -198,11 +198,14 @@ jobs:
       - name: go build e2e commands
         shell: bash
         run: |
-          packages=(./cmd/e2e)
-          if [[ -d cmd/acceptance ]]; then
-            packages+=(./cmd/acceptance)
+          mkdir -p bin
+          go build -o bin/e2e ./cmd/e2e
+
+          if [[ -d e2e/cmd/acceptance ]]; then
+            go build -o bin/acceptance ./e2e/cmd/acceptance
+          elif [[ -d cmd/acceptance ]]; then
+            go build -o bin/acceptance ./cmd/acceptance
           fi
-          go build "${packages[@]}"
 
   build-soperator-images:
     needs:


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
CI on this PR fails because it creates e2e directory in the root but it's the output path for e2e binary on CI. Fixing it temporary, so that CI passes in this PR: https://github.com/nebius/soperator/pull/2805

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
