### PR TITLE
SCHED-2012: Don't render nonexistent nodesets in partitions slurm.conf

### DIFF
--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -1449,6 +1449,7 @@ const (
 	ConditionClusterAccountingAvailable        = "AccountingAvailable"
 	ConditionClusterSConfigControllerAvailable = "SConfigControllerAvailable"
 	ConditionClusterPopulateJailMode           = "PopulateJailMode"
+	ConditionClusterNodeSetRefsResolved        = "NodeSetRefsResolved"
 
 	PhaseClusterPending = "Pending"
 	// PhaseClusterReconciling

--- a/internal/controller/clustercontroller/common.go
+++ b/internal/controller/clustercontroller/common.go
@@ -6,6 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -95,7 +96,7 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 					}
 					stepLogger.V(1).Info("Reconciled")
 
-					return nil
+					return r.reportNodeSetRefs(stepCtx, cluster, clusterValues)
 				},
 			},
 			utils.MultiStepExecutionStep{
@@ -270,4 +271,50 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 	}
 	logger.Info("Reconciled common resources")
 	return nil
+}
+
+const (
+	// The API server rejects conditions with a message longer than 32 KiB. Event messages are kept
+	// much shorter to stay readable in `kubectl describe`.
+	nodeSetRefsConditionMessageLimit = 32768
+	nodeSetRefsEventMessageLimit     = 1024
+
+	nodeSetRefsResolvedReason = "AllNodeSetRefsResolved"
+	nodeSetRefsIgnoredReason  = "IgnoredNodeSetRefs"
+)
+
+// reportNodeSetRefs reflects in the cluster status the partition nodeSetRefs that rendering left
+// out of slurm.conf, so that a partition silently losing its nodes is explained to the user.
+func (r SlurmClusterReconciler) reportNodeSetRefs(
+	ctx context.Context,
+	cluster *slurmv1.SlurmCluster,
+	clusterValues *values.SlurmCluster,
+) error {
+	condition := metav1.Condition{
+		Type:    slurmv1.ConditionClusterNodeSetRefsResolved,
+		Status:  metav1.ConditionTrue,
+		Reason:  nodeSetRefsResolvedReason,
+		Message: "All partition nodeSetRefs are rendered into slurm.conf",
+	}
+
+	if resolution := common.ResolveNodeSetRefs(clusterValues); !resolution.IsEmpty() {
+		condition = metav1.Condition{
+			Type:    slurmv1.ConditionClusterNodeSetRefsResolved,
+			Status:  metav1.ConditionFalse,
+			Reason:  nodeSetRefsIgnoredReason,
+			Message: common.FormatIgnoredNodeSetRefs(resolution, nodeSetRefsConditionMessageLimit),
+		}
+
+		log.FromContext(ctx).Info("Ignored partition nodeSetRefs", "Reason", condition.Message)
+		r.Recorder.Event(
+			cluster,
+			corev1.EventTypeWarning,
+			nodeSetRefsIgnoredReason,
+			common.FormatIgnoredNodeSetRefs(resolution, nodeSetRefsEventMessageLimit),
+		)
+	}
+
+	return r.patchStatus(ctx, cluster, func(status *slurmv1.SlurmClusterStatus) bool {
+		return status.SetCondition(condition)
+	})
 }

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -189,7 +189,13 @@ func AddNodesToSlurmConfig(res *renderutils.PropertiesConfig, cluster *values.Sl
 	}
 }
 
-// AddPartitionsToSlurmConfig adds structured partition configuration to the slurm config
+// AddPartitionsToSlurmConfig adds structured partition configuration to the slurm config.
+//
+// NodeSetRefs pointing to NodeSets that are absent from the NodeSet section are dropped: such a
+// reference makes slurmctld reject the whole config, and it shows up routinely during upgrades,
+// when NodeSets and SlurmCluster are applied one after another. A partition losing all of its refs
+// this way is rendered with a blank node list, which keeps it alive without resources until the
+// NodeSets show up.
 //
 // Example output:
 // PartitionName=main Nodes=ALL AllowGroups=mleng CpuBind=verbose Default=YES DefaultTime=1:00:00 MaxTime=4:00:00 DefCpuPerGPU=8 Hidden=NO OverSubscribe=YES PreemptMode=OFF PriorityTier=10 State=UP
