### PR TITLE
SCHED-2111: Select e2e profiles dynamically by label

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,5 +1,7 @@
 name: E2E test soperator
 
+run-name: "E2E ${{ inputs.profile }}"
+
 on:
   workflow_dispatch:
     inputs:
@@ -13,8 +15,27 @@ on:
         required: false
         default: ""
         type: string
+      # Keep the options in sync with the profiles and labels in E2E_CONFIG.
+      # The default is what scheduler dispatches resolve with too — they omit
+      # this input, and the code refuses an empty profile rather than assuming one.
+      profile:
+        description: "Profile name or @label, see E2E_CONFIG"
+        required: false
+        default: "@auto-select"
+        type: choice
+        options:
+          - "@auto-select"
+          - MAN_H100
+          - MAN_H200
+          - KCS_B200
+          - MDC_B200
+          - KCS_CPU
+          - KCS_MIXED
+      # Ignored. Declared only so dispatches from a scheduler that still sends it
+      # are accepted instead of rejected as an unexpected input. Drop once main
+      # runs the scheduler that stopped sending it.
       profile_env_var:
-        description: "Name of the GitHub variable containing the profile YAML (defaults to env setting)"
+        description: "[deprecated] ignored"
         required: false
         default: ""
         type: string
@@ -32,55 +53,65 @@ jobs:
   resolve-profile:
     runs-on: ubuntu-latest
     environment: e2e
+    # The selector waits here, outside the e2e-test concurrency group, until a
+    # project frees up. Keep this above selector.timeout_minutes in E2E_CONFIG.
+    timeout-minutes: 70
     outputs:
+      profile_name: ${{ steps.resolve.outputs.profile_name }}
+      profile_yaml: ${{ steps.resolve.outputs.profile_yaml }}
       nebius_project_id: ${{ steps.resolve.outputs.nebius_project_id }}
       nebius_region: ${{ steps.resolve.outputs.nebius_region }}
       nebius_tenant_id: ${{ steps.resolve.outputs.nebius_tenant_id }}
     env:
-      E2E_PROFILE: ${{ vars[inputs.profile_env_var || vars.PROFILE_ENV_VAR] }}
+      E2E_CONFIG: ${{ vars.E2E_CONFIG }}
+      E2E_PROFILE_NAME: ${{ inputs.profile }}
+      E2E_IS_SCHEDULED: ${{ inputs.is_scheduled }}
+      E2E_RUN_METADATA_PATH: /tmp/e2e-run-metadata.json
     steps:
-      - name: Install yq
-        uses: frenck/action-setup-yq@c4b5be8b4a215c536a41d436757d9feb92836d4f # v1.0.2
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Install GO
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          version: v4.44.6
+          go-version-file: "go.mod"
+          cache: false
+
+      - name: Build e2e binary
+        run: go build -o bin/e2e ./cmd/e2e
+
+      - name: Configure Nebius credentials
+        shell: bash
+        env:
+          NEBIUS_CLI_CONFIG: ${{ vars.NEBIUS_CLI_CONFIG }}
+          NEBIUS_PRIVATE_KEY: ${{ secrets.NEBIUS_PRIVATE_KEY }}
+        run: |
+          mkdir -p "$HOME/.nebius"
+          echo "$NEBIUS_CLI_CONFIG" > "$HOME/.nebius/config.yaml"
+          yq -i '.profiles.default.private-key = strenv(NEBIUS_PRIVATE_KEY)' "$HOME/.nebius/config.yaml"
+          chmod 600 "$HOME/.nebius/config.yaml"
 
       - name: Resolve profile
         id: resolve
         shell: bash
-        run: |
-          if [[ -z "$E2E_PROFILE" ]]; then
-            echo "::error::E2E_PROFILE is empty or not set"
-            exit 1
-          fi
-          echo "nebius_project_id=$(echo "$E2E_PROFILE" | yq -r '.nebius_project_id')" >> "$GITHUB_OUTPUT"
-          echo "nebius_region=$(echo "$E2E_PROFILE" | yq -r '.nebius_region')" >> "$GITHUB_OUTPUT"
-          echo "nebius_tenant_id=$(echo "$E2E_PROFILE" | yq -r '.nebius_tenant_id')" >> "$GITHUB_OUTPUT"
-
-          # Write metadata for conflict detection
-          jq -n \
-            --arg project_id "$(echo "$E2E_PROFILE" | yq -r '.nebius_project_id')" \
-            --argjson is_scheduled "${{ inputs.is_scheduled == 'true' }}" \
-            '{project_id: $project_id, is_scheduled: $is_scheduled}' \
-            > /tmp/e2e-run-metadata.json
-
-      - name: Print run parameters
-        shell: bash
         env:
