### PR TITLE
Decouple webhooks and certManager in helm

### DIFF
--- a/helm/soperator/templates/deployment.yaml
+++ b/helm/soperator/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - /usr/bin/slurm_operator
         env:
         - name: ENABLE_WEBHOOKS
-          value: {{ quote .Values.certManager.enabled }}
+          value: {{ quote .Values.controllerManager.manager.env.enableWebhooks }}
         - name: IS_APPARMOR_CRD_INSTALLED
           value: {{ quote .Values.controllerManager.manager.env.isApparmorCrdInstalled }}
         - name: IS_PROMETHEUS_CRD_INSTALLED

--- a/helm/soperator/values.yaml
+++ b/helm/soperator/values.yaml
@@ -16,6 +16,7 @@ controllerManager:
         drop:
           - ALL
     env:
+      enableWebhooks: "true"
       isMariadbCrdInstalled: "false"
       isOpentelemetryCollectorCrdInstalled: "false"
       isApparmorCrdInstalled: "false"


### PR DESCRIPTION
## Problem
when cert-manager disabled, webhooks are created in k8s but not handled in soperator.

## Solution
Decouple settings for enable webhooks and cert-manager to allow use webhooks without cert-manager