@@ -202,18 +208,36 @@ func AddPartitionsToSlurmConfig(res *renderutils.PropertiesConfig, cluster *valu
 		return
 	}
 
+	replicas := nodeSetReplicas(cluster)
+
 	for _, partition := range cluster.PartitionConfiguration.Partitions {
-		switch {
-		case partition.IsAll:
+		if partition.IsAll {
 			res.AddProperty("PartitionName", fmt.Sprintf("%s Nodes=ALL %s", partition.Name, partition.Config))
-		case len(partition.NodeSetRefs) > 0:
-			nodes := strings.Join(partition.NodeSetRefs, ",")
+			continue
+		}
+
+		resolved, ignored := resolvePartitionNodeSetRefs(partition, replicas)
+		for _, ref := range ignored {
+			res.AddComment(fmt.Sprintf(
+				"WARNING: Partition %s references NodeSet %s ignored: %s",
+				ref.Partition, ref.NodeSet, ref.Reason,
+			))
+		}
+
+		switch {
+		case len(resolved) > 0:
+			nodes := strings.Join(resolved, ",")
 			res.AddProperty("PartitionName", fmt.Sprintf("%s Nodes=%s %s", partition.Name, nodes, partition.Config))
+		case len(ignored) > 0:
+			// Keeping the partition without resources is better than dropping it: dropping would
+			// delete it from a running cluster on reconfigure, together with its pending jobs, and
+			// would take the cluster's default partition down with it.
+			res.AddComment(fmt.Sprintf("WARNING: Partition %s has no usable nodeset refs, rendering it without nodes", partition.Name))
+			res.AddProperty("PartitionName", fmt.Sprintf(`%s Nodes="" %s`, partition.Name, partition.Config))
 		default:
 			res.AddComment(fmt.Sprintf("WARNING: Partition %s has no nodeset refs and is not 'all', skipping", partition.Name))
 		}
 	}
-
 }
 
 // AddNodesToGresConfig adds node-scoped settings to the slurm config

--- a/internal/render/common/configmap_test.go
+++ b/internal/render/common/configmap_test.go
@@ -1008,11 +1008,24 @@ func TestAddNodeSetsToSlurmConfig(t *testing.T) {
 	}
 }
 