-          PROFILE_ENV_VAR: ${{ inputs.profile_env_var || vars.PROFILE_ENV_VAR }}
-          TERRAFORM_REPO_REF: ${{ github.event.inputs.terraform_repo_ref || github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          rc=0
+          bin/e2e select-profile 2>&1 | tee /tmp/select-profile.log || rc=$?
+
+          # The console log keeps every attempt; the summary shows only the last
+          # one, so a long wait cannot flood the summary page.
           {
-            echo "### Run Parameters"
-            echo ""
-            echo "- Branch: \`${{ github.ref_name }}\`"
-            echo "- Terraform branch: \`$TERRAFORM_REPO_REF\`"
-            echo "- Profile variable: \`$PROFILE_ENV_VAR\`"
-            echo ""
-            echo '```yaml'
-            echo "$E2E_PROFILE"
+            echo "### Profile Selection"
+            echo '```'
+            awk '/^Attempt [0-9]+:/{buf=""} {buf=buf $0 ORS} END{printf "%s", buf}' /tmp/select-profile.log
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+          exit $rc
 
+      # Published right after selection: this is how other runs see the project as
+      # taken before any instance exists to show up in capacity block usage.
       - name: Upload run metadata
         uses: actions/upload-artifact@v7
         with:
@@ -88,67 +119,28 @@ jobs:
           path: /tmp/e2e-run-metadata.json
           retention-days: 1
 
-      - name: Check for same-project conflicts
-        if: inputs.is_scheduled == 'true'
+      - name: Print run parameters
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CURRENT_RUN_ID: ${{ github.run_id }}
-          PROJECT_ID: ${{ steps.resolve.outputs.nebius_project_id }}
+          PROFILE_NAME: ${{ steps.resolve.outputs.profile_name }}
+          PROFILE_YAML: ${{ steps.resolve.outputs.profile_yaml }}
+          TERRAFORM_REPO_REF: ${{ github.event.inputs.terraform_repo_ref || github.ref_name }}
         run: |
-          echo "Checking for pending e2e runs on project $PROJECT_ID..."
-
-          # Only check for pending runs — not in_progress.
-          # One in_progress + one pending is fine (concurrency group handles that).
-          # We self-cancel only to avoid being the 3rd run that would bump an existing pending run.
-          #
-          # Note: there is no global lock on resolve-profile (was removed because GitHub's
-          # 1-pending limit caused queued runs to cancel each other with 3+ runs).
-          # This means two concurrent resolve-profile jobs could both pass this check
-          # before either becomes "pending" in e2e-test. This race requires a manual
-          # and a scheduled run to overlap within the ~6s resolve-profile window,
-          # giving a probability of ~0.05%. If it happens, GitHub bumps the older
-          # pending run from the e2e-test queue — the user just re-triggers.
-          pending_run_ids=$(gh api "repos/${{ github.repository }}/actions/workflows/e2e_test.yml/runs?status=pending" \
-            --jq ".workflow_runs[] | select(.id != $CURRENT_RUN_ID) | .id") || true
-
-          repo_url="https://github.com/${{ github.repository }}"
-
-          if [ -z "$pending_run_ids" ]; then
-            echo "No other pending e2e runs found. Proceeding."
-            echo "### Conflict Check" >> "$GITHUB_STEP_SUMMARY"
-            echo "No other pending e2e runs on project \`$PROJECT_ID\`. Proceeding." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          for run_id in $pending_run_ids; do
-            echo "Checking run $run_id..."
-            tmpdir=$(mktemp -d)
-            if gh run download "$run_id" -n e2e-run-metadata -D "$tmpdir" -R "${{ github.repository }}"; then
-              other_project=$(jq -r '.project_id' "$tmpdir/e2e-run-metadata.json")
-              if [ "$other_project" == "$PROJECT_ID" ]; then
-                echo "::warning::Conflict: run $run_id is already pending on project $PROJECT_ID. Cancelling this scheduled run."
-                {
-                  echo "### Conflict Check"
-                  echo "Run [$run_id]($repo_url/actions/runs/$run_id) is already pending on project \`$PROJECT_ID\`."
-                  echo "Cancelled this scheduled run to avoid bumping it from the queue."
-                } >> "$GITHUB_STEP_SUMMARY"
-                gh run cancel "$CURRENT_RUN_ID" -R "${{ github.repository }}"
-                exit 1
-              fi
-              echo "Run $run_id targets project $other_project (no conflict)"
-            else
-              echo "Run $run_id has no metadata artifact yet, skipping"
-            fi
-            rm -rf "$tmpdir"
-          done
-
-          echo "No conflicting runs found. Proceeding."
-          echo "### Conflict Check" >> "$GITHUB_STEP_SUMMARY"
-          echo "No conflicting pending runs on project \`$PROJECT_ID\`. Proceeding." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Run Parameters"
+            echo ""
+            echo "- Branch: \`${{ github.ref_name }}\`"
+            echo "- Terraform branch: \`$TERRAFORM_REPO_REF\`"
+            echo "- Profile: \`$PROFILE_NAME\`"
+            echo ""
+            echo '```yaml'
+            echo "$PROFILE_YAML"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   e2e-test:
     needs: resolve-profile
+    name: e2e-test (${{ needs.resolve-profile.outputs.profile_name }})
     concurrency:
       # Per-project mutex: runs targeting the same Nebius project are serialized,
       # different projects can run concurrently. Queued runs wait, never cancel in-progress ones.
@@ -163,8 +155,8 @@ jobs:
       TERRAFORM_REPO: "nebius/nebius-solution-library"
       TERRAFORM_REPO_REF: "${{ github.event.inputs.terraform_repo_ref || github.ref_name }}"
       O11Y_ACCESS_TOKEN: ${{ secrets.E2E_O11Y_ACCESS_TOKEN }}
-      PROFILE_ENV_VAR: ${{ inputs.profile_env_var || vars.PROFILE_ENV_VAR }}
-      E2E_PROFILE: ${{ vars[inputs.profile_env_var || vars.PROFILE_ENV_VAR] }}
+      PROFILE_NAME: ${{ needs.resolve-profile.outputs.profile_name }}
+      E2E_PROFILE_YAML: ${{ needs.resolve-profile.outputs.profile_yaml }}
       RUN_UNSTABLE_TESTS: ${{ inputs.run_unstable_tests || 'false' }}
 
     steps:
@@ -779,7 +771,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_URL }}
           BRANCH: ${{ github.ref_name }}
-          PROFILE: ${{ inputs.profile_env_var || vars.PROFILE_ENV_VAR }}
+          PROFILE: ${{ needs.resolve-profile.outputs.profile_name || inputs.profile }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         shell: bash

--- a/.github/workflows/e2e_test_scheduler.yml
+++ b/.github/workflows/e2e_test_scheduler.yml
@@ -24,46 +24,76 @@ jobs:
         with:
           version: v4.44.6
 
-      - name: Trigger E2E tests for all profiles
+      - name: Trigger E2E tests
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCHEDULING_YAML: ${{ vars.SCHEDULING_YAML }}
-          DEFAULT_PROFILE_ENV_VAR: ${{ vars.PROFILE_ENV_VAR }}
+          E2E_CONFIG: ${{ vars.E2E_CONFIG }}
         shell: bash
         run: |
+          if [[ -z "$E2E_CONFIG" ]]; then
+            echo "::error::E2E_CONFIG variable is not set"
+            exit 1
+          fi
+
           readarray -t RELEASE_BRANCHES < <(yq -r '.e2e_release_branches[]' .github/branch-config.yaml)
           BRANCHES=("main" "${RELEASE_BRANCHES[@]}")
           BRANCH_COUNT=${#BRANCHES[@]}
 
           RUN_NUMBER=${{ github.run_number }}
 
-          # Parse profiles from SCHEDULING_YAML, falling back to the default profile variable
-          if [[ -n "$SCHEDULING_YAML" ]]; then
-            readarray -t PROFILES < <(echo "$SCHEDULING_YAML" | yq -r '.profiles[]')
-          else
-            PROFILES=("${DEFAULT_PROFILE_ENV_VAR:-E2E_PROFILE}")
-          fi
-
-          echo "Profiles: ${PROFILES[*]}"
           echo "Branches: ${BRANCHES[*]}"
           echo "Run number: $RUN_NUMBER"
 
-          for i in "${!PROFILES[@]}"; do
-            PROFILE_NAME="${PROFILES[$i]}"
+          # Defaults duplicated from defaultRunsPerTick / defaultMaxInFlight in
+          # internal/e2e/config.go — keep the two in sync.
+          RUNS_PER_TICK=$(echo "$E2E_CONFIG" | yq -r '.scheduler.runs_per_tick // 1')
+          MAX_IN_FLIGHT=$(echo "$E2E_CONFIG" | yq -r '.scheduler.max_in_flight // 2')
+
+          # A run that finds no free profile waits, then fails. Dispatching on every
+          # tick regardless would turn a stretch of tight capacity into a stream of
+          # timed-out runs, so stop adding to the pile once enough are in flight.
+          # Runs still waiting for a profile count: they are the ones at risk.
+          #
+          # Only scheduled runs count. A manual run occupies a project, which the
+          # selector already accounts for, but it must not switch off the schedule.
+          IN_FLIGHT=$(gh api "repos/${{ github.repository }}/actions/workflows/e2e_test.yml/runs?per_page=100" \
+            --jq '[.workflow_runs[]
+                   | select(.status != "completed")
+                   | select(.actor.login == "github-actions[bot]")] | length')
+
+          DISPATCHES=$(( MAX_IN_FLIGHT - IN_FLIGHT ))
+          if (( DISPATCHES > RUNS_PER_TICK )); then
+            DISPATCHES=$RUNS_PER_TICK
+          fi
+
+          echo "In flight: $IN_FLIGHT (max $MAX_IN_FLIGHT), per tick: $RUNS_PER_TICK -> dispatching $DISPATCHES"
+
+          if (( DISPATCHES <= 0 )); then
+            echo "::notice::$IN_FLIGHT e2e run(s) already in flight, dispatching none this tick"
+            {
+              echo "### No dispatch"
+              echo "$IN_FLIGHT scheduled e2e run(s) already in flight, at the cap of $MAX_IN_FLIGHT."
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            # Cancel rather than pass: a green run that dispatched nothing is
+            # indistinguishable from a normal tick in the run list. exit 1 is the
+            # fallback for a cancellation that has not landed by the time the step
+            # ends — a red tick is still better than a silent one.
+            gh run cancel "$GITHUB_RUN_ID" -R "${{ github.repository }}"
+            exit 1
+          fi
+
+          for (( i = 0; i < DISPATCHES; i++ )); do
             BRANCH_INDEX=$(( (RUN_NUMBER + i) % BRANCH_COUNT ))
             REF="${BRANCHES[$BRANCH_INDEX]}"
-            TERRAFORM_REF="$REF"
 
-            echo "---"
-            echo "Profile: $PROFILE_NAME"
-            echo "Branch: $REF (index $BRANCH_INDEX)"
-            echo "Terraform ref: $TERRAFORM_REF"
-
+            # No profile input on purpose: the default declared on e2e_test.yml's profile input applies,
+            # so what scheduled runs select by is decided there, not here.
+            # Omitting the input also keeps this dispatch valid against branches that predate it.
             gh workflow run e2e_test.yml \
               --ref "$REF" \
-              -f profile_env_var="$PROFILE_NAME" \
-              -f terraform_repo_ref="$TERRAFORM_REF" \
+              -f terraform_repo_ref="$REF" \
               -f is_scheduled=true
 
-            echo "Triggered E2E test for profile $PROFILE_NAME on branch $REF"
+            echo "Triggered E2E test on branch $REF (index $BRANCH_INDEX)"
           done

--- a/cmd/e2e/main.go
+++ b/cmd/e2e/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/kelseyhightower/envconfig"
@@ -19,17 +20,25 @@ func main() {
 	log.SetFlags(0)
 
 	if len(os.Args) < 2 {
-		_, _ = fmt.Fprintf(os.Stderr, "Usage: e2e <check-capacity|cleanup-previous|init|apply|destroy|acceptance>\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: e2e <select-profile|check-capacity|cleanup-previous|init|apply|destroy|acceptance>\n")
 		os.Exit(2)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// select-profile runs before a profile exists, so it must not load one.
+	if os.Args[1] == "select-profile" {
+		if err := runSelectProfile(ctx); err != nil {
+			log.Fatalf("select-profile: %v", err)
+		}
+		return
 	}
 
 	profile, err := e2e.LoadProfile()
 	if err != nil {
 		log.Fatalf("Load profile: %v", err)
 	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	switch os.Args[1] {
 	case "check-capacity":
@@ -50,7 +59,7 @@ func main() {
 		cfg := loadFullConfig(profile)
 		err = e2e.RunAcceptance(ctx, cfg)
 	default:
-		_, _ = fmt.Fprintf(os.Stderr, "Unknown command: %s\nUsage: e2e <check-capacity|cleanup-previous|init|apply|destroy|acceptance>\n", os.Args[1])
+		_, _ = fmt.Fprintf(os.Stderr, "Unknown command: %s\nUsage: e2e <select-profile|check-capacity|cleanup-previous|init|apply|destroy|acceptance>\n", os.Args[1])
 		os.Exit(2)
 	}
 	if err != nil {
@@ -94,5 +103,110 @@ func runCheckCapacity(ctx context.Context, profile e2e.Profile) error {
 	}
 
 	log.Printf("Workflow run %s cancelled due to insufficient capacity", runID)
+	return nil
+}
+
+const defaultRunMetadataPath = "/tmp/e2e-run-metadata.json"
+
+// runSelectProfile decides which profile this run uses, publishes the claim so
+// other runs see the project as taken, and hands the profile to the workflow.
+func runSelectProfile(ctx context.Context) error {
+	cfg, err := e2e.LoadE2EConfig()
+	if err != nil {
+		return err
+	}
+
+	name, profile, err := resolveProfile(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Profile %s: project=%s region=%s", name, profile.NebiusProjectID, profile.NebiusRegion)
+
+	body, err := profile.YAML()
+	if err != nil {
+		return err
+	}
+
+	if err := writeOutputs(name, profile, body); err != nil {
+		return err
+	}
+
+	metadataPath := os.Getenv("E2E_RUN_METADATA_PATH")
+	if metadataPath == "" {
+		metadataPath = defaultRunMetadataPath
+	}
+	return e2e.WriteRunMetadata(metadataPath, e2e.RunClaim{
+		RunID:       e2e.CurrentRunID(),
+		ProfileName: name,
+		ProjectID:   profile.NebiusProjectID,
+		Region:      profile.NebiusRegion,
+		IsScheduled: os.Getenv("E2E_IS_SCHEDULED") == "true",
+	})
+}
+
+// resolveProfile turns the request into a profile: a label selects among the
+// profiles carrying it, a name picks exactly one.
+func resolveProfile(ctx context.Context, cfg e2e.E2EConfig) (name string, profile e2e.Profile, err error) {
+	requested := strings.TrimSpace(os.Getenv("E2E_PROFILE_NAME"))
+	if requested == "" {
+		// No fallback on purpose: the workflow's profile input declares the default,
+		// so an empty request here means broken plumbing, not "pick anything".
+		return "", e2e.Profile{}, fmt.Errorf("E2E_PROFILE_NAME env var is not set (profile name or @label)")
+	}
+
+	if label, isLabel := strings.CutPrefix(requested, e2e.LabelPrefix); isLabel {
+		normalized := e2e.NormalizeLabel(label)
+		if normalized == "" {
+			return "", e2e.Profile{}, fmt.Errorf("request %q names an empty label", requested)
+		}
+		return e2e.SelectProfile(ctx, cfg, normalized)
+	}
+
+	name = e2e.NormalizeProfileName(requested)
+	profile, ok := cfg.Profiles[name]
+	if !ok {
+		return "", e2e.Profile{}, fmt.Errorf("unknown profile %q (configured: %s)",
+			requested, strings.Join(cfg.Names(), ", "))
+	}
+
+	log.Printf("Using explicitly requested profile %s", name)
+	return name, profile, nil
+}
+
+func writeOutputs(name string, profile e2e.Profile, body string) error {
+	outputs := [][2]string{
+		{"profile_name", name},
+		{"nebius_project_id", profile.NebiusProjectID},
+		{"nebius_region", profile.NebiusRegion},
+		{"nebius_tenant_id", profile.NebiusTenantID},
+	}
+
+	path := os.Getenv("GITHUB_OUTPUT")
+	if path == "" {
+		for _, kv := range outputs {
+			log.Printf("%s=%s", kv[0], kv[1])
+		}
+		log.Printf("profile_yaml:\n%s", body)
+		return nil
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open GITHUB_OUTPUT: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	for _, kv := range outputs {
+		if _, err := fmt.Fprintf(f, "%s=%s\n", kv[0], kv[1]); err != nil {
+			return fmt.Errorf("write output %s: %w", kv[0], err)
+		}
+	}
+	if _, err := fmt.Fprintf(f, "profile_yaml<<E2E_PROFILE_EOF\n%s\nE2E_PROFILE_EOF\n", strings.TrimRight(body, "\n")); err != nil {
+		return fmt.Errorf("write output profile_yaml: %w", err)
+	}
+
 	return nil
 }

--- a/internal/e2e/capacity.go
+++ b/internal/e2e/capacity.go
@@ -18,6 +18,10 @@ import (
 
 var ErrInsufficientCapacity = errors.New("insufficient GPU capacity")
 
+// errNoCapacityBlockGroup means the affinity (platform + fabric) has no capacity block group at all,
+// which callers treat the same way as a group with nothing available.
+var errNoCapacityBlockGroup = errors.New("no capacity block group found")
+
 var gpuCountRe = regexp.MustCompile(`^(\d+)gpu-`)
 
 func parseGPUCount(preset string) int {
@@ -32,42 +36,107 @@ func parseGPUCount(preset string) int {
 	return n
 }
 
-func CheckCapacity(ctx context.Context, profile Profile) error {
-	type (
-		affinityKey struct {
-			Platform string
-			Fabric   string
-		}
-		affinityDemand struct {
-			required uint64
-			nodesets []string
-		}
-	)
+// affinityKey identifies the capacity block group a nodeset draws from.
+type affinityKey struct {
+	Platform string
+	Fabric   string
+}
 
+type affinityDemand struct {
+	requiredGPUs uint64
+	nodesetNames []string
+}
+
+type skippedNodeSet struct {
+	name   string
+	reason string
+}
+
+// gpuDemands aggregates how many GPUs a profile needs per capacity block group.
+// Preemptible and CPU-only nodesets don't draw from a capacity block, so they are returned as skipped instead.
+func gpuDemands(profile Profile) (demands map[affinityKey]affinityDemand, skipped []skippedNodeSet) {
+	demands = make(map[affinityKey]affinityDemand)
+
+	for _, ns := range profile.NodeSets {
+		if ns.Preemptible {
+			skipped = append(skipped, skippedNodeSet{name: ns.Name, reason: "preemptible"})
+			continue
+		}
+
+		gpuCount := parseGPUCount(ns.Preset)
+		if gpuCount == 0 {
+			skipped = append(skipped, skippedNodeSet{
+				name:   ns.Name,
+				reason: fmt.Sprintf("no GPUs in preset %q", ns.Preset),
+			})
+			continue
+		}
+
+		key := affinityKey{Platform: ns.Platform, Fabric: ns.InfinibandFabric}
+		d := demands[key]
+		d.requiredGPUs += uint64(ns.Size) * uint64(gpuCount)
+		d.nodesetNames = append(d.nodesetNames, ns.Name)
+		demands[key] = d
+	}
+
+	return demands, skipped
+}
+
+type cbgAvailability struct {
+	cbg       *capacityv1.CapacityBlockGroup
+	limit     uint64
+	usage     uint64
+	available uint64
+}
+
+// capacityFor looks up the capacity block group backing one affinity of a profile.
+// It returns errNoCapacityBlockGroup when no such group exists.
+func capacityFor(ctx context.Context, sdk *gosdk.SDK, profile Profile, key affinityKey) (cbgAvailability, error) {
+	cbg, err := sdk.Services().Capacity().V1().CapacityBlockGroup().GetByResourceAffinity(ctx,
+		&capacityv1.GetCapacityBlockGroupByResourceAffinityRequest{
+			ParentId: profile.NebiusTenantID,
+			Region:   profile.NebiusRegion,
+			ResourceAffinity: &capacityv1.ResourceAffinity{
+				Versions: &capacityv1.ResourceAffinity_ComputeV1{
+					ComputeV1: &capacityv1.ResourceAffinityComputeV1{
+						Platform: key.Platform,
+						Fabric:   key.Fabric,
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return cbgAvailability{}, errNoCapacityBlockGroup
+		}
+		return cbgAvailability{}, fmt.Errorf("get capacity block group for platform=%s fabric=%s: %w",
+			key.Platform, key.Fabric, err)
+	}
+
+	cbgStatus := cbg.GetStatus()
+	res := cbgAvailability{
+		cbg:   cbg,
+		limit: cbgStatus.GetCurrentLimit(),
+		usage: cbgStatus.GetUsage(),
+	}
+	if res.limit > res.usage {
+		res.available = res.limit - res.usage
+	}
+
+	return res, nil
+}
+
+func CheckCapacity(ctx context.Context, profile Profile) error {
 	token := os.Getenv("NEBIUS_IAM_TOKEN")
 	if token == "" {
 		log.Print("NEBIUS_IAM_TOKEN is not set, skipping capacity check")
 		return nil
 	}
 
-	demands := make(map[affinityKey]affinityDemand)
-	for _, ns := range profile.NodeSets {
-		if ns.Preemptible {
-			log.Printf("Nodeset %q: preemptible, skipping capacity check", ns.Name)
-			continue
-		}
-
-		gpuCount := parseGPUCount(ns.Preset)
-		if gpuCount == 0 {
-			log.Printf("Nodeset %q: no GPUs in preset %q, skipping capacity check", ns.Name, ns.Preset)
-			continue
-		}
-
-		key := affinityKey{Platform: ns.Platform, Fabric: ns.InfinibandFabric}
-		d := demands[key]
-		d.required += uint64(ns.Size) * uint64(gpuCount)
-		d.nodesets = append(d.nodesets, ns.Name)
-		demands[key] = d
+	demands, skipped := gpuDemands(profile)
+	for _, s := range skipped {
+		log.Printf("Nodeset %q: %s, skipping capacity check", s.name, s.reason)
 	}
 
 	if len(demands) == 0 {
@@ -85,46 +154,25 @@ func CheckCapacity(ctx context.Context, profile Profile) error {
 
 	var insufficient bool
 	for key, d := range demands {
-		cbg, err := sdk.Services().Capacity().V1().CapacityBlockGroup().GetByResourceAffinity(ctx,
-			&capacityv1.GetCapacityBlockGroupByResourceAffinityRequest{
-				ParentId: profile.NebiusTenantID,
-				Region:   profile.NebiusRegion,
-				ResourceAffinity: &capacityv1.ResourceAffinity{
-					Versions: &capacityv1.ResourceAffinity_ComputeV1{
-						ComputeV1: &capacityv1.ResourceAffinityComputeV1{
-							Platform: key.Platform,
-							Fabric:   key.Fabric,
-						},
-					},
-				},
-			},
-		)
-		if err != nil {
-			if status.Code(err) == codes.NotFound {
-				log.Printf("CBG platform=%s fabric=%s: nodesets=%v required=%d — no capacity block group found",
-					key.Platform, key.Fabric, d.nodesets, d.required)
-				insufficient = true
-				continue
-			}
-			return fmt.Errorf("get capacity block group for platform=%s fabric=%s: %w", key.Platform, key.Fabric, err)
+		res, err := capacityFor(ctx, sdk, profile, key)
+		if errors.Is(err, errNoCapacityBlockGroup) {
+			log.Printf("CBG platform=%s fabric=%s: nodesets=%v required=%d — no capacity block group found",
+				key.Platform, key.Fabric, d.nodesetNames, d.requiredGPUs)
+			insufficient = true
+			continue
 		}
-
-		cbgStatus := cbg.GetStatus()
-		currentLimit := cbgStatus.GetCurrentLimit()
-		usage := cbgStatus.GetUsage()
-		var available uint64
-		if currentLimit > usage {
-			available = currentLimit - usage
+		if err != nil {
+			return err
 		}
 
 		log.Printf("CBG platform=%s fabric=%s: nodesets=%v required=%d available=%d (limit=%d usage=%d)",
-			key.Platform, key.Fabric, d.nodesets, d.required, available, currentLimit, usage)
+			key.Platform, key.Fabric, d.nodesetNames, d.requiredGPUs, res.available, res.limit, res.usage)
 
-		if available < d.required {
+		if res.available < d.requiredGPUs {
 			log.Printf("CBG platform=%s fabric=%s: INSUFFICIENT CAPACITY — need %d GPUs but only %d available",
-				key.Platform, key.Fabric, d.required, available)
+				key.Platform, key.Fabric, d.requiredGPUs, res.available)
 			insufficient = true
-			printResourceDetails(ctx, sdk, cbg)
+			printResourceDetails(ctx, sdk, res.cbg)
 		}
 	}
 
@@ -139,6 +187,39 @@ func CheckCapacity(ctx context.Context, profile Profile) error {
 
 	log.Print("Capacity check: insufficient capacity detected but strategy is warn, continuing")
 	return nil
+}
+
+// hasCapacity reports whether a profile's GPU demand currently fits.
+// `reserved` holds demand already claimed by other in-flight runs: those runs have picked a profile
+// but their instances may not exist yet, so the capacity block usage does not  account for them.
+func hasCapacity(
+	ctx context.Context,
+	sdk *gosdk.SDK,
+	profile Profile,
+	reserved map[affinityKey]uint64,
+) (bool, error) {
+	demands, _ := gpuDemands(profile)
+
+	for key, d := range demands {
+		res, err := capacityFor(ctx, sdk, profile, key)
+		if errors.Is(err, errNoCapacityBlockGroup) {
+			log.Printf("  platform=%s fabric=%s: no capacity block group found", key.Platform, key.Fabric)
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+
+		required := d.requiredGPUs + reserved[key]
+		log.Printf("  platform=%s fabric=%s: required=%d (%d reserved by other runs) available=%d (limit=%d usage=%d)",
+			key.Platform, key.Fabric, required, reserved[key], res.available, res.limit, res.usage)
+
+		if res.available < required {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func printResourceDetails(ctx context.Context, sdk *gosdk.SDK, cbg *capacityv1.CapacityBlockGroup) {

--- a/internal/e2e/config.go
+++ b/internal/e2e/config.go
@@ -3,6 +3,10 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
 
 	"sigs.k8s.io/yaml"
 )
@@ -24,6 +28,20 @@ const (
 	CapacityStrategyCancel CapacityStrategy = "cancel"
 )
 
+// LabelPrefix marks a profile request as a label rather than a profile name:
+// a request `@x` picks among the profiles carrying label x, while `MAN_H100` picks that one profile.
+// Which labels exist is entirely up to the config; none is special to this code.
+const LabelPrefix = "@"
+
+var labelRe = regexp.MustCompile(`^[a-z][a-z0-9._-]*$`)
+
+// NormalizeLabel maps the ways a label can be spelled onto its canonical form.
+// The leading "@" that marks a label in the profile input is accepted here too, so
+// `@x` and `x` mean the same thing wherever a label is read.
+func NormalizeLabel(label string) string {
+	return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(label)), LabelPrefix)
+}
+
 // Profile holds infrastructure-specific settings loaded from the PROFILE env var.
 // JSON tags are required by sigs.k8s.io/yaml.
 type Profile struct {
@@ -31,7 +49,13 @@ type Profile struct {
 	NebiusRegion     string           `json:"nebius_region"`
 	NebiusTenantID   string           `json:"nebius_tenant_id"`
 	CapacityStrategy CapacityStrategy `json:"capacity_strategy"`
+	Labels           []string         `json:"labels"`
 	NodeSets         []NodeSetDef     `json:"nodesets"`
+}
+
+// HasLabel reports whether the profile carries the given label.
+func (p *Profile) HasLabel(label string) bool {
+	return slices.Contains(p.Labels, label)
 }
 
 // Validate checks that the profile is well-formed.
@@ -43,6 +67,23 @@ func (p *Profile) Validate() error {
 		// ok
 	default:
 		return fmt.Errorf("unknown capacity_strategy %q (valid: warn, cancel)", p.CapacityStrategy)
+	}
+
+	seenLabels := make(map[string]struct{}, len(p.Labels))
+	for i, label := range p.Labels {
+		// Normalized so a stray capital or space cannot silently drop a profile out of automatic selection.
+		normalized := NormalizeLabel(label)
+		if normalized == "" {
+			return fmt.Errorf("labels[%d]: must not be empty", i)
+		}
+		if !labelRe.MatchString(normalized) {
+			return fmt.Errorf("labels[%d]: %q must match %s", i, label, labelRe)
+		}
+		if _, ok := seenLabels[normalized]; ok {
+			return fmt.Errorf("labels[%d]: duplicate label %q", i, label)
+		}
+		seenLabels[normalized] = struct{}{}
+		p.Labels[i] = normalized
 	}
 
 	if len(p.NodeSets) == 0 {
@@ -72,13 +113,8 @@ func (p *Profile) Validate() error {
 	return nil
 }
 
-// LoadProfile reads the PROFILE env var (already-resolved YAML content) and returns a Profile.
-func LoadProfile() (Profile, error) {
-	raw := os.Getenv("E2E_PROFILE")
-	if raw == "" {
-		return Profile{}, fmt.Errorf("E2E_PROFILE env var is not set")
-	}
-
+// ParseProfile unmarshals and validates a single profile from its YAML body.
+func ParseProfile(raw string) (Profile, error) {
 	var p Profile
 	if err := yaml.Unmarshal([]byte(raw), &p); err != nil {
 		return Profile{}, fmt.Errorf("unmarshal profile YAML: %w", err)
@@ -91,6 +127,172 @@ func LoadProfile() (Profile, error) {
 	return p, nil
 }
 
+// YAML renders the profile back into the form the E2E_PROFILE_YAML env var carries.
+func (p *Profile) YAML() (string, error) {
+	data, err := yaml.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("marshal profile YAML: %w", err)
+	}
+	return string(data), nil
+}
+
+// LoadProfile reads the E2E_PROFILE_YAML env var (already-resolved YAML content) and returns a Profile.
+func LoadProfile() (Profile, error) {
+	raw := os.Getenv("E2E_PROFILE_YAML")
+	if raw == "" {
+		return Profile{}, fmt.Errorf("E2E_PROFILE_YAML env var is not set")
+	}
+
+	return ParseProfile(raw)
+}
+
+// SchedulerSettings caps how many e2e runs the scheduler workflow starts.
+// That workflow is plain bash and reads these with yq — go code doesn't use it.
+// They are declared anyway so that a malformed value fails config load.
+type SchedulerSettings struct {
+	RunsPerTick int `json:"runs_per_tick"`
+	MaxInFlight int `json:"max_in_flight"`
+}
+
+// SelectorSettings drives how long SelectProfile waits for a candidate to become free.
+// Which profiles are candidates is decided by the labels each profile carries, not in Go code.
+type SelectorSettings struct {
+	TimeoutMinutes int `json:"timeout_minutes"`
+	PollSeconds    int `json:"poll_seconds"`
+}
+
+// Zero values fall back to these, so an operator only has to spell out what they want to change.
+const (
+	// Keep in sync with the yq fallbacks in e2e_test_scheduler.yml.
+	defaultRunsPerTick = 1
+	defaultMaxInFlight = 2
+
+	defaultTimeoutMinutes = 60
+	defaultPollSeconds    = 60
+)
+
+func (s *SchedulerSettings) applyDefaults() {
+	if s.RunsPerTick <= 0 {
+		s.RunsPerTick = defaultRunsPerTick
+	}
+	if s.MaxInFlight <= 0 {
+		s.MaxInFlight = defaultMaxInFlight
+	}
+}
+
+func (s *SelectorSettings) applyDefaults() {
+	if s.TimeoutMinutes <= 0 {
+		s.TimeoutMinutes = defaultTimeoutMinutes
+	}
+	if s.PollSeconds <= 0 {
+		s.PollSeconds = defaultPollSeconds
+	}
+}
+
+// E2EConfig is the whole e2e configuration: every known profile, plus the settings of the two things that act on them.
+type E2EConfig struct {
+	Scheduler SchedulerSettings  `json:"scheduler"`
+	Selector  SelectorSettings   `json:"selector"`
+	Profiles  map[string]Profile `json:"profiles"`
+}
+
+var profileNameRe = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+// NormalizeProfileName maps the ways a profile can be spelled onto its config key:
+// "man_h100" and "MAN_H100" both become "MAN_H100".
+func NormalizeProfileName(name string) string {
+	return strings.ToUpper(strings.TrimSpace(name))
+}
+
+// Names returns every configured profile name, sorted, for error messages and logs.
+func (c *E2EConfig) Names() []string {
+	names := make([]string, 0, len(c.Profiles))
+	for name := range c.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Labels returns every label in use across the configured profiles, sorted.
+func (c *E2EConfig) Labels() []string {
+	seen := make(map[string]struct{})
+	for _, profile := range c.Profiles {
+		for _, label := range profile.Labels {
+			seen[label] = struct{}{}
+		}
+	}
+
+	labels := make([]string, 0, len(seen))
+	for label := range seen {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	return labels
+}
+
+// Candidates returns the profiles carrying the given label, sorted so that the
+// order the selector reports is stable across runs.
+func (c *E2EConfig) Candidates(label string) []string {
+	var names []string
+	for _, name := range c.Names() {
+		profile := c.Profiles[name]
+		if profile.HasLabel(label) {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// Validate checks that the configuration is well-formed and fills in defaults.
+func (c *E2EConfig) Validate() error {
+	if len(c.Profiles) == 0 {
+		return fmt.Errorf("profiles must not be empty")
+	}
+
+	// Iterate in sorted order so a broken config always reports the same profile first.
+	for _, name := range c.Names() {
+		if !profileNameRe.MatchString(name) {
+			return fmt.Errorf("profile %q: name must match %s", name, profileNameRe)
+		}
+		p := c.Profiles[name]
+		if err := p.Validate(); err != nil {
+			return fmt.Errorf("profile %q: %w", name, err)
+		}
+		// Validate defaults capacity_strategy in place, and map values are copies.
+		c.Profiles[name] = p
+	}
+
+	c.Scheduler.applyDefaults()
+	c.Selector.applyDefaults()
+
+	return nil
+}
+
+// LoadE2EConfig reads the E2E_CONFIG env var (the whole e2e config as YAML).
+func LoadE2EConfig() (E2EConfig, error) {
+	raw := os.Getenv("E2E_CONFIG")
+	if raw == "" {
+		return E2EConfig{}, fmt.Errorf("E2E_CONFIG env var is not set")
+	}
+
+	var c E2EConfig
+	if err := yaml.Unmarshal([]byte(raw), &c); err != nil {
+		return E2EConfig{}, fmt.Errorf("unmarshal e2e config YAML: %w", err)
+	}
+
+	if err := c.Validate(); err != nil {
+		return E2EConfig{}, fmt.Errorf("validate e2e config: %w", err)
+	}
+
+	return c, nil
+}
+
+// Config is what one e2e run needs at execution time, read from the environment
+// the workflow sets up. Distinct from [E2EConfig], which describes the profiles a run
+// can choose between.
+// TODO: Rename to RunConfig
+//
 //nolint:tagalign
 type Config struct {
 	SoperatorVersion   string `split_words:"true" required:"true"`                // SOPERATOR_VERSION

--- a/internal/e2e/config_test.go
+++ b/internal/e2e/config_test.go
@@ -107,3 +107,184 @@ func TestValidate_CapacityStrategyUnknown(t *testing.T) {
 	p.CapacityStrategy = "unknown"
 	assert.ErrorContains(t, p.Validate(), "unknown capacity_strategy")
 }
+
+func TestNormalizeProfileName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"MAN_H100", "MAN_H100"},
+		{"man_h100", "MAN_H100"},
+		{"  man_h100  ", "MAN_H100"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, NormalizeProfileName(tt.in))
+		})
+	}
+}
+
+// autoSelectLabel mirrors the label the real E2E_CONFIG puts on auto-selectable
+// profiles. It means nothing to the code under test — any label would do.
+const autoSelectLabel = "auto-select"
+
+func validConfig() E2EConfig {
+	labelled := validProfile()
+	labelled.Labels = []string{autoSelectLabel}
+	return E2EConfig{
+		Profiles: map[string]Profile{"MAN_H100": labelled},
+	}
+}
+
+func TestConfigValidate_Valid(t *testing.T) {
+	s := validConfig()
+	assert.NoError(t, s.Validate())
+}
+
+func TestConfigValidate_EmptyProfiles(t *testing.T) {
+	s := E2EConfig{}
+	assert.ErrorContains(t, s.Validate(), "profiles must not be empty")
+}
+
+func TestConfigValidate_BadProfileName(t *testing.T) {
+	for _, name := range []string{
+		"man-h100",  // lowercase and a hyphen
+		"100_H100",  // leading digit
+		"MAN H100",  // space
+		"@MAN_H100", // label marker
+		"_MAN_H100", // leading underscore
+		"",          // empty
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := validConfig()
+			s.Profiles[name] = validProfile()
+			assert.ErrorContains(t, s.Validate(), "name must match")
+		})
+	}
+}
+
+func TestConfigValidate_ProfileErrorNamesTheProfile(t *testing.T) {
+	s := validConfig()
+	broken := validProfile()
+	broken.NodeSets = nil
+	s.Profiles["BROKEN"] = broken
+	assert.ErrorContains(t, s.Validate(), `profile "BROKEN": nodesets must not be empty`)
+}
+
+func TestNormalizeLabel(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"auto-select", "auto-select"},
+		{"Auto-Select", "auto-select"},
+		{"  @auto-select  ", "auto-select"},
+		{"@AUTO-SELECT", "auto-select"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, NormalizeLabel(tt.in))
+		})
+	}
+}
+
+func TestValidate_NormalizesLabels(t *testing.T) {
+	// The "@" that marks a label in the profile input is tolerated in config too.
+	p := validProfile()
+	p.Labels = []string{"  @Auto-Select "}
+	require.NoError(t, p.Validate())
+	assert.Equal(t, []string{autoSelectLabel}, p.Labels)
+	assert.True(t, p.HasLabel(autoSelectLabel))
+}
+
+func TestValidate_EmptyLabel(t *testing.T) {
+	p := validProfile()
+	p.Labels = []string{"  "}
+	assert.ErrorContains(t, p.Validate(), "labels[0]: must not be empty")
+}
+
+func TestValidate_MalformedLabel(t *testing.T) {
+	for _, label := range []string{
+		"auto select",  // space
+		"4-gpu",        // leading digit
+		"-auto-select", // leading hyphen
+		"auto/select",  // separator that is not . _ or -
+	} {
+		t.Run(label, func(t *testing.T) {
+			p := validProfile()
+			p.Labels = []string{label}
+			assert.ErrorContains(t, p.Validate(), "must match")
+		})
+	}
+}
+
+func TestValidate_AcceptedLabelShapes(t *testing.T) {
+	p := validProfile()
+	p.Labels = []string{"auto-select", "auto-select-cpu", "gpu4", "a.b_c-d"}
+	assert.NoError(t, p.Validate())
+}
+
+func TestValidate_DuplicateLabel(t *testing.T) {
+	p := validProfile()
+	p.Labels = []string{autoSelectLabel, "@AUTO-SELECT"}
+	assert.ErrorContains(t, p.Validate(), "duplicate label")
+}
+
+func TestConfigCandidates(t *testing.T) {
+	s := validConfig()
+	// Unlabelled, so configured but not auto-selectable.
+	s.Profiles["KCS_CPU"] = validProfile()
+	// Labelled, and sorts before MAN_H100.
+	labelled := validProfile()
+	labelled.Labels = []string{autoSelectLabel}
+	s.Profiles["KCS_B200"] = labelled
+
+	require.NoError(t, s.Validate())
+	assert.Equal(t, []string{"KCS_B200", "MAN_H100"}, s.Candidates(autoSelectLabel))
+}
+
+func TestConfigCandidates_NoneLabelled(t *testing.T) {
+	// A config with no candidates is valid; only auto-selection fails on it, so
+	// explicitly requested profiles keep working.
+	s := validConfig()
+	s.Profiles["MAN_H100"] = validProfile()
+	require.NoError(t, s.Validate())
+	assert.Empty(t, s.Candidates(autoSelectLabel))
+}
+
+func TestConfigValidate_DefaultsSettings(t *testing.T) {
+	s := validConfig()
+	require.NoError(t, s.Validate())
+	assert.Equal(t, SchedulerSettings{
+		RunsPerTick: defaultRunsPerTick,
+		MaxInFlight: defaultMaxInFlight,
+	}, s.Scheduler)
+	assert.Equal(t, SelectorSettings{
+		TimeoutMinutes: defaultTimeoutMinutes,
+		PollSeconds:    defaultPollSeconds,
+	}, s.Selector)
+}
+
+func TestConfigValidate_KeepsExplicitSettings(t *testing.T) {
+	s := validConfig()
+	s.Scheduler = SchedulerSettings{RunsPerTick: 3, MaxInFlight: 5}
+	s.Selector.TimeoutMinutes = 30
+	s.Selector.PollSeconds = 15
+	require.NoError(t, s.Validate())
+	assert.Equal(t, 3, s.Scheduler.RunsPerTick)
+	assert.Equal(t, 30, s.Selector.TimeoutMinutes)
+}
+
+func TestConfigValidate_WritesProfileDefaultsBack(t *testing.T) {
+	s := validConfig()
+	require.NoError(t, s.Validate())
+	assert.Equal(t, CapacityStrategyWarn, s.Profiles["MAN_H100"].CapacityStrategy)
+}
+
+func TestConfigNames(t *testing.T) {
+	s := validConfig()
+	s.Profiles["KCS_B200"] = validProfile()
+	assert.Equal(t, []string{"KCS_B200", "MAN_H100"}, s.Names())
+}

--- a/internal/e2e/select.go
+++ b/internal/e2e/select.go
@@ -1,0 +1,332 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/rand/v2"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nebius/gosdk"
+	"github.com/nebius/gosdk/config/reader"
+)
+
+// ErrNoProfileAvailable means no configured profile satisfied both constraints before the selection deadline.
+var ErrNoProfileAvailable = errors.New("no e2e profile became available")
+
+const (
+	// e2eWorkflowFile is the workflow whose runs compete for the same projects.
+	e2eWorkflowFile = "e2e_test.yml"
+	// runMetadataArtifact is where a run publishes the profile it took, so that
+	// other runs can see the project as occupied before any instance exists.
+	runMetadataArtifact = "e2e-run-metadata"
+	runMetadataFile     = "e2e-run-metadata.json"
+)
+
+// RunClaim is one run's stake on a Nebius project, published as an artifact right after the run resolves its profile.
+type RunClaim struct {
+	RunID       int64  `json:"run_id"`
+	ProfileName string `json:"profile_name"`
+	ProjectID   string `json:"project_id"`
+	Region      string `json:"region"`
+	IsScheduled bool   `json:"is_scheduled"`
+}
+
+// WriteRunMetadata writes this run's claim to path for upload as an artifact.
+func WriteRunMetadata(path string, claim RunClaim) error {
+	data, err := json.Marshal(claim)
+	if err != nil {
+		return fmt.Errorf("marshal run metadata: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write run metadata to %s: %w", path, err)
+	}
+	return nil
+}
+
+// CurrentRunID returns this GitHub Actions run's id, or 0 outside Actions.
+func CurrentRunID() int64 {
+	id, err := strconv.ParseInt(os.Getenv("GITHUB_RUN_ID"), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}
+
+// activeRunIDs lists e2e runs that have not finished yet, excluding this one.
+// Queued runs count: a run waiting on the concurrency mutex still owns its project.
+func activeRunIDs(ctx context.Context, repo string) ([]int64, error) {
+	cmd := exec.CommandContext(ctx, "gh", "api",
+		fmt.Sprintf("repos/%s/actions/workflows/%s/runs?per_page=100", repo, e2eWorkflowFile),
+		"--jq", `.workflow_runs[] | select(.status != "completed") | .id`,
+	)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("list active e2e runs: %w", err)
+	}
+
+	current := CurrentRunID()
+	var ids []int64
+	for _, line := range strings.Fields(string(out)) {
+		id, err := strconv.ParseInt(line, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse run id %q: %w", line, err)
+		}
+		if id == current {
+			continue
+		}
+		ids = append(ids, id)
+	}
+
+	return ids, nil
+}
+
+// downloadClaim reads another run's claim. A run that has not published one yet is
+// reported as absent rather than as an error — it simply has not picked a profile.
+func downloadClaim(ctx context.Context, repo string, runID int64) (claim RunClaim, ok bool) {
+	dir, err := os.MkdirTemp("", "e2e-claim-")
+	if err != nil {
+		log.Printf("Run %d: create temp dir: %v", runID, err)
+		return RunClaim{}, false
+	}
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	cmd := exec.CommandContext(ctx, "gh", "run", "download", strconv.FormatInt(runID, 10),
+		"-n", runMetadataArtifact, "-D", dir, "-R", repo)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		log.Printf("Run %d: no %s artifact yet, treating as unclaimed", runID, runMetadataArtifact)
+		return RunClaim{}, false
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, runMetadataFile))
+	if err != nil {
+		log.Printf("Run %d: read run metadata: %v", runID, err)
+		return RunClaim{}, false
+	}
+
+	if err := json.Unmarshal(data, &claim); err != nil {
+		log.Printf("Run %d: parse run metadata: %v", runID, err)
+		return RunClaim{}, false
+	}
+	claim.RunID = runID
+
+	return claim, true
+}
+
+// ActiveClaims collects the projects currently held by other e2e runs.
+func ActiveClaims(ctx context.Context) ([]RunClaim, error) {
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	if repo == "" {
+		return nil, fmt.Errorf("GITHUB_REPOSITORY env var is not set")
+	}
+
+	ids, err := activeRunIDs(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	var claims []RunClaim
+	for _, id := range ids {
+		claim, ok := downloadClaim(ctx, repo, id)
+		if !ok {
+			continue
+		}
+		// A run started before profile names were published reports its project
+		// only. That still excludes the project, which is the binding constraint.
+		name := claim.ProfileName
+		if name == "" {
+			name = "unnamed"
+		}
+		log.Printf("Run %d holds project %s (profile %s)", claim.RunID, claim.ProjectID, name)
+		claims = append(claims, claim)
+	}
+
+	return claims, nil
+}
+
+// capacityOracle answers whether a profile's demand fits right now.
+// It is a parameter so the selection logic can be exercised without the capacity API.
+type capacityOracle func(profile Profile, reserved map[affinityKey]uint64) (bool, error)
+
+// reservedDemand sums the GPU demand of the profiles other runs have claimed. Those
+// runs may not have created their instances yet, so their demand is invisible in the
+// capacity block usage. A claim whose instances already exist is counted twice, which
+// is deliberate — the selector would rather leave a busy block alone than crowd it.
+//
+// Claims naming a profile this config no longer knows contribute nothing; their
+// project is still excluded, and once their instances exist the usage covers them.
+func reservedDemand(cfg E2EConfig, claims []RunClaim) map[affinityKey]uint64 {
+	reserved := make(map[affinityKey]uint64)
+	for _, claim := range claims {
+		profile, ok := cfg.Profiles[claim.ProfileName]
+		if !ok {
+			continue
+		}
+		demands, _ := gpuDemands(profile)
+		for key, demand := range demands {
+			reserved[key] += demand.requiredGPUs
+		}
+	}
+	return reserved
+}
+
+// filterFeasible returns the candidates that satisfy both constraints: nobody else
+// holds their project, and their capacity block has room.
+func filterFeasible(cfg E2EConfig, candidates []string, claims []RunClaim, oracle capacityOracle) ([]string, error) {
+	// Keyed by project, not by profile name: several profiles can share one project
+	// and one concurrency group, so claiming any of them takes all of them.
+	occupied := make(map[string]int64, len(claims))
+	for _, claim := range claims {
+		occupied[claim.ProjectID] = claim.RunID
+	}
+	reserved := reservedDemand(cfg, claims)
+
+	var feasible []string
+	for _, name := range candidates {
+		profile := cfg.Profiles[name]
+
+		if runID, taken := occupied[profile.NebiusProjectID]; taken {
+			log.Printf("Profile %s: project %s is held by run %d", name, profile.NebiusProjectID, runID)
+			continue
+		}
+
+		ok, err := oracle(profile, reserved)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			log.Printf("Profile %s: not enough capacity", name)
+			continue
+		}
+
+		log.Printf("Profile %s: available", name)
+		feasible = append(feasible, name)
+	}
+
+	return feasible, nil
+}
+
+type selectOptions struct {
+	timeout time.Duration
+	poll    time.Duration
+	claims  func(context.Context) ([]RunClaim, error)
+	oracle  capacityOracle
+	pick    func(n int) int
+}
+
+// candidatesFor returns the profiles the selector may pick, or an error naming the labels
+// that do exist when the requested one matches nothing.
+func candidatesFor(cfg E2EConfig, label string) ([]string, error) {
+	candidates := cfg.Candidates(label)
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no profile carries the label %q (labels in use: %s)",
+			label, strings.Join(cfg.Labels(), ", "))
+	}
+	return candidates, nil
+}
+
+// newNebiusSDK signs in with the NEBIUS_IAM_TOKEN env var when it is set, and
+// otherwise the way the Nebius CLI would: from the standard config file. On a
+// service-account profile the SDK keeps the exchanged token fresh on its own,
+// which matters when the selector waits for longer than one token stays valid.
+func newNebiusSDK(ctx context.Context) (*gosdk.SDK, error) {
+	if token := os.Getenv("NEBIUS_IAM_TOKEN"); token != "" {
+		sdk, err := gosdk.New(ctx, gosdk.WithCredentials(gosdk.IAMToken(token)))
+		if err != nil {
+			return nil, fmt.Errorf("create nebius sdk with env token: %w", err)
+		}
+		return sdk, nil
+	}
+
+	sdk, err := gosdk.New(ctx, gosdk.WithConfigReader(reader.NewConfigReader(reader.WithoutFileCache())))
+	if err != nil {
+		return nil, fmt.Errorf("create nebius sdk (needs ~/.nebius/config.yaml or NEBIUS_IAM_TOKEN): %w", err)
+	}
+	return sdk, nil
+}
+
+// SelectProfile waits until one of the profiles carrying the given label is free  and returns it.
+func SelectProfile(ctx context.Context, cfg E2EConfig, label string) (name string, profile Profile, err error) {
+	// Checked before authenticating, so a mistyped label fails immediately rather than behind a credentials error.
+	if _, err := candidatesFor(cfg, label); err != nil {
+		return "", Profile{}, err
+	}
+
+	sdk, err := newNebiusSDK(ctx)
+	if err != nil {
+		return "", Profile{}, err
+	}
+	defer func() {
+		_ = sdk.Close()
+	}()
+
+	return selectProfile(ctx, cfg, label, selectOptions{
+		timeout: time.Duration(cfg.Selector.TimeoutMinutes) * time.Minute,
+		poll:    time.Duration(cfg.Selector.PollSeconds) * time.Second,
+		claims:  ActiveClaims,
+		oracle: func(profile Profile, reserved map[affinityKey]uint64) (bool, error) {
+			return hasCapacity(ctx, sdk, profile, reserved)
+		},
+		pick: rand.IntN,
+	})
+}
+
+func selectProfile(ctx context.Context, cfg E2EConfig, label string, opts selectOptions) (name string, profile Profile, err error) {
+	candidates, err := candidatesFor(cfg, label)
+	if err != nil {
+		return "", Profile{}, err
+	}
+
+	deadline := time.Now().Add(opts.timeout)
+
+	for attempt := 1; ; attempt++ {
+		claims, err := opts.claims(ctx)
+		if err != nil {
+			return "", Profile{}, err
+		}
+		log.Printf("Attempt %d: %d other e2e run(s) in flight, checking %s",
+			attempt, len(claims), strings.Join(candidates, ", "))
+
+		feasible, err := filterFeasible(cfg, candidates, claims, opts.oracle)
+		if err != nil {
+			return "", Profile{}, err
+		}
+
+		if len(feasible) > 0 {
+			// Pick at random rather than best-fit: two selectors running at the same
+			// moment see the same state, and a deterministic choice would send both
+			// to the same project.
+			name = feasible[opts.pick(len(feasible))]
+			log.Printf("Selected profile %s out of %d available (%s)",
+				name, len(feasible), strings.Join(feasible, ", "))
+			return name, cfg.Profiles[name], nil
+		}
+
+		if !time.Now().Add(opts.poll).Before(deadline) {
+			return "", Profile{}, fmt.Errorf("%w within %s (candidates: %s)",
+				ErrNoProfileAvailable, opts.timeout, strings.Join(candidates, ", "))
+		}
+
+		log.Printf("No profile available, retrying in %s (giving up in %s)",
+			opts.poll, time.Until(deadline).Round(time.Second))
+
+		select {
+		case <-ctx.Done():
+			return "", Profile{}, ctx.Err()
+		case <-time.After(opts.poll):
+		}
+	}
+}

--- a/internal/e2e/select_test.go
+++ b/internal/e2e/select_test.go
@@ -1,0 +1,252 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func gpuProfile(projectID, region, platform, fabric string, size int) Profile {
+	return Profile{
+		NebiusProjectID:  projectID,
+		NebiusRegion:     region,
+		NebiusTenantID:   "tenant-456",
+		CapacityStrategy: CapacityStrategyWarn,
+		NodeSets: []NodeSetDef{
+			{
+				Name:             "worker",
+				Platform:         platform,
+				Preset:           "8gpu-128vcpu-1600gb",
+				Size:             size,
+				InfinibandFabric: fabric,
+			},
+		},
+	}
+}
+
+// testConfig mirrors the real config shape: two regions with one project each, plus a
+// second profile sharing the us-central1 project (as KCS_B200 and KCS_CPU do). Only
+// the two GPU profiles carry the auto-select label.
+func testConfig() E2EConfig {
+	kcs := gpuProfile("project-kcs", "us-central1", "gpu-b200-sxm", "us-central1-b", 2)
+	kcs.Labels = []string{autoSelectLabel}
+
+	mdc := gpuProfile("project-mdc", "me-west1", "gpu-b200-sxm-a", "me-west1-a", 2)
+	mdc.Labels = []string{autoSelectLabel}
+
+	return E2EConfig{
+		Scheduler: SchedulerSettings{RunsPerTick: 1, MaxInFlight: 2},
+		Selector:  SelectorSettings{TimeoutMinutes: 60, PollSeconds: 60},
+		Profiles: map[string]Profile{
+			"KCS_B200": kcs,
+			"MDC_B200": mdc,
+			"KCS_CPU": {
+				NebiusProjectID:  "project-kcs",
+				NebiusRegion:     "us-central1",
+				NebiusTenantID:   "tenant-456",
+				CapacityStrategy: CapacityStrategyWarn,
+				NodeSets: []NodeSetDef{
+					{Name: "worker", Platform: "cpu-d3", Preset: "32vcpu-128gb", Size: 2},
+				},
+			},
+		},
+	}
+}
+
+// label returns the cfg with an extra label on one of its profiles.
+func withLabel(cfg E2EConfig, name, label string) E2EConfig {
+	profile := cfg.Profiles[name]
+	profile.Labels = append(profile.Labels, label)
+	cfg.Profiles[name] = profile
+	return cfg
+}
+
+func alwaysAvailable(Profile, map[affinityKey]uint64) (bool, error) { return true, nil }
+
+func neverAvailable(Profile, map[affinityKey]uint64) (bool, error) { return false, nil }
+
+func TestFilterFeasible_AllFree(t *testing.T) {
+	cfg := testConfig()
+	feasible, err := filterFeasible(cfg, cfg.Candidates(autoSelectLabel), nil, alwaysAvailable)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"KCS_B200", "MDC_B200"}, feasible)
+}
+
+func TestFilterFeasible_SkipsClaimedProject(t *testing.T) {
+	cfg := testConfig()
+	claims := []RunClaim{{RunID: 1, ProfileName: "KCS_B200", ProjectID: "project-kcs"}}
+	feasible, err := filterFeasible(cfg, cfg.Candidates(autoSelectLabel), claims, alwaysAvailable)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"MDC_B200"}, feasible)
+}
+
+func TestFilterFeasible_SiblingProfileSharesTheClaimedProject(t *testing.T) {
+	cfg := withLabel(testConfig(), "KCS_CPU", autoSelectLabel)
+
+	// A run holding project-kcs through KCS_CPU also blocks KCS_B200: they share the
+	// project, and therefore the concurrency group.
+	claims := []RunClaim{{RunID: 7, ProfileName: "KCS_CPU", ProjectID: "project-kcs"}}
+	feasible, err := filterFeasible(cfg, cfg.Candidates(autoSelectLabel), claims, alwaysAvailable)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"MDC_B200"}, feasible)
+}
+
+func TestFilterFeasible_SkipsProfileWithoutCapacity(t *testing.T) {
+	cfg := testConfig()
+	feasible, err := filterFeasible(cfg, cfg.Candidates(autoSelectLabel), nil, neverAvailable)
+	require.NoError(t, err)
+	assert.Empty(t, feasible)
+}
+
+func TestFilterFeasible_IgnoresUnlabelledProfiles(t *testing.T) {
+	// KCS_CPU is configured but unlabelled, so it is never returned.
+	cfg := testConfig()
+	feasible, err := filterFeasible(cfg, cfg.Candidates(autoSelectLabel), nil, alwaysAvailable)
+	require.NoError(t, err)
+	assert.NotContains(t, feasible, "KCS_CPU")
+}
+
+func TestFilterFeasible_PassesReservedDemandToOracle(t *testing.T) {
+	var seen map[affinityKey]uint64
+	oracle := func(_ Profile, reserved map[affinityKey]uint64) (bool, error) {
+		seen = reserved
+		return true, nil
+	}
+
+	cfg := testConfig()
+	claims := []RunClaim{{RunID: 1, ProfileName: "KCS_B200", ProjectID: "project-kcs"}}
+	_, err := filterFeasible(cfg, cfg.Candidates(autoSelectLabel), claims, oracle)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(16), seen[affinityKey{Platform: "gpu-b200-sxm", Fabric: "us-central1-b"}])
+}
+
+func TestFilterFeasible_OracleError(t *testing.T) {
+	boom := errors.New("capacity api down")
+	cfg := testConfig()
+	_, err := filterFeasible(cfg, cfg.Candidates(autoSelectLabel), nil, func(Profile, map[affinityKey]uint64) (bool, error) {
+		return false, boom
+	})
+	assert.ErrorIs(t, err, boom)
+}
+
+func TestReservedDemand(t *testing.T) {
+	cfg := testConfig()
+	claims := []RunClaim{
+		{RunID: 1, ProfileName: "KCS_B200", ProjectID: "project-kcs"},
+		{RunID: 2, ProfileName: "MDC_B200", ProjectID: "project-mdc"},
+		{RunID: 3, ProfileName: "KCS_CPU", ProjectID: "project-kcs"},
+		{RunID: 4, ProfileName: "GONE_FROM_CONFIG", ProjectID: "project-old"},
+	}
+
+	reserved := reservedDemand(cfg, claims)
+
+	assert.Equal(t, uint64(16), reserved[affinityKey{Platform: "gpu-b200-sxm", Fabric: "us-central1-b"}])
+	assert.Equal(t, uint64(16), reserved[affinityKey{Platform: "gpu-b200-sxm-a", Fabric: "me-west1-a"}])
+	// CPU-only and unknown profiles contribute nothing.
+	assert.Len(t, reserved, 2)
+}
+
+func TestReservedDemand_SumsRunsOnTheSameAffinity(t *testing.T) {
+	cfg := testConfig()
+	claims := []RunClaim{
+		{RunID: 1, ProfileName: "KCS_B200", ProjectID: "project-kcs"},
+		{RunID: 2, ProfileName: "KCS_B200", ProjectID: "project-kcs"},
+	}
+
+	reserved := reservedDemand(cfg, claims)
+	assert.Equal(t, uint64(32), reserved[affinityKey{Platform: "gpu-b200-sxm", Fabric: "us-central1-b"}])
+}
+
+func noClaims(context.Context) ([]RunClaim, error) { return nil, nil }
+
+func testOptions(oracle capacityOracle) selectOptions {
+	return selectOptions{
+		timeout: time.Second,
+		poll:    time.Millisecond,
+		claims:  noClaims,
+		oracle:  oracle,
+		pick:    func(int) int { return 0 },
+	}
+}
+
+func TestSelectProfile_PicksAvailableProfile(t *testing.T) {
+	name, profile, err := selectProfile(context.Background(), testConfig(), autoSelectLabel, testOptions(alwaysAvailable))
+	require.NoError(t, err)
+	assert.Equal(t, "KCS_B200", name)
+	assert.Equal(t, "project-kcs", profile.NebiusProjectID)
+}
+
+func TestSelectProfile_PickIsRandomOverFeasibleOnly(t *testing.T) {
+	cfg := testConfig()
+	claims := func(context.Context) ([]RunClaim, error) {
+		return []RunClaim{{RunID: 1, ProfileName: "KCS_B200", ProjectID: "project-kcs"}}, nil
+	}
+
+	opts := testOptions(alwaysAvailable)
+	opts.claims = claims
+	// The only feasible candidate is at index 0 of the filtered list, not of the
+	// full candidate list.
+	opts.pick = func(n int) int {
+		assert.Equal(t, 1, n)
+		return 0
+	}
+
+	name, _, err := selectProfile(context.Background(), cfg, autoSelectLabel, opts)
+	require.NoError(t, err)
+	assert.Equal(t, "MDC_B200", name)
+}
+
+func TestSelectProfile_RetriesUntilCapacityFrees(t *testing.T) {
+	attempts := 0
+	opts := testOptions(func(Profile, map[affinityKey]uint64) (bool, error) {
+		attempts++
+		return attempts >= 3, nil
+	})
+
+	name, _, err := selectProfile(context.Background(), testConfig(), autoSelectLabel, opts)
+	require.NoError(t, err)
+	assert.Equal(t, "KCS_B200", name)
+	assert.GreaterOrEqual(t, attempts, 3)
+}
+
+func TestSelectProfile_TimesOut(t *testing.T) {
+	opts := testOptions(neverAvailable)
+	opts.timeout = 20 * time.Millisecond
+
+	_, _, err := selectProfile(context.Background(), testConfig(), autoSelectLabel, opts)
+	assert.ErrorIs(t, err, ErrNoProfileAvailable)
+}
+
+func TestSelectProfile_NoLabelledProfiles(t *testing.T) {
+	cfg := testConfig()
+	for name, profile := range cfg.Profiles {
+		profile.Labels = nil
+		cfg.Profiles[name] = profile
+	}
+
+	_, _, err := selectProfile(context.Background(), cfg, autoSelectLabel, testOptions(alwaysAvailable))
+	assert.ErrorContains(t, err, `no profile carries the label "auto-select"`)
+}
+
+func TestSelectProfile_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	opts := testOptions(neverAvailable)
+	_, _, err := selectProfile(ctx, testConfig(), autoSelectLabel, opts)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSelectProfile_ClaimsError(t *testing.T) {
+	boom := errors.New("gh api failed")
+	opts := testOptions(alwaysAvailable)
+	opts.claims = func(context.Context) ([]RunClaim, error) { return nil, boom }
+
+	_, _, err := selectProfile(context.Background(), testConfig(), autoSelectLabel, opts)
+	assert.ErrorIs(t, err, boom)
+}


### PR DESCRIPTION
## Problem

Each e2e run is pinned to a single profile through the `PROFILE_ENV_VAR` GitHub variable. Concurrent runs queue behind each other on that one project while other projects with free GPU capacity sit idle, and the scheduler's conflict check could only self-cancel scheduled runs.

## Solution

- All profiles now live in one `E2E_CONFIG` variable, each carrying labels. The workflow's `profile` input takes a profile name or `@label` (default `@auto-select`).
- New `e2e select-profile` command resolves the input: a name picks that profile, a label polls until one of the labeled profiles is free and picks at random among the feasible ones.
- A profile is feasible when no other active run claims its project (claims are published as `e2e-run-metadata` artifacts) and its capacity block fits the demand, including GPUs reserved by claims whose instances do not exist yet.

## Testing

- E2E runs: https://github.com/nebius/soperator/actions/workflows/e2e_test.yml?query=branch%3ASCHED-2111%2F0


## Release Notes

None
