### PR TITLE
SCHED-2111: Drop deprecated profile_env_var e2e workflow input

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -31,14 +31,6 @@ on:
           - MDC_B200
           - KCS_CPU
           - KCS_MIXED
-      # Ignored. Declared only so dispatches from a scheduler that still sends it
-      # are accepted instead of rejected as an unexpected input. Drop once main
-      # runs the scheduler that stopped sending it.
-      profile_env_var:
-        description: "[deprecated] ignored"
-        required: false
-        default: ""
-        type: string
       run_unstable_tests:
         description: "Run acceptance scenarios tagged @unstable"
         required: false


### PR DESCRIPTION
## Problem
`e2e_test.yml` still declares the ignored `profile_env_var` dispatch input. It was kept only so dispatches from the old main scheduler, which still sent `-f profile_env_var=...`, were accepted instead of rejected. It is the last transition remnant of SCHED-2111.

## Solution
- Drop the deprecated `profile_env_var` workflow_dispatch input from `e2e_test.yml`.

Safe to merge now: merge-back #2850 landed on main, so the scheduler no longer sends this input. Merging before that would have broken scheduled dispatches with an undeclared input error.

## Testing
Workflow YAML change only. Grepped the repo, no remaining `profile_env_var` references.

## Release Notes
None
