### PR TITLE
SCHED-2111: Rotate scheduler branches from the last dispatched run

### DIFF
--- a/.github/workflows/e2e_test_scheduler.yml
+++ b/.github/workflows/e2e_test_scheduler.yml
@@ -39,27 +39,24 @@ jobs:
           BRANCHES=("main" "${RELEASE_BRANCHES[@]}")
           BRANCH_COUNT=${#BRANCHES[@]}
 
-          RUN_NUMBER=${{ github.run_number }}
-
           echo "Branches: ${BRANCHES[*]}"
-          echo "Run number: $RUN_NUMBER"
 
           # Defaults duplicated from defaultRunsPerTick / defaultMaxInFlight in
           # internal/e2e/config.go — keep the two in sync.
           RUNS_PER_TICK=$(echo "$E2E_CONFIG" | yq -r '.scheduler.runs_per_tick // 1')
           MAX_IN_FLIGHT=$(echo "$E2E_CONFIG" | yq -r '.scheduler.max_in_flight // 2')
 
+          # Only scheduled runs count here. A manual run occupies a project, which
+          # the selector already accounts for, but it must not affect the schedule.
+          # The actor= query parameter is avoided on purpose: it serves stale results.
+          RUNS=$(gh api "repos/${{ github.repository }}/actions/workflows/e2e_test.yml/runs?per_page=100" \
+            --jq '[.workflow_runs[] | select(.actor.login == "github-actions[bot]")]')
+
           # A run that finds no free profile waits, then fails. Dispatching on every
           # tick regardless would turn a stretch of tight capacity into a stream of
           # timed-out runs, so stop adding to the pile once enough are in flight.
           # Runs still waiting for a profile count: they are the ones at risk.
-          #
-          # Only scheduled runs count. A manual run occupies a project, which the
-          # selector already accounts for, but it must not switch off the schedule.
-          IN_FLIGHT=$(gh api "repos/${{ github.repository }}/actions/workflows/e2e_test.yml/runs?per_page=100" \
-            --jq '[.workflow_runs[]
-                   | select(.status != "completed")
-                   | select(.actor.login == "github-actions[bot]")] | length')
+          IN_FLIGHT=$(jq '[.[] | select(.status != "completed")] | length' <<<"$RUNS")
 
           DISPATCHES=$(( MAX_IN_FLIGHT - IN_FLIGHT ))
           if (( DISPATCHES > RUNS_PER_TICK )); then
@@ -83,8 +80,22 @@ jobs:
             exit 1
           fi
 
+          # Rotation pointer: the newest scheduler-dispatched run's branch — continue
+          # from the next one. The pointer advances only when something was actually
+          # dispatched, so skipped and double-dispatch ticks cannot skew the rotation.
+          # Unknown or missing branch: start from the top of the list.
+          LAST_BRANCH=$(jq -r '.[0].head_branch // ""' <<<"$RUNS")
+          START=0
+          for i in "${!BRANCHES[@]}"; do
+            if [[ "${BRANCHES[$i]}" == "$LAST_BRANCH" ]]; then
+              START=$(( (i + 1) % BRANCH_COUNT ))
+              break
+            fi
+          done
+          echo "Last scheduled branch: ${LAST_BRANCH:-none}, starting from: ${BRANCHES[$START]}"
+
           for (( i = 0; i < DISPATCHES; i++ )); do
-            BRANCH_INDEX=$(( (RUN_NUMBER + i) % BRANCH_COUNT ))
+            BRANCH_INDEX=$(( (START + i) % BRANCH_COUNT ))
             REF="${BRANCHES[$BRANCH_INDEX]}"
 
             # No profile input on purpose: the default declared on e2e_test.yml's profile input applies,


### PR DESCRIPTION
## Problem

The e2e scheduler picks branches as `(github.run_number + i) % BRANCH_COUNT`. Its run number increments on every cron tick — including ticks that dispatch nothing at the in-flight cap — while the number of dispatches per tick varies (0, 1, or 2). The rotation pointer advances with ticks rather than dispatches, so instead of `main → 4.1 → 4.0 → …` the schedule drifts into patterns like `main → 4.0 → 4.0 → 4.1 → 4.1 → main → main`.

## Solution

Derive the rotation pointer from the run history GitHub already keeps: the newest scheduler-dispatched `e2e_test.yml` run names the branch covered last, and this tick continues from the next entry in the branch list (wrapping; unknown or missing branch starts from the top). The pointer advances only when something was actually dispatched, so skipped and double-dispatch ticks cannot skew coverage. No counter storage is needed, and no extra API call: the runs list already fetched for the in-flight cap is reused (fetched once, read twice).

The API's server-side `actor=` filter is deliberately not used — live testing showed it returns stale results; filtering stays client-side.

## Testing

Workflow YAML validated; the rotation logic was extracted and simulated against the live runs list: current pointer (4.1) → picks 4.0; two dispatches → 4.0 then main (wraps); unknown branch → falls back to main; end-of-list pointer (4.0) → wraps to main.

## Release Notes

None