### PR TITLE
SCHED-2111: Fix e2e environment name mangled by the merge to main

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -155,7 +155,7 @@ jobs:
       group: e2e-${{ needs.resolve-profile.outputs.nebius_project_id }}
     runs-on: ubuntu-latest
 
-    environment: e2
+    environment: e2e
 
     env:
       PATH_TO_INSTALLATION: "${{ github.workspace }}/terraform-repo/soperator/installations/example"

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -31,14 +31,14 @@ on:
           - MDC_B200
           - KCS_CPU
           - KCS_MIXED
-      # Ignored. Declared only so dispatches from a scheduler that still sends it
-      # are accepted instead of rejected as an unexpected input. Drop once main
-      # runs the scheduler that stopped sending it.
       soperator_e2e_repo_branch:
         description: "E2E repo branch"
         required: false
         default: "main"
         type: string
+      # Ignored. Declared only so dispatches from a scheduler that still sends it
+      # are accepted instead of rejected as an unexpected input. Drop once main
+      # runs the scheduler that stopped sending it.
       profile_env_var:
         description: "[deprecated] ignored"
         required: false


### PR DESCRIPTION
## Problem

The merge-back of SCHED-2111 to main (#2850) mangled the `e2e-test` job's environment name in `e2e_test.yml`: `environment: e2` instead of `e2e` (the `resolve-profile` and notify jobs kept the correct name). The job runs against a nonexistent environment, so every environment-scoped variable and secret comes back empty — `NEBIUS_CLI_CONFIG` in particular, which makes the Configure Nebius CLI step write a config with no `default:` profile. Every e2e run on main then dies at the first `.envrc` CLI call with `malformed configuration: default profile is empty` (run 31199352299).

## Solution

Restore `environment: e2e` — a one-character fix.
- Reattach the transition comment to `profile_env_var` — the merge inserted the new `soperator_e2e_repo_branch` input between the comment and the input it describes. Release branches are unaffected (4.0/4.1 carry the correct name).

## Testing

Diffed the job against soperator-release-4.0's, which is the source of the merged content; the environment name is the only remaining divergence in this block. Verified by the failing run's log: the environment-scoped `O11Y_ACCESS_TOKEN` env is visibly empty there.

## Release Notes

None