+func nodeSetWithReplicas(name string, replicas int32) slurmv1alpha1.NodeSet {
+	return slurmv1alpha1.NodeSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "soperator",
+		},
+		Spec: slurmv1alpha1.NodeSetSpec{
+			Replicas: replicas,
+		},
+	}
+}
+
 func TestAddPartitionsToSlurmConfig(t *testing.T) {
 	tests := []struct {
-		name     string
-		cluster  *values.SlurmCluster
-		expected string
+		name        string
+		cluster     *values.SlurmCluster
+		expected    []string
+		notExpected []string
 	}{
 		{
 			name: "Single partition with isAll",
@@ -1032,7 +1045,7 @@ func TestAddPartitionsToSlurmConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: "PartitionName=main Nodes=ALL Default=YES PriorityTier=10 MaxTime=INFINITE State=UP",
+			expected: []string{"PartitionName=main Nodes=ALL Default=YES PriorityTier=10 MaxTime=INFINITE State=UP"},
 		},
 		{
 			name: "Single partition with nodeset refs",
@@ -1040,6 +1053,10 @@ func TestAddPartitionsToSlurmConfig(t *testing.T) {
 				NamespacedName: types.NamespacedName{
 					Namespace: "soperator",
 					Name:      "slurm-test",
+				},
+				NodeSets: []slurmv1alpha1.NodeSet{
+					nodeSetWithReplicas("nodeA", 1),
+					nodeSetWithReplicas("nodeB", 3),
 				},
 				PartitionConfiguration: values.PartitionConfiguration{
 					ConfigType: "structured",
@@ -1052,7 +1069,7 @@ func TestAddPartitionsToSlurmConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: "PartitionName=gpu Nodes=nodeA,nodeB Default=NO PriorityTier=5 State=UP",
+			expected: []string{"PartitionName=gpu Nodes=nodeA,nodeB Default=NO PriorityTier=5 State=UP"},
 		},
 		{
 			name: "Multiple partitions with varying configurations",
@@ -1060,6 +1077,9 @@ func TestAddPartitionsToSlurmConfig(t *testing.T) {
 				NamespacedName: types.NamespacedName{
 					Namespace: "soperator",
 					Name:      "slurm-test",
+				},
+				NodeSets: []slurmv1alpha1.NodeSet{
+					nodeSetWithReplicas("nodeC", 2),
 				},
 				PartitionConfiguration: values.PartitionConfiguration{
 					ConfigType: "structured",
@@ -1077,7 +1097,10 @@ func TestAddPartitionsToSlurmConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: "PartitionName=all-nodes Nodes=ALL Default=NO PriorityTier=1 State=UP",
+			expected: []string{
+				"PartitionName=high-priority Nodes=nodeC Default=YES PriorityTier=10 State=UP",
+				"PartitionName=all-nodes Nodes=ALL Default=NO PriorityTier=1 State=UP",
+			},
 		},
 		{
 			name: "Partition with no nodeset refs and not isAll",
@@ -1096,7 +1119,96 @@ func TestAddPartitionsToSlurmConfig(t *testing.T) {
 					},
 				},
 			},
-			expected: "#WARNING: Partition invalid has no nodeset refs and is not 'all', skipping",
+			expected: []string{"#WARNING: Partition invalid has no nodeset refs and is not 'all', skipping"},
+		},
+		{
+			name: "Partition referencing a nodeset that does not exist yet",
+			cluster: &values.SlurmCluster{
+				NamespacedName: types.NamespacedName{
+					Namespace: "soperator",
+					Name:      "slurm-test",
+				},
+				NodeSets: []slurmv1alpha1.NodeSet{
+					nodeSetWithReplicas("nodeA", 1),
+				},
+				PartitionConfiguration: values.PartitionConfiguration{
+					ConfigType: "structured",
+					Partitions: []slurmv1.Partition{
+						{
+							Name:        "gpu",
+							NodeSetRefs: []string{"nodeA", "missing"},
+							Config:      "Default=NO State=UP",
+						},
+					},
+				},
+			},
+			expected: []string{
+				"#WARNING: Partition gpu references NodeSet missing ignored: NodeSet does not exist",
+				"PartitionName=gpu Nodes=nodeA Default=NO State=UP",
+			},
+			notExpected: []string{"Nodes=nodeA,missing"},
+		},
+		{
+			name: "Partition referencing a nodeset with zero replicas",
+			cluster: &values.SlurmCluster{
+				NamespacedName: types.NamespacedName{
+					Namespace: "soperator",
+					Name:      "slurm-test",
+				},
+				NodeSets: []slurmv1alpha1.NodeSet{
+					nodeSetWithReplicas("nodeA", 2),
+					nodeSetWithReplicas("scaled-down", 0),
+				},
+				PartitionConfiguration: values.PartitionConfiguration{
+					ConfigType: "structured",
+					Partitions: []slurmv1.Partition{
+						{
+							Name:        "gpu",
+							NodeSetRefs: []string{"scaled-down", "nodeA"},
+							Config:      "Default=NO State=UP",
+						},
+					},
+				},
+			},
+			expected: []string{
+				"#WARNING: Partition gpu references NodeSet scaled-down ignored: NodeSet has no replicas",
+				"PartitionName=gpu Nodes=nodeA Default=NO State=UP",
+			},
+		},
+		{
+			name: "Partition losing all of its nodeset refs keeps an empty node list",
+			cluster: &values.SlurmCluster{
+				NamespacedName: types.NamespacedName{
+					Namespace: "soperator",
+					Name:      "slurm-test",
+				},
+				NodeSets: []slurmv1alpha1.NodeSet{
+					nodeSetWithReplicas("nodeA", 1),
+				},
+				PartitionConfiguration: values.PartitionConfiguration{
+					ConfigType: "structured",
+					Partitions: []slurmv1.Partition{
+						{
+							Name:        "gpu",
+							NodeSetRefs: []string{"missing", "also-missing"},
+							Config:      "Default=NO State=UP",
+						},
+						{
+							Name:        "cpu",
+							NodeSetRefs: []string{"nodeA"},
+							Config:      "Default=YES State=UP",
+						},
+					},
+				},
+			},
+			expected: []string{
+				"#WARNING: Partition gpu references NodeSet missing ignored: NodeSet does not exist",
+				"#WARNING: Partition gpu references NodeSet also-missing ignored: NodeSet does not exist",
+				"#WARNING: Partition gpu has no usable nodeset refs, rendering it without nodes",
+				`PartitionName=gpu Nodes="" Default=NO State=UP`,
+				"PartitionName=cpu Nodes=nodeA Default=YES State=UP",
+			},
+			notExpected: []string{"Nodes=missing"},
 		},
 		{
 			name: "No partitions defined",
@@ -1110,7 +1222,7 @@ func TestAddPartitionsToSlurmConfig(t *testing.T) {
 					Partitions: []slurmv1.Partition{},
 				},
 			},
-			expected: "#WARNING: No partitions defined in structured configuration!",
+			expected: []string{"#WARNING: No partitions defined in structured configuration!"},
 		},
 	}
 
@@ -1120,9 +1232,11 @@ func TestAddPartitionsToSlurmConfig(t *testing.T) {
 			AddPartitionsToSlurmConfig(res, tt.cluster)
 			result := res.Render()
 
-			// Check if the expected string is present in the result
-			if !strings.Contains(result, tt.expected) {
-				t.Errorf("Expected string not found in result.\nExpected to contain:\n%s\n\nGot:\n%s", tt.expected, result)
+			for _, expected := range tt.expected {
+				assert.Contains(t, result, expected)
+			}
+			for _, notExpected := range tt.notExpected {
+				assert.NotContains(t, result, notExpected)
 			}
 		})
 	}

--- a/internal/render/common/nodesetrefs.go
+++ b/internal/render/common/nodesetrefs.go
@@ -1,0 +1,149 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	slurmv1 "nebius.ai/slurm-operator/api/v1"
+	"nebius.ai/slurm-operator/internal/values"
+)
+
+// Reasons why a partition's nodeSetRef doesn't get into the rendered slurm.conf.
+const (
+	NodeSetRefIgnoreReasonNotFound   = "NodeSet does not exist"
+	NodeSetRefIgnoreReasonNoReplicas = "NodeSet has no replicas"
+)
+
+// IgnoredNodeSetRef is a partition's nodeSetRef left out of the rendered slurm.conf.
+type IgnoredNodeSetRef struct {
+	Partition string
+	NodeSet   string
+	Reason    string
+}
+
+// NodeSetRefResolution describes which partition nodeSetRefs didn't make it into slurm.conf.
+type NodeSetRefResolution struct {
+	Ignored []IgnoredNodeSetRef
+	// PartitionsWithoutNodes are partitions that lost all of their nodeSetRefs and are therefore
+	// rendered with a blank node list.
+	PartitionsWithoutNodes []string
+}
+
+func (r NodeSetRefResolution) IsEmpty() bool {
+	return len(r.Ignored) == 0 && len(r.PartitionsWithoutNodes) == 0
+}
+
+// ResolveNodeSetRefs reports the partition nodeSetRefs that rendering leaves out of slurm.conf.
+// It repeats the decisions made by [AddPartitionsToSlurmConfig] so that the cluster status can
+// explain them.
+func ResolveNodeSetRefs(cluster *values.SlurmCluster) NodeSetRefResolution {
+	// Only the structured config type renders partitions out of nodeSetRefs. Other types may still
+	// carry a leftover partition list that never reaches slurm.conf.
+	if cluster.PartitionConfiguration.ConfigType != slurmv1.PartitionConfigTypeStructured {
+		return NodeSetRefResolution{}
+	}
+
+	replicas := nodeSetReplicas(cluster)
+
+	var res NodeSetRefResolution
+	for _, partition := range cluster.PartitionConfiguration.Partitions {
+		if partition.IsAll || len(partition.NodeSetRefs) == 0 {
+			continue
+		}
+
+		resolved, ignored := resolvePartitionNodeSetRefs(partition, replicas)
+		res.Ignored = append(res.Ignored, ignored...)
+		if len(resolved) == 0 {
+			res.PartitionsWithoutNodes = append(res.PartitionsWithoutNodes, partition.Name)
+		}
+	}
+
+	return res
+}
+
+// FormatIgnoredNodeSetRefs renders the resolution into a human-readable message, replacing the
+// tail that doesn't fit into limit bytes with "and N more".
+func FormatIgnoredNodeSetRefs(resolution NodeSetRefResolution, limit int) string {
+	var entries []string
+	for _, ref := range resolution.Ignored {
+		entries = append(entries, fmt.Sprintf(
+			"partition %q: nodeSetRef %q ignored (%s)", ref.Partition, ref.NodeSet, ref.Reason,
+		))
+	}
+	for _, partition := range resolution.PartitionsWithoutNodes {
+		entries = append(entries, fmt.Sprintf(
+			"partition %q has no nodes: none of its nodeSetRefs are usable", partition,
+		))
+	}
+
+	return joinWithinLimit(entries, limit)
+}
+
+// resolvePartitionNodeSetRefs splits a partition's nodeSetRefs into the ones that can be rendered
+// and the ones that can't.
+//
+// A ref is renderable only when its NodeSet reaches the `NodeSet=` section of slurm.conf, i.e. the
+// NodeSet exists and [AddNodeSetsToSlurmConfig] emits a line for it, which it does for a positive
+// replica count only. Referring to a NodeSet missing from that section makes slurmctld reject the
+// whole config.
+func resolvePartitionNodeSetRefs(
+	partition slurmv1.Partition,
+	replicas map[string]int32,
+) ([]string, []IgnoredNodeSetRef) {
+	var resolved []string
+	var ignored []IgnoredNodeSetRef
+
+	for _, ref := range partition.NodeSetRefs {
+		nodeSetReplicas, found := replicas[ref]
+		switch {
+		case !found:
+			ignored = append(ignored, IgnoredNodeSetRef{
+				Partition: partition.Name,
+				NodeSet:   ref,
+				Reason:    NodeSetRefIgnoreReasonNotFound,
+			})
+		case nodeSetReplicas <= 0:
+			ignored = append(ignored, IgnoredNodeSetRef{
+				Partition: partition.Name,
+				NodeSet:   ref,
+				Reason:    NodeSetRefIgnoreReasonNoReplicas,
+			})
+		default:
+			resolved = append(resolved, ref)
+		}
+	}
+
+	return resolved, ignored
+}
+
+func nodeSetReplicas(cluster *values.SlurmCluster) map[string]int32 {
+	res := make(map[string]int32, len(cluster.NodeSets))
+	for _, nodeSet := range cluster.NodeSets {
+		res[nodeSet.Name] = nodeSet.Spec.Replicas
+	}
+
+	return res
+}
+
+func joinWithinLimit(entries []string, limit int) string {
+	var res strings.Builder
+
+	appendPart := func(part string) {
+		if res.Len() > 0 {
+			res.WriteString("; ")
+		}
+		res.WriteString(part)
+	}
+
+	for i, entry := range entries {
+		tail := fmt.Sprintf("and %d more", len(entries)-i)
+		// Reserve room for both separators so the tail always fits.
+		if res.Len()+len("; ")+len(entry)+len("; ")+len(tail) > limit {
+			appendPart(tail)
+			break
+		}
+		appendPart(entry)
+	}
+
+	return res.String()
+}

