### PR TITLE
SCHED-2206: Make build-e2e tolerate the release-branch e2e layout

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -187,38 +187,64 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      # This job always runs with the default-branch definition, including for PRs
+      # into release branches, which check out a tree where the e2e code still
+      # lives in internal/e2e of the root module. Detect what was actually checked
+      # out and pick the matching steps below.
+      - name: Detect E2E module layout
+        id: layout
+        shell: bash
+        run: |
+          if [[ -f e2e/go.mod ]]; then
+            echo "standalone=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "standalone=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install GO
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: "e2e/go.mod"
+          go-version-file: ${{ steps.layout.outputs.standalone == 'true' && 'e2e/go.mod' || 'go.mod' }}
           cache: false
 
       - name: Check E2E module tidy
+        if: steps.layout.outputs.standalone == 'true'
         shell: bash
         run: |
           go -C e2e mod tidy
           git diff --exit-code -- e2e/go.mod e2e/go.sum
 
       - name: Test E2E module
+        if: steps.layout.outputs.standalone == 'true'
         shell: bash
         run: go -C e2e test ./...
 
       - name: Vet E2E module
+        if: steps.layout.outputs.standalone == 'true'
         shell: bash
         run: go -C e2e vet ./...
 
       - name: golangci-lint E2E module
+        if: steps.layout.outputs.standalone == 'true'
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
         with:
           version: v2.12.2 # version of golangci-lint, should be in sync with Makefile.
           working-directory: e2e
 
       - name: Build E2E commands
+        if: steps.layout.outputs.standalone == 'true'
         shell: bash
         run: |
           mkdir -p bin
           go -C e2e build -o ../bin/acceptance ./cmd/acceptance
           go build -o bin/e2e ./cmd/e2e
+
+      # Release branches keep the e2e code in the root module; build it the way
+      # their own CI job did, so their PRs stay green under this definition.
+      - name: Build E2E command (root module)
+        if: steps.layout.outputs.standalone != 'true'
+        shell: bash
+        run: go build -o /dev/null ./cmd/e2e
 
   build-soperator-images:
     needs:


### PR DESCRIPTION
## Problem

Since SCHED-2206 moved the e2e code into a standalone `e2e/` Go module, the `build-e2e` job in `one_job.yml` assumes `e2e/go.mod` exists. `one_job.yml` triggers on `pull_request_target`, so its **default-branch definition** runs for every PR — including PRs into `soperator-release-4.0`/`4.1`, which check out a tree where the e2e code still lives in `internal/e2e` of the root module. Every Go-touching PR into a release branch now fails at setup-go (`e2e/go.mod does not exist`), and the required `CI Success` check aggregates `build-e2e`, blocking merges (first hit: #2844).

## Solution

Detect the checked-out layout in the job and branch on it:

- `e2e/go.mod` present → the existing standalone-module steps run unchanged (tidy check, test, vet, golangci-lint, build both commands).
- absent → build `./cmd/e2e` from the root module, exactly what the release branches' own `build-e2e` job did.

No cherry-picks needed: the definition comes from main, so merging this heals all release-branch PRs immediately.

## Testing

CI on this PR exercises the standalone path. The root-module path matches the release branches' previous job verbatim; re-running `build-e2e` on #2844 after merge verifies it.

## Release Notes

None