--- a/internal/render/common/nodesetrefs_test.go
+++ b/internal/render/common/nodesetrefs_test.go
@@ -1,0 +1,174 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	slurmv1 "nebius.ai/slurm-operator/api/v1"
+	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
+	"nebius.ai/slurm-operator/internal/values"
+)
+
+func TestResolveNodeSetRefs(t *testing.T) {
+	tests := []struct {
+		name     string
+		cluster  *values.SlurmCluster
+		expected NodeSetRefResolution
+	}{
+		{
+			name: "All refs resolvable",
+			cluster: &values.SlurmCluster{
+				NodeSets: []slurmv1alpha1.NodeSet{
+					nodeSetWithReplicas("nodeA", 1),
+					nodeSetWithReplicas("nodeB", 4),
+				},
+				PartitionConfiguration: values.PartitionConfiguration{
+					ConfigType: slurmv1.PartitionConfigTypeStructured,
+					Partitions: []slurmv1.Partition{
+						{Name: "gpu", NodeSetRefs: []string{"nodeA", "nodeB"}},
+						{Name: "main", IsAll: true},
+					},
+				},
+			},
+			expected: NodeSetRefResolution{},
+		},
+		{
+			name: "Missing and scaled down nodesets",
+			cluster: &values.SlurmCluster{
+				NodeSets: []slurmv1alpha1.NodeSet{
+					nodeSetWithReplicas("nodeA", 1),
+					nodeSetWithReplicas("scaled-down", 0),
+				},
+				PartitionConfiguration: values.PartitionConfiguration{
+					ConfigType: slurmv1.PartitionConfigTypeStructured,
+					Partitions: []slurmv1.Partition{
+						{Name: "gpu", NodeSetRefs: []string{"nodeA", "missing", "scaled-down"}},
+					},
+				},
+			},
+			expected: NodeSetRefResolution{
+				Ignored: []IgnoredNodeSetRef{
+					{Partition: "gpu", NodeSet: "missing", Reason: NodeSetRefIgnoreReasonNotFound},
+					{Partition: "gpu", NodeSet: "scaled-down", Reason: NodeSetRefIgnoreReasonNoReplicas},
+				},
+			},
+		},
+		{
+			name: "Partition losing all refs is reported as left without nodes",
+			cluster: &values.SlurmCluster{
+				PartitionConfiguration: values.PartitionConfiguration{
+					ConfigType: slurmv1.PartitionConfigTypeStructured,
+					Partitions: []slurmv1.Partition{
+						{Name: "gpu", NodeSetRefs: []string{"missing"}},
+					},
+				},
+			},
+			expected: NodeSetRefResolution{
+				Ignored: []IgnoredNodeSetRef{
+					{Partition: "gpu", NodeSet: "missing", Reason: NodeSetRefIgnoreReasonNotFound},
+				},
+				PartitionsWithoutNodes: []string{"gpu"},
+			},
+		},
+		{
+			name: "Negative replicas are treated as no replicas",
+			cluster: &values.SlurmCluster{
+				NodeSets: []slurmv1alpha1.NodeSet{
+					nodeSetWithReplicas("nodeA", -1),
+				},
+				PartitionConfiguration: values.PartitionConfiguration{
+					ConfigType: slurmv1.PartitionConfigTypeStructured,
+					Partitions: []slurmv1.Partition{
+						{Name: "gpu", NodeSetRefs: []string{"nodeA"}},
+					},
+				},
+			},
+			expected: NodeSetRefResolution{
+				Ignored: []IgnoredNodeSetRef{
+					{Partition: "gpu", NodeSet: "nodeA", Reason: NodeSetRefIgnoreReasonNoReplicas},
+				},
+				PartitionsWithoutNodes: []string{"gpu"},
+			},
+		},
+		{
+			name: "Non-structured config type keeps its leftover partitions unreported",
+			cluster: &values.SlurmCluster{
+				PartitionConfiguration: values.PartitionConfiguration{
+					ConfigType: slurmv1.PartitionConfigTypeDefault,
+					Partitions: []slurmv1.Partition{
+						{Name: "gpu", NodeSetRefs: []string{"missing"}},
+					},
+				},
+			},
+			expected: NodeSetRefResolution{},
+		},
+		{
+			name: "Partitions without refs are not reported",
+			cluster: &values.SlurmCluster{
+				PartitionConfiguration: values.PartitionConfiguration{
+					ConfigType: slurmv1.PartitionConfigTypeStructured,
+					Partitions: []slurmv1.Partition{
+						{Name: "main", IsAll: true},
+						{Name: "invalid"},
+					},
+				},
+			},
+			expected: NodeSetRefResolution{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolution := ResolveNodeSetRefs(tt.cluster)
+
+			assert.Equal(t, tt.expected, resolution)
+			assert.Equal(t, tt.expected.IsEmpty(), resolution.IsEmpty())
+		})
+	}
+}
+
+func TestFormatIgnoredNodeSetRefs(t *testing.T) {
+	t.Run("lists refs and partitions left without nodes", func(t *testing.T) {
+		message := FormatIgnoredNodeSetRefs(NodeSetRefResolution{
+			Ignored: []IgnoredNodeSetRef{
+				{Partition: "gpu", NodeSet: "missing", Reason: NodeSetRefIgnoreReasonNotFound},
+				{Partition: "cpu", NodeSet: "scaled-down", Reason: NodeSetRefIgnoreReasonNoReplicas},
+			},
+			PartitionsWithoutNodes: []string{"gpu"},
+		}, 32768)
+
+		assert.Equal(
+			t,
+			`partition "gpu": nodeSetRef "missing" ignored (NodeSet does not exist); `+
+				`partition "cpu": nodeSetRef "scaled-down" ignored (NodeSet has no replicas); `+
+				`partition "gpu" has no nodes: none of its nodeSetRefs are usable`,
+			message,
+		)
+	})
+
+	t.Run("empty resolution renders nothing", func(t *testing.T) {
+		assert.Empty(t, FormatIgnoredNodeSetRefs(NodeSetRefResolution{}, 32768))
+	})
+
+	t.Run("truncates the tail that does not fit", func(t *testing.T) {
+		var ignored []IgnoredNodeSetRef
+		for i := range 100 {
+			ignored = append(ignored, IgnoredNodeSetRef{
+				Partition: "gpu",
+				NodeSet:   fmt.Sprintf("missing-%d", i),
+				Reason:    NodeSetRefIgnoreReasonNotFound,
+			})
+		}
+
+		const limit = 256
+		message := FormatIgnoredNodeSetRefs(NodeSetRefResolution{Ignored: ignored}, limit)
+
+		assert.LessOrEqual(t, len(message), limit)
+		assert.Contains(t, message, `partition "gpu": nodeSetRef "missing-0" ignored`)
+		assert.NotContains(t, message, `"missing-99"`)
+		assert.True(t, strings.HasSuffix(message, " more"), "message must end with the truncation tail: %s", message)
+	})
+}


### PR DESCRIPTION
## Problem
During upgrades NodeSets and the SlurmCluster HR are applied one after another, so a partition can reference a NodeSet that doesn't exist yet. Soperator rendered that reference into `slurm.conf`, and slurmctld rejected the whole config and went into backoff.

## Solution
Partition `nodeSetRefs` are now matched against the NodeSets that actually reach the `NodeSet=` section (NodeSet exists and has replicas). Unusable refs are dropped from `Nodes=`; a partition that loses all of them is rendered with a blank node list (`Nodes=""`) so it stays alive without resources instead of being deleted from a running cluster. Every dropped ref is reported in the `NodeSetRefsResolved` condition on SlurmCluster and as a Warning event, with the reason (NodeSet does not exist / has no replicas). The state self-heals: the cluster controller watches NodeSets, so the partition regains its nodes once they appear.

## Testing
`make test`, `make lint`, `make helmtest` — all green. New unit tests cover a missing NodeSet, a NodeSet scaled to zero, partial filtering, and a partition losing all refs. Blank `Nodes=""` validity confirmed against the slurm.conf man page of the pinned Slurm 25.11.2.1.
manually on the live cluster.

## Release Notes
Fix: partition `nodeSetRefs` pointing to NodeSets that don't exist yet no longer produce an invalid `slurm.conf` that puts slurmctld into backoff during upgrades. Ignored refs are surfaced in the new `NodeSetRefsResolved` status condition; a partition with no usable refs is now rendered without nodes instead of being dropped.