### PR TITLE
SCHED-2156: New metrics and labels for NVLink Instance Group

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -285,11 +286,22 @@ func main() {
 		}
 	}
 	var ctrlClient client.Client
+	var topologyCache ctrlcache.Cache
 	if cfg != nil {
 		ctrlClient, err = client.New(cfg, client.Options{})
 		if err != nil {
 			log.Error(err, "Failed to create Kubernetes client, continuing in standalone mode")
 			ctrlClient = nil
+		} else {
+			topologyCache, err = exporter.NewKubernetesNodeTopologyCache(
+				cfg,
+				flags.clusterNamespace,
+				flags.clusterName,
+			)
+			if err != nil {
+				log.Error(err, "Failed to create Kubernetes topology cache, topology metrics will be unavailable")
+				topologyCache = nil
+			}
 		}
 	}
 
@@ -315,6 +327,25 @@ func main() {
 		cli.Fail(log, err, "Failed to parse job collection configuration")
 	}
 
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	var nodeTopologySource exporter.NodeTopologySource
+	if topologyCache != nil {
+		if err := exporter.RegisterKubernetesNodeTopologyInformers(ctx, topologyCache); err != nil {
+			log.Error(err, "Failed to register Kubernetes topology informers, collection will retry lazily")
+		}
+		go func() {
+			if err := topologyCache.Start(ctx); err != nil && ctx.Err() == nil {
+				log.Error(err, "Kubernetes topology cache stopped unexpectedly")
+			}
+		}()
+		nodeTopologySource = exporter.NewKubernetesNodeTopologySource(
+			topologyCache,
+			flags.clusterNamespace,
+			flags.clusterName,
+		)
+	}
+
 	clusterExporter := exporter.NewClusterExporter(
 		slurmAPIClient,
 		exporter.Params{
@@ -323,11 +354,9 @@ func main() {
 			CollectionInterval:   interval,
 			MaxCollectorInflight: maxCollectorInflight,
 			JobListParams:        jobListParams,
+			NodeTopologySource:   nodeTopologySource,
 		},
 	)
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	if flags.standalone {
 		log.Info("Using standalone token issuer", "scontrol_path", flags.scontrolPath, "rotation_interval", flags.keyRotationInterval)

--- a/docs/slurm-exporter.md
+++ b/docs/slurm-exporter.md
@@ -108,11 +108,37 @@ Boolean state flag label convention:
 | **slurm_node_memory_free_bytes**<br>*Gauge* | Free memory on the node in bytes<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node |
 | **slurm_node_memory_effective_bytes**<br>*Gauge* | Effective memory on the node in bytes (total minus specialized memory reserved for system daemons)<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node |
 | **slurm_node_partition**<br>*Gauge* | Maps nodes to their partitions, enabling partition-level aggregation via PromQL joins<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node<br>• `partition` - Name of the SLURM partition |
+| **slurm_node_nvlink_instance_group**<br>*Gauge* | Maps Slurm nodes to their NVLink instance group. Emitted only for nodes with the `topology.nebius.com/nvl-instance-group-id` Kubernetes label.<br><br>**Labels:**<br>• `node_name` - Name of the Slurm node and worker Pod<br>• `instance_id` - Compute instance identifier reported by Slurm<br>• `nvlink_instance_group` - Value of the Kubernetes Node's `topology.nebius.com/nvl-instance-group-id` label<br>• `nodeset_name` - Value of the Kubernetes Node's `slurm.nebius.ai/nodeset-name` label |
 | **slurm_job_info**<br>*Gauge* | Detailed information about SLURM jobs<br><br>**Labels:**<br>• `job_id` - SLURM job identifier<br>• `job_state` - Current job state (PENDING, RUNNING, COMPLETED, FAILED, etc.)<br>• `job_state_reason` - Reason for current job state<br>• `slurm_partition` - SLURM partition name<br>• `job_name` - User-defined job name<br>• `user_name` - Username who submitted the job<br>• `user_id` - Numeric user ID who submitted the job<br>• `standard_error` - Path to stderr file<br>• `standard_output` - Path to stdout file<br>• `array_job_id` - Array job ID (if applicable)<br>• `array_task_id` - Array task identity. Either a single task index (e.g. `3`) for an exploded task or a range expression (e.g. `1-5`, `1,3,5-9:2`) for a collapsed array master record on the accounting path. Empty for non-array jobs.<br>• `submit_time` - When the job was submitted (Unix timestamp seconds, empty if not available or zero)<br>• `start_time` - When the job started execution (Unix timestamp seconds, empty if not available or zero)<br>• `end_time` - When the job completed (Unix timestamp seconds, empty if not available or zero). **Warning:** For non-terminal states like RUNNING, this may contain a future timestamp representing the forecasted end time based on the job's time limit<br>• `finished_time` - When the job actually finished for terminal states only (Unix timestamp seconds, empty for non-terminal states or if end_time is zero). Unlike `end_time`, this field only contains actual completion times, never forecasted values |
-| **slurm_node_job**<br>*Gauge* | Mapping between jobs and the nodes they're running on<br><br>**Labels:**<br>• `job_id` - SLURM job identifier<br>• `node_name` - Name of the node running the job |
+| **slurm_node_job**<br>*Gauge* | Mapping between jobs and the nodes they're running on<br><br>**Labels:**<br>• `job_id` - SLURM job identifier<br>• `node_name` - Name of the node running the job<br>• `nvlink_instance_group` - NVLink instance group of the node, or empty when unavailable<br>• `nodeset_name` - Slurm NodeSet name of the node, or empty when unavailable |
 | **slurm_job_duration_seconds**<br>*Gauge* | Job duration in seconds. For running jobs, this is the time elapsed since the job started. For completed jobs, this is the total execution time.<br><br>**Labels:**<br>• `job_id` - SLURM job identifier<br><br>**Notes:**<br>• Only exported for jobs with a valid start time<br>• For non-terminal states (RUNNING, etc.): duration = current_time - start_time<br>• For terminal states (COMPLETED, FAILED, etc.): duration = end_time - start_time (only if end_time is valid) |
 | **slurm_job_cpus**<br>*Gauge* | Number of CPUs allocated to the job<br><br>**Labels:**<br>• `job_id` - SLURM job identifier |
 | **slurm_job_memory_bytes**<br>*Gauge* | Memory allocated to the job in bytes<br><br>**Labels:**<br>• `job_id` - SLURM job identifier |
+
+### NVLink topology joins
+
+The node mapping is the canonical topology metric. Job, partition, and user relationships can be derived without duplicating job-level resource metrics.
+
+```promql
+# Jobs to NVLink instance groups
+max by (job_id, nvlink_instance_group, nodeset_name) (
+  slurm_node_job{nvlink_instance_group!=""}
+)
+
+# Partitions to NVLink instance groups
+max by (partition, nvlink_instance_group, nodeset_name) (
+  slurm_node_partition
+    * on (node_name) group_left(nvlink_instance_group, nodeset_name)
+  slurm_node_nvlink_instance_group
+)
+
+# Users with running jobs on NVLink instance groups
+max by (user_name, nvlink_instance_group, nodeset_name) (
+  slurm_node_job{nvlink_instance_group!=""}
+    * on (job_id) group_left(user_name)
+  slurm_job_info{job_state="RUNNING"}
+)
+```
 
 ### Controller RPC Metrics
 
@@ -135,10 +161,10 @@ The exporter provides self-monitoring metrics to track its own health and perfor
 | **slurm_exporter_collection_duration_seconds**<br>*Gauge* | Duration of the most recent metrics collection from SLURM APIs<br><br>**Labels:** None |
 | **slurm_exporter_collection_attempts_total**<br>*Counter* | Total number of metrics collection attempts<br><br>**Labels:** None |
 | **slurm_exporter_collection_failures_total**<br>*Counter* | Total number of failed metrics collection attempts<br><br>**Labels:** None |
-| **slurm_exporter_collector_duration_seconds**<br>*Gauge* | Duration of the most recent sub-collector run during metrics collection<br><br>**Labels:** `collector` (one of `nodes`, `jobs`, `diag`) |
-| **slurm_exporter_collector_errors_total**<br>*Counter* | Total number of errors per sub-collector during metrics collection. Sub-collectors are isolated, so a failure in one does not drop the others' metrics for that cycle; the failed collector keeps exporting its last successfully collected data until it recovers.<br><br>**Labels:** `collector` (one of `nodes`, `jobs`, `diag`) |
-| **slurm_exporter_collector_inflight**<br>*Gauge* | Number of sub-collector runs currently in progress<br><br>**Labels:** `collector` (one of `nodes`, `jobs`, `diag`) |
-| **slurm_exporter_collector_skipped_total**<br>*Counter* | Total number of skipped sub-collector runs because the configured in-flight limit was reached<br><br>**Labels:** `collector` (one of `nodes`, `jobs`, `diag`) |
+| **slurm_exporter_collector_duration_seconds**<br>*Gauge* | Duration of the most recent sub-collector run during metrics collection<br><br>**Labels:** `collector` (one of `nodes`, `jobs`, `diag`, `topology`) |
+| **slurm_exporter_collector_errors_total**<br>*Counter* | Total number of errors per sub-collector during metrics collection. Sub-collectors are isolated, so a failure in one does not drop the others' metrics for that cycle; the failed collector keeps exporting its last successfully collected data until it recovers.<br><br>**Labels:** `collector` (one of `nodes`, `jobs`, `diag`, `topology`) |
+| **slurm_exporter_collector_inflight**<br>*Gauge* | Number of sub-collector runs currently in progress<br><br>**Labels:** `collector` (one of `nodes`, `jobs`, `diag`, `topology`) |
+| **slurm_exporter_collector_skipped_total**<br>*Counter* | Total number of skipped sub-collector runs because the configured in-flight limit was reached<br><br>**Labels:** `collector` (one of `nodes`, `jobs`, `diag`, `topology`) |
 | **slurm_exporter_metrics_requests_total**<br>*Counter* | Total number of requests to the `/metrics` endpoint<br><br>**Labels:** None |
 | **slurm_exporter_metrics_exported**<br>*Gauge* | Number of metrics exported in the last scrape<br><br>**Labels:** None |
 

--- a/helm/slurm-cluster/templates/exporter-node-rbac.yaml
+++ b/helm/slurm-cluster/templates/exporter-node-rbac.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.slurmNodes.exporter.enabled .Values.slurmNodes.exporter.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "slurm-cluster.name" . }}-exporter-node-reader
+  labels:
+    {{- include "slurm-cluster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: slurm-exporter
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "slurm-cluster.name" . }}-exporter-node-reader
+  labels:
+    {{- include "slurm-cluster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: slurm-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "slurm-cluster.name" . }}-exporter-node-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "slurm-cluster.exporter.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/slurm-cluster/templates/exporter-role.yaml
+++ b/helm/slurm-cluster/templates/exporter-role.yaml
@@ -11,4 +11,7 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "watch"]
 {{- end }}

--- a/helm/slurm-cluster/tests/exporter-rbac_test.yaml
+++ b/helm/slurm-cluster/tests/exporter-rbac_test.yaml
@@ -3,6 +3,7 @@ templates:
   - templates/exporter-serviceaccount.yaml
   - templates/exporter-role.yaml
   - templates/exporter-rolebinding.yaml
+  - templates/exporter-node-rbac.yaml
   - templates/slurm-cluster-cr.yaml
 tests:
   # Test ServiceAccount creation with default values
@@ -73,10 +74,60 @@ tests:
             apiGroups: [""]
             resources: ["secrets"]
             verbs: ["get", "list", "watch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods"]
+            verbs: ["list", "watch"]
+
+  - it: should grant exporter read access to Kubernetes nodes
+    template: templates/exporter-node-rbac.yaml
+    set:
+      clusterName: test-cluster
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ClusterRole
+        documentIndex: 0
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["nodes"]
+            verbs: ["list", "watch"]
+        documentIndex: 0
+      - isKind:
+          of: ClusterRoleBinding
+        documentIndex: 1
+      - equal:
+          path: roleRef.name
+          value: test-cluster-exporter-node-reader
+        documentIndex: 1
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: test-cluster-exporter-sa
+            namespace: NAMESPACE
+        documentIndex: 1
 
   # Test Role not created when rbac.create=false
   - it: should not create Role when rbac.create is false
     template: templates/exporter-role.yaml
+    set:
+      clusterName: test-cluster
+      slurmNodes:
+        exporter:
+          rbac:
+            create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create node RBAC when rbac.create is false
+    template: templates/exporter-node-rbac.yaml
     set:
       clusterName: test-cluster
       slurmNodes:

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -620,7 +620,7 @@ slurmNodes:
       scrapeTimeout: "28s"
     # RBAC settings for exporter
     rbac:
-      # Specifies whether RBAC resources (Role/RoleBinding) should be created
+      # Specifies whether RBAC resources for Secrets, worker Pods, and Kubernetes Nodes should be created
       create: true
     # ServiceAccount settings for exporter
     serviceAccount:

--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -111,7 +111,7 @@ spec:
           - '--metric-allowlist=kube_node_info'
           - '--metric-allowlist=kube_customresource_.*'
           - '--metric-allowlist=kube_node_labels'
-          - '--metric-labels-allowlist=nodes=[nebius.com/driverful,nebius.com/gpu,nebius.com/gpu-name,nebius.com/node-group-id,nebius.com/nvlink-instance-group,nebius.com/resource-preset,slurm.nebius.ai/nodeset,slurm.nebius.ai/nodeset-name,slurm.nebius.ai/workload]'
+          - '--metric-labels-allowlist=nodes=[nebius.com/driverful,nebius.com/gpu,nebius.com/gpu-name,nebius.com/node-group-id,topology.nebius.com/nvl-instance-group-id,nebius.com/resource-preset,slurm.nebius.ai/nodeset,slurm.nebius.ai/nodeset-name,slurm.nebius.ai/workload]'
         rbac:
           extraRules:
             - apiGroups:

--- a/helm/soperator-monitoring-dashboards/dashboards/cluster_health.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/cluster_health.json
@@ -50,7 +50,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -100,7 +100,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -119,7 +119,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -168,7 +168,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -187,7 +187,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -236,7 +236,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -255,7 +255,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "For GB platform only",
       "fieldConfig": {
@@ -317,7 +317,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "GPU Nodes",
       "fieldConfig": {
@@ -379,7 +379,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -430,7 +430,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -449,7 +449,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -498,7 +498,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -517,7 +517,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -579,7 +579,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "For GB platform only",
       "fieldConfig": {
@@ -627,7 +627,7 @@
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(\n  count by (label_nebius_com_nvlink_instance_group) (\n    kube_node_labels{\n      label_nebius_com_gpu_name=~\"GB.*\",\n      label_nebius_com_nvlink_instance_group!=\"\"\n    }\n  )\n)",
+          "expr": "count(\n  count by (label_topology_nebius_com_nvl_instance_group_id) (\n    kube_node_labels{\n      label_nebius_com_gpu_name=~\"GB.*\",\n      label_topology_nebius_com_nvl_instance_group_id!=\"\"\n    }\n  )\n)",
           "instant": true,
           "range": false,
           "refId": "A",
@@ -654,7 +654,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -719,7 +719,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Based on number of nodes per job (nodes > 1)\n\nOver the selected time window",
       "fieldConfig": {
@@ -774,7 +774,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -794,7 +794,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Over the selected time window",
       "fieldConfig": {
@@ -845,7 +845,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -864,7 +864,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -926,7 +926,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -991,7 +991,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Time nodes are in states where new jobs cannot be started on them",
       "fieldConfig": {
@@ -1045,7 +1045,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "histogram_avg(sum(increase(slurm_node_unavailability_duration_seconds_bucket{}[$__rate_interval])) by (le))",
@@ -1062,7 +1062,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -1127,7 +1127,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Based on number of nodes per job\n\nOver the selected time window",
       "fieldConfig": {
@@ -1182,7 +1182,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1202,7 +1202,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -1266,7 +1266,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -1337,7 +1337,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "In selected time window",
       "fieldConfig": {
@@ -1399,7 +1399,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(increase(max by(node_name, reason, state_base, state_is_drain, state_is_maintenance, state_is_reserved) (slurm_node_fails_total{state_is_maintenance=\"false\", })[$__range]))",
@@ -1418,7 +1418,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Time nodes spent in `draining` state",
       "fieldConfig": {
@@ -1472,7 +1472,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "histogram_avg(sum(increase(slurm_node_draining_duration_seconds_bucket{}[$__rate_interval])) by (le))",
@@ -1489,7 +1489,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -1553,7 +1553,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "GPU Nodes",
       "fieldConfig": {
@@ -1616,7 +1616,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1668,7 +1668,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "(\n  sum (\n    increase(\n      sum by (node_name, state_base, state_is_drain, state_is_maintenance, state_is_reserved) (\n        slurm_node_gpu_seconds_total{\n          \n          state_is_maintenance=\"false\",\n          state_base=~\".*\"\n        }\n      )[7d]\n    )\n  )\n  /\n  (\n    sum (\n      increase(\n        max by (node_name, reason, state_base, state_is_drain, state_is_maintenance, state_is_reserved) (\n          slurm_node_fails_total{\n            \n            state_is_maintenance=\"false\"\n          }\n        )[7d]\n      )\n    )\n    or\n    (\n      sum (\n        increase(\n          slurm_node_gpu_seconds_total{\n            \n            state_is_maintenance=\"false\",\n            state_base=~\".*\"\n          }[7d]\n        )\n      ) * 0\n    )\n  )\n) / 3600",
@@ -1700,7 +1700,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Proportion of GPUs with at least 10% utilization to total",
       "fieldConfig": {
@@ -1782,7 +1782,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "(\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n        }\n      >=\n    10\n  ) by(cluster)\n    /\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n        }\n  ) by(cluster)\n)\n  *\n100",
@@ -1799,7 +1799,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1880,7 +1880,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "(\n  sum (\n    increase(\n      sum by (node_name, state_base, state_is_drain, state_is_maintenance, state_is_reserved) (\n        slurm_node_gpu_seconds_total{\n          state_is_maintenance=\"false\",\n        }\n      )[7d]\n    )\n  )\n  /\n  (\n    sum (\n      increase(\n        max by (node_name, reason, state_base, state_is_drain, state_is_maintenance, state_is_reserved) (\n          slurm_node_fails_total{\n            state_is_maintenance=\"false\"\n          }\n        )[7d]\n      )\n    )\n    or\n    (\n      sum (\n        increase(\n          slurm_node_gpu_seconds_total{\n            state_is_maintenance=\"false\",\n          }[7d]\n        )\n      ) * 0\n    )\n  )\n) / 36",
@@ -1899,7 +1899,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Only for GPUs with at least 10% utilization",
       "fieldConfig": {
@@ -2036,7 +2036,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max(\n  DCGM_FI_DEV_POWER_USAGE{\n    }\n    and on(exported_pod,gpu)\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n        }\n      >=\n    10\n  ) by(exported_pod,gpu)\n)",
@@ -2050,7 +2050,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(\n  DCGM_FI_DEV_POWER_USAGE{\n      }\n    and on(exported_pod,gpu)\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n        }\n      >=\n    10\n  ) by(exported_pod,gpu)\n)",
@@ -2064,7 +2064,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(\n  DCGM_FI_DEV_POWER_USAGE{\n    }\n    and on(exported_pod,gpu)\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n        }\n      >=\n    10\n  ) by(exported_pod,gpu)\n)",
@@ -2082,7 +2082,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "description": "Jobs in `PENDING` state by reason",
       "fieldConfig": {
@@ -2179,7 +2179,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -2318,7 +2318,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max(\n  DCGM_FI_PROF_SM_ACTIVE\n)",
@@ -2332,7 +2332,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(\n  DCGM_FI_PROF_SM_ACTIVE\n)",
@@ -2346,7 +2346,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(\n  DCGM_FI_PROF_SM_ACTIVE\n)",
@@ -2374,7 +2374,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Proportion of GPUs with at least 10% utilization to total for selected racks",
           "fieldConfig": {
@@ -2456,7 +2456,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "(\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n      slurm_nodeset_name=~\"$rack\"\n    }\n      >=\n    10\n  ) by(cluster)\n    /\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n      slurm_nodeset_name=~\"$rack\"\n    }\n  ) by(cluster)\n)\n  *\n100",
@@ -2473,7 +2473,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Only for GPUs with at least 10% utilization for selected racks",
           "fieldConfig": {
@@ -2610,7 +2610,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "max(\n  DCGM_FI_DEV_POWER_USAGE{\n      slurm_nodeset_name=~\"$rack\"\n    }\n    and on(exported_pod,gpu)\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n      slurm_nodeset_name=~\"$rack\"\n    }\n      >=\n    10\n  ) by(exported_pod,gpu)\n)",
@@ -2624,7 +2624,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "avg(\n  DCGM_FI_DEV_POWER_USAGE{\n    slurm_nodeset_name=~\"$rack\"\n  }\n    and on(exported_pod,gpu)\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n      slurm_nodeset_name=~\"$rack\"\n    }\n      >=\n    10\n  ) by(exported_pod,gpu)\n)",
@@ -2638,7 +2638,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "min(\n  DCGM_FI_DEV_POWER_USAGE{\n    slurm_nodeset_name=~\"$rack\"\n  }\n    and on(exported_pod,gpu)\n  count(\n    DCGM_FI_DEV_GPU_UTIL{\n      slurm_nodeset_name=~\"$rack\"\n    }\n      >=\n    10\n  ) by(exported_pod,gpu)\n)",
@@ -2670,7 +2670,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Node states breakdown:\n- **Down**: Nodes not operational (DOWN or ERROR states)\n- **Drained**: IDLE nodes with DRAIN flag\n- **Draining**: Nodes with DRAIN flag running jobs\n- **Busy**: Nodes running jobs normally (ALLOCATED or MIXED)\n- **Idle**: Nodes ready and available to accept new jobs\n- **Maintenance**: Nodes temporarily unavailable for administrative tasks",
           "fieldConfig": {
@@ -2861,7 +2861,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=~\"DOWN|ERROR\", state_is_maintenance!=\"true\", node_name=~\"$node_name\"})",
@@ -2875,7 +2875,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=\"IDLE\", state_is_maintenance!=\"true\", state_is_drain=\"true\", node_name=~\"$node_name\"})",
@@ -2889,7 +2889,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=~\"ALLOCATED|MIXED\", state_is_maintenance!=\"true\", state_is_drain=\"true\", node_name=~\"$node_name\"})",
@@ -2903,7 +2903,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=~\"ALLOCATED|MIXED\", state_is_maintenance!=\"true\", state_is_drain!=\"true\", node_name=~\"$node_name\"})",
@@ -2917,7 +2917,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=\"IDLE\", state_is_maintenance!=\"true\", state_is_drain!=\"true\", node_name=~\"$node_name\"})",
@@ -2931,7 +2931,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_is_maintenance=\"true\", node_name=~\"$node_name\"})",
@@ -2945,7 +2945,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=\"UNKNOWN\", state_is_maintenance!=\"true\", node_name=~\"$node_name\"})",
@@ -2963,7 +2963,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Timeline of node problems showing Down (DOWN/ERROR states), Drained (IDLE with drain), and Draining (ALLOCATED/MIXED with drain) states. Maintenance nodes are filtered out.",
           "fieldConfig": {
@@ -3050,7 +3050,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "with (\n  node_fails = sum by (node_name) (\n      # Down: Nodes in DOWN or ERROR state (not in maintenance)\n      count by (node_name) (slurm_node_info{state_base=~\"DOWN|ERROR\", state_is_maintenance!=\"true\", node_name=~\"$node_name\", }) * 1 or\n      # Drained: IDLE nodes with drain flag (not in maintenance)\n      count by (node_name) (slurm_node_info{state_base=\"IDLE\", state_is_drain=\"true\", state_is_maintenance!=\"true\", node_name=~\"$node_name\", }) * 2 or\n      # Draining: ALLOCATED/MIXED nodes with drain flag (not in maintenance)\n      count by (node_name) (slurm_node_info{state_base=~\"ALLOCATED|MIXED\", state_is_drain=\"true\", state_is_maintenance!=\"true\", node_name=~\"$node_name\", }) * 3\n    )\n)\nnode_fails\nor\n(\n  # To show recovery as IDLE without drain state after failure\n  count by (node_name) (slurm_node_info{state_base=~\"IDLE\", state_is_drain=\"false\", state_is_maintenance!=\"true\", node_name=~\"$node_name\", }) * 4\n  and\n  min_over_time(node_fails[15m:1m]) > 0\n)",
@@ -3082,7 +3082,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Time nodes are in states where new jobs cannot be started on them",
           "fieldConfig": {
@@ -3212,7 +3212,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(1, sum(increase(slurm_node_unavailability_duration_seconds_bucket{}[$__rate_interval])) by (le))",
@@ -3226,7 +3226,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "histogram_avg(sum(increase(slurm_node_unavailability_duration_seconds_bucket{}[$__rate_interval])) by (le))",
@@ -3240,7 +3240,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0, sum(increase(slurm_node_unavailability_duration_seconds_bucket{}[$__rate_interval])) by (le))",
@@ -3258,7 +3258,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Time nodes spent in `draining` state",
           "fieldConfig": {
@@ -3388,7 +3388,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(1, sum(increase(slurm_node_draining_duration_seconds_bucket{}[$__rate_interval])) by (le))",
@@ -3402,7 +3402,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "histogram_avg(sum(increase(slurm_node_draining_duration_seconds_bucket{}[$__rate_interval])) by (le))",
@@ -3416,7 +3416,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0, sum(increase(slurm_node_draining_duration_seconds_bucket{}[$__rate_interval])) by (le))",
@@ -3434,7 +3434,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Lists nodes that are DOWN, in ERROR state, or have DRAIN flag set (maintenance nodes excluded).\n\n**Columns:**\n- Fail Reason: From failure counter metrics\n- State Reason: From node info (Soperator 1.22+)\n\n**Note:** Rows group events by state - same node may appear multiple times with overlapping time ranges.",
           "fieldConfig": {
@@ -3636,7 +3636,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -3823,7 +3823,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Jobs in `RUNNING` state at the end of selected time window.",
           "fieldConfig": {
@@ -4122,7 +4122,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4137,7 +4137,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "P4169E866C3094E38"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4152,7 +4152,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "P4169E866C3094E38"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4167,7 +4167,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "P4169E866C3094E38"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -4323,7 +4323,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "For jobs with at least 4 nodes",
           "fieldConfig": {
@@ -4410,7 +4410,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "(\n  sum(\n    slurm_job_info{\n      \n      slurm_partition${partition_match_exp},\n      job_state=~\"COMPLETED\"\n    }\n      and on(job_id)\n    (\n      count(\n        slurm_node_job{ }\n      ) by(job_id)\n        >=\n      0\n    )\n  ) by (cluster)\n    /\n  sum(\n    slurm_job_info{\n      slurm_partition${partition_match_exp},\n      job_state=~\"COMPLETED|FAILED|CANCELLED|TIMEOUT|DEADLINE\",\n    }\n      and on(job_id)\n    (\n      count(\n        slurm_node_job{ }\n      ) by(job_id)\n        >=\n      0\n    )\n  ) by (cluster)\n) \n  *\n100",
@@ -4428,7 +4428,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Based on number of nodes per job (nodes > 1)",
           "fieldConfig": {
@@ -4561,7 +4561,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "max(\n  (\n    count(\n      slurm_node_job{\n            }\n    ) by(job_id)\n      * on(job_id)\n    slurm_job_info{\n      \n      slurm_partition${partition_match_exp}\n    }\n  )\n    >\n  0\n) by()",
@@ -4575,7 +4575,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "avg(\n  (\n    count(\n      slurm_node_job{\n            }\n    ) by(job_id)\n      * on(job_id)\n    slurm_job_info{\n      \n      slurm_partition${partition_match_exp}\n    }\n  )\n    >\n  0\n) by()",
@@ -4589,7 +4589,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "min(\n  (\n    count(\n      slurm_node_job{\n            }\n    ) by(job_id)\n      * on(job_id)\n    slurm_job_info{\n      \n      slurm_partition${partition_match_exp}\n    }\n  )\n    >\n  0\n) by()",
@@ -4607,7 +4607,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Excluding system jobs",
           "fieldConfig": {
@@ -4740,7 +4740,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "max(\n  slurm_job_duration_seconds\n  and on(job_id)\n  slurm_job_info{slurm_partition${partition_match_exp} }\n)",
@@ -4754,7 +4754,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "avg(\n  slurm_job_duration_seconds{ }\n    and on(job_id)\n  slurm_job_info{slurm_partition${partition_match_exp} }\n)",
@@ -4768,7 +4768,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "min(\n  slurm_job_duration_seconds{ }\n    and on(job_id)\n  slurm_job_info{slurm_partition${partition_match_exp} }\n)",
@@ -4786,7 +4786,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P4169E866C3094E38"
+            "uid": "${datasource}"
           },
           "description": "Over the entire selected range (excluding system jobs)",
           "fieldConfig": {
@@ -4869,7 +4869,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "% of workers that where not drawing much power when job was in `RUNNING` state\n\nonly jobs with `>=70%` under-utilized workers for more than `20m` are shown",
           "fieldConfig": {
@@ -4944,7 +4944,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "disableTextWrap": false,
               "editorMode": "code",
@@ -4969,7 +4969,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Paginated",
           "fieldConfig": {
@@ -5145,7 +5145,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "with (\n    filters = {slurm_partition${partition_match_exp}},\n)\nsum by (job_id,)(\n  count by (job_id, job_name) (slurm_job_info{job_state=\"PENDING\", filters}) * 1 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"CONFIGURING\",filters}) * 2 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"RUNNING\", filters}) * 3 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"COMPLETING\", filters}) * 4 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"COMPLETED\", filters}) * 5 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"CANCELLED\", filters}) * 6 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"FAILED\", filters}) * 7 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"TIMEOUT\", filters}) * 8 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"PREEMPTED\", filters}) * 9 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"NODE_FAIL\", filters}) * 10 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"BOOT_FAIL\", filters}) * 11 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"DEADLINE\", filters}) * 12 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"OUT_OF_MEMORY\", filters}) * 13 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"REQUEUED\", filters}) * 14 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"RESIZING\", filters}) * 15 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"SUSPENDED\", filters}) * 16 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"STOPPED\", filters}) * 17 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"POWER_UP_NODE\", filters}) * 18 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"SIGNALING\", filters}) * 19 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"STAGE_OUT\", filters}) * 20 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"UPDATE_DB\", filters}) * 21\n)",
@@ -5164,7 +5164,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5248,7 +5248,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count by(job_state) (slurm_job_info{user_name=~\"$user_name\", slurm_partition${partition_match_exp}, })",
@@ -5267,7 +5267,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5351,7 +5351,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count by(slurm_partition) (slurm_job_info{job_state=\"RUNNING\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}, })",
@@ -5370,7 +5370,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Shows jobs in terminal states (COMPLETED, CANCELLED, FAILED, TIMEOUT). All times are displayed in the current Grafana timezone.",
           "fieldConfig": {
@@ -5611,7 +5611,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "with (\n  filters = {}\n)\nslurm_job_info{\n  filters,\n  job_state=~\"COMPLETED|CANCELLED|FAILED|TIMEOUT\", \n  user_name=~\"$user_name\", \n  slurm_partition${partition_match_exp}, \n}\n* on (job_id) group_left()\ncount by (job_id) (slurm_node_job{filters}) ",
@@ -5836,7 +5836,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5920,7 +5920,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count by(user_name) (slurm_job_info{job_state=\"RUNNING\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}, })",
@@ -5939,7 +5939,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -6023,7 +6023,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count by(user_name) (slurm_job_info{user_name=~\"$user_name\", slurm_partition${partition_match_exp}, })",
@@ -6042,7 +6042,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -6123,7 +6123,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "with (\n  filters = {}\n)\navg(\n  label_move(DCGM_FI_DEV_GPU_UTIL{filters, hpc_job!=\"\"}, 'hpc_job','job_id')\n  * on (job_id) group_left(user_name)\n  slurm_job_info{\n    filters,\n    job_state=\"RUNNING\",\n    user_name=~\"$user_name\", \n    slurm_partition${partition_match_exp}\n  }\n) by (user_name)",
@@ -6142,7 +6142,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Users who have run some jobs",
           "fieldConfig": {
@@ -6267,7 +6267,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -6347,7 +6347,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "with (\n  filters = {}\n)\ncount(\n  slurm_node_job{filters}\n  * on (job_id) group_left(user_name)\n  slurm_job_info{\n    filters,\n    job_state=\"RUNNING\",\n    user_name=~\"$user_name\", \n    slurm_partition${partition_match_exp}\n  }\n) by (user_name)",
@@ -6374,10 +6374,32 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allowCustomValue": false,
         "current": {
           "text": ["All"],
           "value": ["$__all"]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
         "definition": "label_values(kube_node_labels{label_nebius_com_gpu_name=~\"GB.*\"},label_slurm_nebius_ai_nodeset_name)",
         "description": "For GB platforms",
@@ -6403,7 +6425,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(slurm_node_info{node_name=~\"$rack-.*\"}, node_name)",
         "description": "",
@@ -6431,7 +6453,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(slurm_job_info,user_name)",
         "description": "",

--- a/helm/soperator-monitoring-dashboards/dashboards/gpu_cluster_stats.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/gpu_cluster_stats.json
@@ -23,7 +23,8 @@
   "panels": [
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Number of compute instances (nodes) reporting metrics in this cluster.",
       "fieldConfig": {
@@ -84,7 +85,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Total number of GPU devices reporting metrics in this cluster.",
       "fieldConfig": {
@@ -145,7 +147,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Average number of GPUs with VRAM allocated above 100 MiB over the selected time range — proxy for GPUs running a workload.",
       "fieldConfig": {
@@ -202,7 +205,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Average number of GPUs with VRAM at or below 100 MiB over the selected time range — no workload detected.",
       "fieldConfig": {
@@ -262,7 +266,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Average SM (Streaming Multiprocessor) active fraction across all GPUs over the selected time range. 'Compute density' reflects how many SMs are scheduled with work — not how busy the GPU is overall. Typical healthy range for real ML workloads is 40–70%, driven by the natural mix of attention, GEMM, softmax, and comm kernels. See the GPU Busy % panel for the 'is anything running' signal.",
       "fieldConfig": {
@@ -328,7 +333,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Sum of GPU power draw across all nodes in the cluster in kilowatts.",
       "fieldConfig": {
@@ -436,7 +442,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Average, P95, and max SM active % across all GPUs in the cluster over time. 40–70% is typical for real mixed ML workloads at 15s resolution — do not treat <100% as a problem. Max line reveals stragglers: if max is high while avg is low, one node may be bottlenecking distributed training.",
       "fieldConfig": {
@@ -557,7 +564,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Count of GPUs with VRAM > 100 MiB (in use) vs. ≤ 100 MiB (idle) over time. A sudden drop in 'In Use' indicates a job crash or node removal.",
       "fieldConfig": {
@@ -681,7 +689,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Average fraction of time a CUDA kernel was executing on each GPU (DCGM_FI_DEV_GPU_UTIL). This is the 'liveness' / 'not idle' signal — 100% means a kernel is always running, but says nothing about whether it's using the hardware efficiently. Sudden drops during training indicate NCCL timeouts, node issues, or checkpointing. Normal healthy training: 95–100%.",
       "fieldConfig": {
@@ -775,7 +784,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Average fraction of time tensor core pipes were active (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE). The single most actionable metric for LLM / transformer training: if this drops while SM Active stays up, the workload has regressed to non-tensor ops (e.g. unfused softmax, fp32 paths). Typical healthy range in bf16/fp16 LLM training: 15–50%. Much lower = fusion / precision opportunity.",
       "fieldConfig": {
@@ -869,7 +879,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Average SM occupancy (DCGM_FI_PROF_SM_OCCUPANCY) — of the SMs that are active, how many warps they are actually running vs theoretical max. SM Active says an SM scheduled work; SM Occupancy says how full it was. Typical healthy range: 20–40%. Together with SM Active, this catches the '1 SM busy = high GPU_UTIL but nothing real happening' case described in the Trainy blog post.",
       "fieldConfig": {
@@ -956,7 +967,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Total GPU power draw across all nodes in the cluster. Sudden drops during training typically indicate checkpointing or NCCL stalls. GPU power ≈ 80% of total server power.",
       "fieldConfig": {
@@ -1042,7 +1054,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Total GPU frame buffer (VRAM) used across all GPUs in the cluster. Steady high VRAM with variable power/SM-active is a sign of idle-but-loaded GPUs.",
       "fieldConfig": {
@@ -1166,7 +1179,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "SM active % for each node over time. Each line = one instance. Diverging lines reveal stragglers. Range 40–70% is typical. For clusters >128 nodes this panel is hidden in favor of the stat-grid variant below.",
       "fieldConfig": {
@@ -1269,7 +1283,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "One tile per node, colored by average SM active % over the selected time range. 40–70% is normal for mixed ML workloads — use this view to spot outliers relative to the cluster, not to flag <100% as bad.",
       "fieldConfig": {
@@ -1341,7 +1356,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Per-node Compute Density (SM Active %) over time. One row per node, averaged across the node's GPUs. Use this to spot stragglers during a training run — rows that go cool while peers stay warm indicate NCCL waits, dataloader stalls, or unhealthy GPUs. SM Active is preferred over GPU Util here because it reflects actual compute work, not just kernel presence.",
       "fieldConfig": {
@@ -1434,7 +1450,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Max and average GPU core temperature across the cluster. Sustained max above 80°C warrants investigation. Non-critical overheating increases InfiniBand bit error probability and can degrade performance before triggering shutdown.",
       "fieldConfig": {
@@ -1571,7 +1588,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "Max and average GPU Memory temperature across the cluster. Sustained max above 80°C warrants investigation. Non-critical overheating increases InfiniBand bit error probability and can degrade performance before triggering shutdown.",
       "fieldConfig": {
@@ -1713,7 +1731,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "One tile per node, colored by max GPU temperature over the selected time range. Relative color scale — hottest node shows red even on an all-healthy cluster.",
       "fieldConfig": {
@@ -1786,13 +1805,32 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allowCustomValue": false,
         "current": {
           "text": "4",
           "value": "4"
         },
         "datasource": {
-          "type": "prometheus"
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
         "definition": "query_result(count(count by (Hostname) (DCGM_FI_DEV_POWER_USAGE{})))",
         "hide": 2,

--- a/helm/soperator-monitoring-dashboards/dashboards/jobs_overview.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/jobs_overview.json
@@ -22,7 +22,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "enable": false,
         "expr": "group by (node, pod) (\n  changes(\n      sum without (uid, pod_ip)(\n          kube_pod_info{pod=~\"worker-.*\", node!=\"\"}\n      )\n  ) > 0\n  and on (pod) \n  sum by (pod)(\n      kube_pod_info{pod=~\"worker-.*\", node!=\"\"}\n  ) @ start()\n)",
@@ -95,7 +95,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Avg of utilization across all selected workers and instances",
       "fieldConfig": {
@@ -154,7 +154,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg (\n  (1 - rate(node_cpu_seconds_total{mode=\"idle\"}[1m]))\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(hpc_job) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{hpc_job=~\"$slurm_job\"}, \"Hostname\", \"nodename\")), 1, 1)\n) * 100",
@@ -170,7 +170,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -229,7 +229,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_SM_CLOCK{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}*1000000)",
@@ -247,7 +248,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -315,7 +316,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(DCGM_FI_DEV_POWER_USAGE{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -333,7 +335,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -399,7 +401,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_MEM_COPY_UTIL{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -417,7 +420,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -483,7 +486,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(\n    (\n        node_memory_MemTotal_bytes - \n        node_memory_MemFree_bytes  - \n        node_memory_Buffers_bytes - \n        node_memory_Cached_bytes\n    ) / \n    node_memory_MemTotal_bytes{instance=~\"$ip\"}\n    * on(instance) group_left(nodename) node_uname_info\n    * on(nodename) group_left(hpc_job) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{hpc_job=~\"$slurm_job\"}, \"Hostname\", \"nodename\")), 1, 1)\n) * 100",
@@ -501,7 +505,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -560,7 +564,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_MEM_CLOCK{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}*1000000)",
@@ -578,7 +583,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -648,7 +653,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -666,7 +672,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "GPU Shutdown Temp: 90 C<br>\nGPU Slowdown Temp: 87 C<br>\nGPU Max Operating Temp: 83 C<br>",
       "fieldConfig": {
@@ -732,7 +738,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -763,7 +770,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -878,7 +885,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -989,7 +996,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Paginated",
       "fieldConfig": {
@@ -1165,7 +1172,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "with (\n    filters = { job_id=~\"$slurm_job\"},\n)\nsum by (job_id,)(\n  count by (job_id, job_name) (slurm_job_info{job_state=\"PENDING\", filters}) * 1 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"CONFIGURING\",filters}) * 2 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"RUNNING\", filters}) * 3 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"COMPLETING\", filters}) * 4 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"COMPLETED\", filters}) * 5 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"CANCELLED\", filters}) * 6 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"FAILED\", filters}) * 7 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"TIMEOUT\", filters}) * 8 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"PREEMPTED\", filters}) * 9 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"NODE_FAIL\", filters}) * 10 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"BOOT_FAIL\", filters}) * 11 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"DEADLINE\", filters}) * 12 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"OUT_OF_MEMORY\", filters}) * 13 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"REQUEUED\", filters}) * 14 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"RESIZING\", filters}) * 15 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"SUSPENDED\", filters}) * 16 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"STOPPED\", filters}) * 17 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"POWER_UP_NODE\", filters}) * 18 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"SIGNALING\", filters}) * 19 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"STAGE_OUT\", filters}) * 20 or\n  count by (job_id, job_name) (slurm_job_info{job_state=\"UPDATE_DB\", filters}) * 21\n)",
@@ -1197,7 +1204,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1328,7 +1335,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max(DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -1342,7 +1350,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -1356,7 +1365,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -1375,7 +1385,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1454,7 +1464,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"} * 1979)",
@@ -1468,7 +1479,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"} * 989.7)",
@@ -1487,7 +1499,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1635,7 +1647,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max (DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -1649,7 +1662,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg (DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -1663,7 +1677,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min (DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -1682,7 +1697,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1813,7 +1828,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max(\n  (1 - rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"$ip\"}[$__rate_interval]))\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(hpc_job) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{hpc_job=~\"$slurm_job\"}, \"Hostname\", \"nodename\")), 1, 1)\n)",
@@ -1825,7 +1840,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(\n  (1 - rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"$ip\"}[$__rate_interval]))\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(hpc_job) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{hpc_job=~\"$slurm_job\"}, \"Hostname\", \"nodename\")), 1, 1)\n)",
@@ -1838,7 +1853,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(\n  (1 - rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"$ip\"}[$__rate_interval]))\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(hpc_job) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{hpc_job=~\"$slurm_job\"}, \"Hostname\", \"nodename\")), 1, 1)\n)",
@@ -1855,7 +1870,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1994,7 +2009,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}/(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}+DCGM_FI_DEV_FB_FREE{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}))",
@@ -2008,7 +2024,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}/(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}+DCGM_FI_DEV_FB_FREE{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}))",
@@ -2022,7 +2039,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}/(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}+DCGM_FI_DEV_FB_FREE{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}))",
@@ -2041,7 +2059,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Sum of Tx and Rx for all selected Workers ",
       "fieldConfig": {
@@ -2160,7 +2178,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(\n  rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$ip\"}[$__interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(hpc_job) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{hpc_job=~\"$slurm_job\"}, \"Hostname\", \"nodename\")), 1, 1)\n)",
@@ -2174,7 +2193,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(\n  rate(node_infiniband_port_data_received_bytes_total{instance=~\"$ip\"}[$__interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(hpc_job) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{hpc_job=~\"$slurm_job\"}, \"Hostname\", \"nodename\")), 1, 1)\n)",
@@ -2193,7 +2213,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2331,7 +2351,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max(\n  (\n    (\n      node_memory_MemTotal_bytes - \n      node_memory_MemFree_bytes - \n      node_memory_Buffers_bytes - \n      node_memory_Cached_bytes\n    )\n    /\n    node_memory_MemTotal_bytes{instance=~\"$ip\"}\n  )\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(hpc_job) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{hpc_job=~\"$slurm_job\"}, \"Hostname\", \"nodename\")), 1, 1)\n)",
@@ -2345,7 +2366,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(\n  (\n    (\n      node_memory_MemTotal_bytes - \n      node_memory_MemFree_bytes - \n      node_memory_Buffers_bytes - \n      node_memory_Cached_bytes\n    )\n    /\n    node_memory_MemTotal_bytes{instance=~\"$ip\"}\n  )\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(hpc_job) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{hpc_job=~\"$slurm_job\"}, \"Hostname\", \"nodename\")), 1, 1)\n)",
@@ -2359,7 +2381,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(\n  (\n    (\n      node_memory_MemTotal_bytes - \n      node_memory_MemFree_bytes - \n      node_memory_Buffers_bytes - \n      node_memory_Cached_bytes\n    )\n    /\n    node_memory_MemTotal_bytes{instance=~\"$ip\"}\n  )\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(hpc_job) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{hpc_job=~\"$slurm_job\"}, \"Hostname\", \"nodename\")), 1, 1)\n)",
@@ -2391,7 +2414,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2477,7 +2500,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg by (exported_pod) (DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -2496,7 +2520,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2579,7 +2603,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg by (exported_pod) (DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}/(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}+DCGM_FI_DEV_FB_FREE{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}))",
@@ -2598,7 +2623,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2683,7 +2708,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg by (exported_pod) (DCGM_FI_DEV_MEM_COPY_UTIL{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -2702,7 +2728,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2782,7 +2808,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (exported_pod) (DCGM_FI_DEV_POWER_USAGE{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -2801,7 +2828,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2884,7 +2911,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg by (exported_pod) (DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"})",
@@ -2903,7 +2931,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -3000,7 +3028,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (err_msg, exported_pod) (rate(DCGM_FI_DEV_XID_ERRORS{exported_pod=~\"$worker\",hpc_job=~\"$slurm_job\"}))",
@@ -3020,6 +3048,24 @@
   "tags": ["nebius", "soperator", "overview", "jobs"],
   "templating": {
     "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
       {
         "current": {
           "text": "1",
@@ -3043,6 +3089,10 @@
         "current": {
           "text": ["102"],
           "value": ["102"]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
         "definition": "query_result(count by (job_id) (slurm_job_info{user_name!=\"soperatorchecks\"}))",
         "description": "",
@@ -3068,7 +3118,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(DCGM_FI_DEV_GPU_TEMP{hpc_job=~\"$slurm_job\"},exported_pod)",
         "description": "Filtered by selected Jobs",
@@ -3094,7 +3144,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(kube_pod_info{pod=~\"$worker\"},node)",
         "hide": 2,
@@ -3120,7 +3170,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(node_uname_info{container=\"node-exporter\", nodename=~\"$hostname\"},instance)",
         "hide": 2,

--- a/helm/soperator-monitoring-dashboards/dashboards/nccl_inspector_job_performance.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/nccl_inspector_job_performance.json
@@ -34,7 +34,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P4169E866C3094E38"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -122,7 +122,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${prom_datasource}"
+                "uid": "${datasource}"
               },
               "disableTextWrap": false,
               "editorMode": "builder",
@@ -141,7 +141,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P4169E866C3094E38"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -229,7 +229,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${prom_datasource}"
+                "uid": "${datasource}"
               },
               "disableTextWrap": false,
               "editorMode": "builder",
@@ -248,7 +248,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P4169E866C3094E38"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -336,7 +336,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${prom_datasource}"
+                "uid": "${datasource}"
               },
               "disableTextWrap": false,
               "editorMode": "builder",
@@ -355,7 +355,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P4169E866C3094E38"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -443,7 +443,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${prom_datasource}"
+                "uid": "${datasource}"
               },
               "disableTextWrap": false,
               "editorMode": "builder",
@@ -476,7 +476,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P4169E866C3094E38"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -564,7 +564,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${prom_datasource}"
+                "uid": "${datasource}"
               },
               "disableTextWrap": false,
               "editorMode": "builder",
@@ -583,7 +583,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P4169E866C3094E38"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -671,7 +671,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${prom_datasource}"
+                "uid": "${datasource}"
               },
               "disableTextWrap": false,
               "editorMode": "builder",
@@ -690,7 +690,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P4169E866C3094E38"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -778,7 +778,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${prom_datasource}"
+                "uid": "${datasource}"
               },
               "disableTextWrap": false,
               "editorMode": "builder",
@@ -797,7 +797,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P4169E866C3094E38"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -885,7 +885,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${prom_datasource}"
+                "uid": "${datasource}"
               },
               "disableTextWrap": false,
               "editorMode": "builder",
@@ -921,7 +921,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1009,7 +1009,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1028,7 +1028,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1116,7 +1116,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1135,7 +1135,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1223,7 +1223,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1242,7 +1242,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1330,7 +1330,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1362,7 +1362,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1450,7 +1450,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1469,7 +1469,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1557,7 +1557,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1576,7 +1576,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1664,7 +1664,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1683,7 +1683,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1771,7 +1771,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1803,7 +1803,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1891,7 +1891,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1910,7 +1910,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1998,7 +1998,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2017,7 +2017,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2105,7 +2105,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2124,7 +2124,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2212,7 +2212,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${prom_datasource}"
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -2239,12 +2239,34 @@
     "list": [
       {
         "current": {
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
           "text": [
             "All"
           ],
           "value": [
             "$__all"
           ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
         "definition": "label_values({__name__=~\"nccl_.*\", slurm_job_id!=\"\"}, slurm_job_id)",
         "includeAll": true,
@@ -2269,6 +2291,10 @@
           "value": [
             "$__all"
           ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
         "definition": "label_values({__name__=~\"nccl_.*\", hostname!=\"\"}, hostname)",
         "includeAll": true,

--- a/helm/soperator-monitoring-dashboards/dashboards/nccl_inspector_metrics.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/nccl_inspector_metrics.json
@@ -37,7 +37,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -126,8 +126,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "fe5bb007f2ec39"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -164,7 +164,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -254,8 +254,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "fe5bb007f2ec39"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -277,7 +277,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -341,8 +341,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "fe5bb007f2ec39"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -364,7 +364,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -438,8 +438,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "fe5bb007f2ec39"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -475,7 +475,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -563,8 +563,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "fe5bb007f2ec39"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -586,7 +586,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -648,8 +648,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "fe5bb007f2ec39"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -672,7 +672,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -734,8 +734,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "fe5bb007f2ec39"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -757,7 +757,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -840,8 +840,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "fe5bb007f2ec39"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -876,7 +876,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -963,8 +963,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "fe5bb007f2ec39"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -999,7 +999,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1085,8 +1085,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "fe5bb007f2ec39"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -1115,6 +1115,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": ".*",
         "current": {
           "text": "All",
@@ -1122,7 +1140,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "P4169E866C3094E38"
+          "uid": "${datasource}"
         },
         "definition": "label_values({__name__=~\"nccl.*\", rank!=\"\"}, rank)",
         "includeAll": true,
@@ -1147,7 +1165,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "P4169E866C3094E38"
+          "uid": "${datasource}"
         },
         "definition": "label_values({__name__=~\"nccl.*\", nranks!=\"\"}, nranks)",
         "includeAll": true,
@@ -1172,7 +1190,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "P4169E866C3094E38"
+          "uid": "${datasource}"
         },
         "definition": "label_values({__name__=~\"nccl.*\", collective!=\"\"}, collective)",
         "includeAll": true,
@@ -1198,6 +1216,10 @@
             "746"
           ]
         },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
         "definition": "label_values({__name__=~\"nccl.*\", slurm_job_id!=\"\"}, slurm_job_id)",
         "includeAll": true,
         "label": "Slurm Job ID",
@@ -1221,6 +1243,10 @@
           "value": [
             "$__all"
           ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
         "definition": "label_values({__name__=~\"nccl.*\", hostname!=\"\"}, hostname)",
         "includeAll": true,

--- a/helm/soperator-monitoring-dashboards/dashboards/nccl_inspector_raw_metrics.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/nccl_inspector_raw_metrics.json
@@ -24,7 +24,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -111,8 +111,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "${ds}"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "nccl_algorithm_bandwidth_gbs{hostname=~\"$hostname\", slurm_job_id=~\"$jobid\"}",
@@ -130,7 +130,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -217,8 +217,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "${ds}"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "nccl_bus_bandwidth_gbs{hostname=~\"$hostname\", slurm_job_id=~\"$jobid\"}",
@@ -236,7 +236,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -323,8 +323,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "${ds}"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "nccl_collective_exec_time_microseconds{hostname=~\"$hostname\", slurm_job_id=~\"$jobid\"}",
@@ -342,7 +342,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -429,8 +429,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
-            "uid": "${ds}"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "nccl_message_size_bytes{hostname=~\"$hostname\", slurm_job_id=~\"$jobid\"}",
@@ -455,6 +455,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allowCustomValue": false,
         "current": {
           "text": [
@@ -463,6 +481,10 @@
           "value": [
             "$__all"
           ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
         "definition": "label_values({__name__=~\"nccl.*\", slurm_job_id!=\"\"}, slurm_job_id)",
         "includeAll": true,
@@ -491,7 +513,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "P4169E866C3094E38"
+          "uid": "${datasource}"
         },
         "definition": "label_values({__name__=~\"nccl.*\", hostname!=\"\"}, hostname)",
         "includeAll": true,

--- a/helm/soperator-monitoring-dashboards/dashboards/nfs_server_client.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/nfs_server_client.json
@@ -29,7 +29,8 @@
   "panels": [
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -80,7 +81,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "node_nfsd_server_threads{   namespace=\"nfs-system\"}",
@@ -97,7 +99,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -156,7 +158,7 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
+            "type": "prometheus",
             "uid": "${datasource}"
           },
           "editorMode": "code",
@@ -173,7 +175,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -233,7 +235,7 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource",
+            "type": "prometheus",
             "uid": "${datasource}"
           },
           "editorMode": "code",
@@ -250,7 +252,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -310,7 +312,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (cluster) (rate(node_nfs_rpc_retransmissions_total{  }[$__rate_interval]))",
@@ -344,7 +347,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -439,7 +442,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "rate(node_nfs_rpcs_total{  }[$__rate_interval])\n* on(cluster, pod) group_left(node)\nkube_pod_info{  node=~\"$compute_instance\"}",
@@ -460,7 +464,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -555,7 +559,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "rate(node_nfs_rpc_retransmissions_total{  }[$__rate_interval])\n* on(cluster, pod) group_left(node)\nkube_pod_info{  node=~\"$compute_instance\"}",
@@ -576,7 +581,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -673,7 +678,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(\n  rate(node_nfs_requests_total{  proto=\"4\"}[$__rate_interval])\n  * on(cluster, pod) group_left(node)\n  kube_pod_info{  node=~\"$compute_instance\"}\n) by (method)",
@@ -707,7 +713,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -861,7 +867,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "rate(node_nfsd_disk_bytes_read_total{   namespace=\"nfs-system\"}[$__rate_interval])",
@@ -876,7 +883,8 @@
         },
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "rate(node_nfsd_disk_bytes_written_total{   namespace=\"nfs-system\"}[$__rate_interval])",
@@ -896,7 +904,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1039,7 +1047,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "rate(node_nfsd_packets_total{proto=\"tcp\",   namespace=\"nfs-system\"}[$__rate_interval])",
@@ -1054,7 +1063,8 @@
         },
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "rate(node_nfsd_packets_total{proto=\"udp\",   namespace=\"nfs-system\"}[$__rate_interval])",
@@ -1074,7 +1084,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1156,7 +1166,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "expr": "rate(node_nfsd_read_ahead_cache_not_found_total{ namespace=\"nfs-system\" }[$__rate_interval])",
           "format": "time_series",
@@ -1169,7 +1180,8 @@
         },
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "expr": "rate(node_nfsd_reply_cache_hits_total{ namespace=\"nfs-system\" }[$__rate_interval])",
           "format": "time_series",
@@ -1182,7 +1194,8 @@
         },
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "expr": "rate(node_nfsd_reply_cache_misses_total{ namespace=\"nfs-system\" }[$__rate_interval])",
           "format": "time_series",
@@ -1195,7 +1208,8 @@
         },
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "expr": "rate(node_nfsd_reply_cache_nocache_total{ namespace=\"nfs-system\" }[$__rate_interval])",
           "format": "time_series",
@@ -1213,7 +1227,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1307,7 +1321,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "expr": "rate(node_nfsd_rpc_errors_total{ namespace=\"nfs-system\" }[$__rate_interval])",
           "format": "time_series",
@@ -1320,7 +1335,8 @@
         },
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "expr": "rate(node_nfsd_server_rpcs_total{ namespace=\"nfs-system\" }[$__rate_interval])",
           "format": "time_series",
@@ -1338,7 +1354,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P4169E866C3094E38"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1419,7 +1435,8 @@
       "targets": [
         {
           "datasource": {
-            "type": "victoriametrics-datasource"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "rate(node_nfsd_requests_total{proto=\"4\",  namespace=\"nfs-system\" }[$__rate_interval])",
@@ -1443,6 +1460,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": ".*",
         "allowCustomValue": true,
         "current": {
@@ -1451,7 +1486,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "P4169E866C3094E38"
+          "uid": "${datasource}"
         },
         "definition": "label_values(kube_pod_info{}, node)",
         "description": "NFS client compute instance",

--- a/helm/soperator-monitoring-dashboards/dashboards/slurm_controller.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/slurm_controller.json
@@ -48,7 +48,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Time since the slurmctld container last (re)started (`container_start_time_seconds`). Container restarts due to crashes or rollouts reset this to zero \u2014 useful for spotting unexpected slurmctld restarts.",
           "fieldConfig": {
@@ -108,7 +108,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "time() - max(container_start_time_seconds{namespace=~\"soperator\", pod=\"$pod\", container=\"slurmctld\"})",
@@ -123,7 +123,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Current pod phase from kube_pod_status_phase.",
           "fieldConfig": {
@@ -195,7 +195,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "max(kube_pod_status_phase{namespace=~\"soperator\", pod=\"$pod\", phase=\"Running\"})",
@@ -211,7 +211,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Cumulative container restart count over time. Each step up marks a restart event; flat means none. Drag to zoom into a window when investigating a specific restart.",
           "fieldConfig": {
@@ -289,7 +289,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (container) (\n  kube_pod_container_status_restarts_total{namespace=~\"soperator\", pod=\"$pod\"}\n)",
@@ -304,7 +304,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Number of times the controller pod was rescheduled to a different node in the last 24h. Detected via changes in kube_pod_info node label.",
           "fieldConfig": {
@@ -360,7 +360,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(\n  changes(\n    sum without (uid, pod_ip) (\n      kube_pod_info{namespace=~\"soperator\", pod=\"$pod\", node!=\"\"}\n    )[1d:1m]\n  )\n)",
@@ -381,7 +381,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Number of server threads running inside slurmctld (slurm_controller_server_thread_count).",
       "fieldConfig": {
@@ -471,7 +471,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max(slurm_controller_server_thread_count)",
@@ -486,7 +486,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Slurmctld container memory working set as % of the container memory limit (`container_memory_working_set_bytes` \u00f7 `kube_pod_container_resource_limits{resource=\"memory\"}`). Approaching 100% means slurmctld is close to being OOM-killed by the kubelet. Requires a memory limit to be set on the slurmctld container; if no limit is configured this panel will show \"No data\". For the absolute byte timeseries see the **Memory** row \u2192 'Memory Working Set'.\n\nValue shown is the **1h moving average**, not the instantaneous reading \u2014 smooths out scrape jitter and short bursts.",
       "fieldConfig": {
@@ -545,7 +545,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg_over_time((100 * sum(container_memory_working_set_bytes{namespace=\"soperator\", pod=\"$pod\", container=\"slurmctld\"}) / sum(kube_pod_container_resource_limits{namespace=\"soperator\", pod=\"$pod\", container=\"slurmctld\", resource=\"memory\"}))[1h:])",
@@ -560,7 +560,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Inode usage % of the controller spool PVC (`controller-spool-$pod`) \u2014 slurmctld's state-save directory accumulates many small files, so inode pressure typically hits before byte capacity. For bytes usage and the underlying timeseries see the **Storage** row.\n\nValue shown is the **1h moving average**, not the instantaneous reading \u2014 smooths out scrape jitter and short bursts.",
       "fieldConfig": {
@@ -619,7 +619,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg_over_time((100 * (1 - max(kubelet_volume_stats_inodes_free{persistentvolumeclaim=\"controller-spool-$pod\"} / kubelet_volume_stats_inodes{persistentvolumeclaim=\"controller-spool-$pod\"})))[1h:])",
@@ -634,7 +634,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Slurmctld container CPU usage in cores (5m rate of `container_cpu_usage_seconds_total`). Full CPU timeseries lives in the **System** row \u2192 \"CPU Usage (cores)\" panel.\n\nValue shown is the **1h moving average**, not the instantaneous reading \u2014 smooths out scrape jitter and short bursts.",
       "fieldConfig": {
@@ -693,7 +693,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"soperator\", pod=\"$pod\", container=\"slurmctld\"}[1h]))",
@@ -708,7 +708,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Share of GPUs Slurm is currently using, as reported by the DCGM exporter via the `hpc_job` label (set by soperator's `map_job_dcgm.sh` prolog/epilog).\n\nBoth numerator and denominator are joined with `slurm_node_info{is_unavailable=\"\"}` on `exported_pod` \u2194 `node_name`, so only GPUs on *available* nodes (not DOWN or DRAINED) are counted. This means drained/down hosts don't dilute the score on either side \u2014 no manual ratio correction needed.\n\nRequires the DCGM exporter and soperator's GPU-mapping scripts (default in the chart). CPU-only clusters or non-soperator deployments will show \"No data\".\n\nValue shown is the **1h moving average**, not the instantaneous reading \u2014 smooths out scrape jitter and short bursts.\n\n**Note on join keys**: DCGM's `pod` label is the DaemonSet-pod name and conflicts with the Prometheus scrape target's `pod`, so the scrape rules relabel the original (worker pod) to `exported_pod`. That's the label we join on.",
       "fieldConfig": {
@@ -767,7 +767,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg_over_time((100 * (count(DCGM_FI_DEV_GPU_TEMP{hpc_job!=\"\"} and on(exported_pod) label_replace(slurm_node_info{is_unavailable=\"\"}, \"exported_pod\", \"$1\", \"node_name\", \"(.*)\")) or vector(0)) / count(DCGM_FI_DEV_GPU_TEMP and on(exported_pod) label_replace(slurm_node_info{is_unavailable=\"\"}, \"exported_pod\", \"$1\", \"node_name\", \"(.*)\")))[1h:])",
@@ -782,7 +782,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Share of GPUs currently doing real work \u2014 DCGM reports `DCGM_FI_DEV_GPU_UTIL \u2265 10%`. Same metric and definition as the **Cluster Usage \u2192 GPU Utilization %** timeseries, shown here as an at-a-glance gauge.\n\nRequires the DCGM exporter (default in the soperator chart). CPU-only clusters or non-soperator deployments will show \"No data\".\n\nValue shown is the **1h moving average**, not the instantaneous reading \u2014 smooths out scrape jitter and short bursts.",
       "fieldConfig": {
@@ -841,7 +841,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg_over_time((100 * (count(DCGM_FI_DEV_GPU_UTIL >= 10) or vector(0)) / count(DCGM_FI_DEV_GPU_UTIL))[1h:])",
@@ -866,7 +866,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Container filesystem read/write throughput (rate over 5m). Read positive, Write negative. Split by `device` so per-disk hot spots are visible (typically only one device on the controller pod's spool PVC).",
           "fieldConfig": {
@@ -948,7 +948,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (device) (\n  rate(container_fs_reads_bytes_total{namespace=~\"soperator\", pod=\"$pod\", container!=\"\", container!=\"POD\"}[5m])\n)",
@@ -959,7 +959,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "-1 * sum by (device) (\n  rate(container_fs_writes_bytes_total{namespace=~\"soperator\", pod=\"$pod\", container!=\"\", container!=\"POD\"}[5m])\n)",
@@ -974,7 +974,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Bytes used vs total capacity of the controller-spool PVC over time.",
           "fieldConfig": {
@@ -1084,7 +1084,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "max(kubelet_volume_stats_used_bytes{persistentvolumeclaim=\"controller-spool-$pod\"})",
@@ -1095,7 +1095,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "max(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=\"controller-spool-$pod\"})",
@@ -1110,7 +1110,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Used inodes on the controller-spool PVC over time, with total inode capacity as a dashed reference. A steady upward drift hints at an inode leak.",
           "fieldConfig": {
@@ -1220,7 +1220,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "max(kubelet_volume_stats_inodes_used{persistentvolumeclaim=\"controller-spool-$pod\"})",
@@ -1231,7 +1231,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "max(kubelet_volume_stats_inodes{persistentvolumeclaim=\"controller-spool-$pod\"})",
@@ -1246,7 +1246,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Average per-IO wait time on the controller-host's block devices. High values indicate the underlying storage is the bottleneck (relevant for slurmctld spool writes).",
           "fieldConfig": {
@@ -1328,7 +1328,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_disk_read_time_seconds_total{instance=\"$instance\"}[$__rate_interval])\n/\nirate(node_disk_reads_completed_total{instance=\"$instance\"}[$__rate_interval])",
@@ -1339,7 +1339,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_disk_write_time_seconds_total{instance=\"$instance\"}[$__rate_interval])\n/\nirate(node_disk_writes_completed_total{instance=\"$instance\"}[$__rate_interval])",
@@ -1354,7 +1354,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Open file descriptors on the controller node (system-wide). slurmctld can run out of FDs under heavy connection load. Max is omitted when the kernel reports it as effectively unlimited.",
           "fieldConfig": {
@@ -1436,7 +1436,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_filefd_allocated{instance=\"$instance\"}",
@@ -1451,7 +1451,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Per-mountpoint read-only and device-error flags (1 = bad). All zero in healthy state \u2014 any non-zero series indicates a filesystem in trouble. Mountpoints that are read-only by design (e.g. /mnt/cloud-metadata) are excluded.",
           "fieldConfig": {
@@ -1537,7 +1537,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_filesystem_readonly{instance=\"$instance\", device!~\"rootfs\", mountpoint!~\"/mnt/cloud-metadata\"}",
@@ -1548,7 +1548,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_filesystem_device_error{instance=\"$instance\", device!~\"rootfs\", fstype!~\"tmpfs\"}",
@@ -1563,7 +1563,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Per-device read and write IOPS on the controller node.",
           "fieldConfig": {
@@ -1645,7 +1645,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_disk_reads_completed_total{instance=\"$instance\"}[$__rate_interval])",
@@ -1656,7 +1656,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_disk_writes_completed_total{instance=\"$instance\"}[$__rate_interval])",
@@ -1671,7 +1671,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Per-device read/write throughput at the block-device layer. Differs from Container Filesystem IO (which is cgroup-scoped) \u2014 surfaces noisy-neighbour contention if any.",
           "fieldConfig": {
@@ -1753,7 +1753,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_disk_read_bytes_total{instance=\"$instance\"}[$__rate_interval])",
@@ -1764,7 +1764,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "-1 * irate(node_disk_written_bytes_total{instance=\"$instance\"}[$__rate_interval])",
@@ -1779,7 +1779,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Fraction of time each block device was busy serving I/O. Persistent values near 1 mean the device is the bottleneck.",
           "fieldConfig": {
@@ -1863,7 +1863,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_disk_io_time_seconds_total{instance=\"$instance\"}[$__rate_interval])",
@@ -1895,7 +1895,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Jobs in any non-terminal state (`PENDING`, `RUNNING`, `SUSPENDED`, `COMPLETING`, `CONFIGURING`, `RESIZING`, `REQUEUED`, `SIGNALING`, `STAGE_OUT`), sourced from the soperator exporter (`slurm_job_info`). Stacked \u2014 the total is the count of jobs slurmctld is currently tracking. PENDING is the most operationally significant: a sustained pending backlog degrades scheduler performance (more jobs per cycle, higher chance of hitting `default_queue_depth` / `bf_max_job_test`). Cross-check with the Main Scheduler exit-reasons panel when PENDING climbs.",
           "fieldConfig": {
@@ -1978,7 +1978,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count by (job_state) (slurm_job_info{job_state=~\"PENDING|RUNNING|SUSPENDED|COMPLETING|CONFIGURING|RESIZING|REQUEUED|SIGNALING|STAGE_OUT\"}) or label_replace(vector(0), \"job_state\", \"PENDING\", \"\", \"\")",
@@ -1993,7 +1993,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Share of GPUs Slurm is currently using, per-scrape. Both numerator and denominator are joined with `slurm_node_info{is_unavailable=\"\"}` on `exported_pod` \u2194 `node_name`, so only GPUs on *available* nodes (not DOWN or DRAINED) are counted \u2014 drained/down hosts don't dilute the score on either side.\n\nComplement to the GPU Utilization % panel \u2014 together they show scheduler packing vs actual GPU work.\n\n**Note on join keys**: DCGM's `pod` label is the DaemonSet-pod name and conflicts with the Prometheus scrape target's `pod`, so the scrape rules relabel the original (worker pod) to `exported_pod`. That's the label we join on.",
           "fieldConfig": {
@@ -2078,7 +2078,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "100 * (count(DCGM_FI_DEV_GPU_TEMP{hpc_job!=\"\"} and on(exported_pod) label_replace(slurm_node_info{is_unavailable=\"\"}, \"exported_pod\", \"$1\", \"node_name\", \"(.*)\")) or vector(0)) / count(DCGM_FI_DEV_GPU_TEMP and on(exported_pod) label_replace(slurm_node_info{is_unavailable=\"\"}, \"exported_pod\", \"$1\", \"node_name\", \"(.*)\"))",
@@ -2093,7 +2093,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Share of GPUs currently doing real work (DCGM reports `DCGM_FI_DEV_GPU_UTIL \u2265 10%`). Distinct from allocation: a GPU can be allocated to a Slurm job but idle (the job isn't actively using it). Mirrors the 'Cluster Utilization' panel in the Slurm Cluster Health dashboard.\n\nThis value should generally stay **below** GPU allocation %. The gap between allocation and utilization is the cost of running real jobs \u2014 GPUs assigned but not computing yet (container startup, dataset load, IO stalls, gradient sync waits, idle launchers, multi-node sync barriers). A widening gap means jobs are spending more time waiting than computing.",
           "fieldConfig": {
@@ -2178,7 +2178,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "100 * (count(DCGM_FI_DEV_GPU_UTIL >= 10) or vector(0)) / count(DCGM_FI_DEV_GPU_UTIL)",
@@ -2193,7 +2193,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Node states breakdown:\n- **Down**: Nodes not operational (DOWN or ERROR states)\n- **Drained**: IDLE nodes with DRAIN flag\n- **Draining**: Nodes with DRAIN flag running jobs\n- **Busy**: Nodes running jobs normally (ALLOCATED or MIXED)\n- **Idle**: Nodes ready and available to accept new jobs\n- **Maintenance**: Nodes temporarily unavailable for administrative tasks",
           "fieldConfig": {
@@ -2388,7 +2388,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=~\"DOWN|ERROR\", state_is_maintenance!=\"true\"})",
@@ -2402,7 +2402,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=\"IDLE\", state_is_maintenance!=\"true\", state_is_drain=\"true\"})",
@@ -2416,7 +2416,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=~\"ALLOCATED|MIXED\", state_is_maintenance!=\"true\", state_is_drain=\"true\"})",
@@ -2430,7 +2430,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=~\"ALLOCATED|MIXED\", state_is_maintenance!=\"true\", state_is_drain!=\"true\"})",
@@ -2444,7 +2444,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=\"IDLE\", state_is_maintenance!=\"true\", state_is_drain!=\"true\"})",
@@ -2458,7 +2458,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_is_maintenance=\"true\"})",
@@ -2472,7 +2472,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "count(slurm_node_info{state_base=\"UNKNOWN\", state_is_maintenance!=\"true\"})",
@@ -2490,7 +2490,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Share of *schedulable* nodes Slurm is currently using (at least partially). Numerator: nodes where `state_base \u2208 {ALLOCATED, MIXED}` regardless of drain flag \u2014 DRAINING nodes are still doing useful work and count. Denominator: `count(slurm_node_info{is_unavailable=\"\"})` \u2014 the exporter's computed schedulability flag (`true` when node is DOWN+* or IDLE+DRAIN+*, empty otherwise). So DOWN and DRAINED nodes are excluded from both sides automatically.\n\nComplement to the **GPU Allocation %** panel above: node-level packing is coarser but works on CPU-only clusters and doesn't depend on DCGM.",
           "fieldConfig": {
@@ -2576,7 +2576,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "100 * (count(slurm_node_info{state_base=~\"ALLOCATED|MIXED\"}) or vector(0)) / count(slurm_node_info{is_unavailable=\"\"})",
@@ -2604,7 +2604,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "RPC call rate broken down by message type (rate over 5m, stacked).",
           "fieldConfig": {
@@ -2686,7 +2686,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (message_type) (\n  rate(slurm_controller_rpc_calls_total[5m])\n)",
@@ -2701,7 +2701,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Average RPC latency per message type (rate(duration)/rate(calls), 5m window).",
           "fieldConfig": {
@@ -2783,7 +2783,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (message_type) (rate(slurm_controller_rpc_duration_seconds_total[5m]))\n/\nsum by (message_type) (rate(slurm_controller_rpc_calls_total[5m]))",
@@ -2798,7 +2798,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Per-message-type RPC processing time, as `rate(duration_seconds[5m])` without dividing by call count. Stacked area; the total stack height is the cluster-wide RPC processing concurrency.\n\nReading: a value of 1.0 for a message type means one worker thread of slurmctld was on average kept fully busy by that message type over the last 5 minutes. Latency \u00d7 call rate = duration rate \u2014 this panel highlights the message types that *cost* the most slurmctld time, even if individual calls are cheap.",
           "fieldConfig": {
@@ -2880,7 +2880,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (message_type) (rate(slurm_controller_rpc_duration_seconds_total[5m]))",
@@ -2895,7 +2895,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Top 10 users by RPC call rate (rate of slurm_controller_rpc_user_calls_total over 5m).",
           "fieldConfig": {
@@ -2977,7 +2977,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "topk(10,\n  sum by (user) (\n    rate(slurm_controller_rpc_user_calls_total[5m])\n  )\n)",
@@ -2992,7 +2992,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Top 10 users by aggregate RPC time consumed per second (rate of slurm_controller_rpc_user_duration_seconds_total over 5m). A value of 1 means a user kept slurmctld busy for one full thread-second every second on average.",
           "fieldConfig": {
@@ -3074,7 +3074,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "topk(10,\n  sum by (user) (\n    rate(slurm_controller_rpc_user_duration_seconds_total[5m])\n  )\n)",
@@ -3089,7 +3089,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Top 10 users by average RPC latency (rate of `slurm_controller_rpc_user_duration_seconds_total` divided by rate of `slurm_controller_rpc_user_calls_total`, 5m window). High latency for a specific user often points at expensive RPC patterns (`squeue` with large filters, repeated `scontrol show job` polls, etc.).",
           "fieldConfig": {
@@ -3171,7 +3171,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "topk(10,\n  sum by (user) (rate(slurm_controller_rpc_user_duration_seconds_total[5m]))\n  /\n  sum by (user) (rate(slurm_controller_rpc_user_calls_total[5m]))\n)",
@@ -3186,7 +3186,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "slurmctld \u2192 slurmd outbound RPC pool. `queued` is messages waiting to dispatch; should sit near zero. Sustained non-zero queue means dispatch is slower than enqueue and downstream slurmd operations (job start/cancel/reconfig) are being delayed.",
           "fieldConfig": {
@@ -3268,7 +3268,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_agent_queue_size",
@@ -3279,7 +3279,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_agent_thread_cnt",
@@ -3290,7 +3290,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_agent_cnt",
@@ -3305,7 +3305,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Number of accounting messages slurmctld has buffered for slurmdbd. Should be near zero; growth means slurmdbd is unreachable or slow. Sustained growth is followed by a flush storm when slurmdbd recovers.",
           "fieldConfig": {
@@ -3387,7 +3387,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_slurmdbd_queue_size",
@@ -3420,7 +3420,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Duration of the most recent main scheduler cycle. The slurmctld native endpoint exposes only the *last* cycle, so each scrape captures one sample (default scrape interval 30s) \u2014 cycles that ran between scrapes are not represented. Yellow above 50 ms, red above 500 ms.",
           "fieldConfig": {
@@ -3510,7 +3510,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_schedule_cycle_last / 1e6",
@@ -3525,7 +3525,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Main scheduler throughput and the last-cycle queue length (both from the slurmctld native OpenMetrics endpoint, Slurm 25.x+). For the exporter-based pending-jobs view, see the Cluster Usage row.",
           "fieldConfig": {
@@ -3607,7 +3607,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_schedule_cycle_cnt[5m]) * 60",
@@ -3618,7 +3618,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_schedule_queue_len",
@@ -3633,7 +3633,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Rate of main scheduling cycles that ended for each reason \u2014 same data as `sdiag` \u2192 'Main scheduling statistics' \u2192 'Last cycle exited as'. The healthy series is `End of job queue`; every other reason means the cycle was cut short by a cap.\n\n- `End of job queue` (`slurm_sched_exit_end`) \u2014 examined every pending job and finished. Desired.\n- `Hit default_queue_depth` (`slurm_sched_exit_max_depth`) \u2014 capped after examining `default_queue_depth` jobs (SchedulerParameters, default 100). Raise if consistently non-zero.\n- `Hit sched_max_job_start` (`slurm_sched_exit_max_job_start`) \u2014 started `sched_max_job_start` jobs in one cycle (default 0 = unlimited; non-zero only if explicitly set).\n- `Blocked on licenses` (`slurm_sched_exit_lic`) \u2014 pending jobs were waiting on Slurm licenses; check `sacctmgr show license`.\n- `Hit max_rpc_cnt` (`slurm_sched_exit_rpc_cnt`) \u2014 slurmctld's RPC queue grew past `max_rpc_cnt`; scheduler deferred to drain it.\n- `Timeout (max_sched_time)` (`slurm_sched_exit_timeout`) \u2014 cycle exceeded `max_sched_time` seconds and was cut short.\n\nA non-zero rate on any reason other than `End of job queue` means the main scheduler is being throttled \u2014 raise the matching cap in `SchedulerParameters`.",
           "fieldConfig": {
@@ -3715,7 +3715,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_sched_exit_end[5m]) * 60",
@@ -3726,7 +3726,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_sched_exit_max_depth[5m]) * 60",
@@ -3737,7 +3737,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_sched_exit_max_job_start[5m]) * 60",
@@ -3748,7 +3748,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_sched_exit_lic[5m]) * 60",
@@ -3759,7 +3759,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_sched_exit_rpc_cnt[5m]) * 60",
@@ -3770,7 +3770,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_sched_exit_timeout[5m]) * 60",
@@ -3800,7 +3800,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Whether the backfill scheduler is currently mid-cycle (`slurm_bf_active`: 0 = idle, 1 = running).",
           "fieldConfig": {
@@ -3872,7 +3872,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_bf_active",
@@ -3887,7 +3887,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Wall-clock age of the most recent backfill cycle (`time() - slurm_bf_when_last_cycle`). Sawtooth pattern; spikes indicate stalls. Yellow over 1 min, red over 5 min \u2014 likely a hung backfill.",
           "fieldConfig": {
@@ -3977,7 +3977,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "time() - slurm_bf_when_last_cycle",
@@ -3992,7 +3992,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Duration of the most recent backfill cycle. The slurmctld native endpoint exposes only the *last* cycle, so each scrape captures one sample (default scrape interval 30s) \u2014 cycles that ran between scrapes are not represented. Backfill is naturally slower than the main scheduler; yellow above 1 s, red above 5 s.",
           "fieldConfig": {
@@ -4082,7 +4082,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_bf_cycle_last / 1e6",
@@ -4097,7 +4097,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Backfill cycles per minute (5m rate \u00d7 60). Rate is bounded above by `1 / bf_interval` (default 30s \u2192 2/min).",
           "fieldConfig": {
@@ -4179,7 +4179,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_bf_cycle_cnt[5m]) * 60",
@@ -4194,7 +4194,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Pending jobs awaiting backfill processing.",
           "fieldConfig": {
@@ -4276,7 +4276,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_bf_queue_len",
@@ -4291,7 +4291,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "`all` = jobs examined; `try` = jobs the scheduler actually attempted to start (the CPU-intensive subset).",
           "fieldConfig": {
@@ -4373,7 +4373,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_bf_last_depth",
@@ -4384,7 +4384,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_bf_last_depth_try",
@@ -4399,7 +4399,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Distinct reservation time slots tested per cycle. Grows with `bf_window` and `bf_resolution`.",
           "fieldConfig": {
@@ -4481,7 +4481,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "slurm_bf_table_size",
@@ -4496,7 +4496,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Rate of backfill cycles that ended for each reason \u2014 same data as `sdiag` \u2192 'Backfilling stats' \u2192 'Last cycle exited as'. The healthy series is `End of job queue`; every other reason means the cycle was cut short.\n\n- `End of job queue` (`slurm_bf_exit_end`) \u2014 examined every pending job and finished. Desired.\n- `Hit bf_max_job_start` (`slurm_bf_exit_max_job_start`) \u2014 started `bf_max_job_start` jobs in one cycle (default 0 = unlimited).\n- `Hit bf_max_job_test` (`slurm_bf_exit_max_job_test`) \u2014 examined `bf_max_job_test` jobs and stopped (default 100). Raise to let backfill look deeper into the queue.\n- `System state changed` (`slurm_bf_exit_state_changed`) \u2014 a job completed or a node state changed mid-cycle; backfill restarts with fresh data. Benign, but a sustained rate means the cluster is so dynamic that backfill never finishes a clean pass.\n- `Hit table size limit (bf_node_space_size)` (`slurm_bf_exit_table_limit`) \u2014 backfill's per-node reservation table hit `bf_node_space_size` entries (default 50, capped at 4000); cycle stops to avoid runaway memory.\n- `Timeout (bf_max_time)` (`slurm_bf_exit_timeout`) \u2014 cycle exceeded `bf_max_time` seconds (default 30, capped by `bf_interval`).\n\nA non-zero rate on any reason other than `End of job queue` (or, sometimes, `System state changed`) means backfill is being throttled \u2014 raise the matching cap in `SchedulerParameters`.",
           "fieldConfig": {
@@ -4578,7 +4578,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_bf_exit_end[5m]) * 60",
@@ -4589,7 +4589,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_bf_exit_max_job_start[5m]) * 60",
@@ -4600,7 +4600,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_bf_exit_max_job_test[5m]) * 60",
@@ -4611,7 +4611,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_bf_exit_state_changed[5m]) * 60",
@@ -4622,7 +4622,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_bf_exit_table_limit[5m]) * 60",
@@ -4633,7 +4633,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(slurm_bf_exit_timeout[5m]) * 60",
@@ -4660,7 +4660,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Working-set memory of each container in the controller pod, stacked. The dashed line shows node_memory_MemAvailable_bytes \u2014 when the stacked total approaches it, the node is running out of allocatable memory.",
           "fieldConfig": {
@@ -4779,7 +4779,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (container) (\n  container_memory_working_set_bytes{namespace=~\"soperator\", pod=\"$pod\", container!=\"\", container!=\"POD\"}\n)",
@@ -4790,7 +4790,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_MemAvailable_bytes{instance=\"$instance\"}",
@@ -4805,7 +4805,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Working-set memory as a percentage of the per-container memory limit. Containers with no limit set fall back to node_memory_MemAvailable_bytes (memory the kernel believes is allocatable without pressure) as the denominator.",
           "fieldConfig": {
@@ -4888,7 +4888,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "100\n* sum by (container) (\n    container_memory_working_set_bytes{namespace=~\"soperator\", pod=\"$pod\", container!=\"\", container!=\"POD\"}\n  )\n/ on (container)\n  (\n    sum by (container) (\n      kube_pod_container_resource_limits{namespace=~\"soperator\", pod=\"$pod\", resource=\"memory\"}\n    )\n    or\n    on (container)\n    sum by (container) (\n      container_memory_working_set_bytes{namespace=~\"soperator\", pod=\"$pod\", container!=\"\", container!=\"POD\"} * 0\n    )\n    + on () group_left scalar(node_memory_MemAvailable_bytes{instance=\"$instance\"})\n  )",
@@ -4903,7 +4903,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Active vs inactive memory on the controller node. Active is recently used; inactive is reclaimable on demand.",
           "fieldConfig": {
@@ -4985,7 +4985,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_Active_bytes{instance=\"$instance\"}",
@@ -4996,7 +4996,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_Inactive_bytes{instance=\"$instance\"}",
@@ -5011,7 +5011,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Committed_AS vs CommitLimit. The kernel will refuse new allocations once Committed_AS approaches the limit (when overcommit is disabled).",
           "fieldConfig": {
@@ -5123,7 +5123,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_Committed_AS_bytes{instance=\"$instance\"}",
@@ -5134,7 +5134,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_CommitLimit_bytes{instance=\"$instance\"}",
@@ -5149,7 +5149,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Pages awaiting writeback to disk and dirty pages. Sustained high values can indicate slow storage or heavy IO.",
           "fieldConfig": {
@@ -5231,7 +5231,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_Writeback_bytes{instance=\"$instance\"}",
@@ -5242,7 +5242,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_WritebackTmp_bytes{instance=\"$instance\"}",
@@ -5253,7 +5253,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_Dirty_bytes{instance=\"$instance\"}",
@@ -5268,7 +5268,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Minor and major page faults per second on the controller node. Major faults imply disk IO under memory pressure.",
           "fieldConfig": {
@@ -5350,7 +5350,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_vmstat_pgfault{instance=\"$instance\"}[$__rate_interval])",
@@ -5361,7 +5361,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_vmstat_pgmajfault{instance=\"$instance\"}[$__rate_interval])",
@@ -5376,7 +5376,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Rate of OOM kill events on the controller node (node_vmstat_oom_kill).",
           "fieldConfig": {
@@ -5461,7 +5461,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_vmstat_oom_kill{instance=\"$instance\"}[$__rate_interval])",
@@ -5476,7 +5476,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Rate of pages read from / written to disk by the kernel (node_vmstat_pgpgin/pgpgout). High values can correlate with memory pressure or heavy IO.",
           "fieldConfig": {
@@ -5558,7 +5558,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_vmstat_pgpgin{instance=\"$instance\"}[$__rate_interval])",
@@ -5569,7 +5569,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "-1 * irate(node_vmstat_pgpgout{instance=\"$instance\"}[$__rate_interval])",
@@ -5584,7 +5584,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Shared memory and file mappings on the controller node. slurmctld uses POSIX shared memory for IPC; large or growing values can hint at file-backed working set or IPC pressure.",
           "fieldConfig": {
@@ -5666,7 +5666,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_Mapped_bytes{instance=\"$instance\"}",
@@ -5677,7 +5677,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_Shmem_bytes{instance=\"$instance\"}",
@@ -5688,7 +5688,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_ShmemHugePages_bytes{instance=\"$instance\"}",
@@ -5699,7 +5699,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_ShmemPmdMapped_bytes{instance=\"$instance\"}",
@@ -5714,7 +5714,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Anonymous (heap/stack) memory on the controller node. AnonPages is the closest single signal for slurmctld's actual memory footprint outside of file-backed caches.",
           "fieldConfig": {
@@ -5796,7 +5796,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_AnonHugePages_bytes{instance=\"$instance\"}",
@@ -5807,7 +5807,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_memory_AnonPages_bytes{instance=\"$instance\"}",
@@ -5822,7 +5822,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Container-level memory breakdown for the controller pod, split by container. Complements **Memory Working Set** with three orthogonal views of where the pod's memory is sitting:\n\n- **`rss`** \u2014 actual heap + private anonymous mappings. Typically the dominant component for slurmctld.\n- **`cache`** \u2014 kernel page cache touched by this container's file I/O. Reclaimable; not real pressure.\n- **`mapped_file`** \u2014 pages mmap'd into the container's address space (subset of cache). slurmctld memory-maps state files in `StateSaveLocation`, so this can be MBs\u2013GBs on busy clusters.\n\nSum of `rss + cache` \u2248 container memory usage; sum of `rss + (cache \u2212 mapped_file)` is roughly what's accounted as Working Set.",
           "fieldConfig": {
@@ -5904,7 +5904,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "container_memory_rss{namespace=~\"soperator\", pod=\"$pod\", container!=\"\", container!=\"POD\"}",
@@ -5915,7 +5915,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "container_memory_cache{namespace=~\"soperator\", pod=\"$pod\", container!=\"\", container!=\"POD\"}",
@@ -5926,7 +5926,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "container_memory_mapped_file{namespace=~\"soperator\", pod=\"$pod\", container!=\"\", container!=\"POD\"}",
@@ -5956,7 +5956,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Network throughput on the controller pod's network namespace (rate over 5m). RX positive, TX negative.",
           "fieldConfig": {
@@ -6038,7 +6038,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(\n  rate(container_network_receive_bytes_total{namespace=~\"soperator\", pod=\"$pod\"}[5m])\n)",
@@ -6049,7 +6049,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "-1 * sum(\n  rate(container_network_transmit_bytes_total{namespace=~\"soperator\", pod=\"$pod\"}[5m])\n)",
@@ -6064,7 +6064,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Per-NIC packet rate (rate over 5m) on the controller node. Rx as positive, Tx as negative for visual symmetry.",
           "fieldConfig": {
@@ -6146,7 +6146,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_network_receive_packets_total{instance=\"$instance\", device=~\"eth.*|en.*|bond.*\"}[$__rate_interval])",
@@ -6157,7 +6157,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "-1 * irate(node_network_transmit_packets_total{instance=\"$instance\", device=~\"eth.*|en.*|bond.*\"}[$__rate_interval])",
@@ -6172,7 +6172,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Per-NIC packet errors and drops on the controller node. Both should be zero in healthy state.",
           "fieldConfig": {
@@ -6254,7 +6254,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_network_receive_errs_total{instance=\"$instance\", device=~\"eth.*|en.*|bond.*\"}[$__rate_interval])",
@@ -6265,7 +6265,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_network_transmit_errs_total{instance=\"$instance\", device=~\"eth.*|en.*|bond.*\"}[$__rate_interval])",
@@ -6276,7 +6276,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_network_receive_drop_total{instance=\"$instance\", device=~\"eth.*|en.*|bond.*\"}[$__rate_interval])",
@@ -6287,7 +6287,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_network_transmit_drop_total{instance=\"$instance\", device=~\"eth.*|en.*|bond.*\"}[$__rate_interval])",
@@ -6302,7 +6302,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Currently established TCP connections on the controller node. For slurmctld this directly reflects how many slurmd/srun/sacct clients are connected.",
           "fieldConfig": {
@@ -6384,7 +6384,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_netstat_Tcp_CurrEstab{instance=\"$instance\"}",
@@ -6395,7 +6395,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_ActiveOpens{instance=\"$instance\"}[$__rate_interval])",
@@ -6406,7 +6406,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_PassiveOpens{instance=\"$instance\"}[$__rate_interval])",
@@ -6421,7 +6421,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "TCP-level errors and retransmits. Listen drops and retransmits are early signs of overload or network problems.",
           "fieldConfig": {
@@ -6503,7 +6503,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_RetransSegs{instance=\"$instance\"}[$__rate_interval])",
@@ -6514,7 +6514,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_TCPSynRetrans{instance=\"$instance\"}[$__rate_interval])",
@@ -6525,7 +6525,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_ListenDrops{instance=\"$instance\"}[$__rate_interval])",
@@ -6536,7 +6536,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_ListenOverflows{instance=\"$instance\"}[$__rate_interval])",
@@ -6547,7 +6547,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_OutRsts{instance=\"$instance\"}[$__rate_interval])",
@@ -6562,7 +6562,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Netfilter connection-tracking entries vs limit. slurmctld sees many concurrent connections; if entries approach the limit, new connections fail silently.",
           "fieldConfig": {
@@ -6673,7 +6673,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_nf_conntrack_entries{instance=\"$instance\"}",
@@ -6684,7 +6684,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_nf_conntrack_entries_limit{instance=\"$instance\"}",
@@ -6699,7 +6699,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Per-NIC operational state. UP/carrier should be 1 in healthy state \u2014 drops to 0 indicate the interface is administratively down or the cable/link has gone away.",
           "fieldConfig": {
@@ -6782,7 +6782,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_network_up{instance=\"$instance\", device=~\"eth.*|en.*|bond.*\"}",
@@ -6793,7 +6793,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_network_carrier{instance=\"$instance\", device=~\"eth.*|en.*|bond.*\"}",
@@ -6813,7 +6813,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -6826,7 +6826,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Pod-level network throughput on controller-0 (RX = receive, TX = transmit). Source is the `node-exporter` sidecar running in the controller pod, scraped via `VMPodScrape` `custom-node-exporter`. Excludes `lo`. Note: this is **pod-level** traffic (slurmctld + sidecars), distinct from the host-level Network row below which shows the whole K8s node.",
           "fieldConfig": {
@@ -6908,7 +6908,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_network_receive_bytes_total{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\", device!=\"lo\"}[$__rate_interval])",
@@ -6919,7 +6919,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "-1 * irate(node_network_transmit_bytes_total{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\", device!=\"lo\"}[$__rate_interval])",
@@ -6934,7 +6934,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Currently established TCP connections inside the controller pod (`node_netstat_Tcp_CurrEstab`). This is essentially the count of live slurmctld RPC clients plus a few sidecar/operator connections. Spikes correlate with bursts of `sbatch`/`squeue`/`sinfo` traffic.",
           "fieldConfig": {
@@ -7016,7 +7016,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_netstat_Tcp_CurrEstab{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\"}",
@@ -7031,7 +7031,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Pod-level packet rate (RX/TX packets per second), excluding `lo`. Useful for spotting packet-flood patterns that don't show up clearly in bytes (lots of small RPCs).",
           "fieldConfig": {
@@ -7113,7 +7113,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_network_receive_packets_total{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\", device!=\"lo\"}[$__rate_interval])",
@@ -7124,7 +7124,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "-1 * irate(node_network_transmit_packets_total{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\", device!=\"lo\"}[$__rate_interval])",
@@ -7139,7 +7139,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Rate of TCP retransmissions (`node_netstat_Tcp_RetransSegs`) and SYN retransmissions (`node_netstat_TcpExt_TCPSynRetrans`). Both should sit near zero. Sustained non-zero values indicate packet loss between the pod and its peers \u2014 slurmd nodes, slurmdbd, or external clients.",
           "fieldConfig": {
@@ -7221,7 +7221,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_RetransSegs{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\"}[$__rate_interval])",
@@ -7232,7 +7232,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_TCPSynRetrans{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\"}[$__rate_interval])",
@@ -7247,7 +7247,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Interface-level errors and drops (`node_network_receive_errs_total`, `node_network_receive_drop_total`, `node_network_transmit_errs_total`, `node_network_transmit_drop_total`), excluding `lo`. Healthy is flat-zero. Anything non-zero typically means a network-stack or NIC problem.",
           "fieldConfig": {
@@ -7329,7 +7329,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_network_receive_errs_total{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\", device!=\"lo\"}[$__rate_interval])",
@@ -7340,7 +7340,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_network_receive_drop_total{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\", device!=\"lo\"}[$__rate_interval])",
@@ -7351,7 +7351,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_network_transmit_errs_total{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\", device!=\"lo\"}[$__rate_interval])",
@@ -7362,7 +7362,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_network_transmit_drop_total{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\", device!=\"lo\"}[$__rate_interval])",
@@ -7377,7 +7377,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Rate of TCP listen-queue overflows (`node_netstat_TcpExt_ListenDrops`) and connections from the SYN-cookie / SYN-queue path that got dropped. A non-zero rate here is a strong signal that slurmctld is being overwhelmed and the kernel can't keep up enqueuing new connections \u2014 cross-reference with the RPC row's *Outbound RPC* and inbound rate panels.",
           "fieldConfig": {
@@ -7459,7 +7459,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_ListenDrops{pod=~\"controller-.*\", job=\"soperator/custom-node-exporter\"}[$__rate_interval])",
@@ -7489,7 +7489,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "CPU cores consumed by each container in the controller pod (rate over 5m).",
           "fieldConfig": {
@@ -7571,7 +7571,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (container) (\n  rate(container_cpu_usage_seconds_total{namespace=~\"soperator\", pod=\"$pod\", container!=\"\", container!=\"POD\"}[5m])\n)",
@@ -7586,7 +7586,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Per-mode CPU utilisation on the controller node, stacked to 100%. Iowait, Steal, and Softirq are particularly informative when the controller feels slow.",
           "fieldConfig": {
@@ -7667,7 +7667,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{instance=\"$instance\", mode=\"system\"}[$__rate_interval]))",
@@ -7678,7 +7678,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{instance=\"$instance\", mode=\"user\"}[$__rate_interval]))",
@@ -7689,7 +7689,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{instance=\"$instance\", mode=\"nice\"}[$__rate_interval]))",
@@ -7700,7 +7700,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{instance=\"$instance\", mode=\"iowait\"}[$__rate_interval]))",
@@ -7711,7 +7711,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{instance=\"$instance\", mode=\"irq\"}[$__rate_interval]))",
@@ -7722,7 +7722,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{instance=\"$instance\", mode=\"softirq\"}[$__rate_interval]))",
@@ -7733,7 +7733,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{instance=\"$instance\", mode=\"steal\"}[$__rate_interval]))",
@@ -7744,7 +7744,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{instance=\"$instance\", mode=\"idle\"}[$__rate_interval]))",
@@ -7759,7 +7759,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "System load averages over 1, 5 and 15 minutes. Includes runnable + uninterruptible-IO tasks; values trending above the CPU count indicate scheduling backlog.",
           "fieldConfig": {
@@ -7841,7 +7841,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_load1{instance=\"$instance\"}",
@@ -7852,7 +7852,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_load5{instance=\"$instance\"}",
@@ -7863,7 +7863,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "node_load15{instance=\"$instance\"}",
@@ -7878,7 +7878,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Context-switch and interrupt rate on the controller node. Spikes here often correlate with bursts of slurmctld RPC traffic.",
           "fieldConfig": {
@@ -7960,7 +7960,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_context_switches_total{instance=\"$instance\"}[$__rate_interval])",
@@ -7971,7 +7971,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_intr_total{instance=\"$instance\"}[$__rate_interval])",
@@ -7986,7 +7986,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Multi-dimensional pressure on the controller node:\n\u2022 Kubelet MemoryPressure (binary 0/100) \u2014 when kubelet flags the node memory-pressured, it may evict pods.\n\u2022 Memory PSI some/full \u2014 kernel fraction of time tasks were stalled waiting for memory.\n\u2022 CPU PSI some \u2014 fraction of time tasks were stalled waiting for CPU.\n\u2022 I/O PSI some/full \u2014 fraction of time tasks were stalled on I/O.\n\nPSI usually rises before the kubelet condition trips.",
           "fieldConfig": {
@@ -8097,7 +8097,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "100 * max(kube_node_status_condition{node=\"$node\", condition=\"MemoryPressure\", status=\"true\"})",
@@ -8108,7 +8108,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "100 * irate(node_pressure_memory_waiting_seconds_total{instance=\"$instance\"}[$__rate_interval])",
@@ -8119,7 +8119,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "100 * irate(node_pressure_memory_stalled_seconds_total{instance=\"$instance\"}[$__rate_interval])",
@@ -8130,7 +8130,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "100 * irate(node_pressure_cpu_waiting_seconds_total{instance=\"$instance\"}[$__rate_interval])",
@@ -8141,7 +8141,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "100 * irate(node_pressure_io_waiting_seconds_total{instance=\"$instance\"}[$__rate_interval])",
@@ -8152,7 +8152,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "100 * irate(node_pressure_io_stalled_seconds_total{instance=\"$instance\"}[$__rate_interval])",
@@ -8180,6 +8180,24 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allowCustomValue": false,
         "current": {
           "text": "controller-0",
@@ -8187,7 +8205,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(kube_pod_info{namespace=~\"soperator\", pod=~\"controller-[0-9]+\"}, pod)",
         "description": "Controller pod to inspect. Discovered from kube_pod_info; defaults to controller-0.",
@@ -8214,7 +8232,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(kube_pod_info{namespace=~\"soperator\", pod=\"$pod\"}, node)",
         "description": "K8s node hosting the selected controller pod. Hidden; used for joining node-exporter metrics.",
@@ -8242,7 +8260,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(node_uname_info{nodename=\"$node\"}, instance)",
         "description": "node-exporter `instance` label for the controller node. Hidden; used to filter node_* metrics.",

--- a/helm/soperator-monitoring-dashboards/dashboards/workers_detailed_stats.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/workers_detailed_stats.json
@@ -23,7 +23,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "enable": false,
         "expr": "group by (node, pod) (\n  changes(\n      sum without (uid, pod_ip)(\n          kube_pod_info{pod=~\"worker-.*\", node!=\"\"}\n      )\n  ) > 0\n  and on (pod) \n  sum by (pod)(\n      kube_pod_info{pod=~\"worker-.*\", node!=\"\"}\n  )\n)",
@@ -49,7 +49,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -107,7 +107,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "group by (node) (kube_pod_info{pod=\"$worker\",node!=\"\"})",
@@ -123,7 +123,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -182,7 +182,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_SM_CLOCK{Hostname=~\"$node\"}*1000000)",
@@ -200,7 +201,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -259,7 +260,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_MEM_CLOCK{Hostname=~\"$node\"}*1000000)",
@@ -290,7 +292,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -372,7 +374,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (gpu) (\n  DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", exported_pod=~\"$worker\"}/(DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", exported_pod=~\"$worker\"}+DCGM_FI_DEV_FB_FREE{Hostname=~\"$node\", exported_pod=~\"$worker\"})\n)",
@@ -391,7 +394,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -474,7 +477,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by(gpu) (DCGM_FI_DEV_GPU_UTIL{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
@@ -493,7 +497,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -575,7 +579,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "1e6*sum(DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
@@ -594,7 +599,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -677,7 +682,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by(gpu) (DCGM_FI_DEV_MEM_COPY_UTIL{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
@@ -696,7 +702,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -777,7 +783,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by(gpu) (DCGM_FI_DEV_POWER_USAGE{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
@@ -796,7 +803,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -877,7 +884,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by(gpu) (DCGM_FI_DEV_GPU_TEMP{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
@@ -896,7 +904,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -990,7 +998,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(DCGM_FI_PROF_PCIE_TX_BYTES{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
@@ -1004,7 +1013,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(DCGM_FI_PROF_PCIE_RX_BYTES{Hostname=~\"$node\", exported_pod=~\"$worker\"})",
@@ -1022,7 +1032,8 @@
     },
     {
       "datasource": {
-        "uid": "VictoriaMetrics"
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1116,7 +1127,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(\n  rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$ip\"}[$__interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n)\n",
@@ -1130,7 +1142,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(\n  rate(node_infiniband_port_data_received_bytes_total{instance=~\"$ip\"}[$__interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n)",
@@ -1149,7 +1162,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1230,7 +1243,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by(gpu) (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{Hostname=~\"$node\", exported_pod=~\"$worker\"} * 100)",
@@ -1249,7 +1263,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1330,7 +1344,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by(gpu) (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{Hostname=~\"$node\", exported_pod=~\"$worker\"} * 1979)",
@@ -1349,7 +1364,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1430,7 +1445,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by(gpu) (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{Hostname=~\"$node\", exported_pod=~\"$worker\"} * 989.7)",
@@ -1459,7 +1475,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -1666,7 +1682,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"system\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
@@ -1681,7 +1697,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"user\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
@@ -1695,7 +1711,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"nice\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
@@ -1709,7 +1725,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"iowait\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
@@ -1723,7 +1739,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"irq\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
@@ -1737,7 +1753,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"softirq\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
@@ -1751,7 +1767,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"steal\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
@@ -1765,7 +1781,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum(\n  irate(node_cpu_seconds_total{instance=~\"$ip\", mode=\"idle\"}[$__rate_interval])\n  * on(instance) group_left(nodename) node_uname_info\n  * on(nodename) group_left(exported_pod) clamp(count by (nodename, hpc_job) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)\n) / scalar(count(count(node_cpu_seconds_total{instance=~\"$ip\"}) by (cpu)))",
@@ -1784,7 +1800,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -2171,7 +2187,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "(node_memory_MemTotal_bytes{instance=~\"$ip\"} - node_memory_MemFree_bytes{instance=~\"$ip\"} - node_memory_Buffers_bytes{instance=~\"$ip\"} - node_memory_Cached_bytes{instance=~\"$ip\"} - node_memory_Slab_bytes{instance=~\"$ip\"} - node_memory_PageTables_bytes{instance=~\"$ip\"} - node_memory_SwapCached_bytes{instance=~\"$ip\"})\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
@@ -2186,7 +2202,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_PageTables_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -2199,7 +2215,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_SwapCached_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -2211,7 +2227,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Slab_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -2224,7 +2240,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Cached_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -2237,7 +2253,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Buffers_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -2250,7 +2266,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_MemFree_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -2263,7 +2279,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "(node_memory_SwapTotal_bytes{instance=~\"$ip\"} - node_memory_SwapFree_bytes{instance=~\"$ip\"})\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -2276,7 +2292,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_HardwareCorrupted_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -2293,7 +2309,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2449,7 +2465,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_network_receive_bytes_total{instance=~\"$ip\"}[$__rate_interval])*8\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -2461,7 +2477,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_network_transmit_bytes_total{instance=~\"$ip\"}[$__rate_interval])*8\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -2477,7 +2493,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -2562,7 +2578,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "(node_filesystem_size_bytes{instance=~\"$ip\",device!~'rootfs'} - node_filesystem_avail_bytes{instance=~\"$ip\",device!~'rootfs'})\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
@@ -2580,7 +2596,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -2992,7 +3008,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_reads_completed_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "intervalFactor": 4,
@@ -3003,7 +3019,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_writes_completed_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "intervalFactor": 1,
@@ -3018,7 +3034,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -3217,7 +3233,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_read_bytes_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -3230,7 +3246,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_written_bytes_total{instance=~\"$ip\",device=~\"$diskdevices\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -3247,7 +3263,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -3360,7 +3376,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_io_time_seconds_total{instance=~\"$ip\",device=~\"$diskdevices\"} [$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -3378,7 +3394,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3492,7 +3508,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by(instance) (irate(node_cpu_guest_seconds_total{instance=~\"$ip\", mode=\"user\"}[1m])) / on(instance) group_left sum by (instance)((irate(node_cpu_seconds_total{instance=~\"$ip\"}[1m])))",
@@ -3504,7 +3520,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by(instance) (irate(node_cpu_guest_seconds_total{instance=~\"$ip\", mode=\"nice\"}[1m])) / on(instance) group_left sum by (instance)((irate(node_cpu_seconds_total{instance=~\"$ip\"}[1m])))",
@@ -3534,7 +3550,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3875,7 +3891,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Inactive_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -3887,7 +3903,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Active_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -3903,7 +3919,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4263,7 +4279,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Committed_AS_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -4275,7 +4291,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_CommitLimit_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -4291,7 +4307,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4632,7 +4648,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Inactive_file_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -4645,7 +4661,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Inactive_anon_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -4658,7 +4674,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Active_file_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -4671,7 +4687,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Active_anon_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -4688,7 +4704,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5058,7 +5074,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Writeback_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -5070,7 +5086,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_WritebackTmp_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -5082,7 +5098,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Dirty_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -5098,7 +5114,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5463,7 +5479,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Mapped_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -5475,7 +5491,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Shmem_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -5487,7 +5503,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_ShmemHugePages_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -5500,7 +5516,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_ShmemPmdMapped_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -5517,7 +5533,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5858,7 +5874,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_KernelStack_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -5870,7 +5886,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_Percpu_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -5887,7 +5903,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -6242,7 +6258,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_VmallocChunk_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -6255,7 +6271,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_VmallocTotal_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -6268,7 +6284,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_VmallocUsed_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -6285,7 +6301,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -6652,7 +6668,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_AnonHugePages_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -6664,7 +6680,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_AnonPages_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -6680,7 +6696,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -7050,7 +7066,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_memory_NFS_Unstable_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -7066,7 +7082,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -7436,7 +7452,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_vmstat_oom_kill{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -7453,7 +7469,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -7549,7 +7565,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_vmstat_pgpgin{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -7561,7 +7577,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_vmstat_pgpgout{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -7577,7 +7593,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -7937,7 +7953,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_vmstat_pgfault{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -7949,7 +7965,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_vmstat_pgmajfault{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -7961,7 +7977,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_vmstat_pgfault{instance=~\"$ip\"}[$__rate_interval])  - irate(node_vmstat_pgmajfault{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -7991,7 +8007,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "The number (after merges) of I/O requests completed per second for the device",
           "fieldConfig": {
@@ -8388,7 +8404,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_reads_completed_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "intervalFactor": 4,
@@ -8399,7 +8415,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_writes_completed_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "intervalFactor": 1,
@@ -8414,7 +8430,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "The number of bytes read from or written to the device per second",
           "fieldConfig": {
@@ -8811,7 +8827,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_read_bytes_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -8823,7 +8839,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_written_bytes_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -8839,7 +8855,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "The average time for requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.",
           "fieldConfig": {
@@ -9236,7 +9252,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_read_time_seconds_total{instance=~\"$ip\"}[$__rate_interval]) / irate(node_disk_reads_completed_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "hide": false,
@@ -9249,7 +9265,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_write_time_seconds_total{instance=~\"$ip\"}[$__rate_interval]) / irate(node_disk_writes_completed_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "hide": false,
@@ -9266,7 +9282,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "The average queue length of the requests that were issued to the device",
           "fieldConfig": {
@@ -9652,7 +9668,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_io_time_weighted_seconds_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "interval": "",
@@ -9668,7 +9684,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "The number of read and write requests merged per second that were queued to the device",
           "fieldConfig": {
@@ -10065,7 +10081,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_reads_merged_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "intervalFactor": 1,
@@ -10076,7 +10092,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_writes_merged_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "intervalFactor": 1,
@@ -10091,7 +10107,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "Percentage of elapsed time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100% for devices serving requests serially.  But for devices  serving requests in parallel, such as RAID arrays and modern SSDs, this number does not reflect their performance limits.",
           "fieldConfig": {
@@ -10477,7 +10493,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_io_time_seconds_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "interval": "",
@@ -10489,7 +10505,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_discard_time_seconds_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "interval": "",
@@ -10505,7 +10521,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "The number of outstanding requests at the instant the sample was taken. Incremented as requests are given to appropriate struct request_queue and decremented as they finish.",
           "fieldConfig": {
@@ -10891,7 +10907,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_disk_io_now{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "interval": "",
@@ -10907,7 +10923,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -11292,7 +11308,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_discards_completed_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "interval": "",
@@ -11304,7 +11320,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_disk_discards_merged_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "interval": "",
@@ -11334,7 +11350,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -11419,7 +11435,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_filesystem_avail_bytes{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -11433,7 +11449,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_filesystem_free_bytes{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -11446,7 +11462,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_filesystem_size_bytes{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -11463,7 +11479,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -11548,7 +11564,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_filesystem_files_free{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -11565,7 +11581,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -11650,7 +11666,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_filefd_maximum{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -11662,7 +11678,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_filefd_allocated{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -11678,7 +11694,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -11763,7 +11779,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_filesystem_files{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -11780,7 +11796,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -11882,7 +11898,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_filesystem_readonly{instance=~\"$ip\",device!~'rootfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -11894,7 +11910,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_filesystem_device_error{instance=~\"$ip\",device!~'rootfs',fstype!~'tmpfs'}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -11925,7 +11941,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -12082,7 +12098,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_network_receive_packets_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12095,7 +12111,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_network_transmit_packets_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12112,7 +12128,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -12209,7 +12225,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_network_receive_errs_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12221,7 +12237,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_network_transmit_errs_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12237,7 +12253,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -12334,7 +12350,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_network_receive_drop_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12346,7 +12362,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_network_transmit_drop_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12362,7 +12378,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -12466,7 +12482,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_nf_conntrack_entries{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12478,7 +12494,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_nf_conntrack_entries_limit{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12494,7 +12510,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -12579,7 +12595,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_network_speed_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12595,7 +12611,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -12679,7 +12695,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_network_up{operstate=\"up\",instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12691,7 +12707,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_network_carrier{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12720,7 +12736,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "$worker\n\n$node\n\n$ip",
           "fieldConfig": {
@@ -12829,7 +12845,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Udp_InDatagrams{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12842,7 +12858,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Udp_OutDatagrams{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12859,7 +12875,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -12942,7 +12958,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Udp_InErrors{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12955,7 +12971,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Udp_NoPorts{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12968,7 +12984,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_UdpLite_InErrors{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "interval": "",
@@ -12978,7 +12994,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Udp_RcvbufErrors{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -12991,7 +13007,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Udp_SndbufErrors{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13008,7 +13024,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -13116,7 +13132,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Tcp_InSegs{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13130,7 +13146,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Tcp_OutSegs{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13147,7 +13163,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -13232,7 +13248,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_TcpExt_ListenOverflows{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13246,7 +13262,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_TcpExt_ListenDrops{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13260,7 +13276,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_TcpExt_TCPSynRetrans{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13273,7 +13289,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Tcp_RetransSegs{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "interval": "",
@@ -13283,7 +13299,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Tcp_InErrs{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "interval": "",
@@ -13293,7 +13309,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Tcp_OutRsts{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "interval": "",
@@ -13303,7 +13319,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_TCPRcvQDrop{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
@@ -13316,7 +13332,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_TCPOFOQueue{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
@@ -13333,7 +13349,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -13437,7 +13453,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_netstat_Tcp_CurrEstab{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13451,7 +13467,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_netstat_Tcp_MaxConn{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13469,7 +13485,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -13553,7 +13569,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Tcp_ActiveOpens{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13566,7 +13582,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_netstat_Tcp_PassiveOpens{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13597,7 +13613,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -13681,7 +13697,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_context_switches_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13693,7 +13709,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_intr_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13710,7 +13726,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -13794,7 +13810,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_load1{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13806,7 +13822,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_load5{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13818,7 +13834,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_load15{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13834,7 +13850,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -13918,7 +13934,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_entropy_available_bits{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -13934,7 +13950,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "https://docs.kernel.org/accounting/psi.html",
           "fieldConfig": {
@@ -14080,7 +14096,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(node_pressure_cpu_waiting_seconds_total{instance=~\"$ip\"}[$__rate_interval])",
@@ -14094,7 +14110,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(node_pressure_memory_waiting_seconds_total{instance=~\"$ip\"}[$__rate_interval])",
@@ -14109,7 +14125,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(node_pressure_memory_stalled_seconds_total{instance=~\"$ip\"}[$__rate_interval])",
@@ -14124,7 +14140,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(node_pressure_io_waiting_seconds_total{instance=~\"$ip\"}[$__rate_interval])",
@@ -14139,7 +14155,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "rate(node_pressure_io_stalled_seconds_total{instance=~\"$ip\"}[$__rate_interval])",
@@ -14158,7 +14174,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -14262,7 +14278,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "process_max_fds{instance=~\"$ip\"}",
               "interval": "",
@@ -14274,7 +14290,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "process_open_fds{instance=~\"$ip\"}",
               "interval": "",
@@ -14290,7 +14306,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -14373,7 +14389,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(node_schedstat_timeslices_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -14390,7 +14406,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -14473,7 +14489,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "irate(process_cpu_seconds_total{instance=~\"$ip\"}[$__rate_interval])\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -14504,7 +14520,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -14604,7 +14620,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_timex_estimated_error_seconds{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -14618,7 +14634,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_timex_offset_seconds{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -14632,7 +14648,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_timex_maxerror_seconds{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -14650,7 +14666,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -14734,7 +14750,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_timex_loop_time_constant{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -14751,7 +14767,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -14851,7 +14867,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_timex_sync_status{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -14864,7 +14880,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_timex_frequency_adjustment_ratio{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -14881,7 +14897,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -14965,7 +14981,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_timex_tick_seconds{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -14978,7 +14994,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "expr": "node_timex_tai_offset_seconds{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(exported_pod) clamp(count by (nodename, exported_pod) (label_move(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"}, \"Hostname\", \"nodename\")), 1, 1)",
               "format": "time_series",
@@ -15005,12 +15021,30 @@
     "list": [
       {
         "current": {
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
           "text": "worker-0",
           "value": "worker-0"
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(kube_pod_info,pod)",
         "description": "Select one worker to check it's detailed stats in panels.",
@@ -15034,7 +15068,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(kube_pod_info{pod=~\"$worker\"},node)",
         "hide": 2,
@@ -15078,7 +15112,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(node_uname_info{nodename=~\"$node\"},instance)",
         "hide": 2,

--- a/helm/soperator-monitoring-dashboards/dashboards/workers_overview.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/workers_overview.json
@@ -22,7 +22,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "enable": false,
         "expr": "group by (node, pod) (\n  changes(\n      sum without (uid, pod_ip)(\n          kube_pod_info{pod=~\"worker-.*\", node!=\"\"}\n      )\n  ) > 0\n  and on (pod) \n  sum by (pod)(\n      kube_pod_info{pod=~\"worker-.*\", node!=\"\"}\n  )\n)",
@@ -99,7 +99,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "Avg of utilization across all selected workers and instances",
       "fieldConfig": {
@@ -158,7 +158,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg (\n  1 - rate(node_cpu_seconds_total{mode=\"idle\"}[1m])\n) * 100",
@@ -174,7 +174,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -240,7 +240,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(\n    (\n        node_memory_MemTotal_bytes - \n        node_memory_MemFree_bytes - \n        node_memory_Buffers_bytes - \n        node_memory_Cached_bytes\n    ) / \n    node_memory_MemTotal_bytes{instance=~\"$ip\"}\n) * 100",
@@ -258,7 +259,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -324,7 +325,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "(\n  sum(node_filesystem_size_bytes{device!=\"rootfs\",instance=~\"$ip\"}) - \n  sum(node_filesystem_avail_bytes{device!=\"rootfs\",instance=~\"$ip\"})\n) / \nsum(node_filesystem_size_bytes{device!=\"rootfs\",instance=~\"$ip\"})",
@@ -342,7 +344,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -412,7 +414,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\"})",
@@ -430,7 +433,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -498,7 +501,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(DCGM_FI_DEV_POWER_USAGE{exported_pod=~\"$worker\"})",
@@ -516,7 +520,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "GPU Shutdown Temp: 90 C<br>\nGPU Slowdown Temp: 87 C<br>\nGPU Max Operating Temp: 83 C<br>",
       "fieldConfig": {
@@ -582,7 +586,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"})",
@@ -600,7 +605,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -666,7 +671,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_MEM_COPY_UTIL{exported_pod=~\"$worker\"})",
@@ -684,7 +690,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -743,7 +749,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_SM_CLOCK{exported_pod=~\"$worker\"}*1000000)",
@@ -761,7 +768,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -820,7 +827,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_MEM_CLOCK{exported_pod=~\"$worker\"}*1000000)",
@@ -876,7 +884,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -1089,7 +1097,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -1121,7 +1129,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1252,7 +1260,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max(DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\"})",
@@ -1266,7 +1275,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\"})",
@@ -1280,7 +1290,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\"})",
@@ -1299,7 +1310,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1438,7 +1449,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}/(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}+DCGM_FI_DEV_FB_FREE{exported_pod=~\"$worker\"}))",
@@ -1452,7 +1464,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}/(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}+DCGM_FI_DEV_FB_FREE{exported_pod=~\"$worker\"}))",
@@ -1466,7 +1479,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}/(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}+DCGM_FI_DEV_FB_FREE{exported_pod=~\"$worker\"}))",
@@ -1485,7 +1499,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1633,7 +1647,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max (DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"})",
@@ -1647,7 +1662,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg (DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"})",
@@ -1661,7 +1677,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min (DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"})",
@@ -1680,7 +1697,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1811,7 +1828,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max(1 - rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"$ip\"}[$__rate_interval]))",
@@ -1823,7 +1840,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(1 - rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"$ip\"}[$__rate_interval]))",
@@ -1836,7 +1853,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(1 - rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"$ip\"}[$__rate_interval]))",
@@ -1853,7 +1870,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1932,7 +1949,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{exported_pod=~\"$worker\"} * 1979)",
@@ -1946,7 +1964,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{exported_pod=~\"$worker\"} * 989.7)",
@@ -1965,7 +1984,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2082,7 +2101,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum (rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$ip\"}[$__interval]))",
@@ -2096,7 +2116,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum (rate(node_infiniband_port_data_received_bytes_total{instance=~\"$ip\"}[$__interval]))",
@@ -2115,7 +2136,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2253,7 +2274,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "max(\n    (\n        node_memory_MemTotal_bytes - \n        node_memory_MemFree_bytes - \n        node_memory_Buffers_bytes - \n        node_memory_Cached_bytes\n    )\n    /\n    node_memory_MemTotal_bytes{instance=~\"$ip\"}\n)",
@@ -2267,7 +2289,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(\n    (\n        node_memory_MemTotal_bytes - \n        node_memory_MemFree_bytes - \n        node_memory_Buffers_bytes - \n        node_memory_Cached_bytes\n    )\n    /\n    node_memory_MemTotal_bytes{instance=~\"$ip\"}\n)",
@@ -2281,7 +2304,8 @@
         },
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "min(\n    (\n        node_memory_MemTotal_bytes - \n        node_memory_MemFree_bytes - \n        node_memory_Buffers_bytes - \n        node_memory_Cached_bytes\n    )\n    /\n    node_memory_MemTotal_bytes{instance=~\"$ip\"}\n)",
@@ -2313,7 +2337,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2396,7 +2420,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg by (exported_pod) (DCGM_FI_DEV_GPU_UTIL{exported_pod=~\"$worker\"})",
@@ -2415,7 +2440,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2498,7 +2523,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg by (exported_pod) (DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}/(DCGM_FI_DEV_FB_USED{exported_pod=~\"$worker\"}+DCGM_FI_DEV_FB_FREE{exported_pod=~\"$worker\"}))",
@@ -2517,7 +2543,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2602,7 +2628,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg by (exported_pod) (DCGM_FI_DEV_MEM_COPY_UTIL{exported_pod=~\"$worker\"})",
@@ -2621,7 +2648,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2699,7 +2726,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (exported_pod) (DCGM_FI_DEV_POWER_USAGE{exported_pod=~\"$worker\"})",
@@ -2718,7 +2746,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2799,7 +2827,8 @@
       "targets": [
         {
           "datasource": {
-            "uid": "VictoriaMetrics"
+            "type": "prometheus",
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg by (exported_pod) (DCGM_FI_DEV_GPU_TEMP{exported_pod=~\"$worker\"})",
@@ -2818,7 +2847,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "VictoriaMetrics"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2913,7 +2942,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (err_msg, exported_pod) (rate(DCGM_FI_DEV_XID_ERRORS{exported_pod=~\"$worker\"}))",
@@ -2939,7 +2968,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3020,7 +3049,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "avg(1 - rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"$ip\"}[$__rate_interval])) by (instance)\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(pod) label_move(kube_pod_info{pod=~\"worker.*\"}, \"node\", \"nodename\")",
@@ -3036,7 +3065,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3116,7 +3145,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "VictoriaMetrics"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "(\n    node_memory_MemTotal_bytes - \n    node_memory_MemFree_bytes - \n    node_memory_Buffers_bytes - \n    node_memory_Cached_bytes\n)\n/\nnode_memory_MemTotal_bytes{instance=~\"$ip\"}\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(pod) label_move(kube_pod_info{pod=~\"worker.*\"}, \"node\", \"nodename\")",
@@ -3135,7 +3165,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3234,7 +3264,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "VictoriaMetrics"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (instance) (rate(node_disk_read_bytes_total{instance=~\"$ip\"}[$__interval]))\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(pod) label_move(kube_pod_info{pod=~\"worker.*\"}, \"node\", \"nodename\")",
@@ -3248,7 +3279,8 @@
             },
             {
               "datasource": {
-                "uid": "VictoriaMetrics"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (instance) (rate(node_disk_written_bytes_total{instance=~\"$ip\"}[$__interval]))\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(pod) label_move(kube_pod_info{pod=~\"worker.*\"}, \"node\", \"nodename\")",
@@ -3267,7 +3299,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -3349,7 +3381,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "(\n  sum by (instance, device) (node_filesystem_size_bytes{instance=~\"$ip\"}) - \n  sum by (instance, device) (node_filesystem_avail_bytes{instance=~\"$ip\"})\n) / \nsum by (instance, device) (node_filesystem_size_bytes{instance=~\"$ip\",device!~\"none|shm|tmpfs|cloud-metadata|accounting|.*vda15\"})\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(pod) label_move(kube_pod_info{pod=~\"worker.*\"}, \"node\", \"nodename\")",
@@ -3366,7 +3398,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -3452,7 +3484,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "avg by (instance, device) (\n  1 - \n  (\n    node_filesystem_files_free{instance=~\"$ip\",device!~'none|shm|tmpfs|cloud-metadata|accounting|.*vda15'}\n    /\n    node_filesystem_files{instance=~\"$ip\",device!~'none|shm|tmpfs|cloud-metadata|accounting|.*vda15'}\n  )\n)\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(pod) label_move(kube_pod_info{pod=~\"worker.*\"}, \"node\", \"nodename\")",
@@ -3485,7 +3517,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3597,7 +3629,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "VictoriaMetrics"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (instance) (rate(node_network_transmit_bytes_total{instance=~\"$ip\",device=~\"eth.*\"}[$__interval]))\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(pod) label_move(kube_pod_info{pod=~\"worker.*\"}, \"node\", \"nodename\")",
@@ -3611,7 +3644,8 @@
             },
             {
               "datasource": {
-                "uid": "VictoriaMetrics"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (instance) (rate(node_network_receive_bytes_total{instance=~\"$ip\",device=~\"eth.*\"}[$__interval]))\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(pod) label_move(kube_pod_info{pod=~\"worker.*\"}, \"node\", \"nodename\")",
@@ -3630,7 +3664,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3746,7 +3780,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "VictoriaMetrics"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (instance) (rate(node_infiniband_port_data_transmitted_bytes_total{instance=~\"$ip\"}[$__interval]))\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(pod) label_move(kube_pod_info{pod=~\"worker.*\"}, \"node\", \"nodename\")",
@@ -3760,7 +3795,8 @@
             },
             {
               "datasource": {
-                "uid": "VictoriaMetrics"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (instance) (rate(node_infiniband_port_data_received_bytes_total{instance=~\"$ip\"}[$__interval]))\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(pod) label_move(kube_pod_info{pod=~\"worker.*\"}, \"node\", \"nodename\")",
@@ -3779,7 +3815,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3878,7 +3914,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "VictoriaMetrics"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (exported_pod) (DCGM_FI_PROF_PCIE_TX_BYTES{exported_pod=~\"$worker\"})",
@@ -3892,7 +3929,8 @@
             },
             {
               "datasource": {
-                "uid": "VictoriaMetrics"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (exported_pod) (DCGM_FI_PROF_PCIE_RX_BYTES{exported_pod=~\"$worker\"})",
@@ -3911,7 +3949,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3990,7 +4028,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "VictoriaMetrics"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "1e6*sum by (exported_pod) (DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL{exported_pod=~\"$worker\"})",
@@ -4009,7 +4048,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4090,7 +4129,8 @@
           "targets": [
             {
               "datasource": {
-                "uid": "VictoriaMetrics"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (instance) (\n  rate({__name__=~\"node_infiniband_.*(error|downed|discards|dropped).*\", instance=~\"$ip\"}[$__interval])\n)\n* on(instance) group_left(nodename) node_uname_info\n* on(nodename) group_left(pod) label_move(kube_pod_info{pod=~\"worker.*\"}, \"node\", \"nodename\")",
@@ -4109,7 +4149,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "VictoriaMetrics"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4191,7 +4231,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "VictoriaMetrics"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "sum by (error) (\n    rate(\n        label_copy(\n            {__name__=~\"node_infiniband_.*(error|downed|discards|dropped).*\", instance=~\".*\"},\n            \"__name__\",\n            \"error\",\n        )[$__interval]\n    )\n)\n",
@@ -4217,10 +4257,32 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": true,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allowCustomValue": false,
         "current": {
           "text": ["All"],
           "value": ["$__all"]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
         "definition": "label_values(kube_node_labels{label_nebius_com_gpu_name=~\"GB.*\"},label_slurm_nebius_ai_nodeset_name)",
         "description": "For GB platforms",
@@ -4247,7 +4309,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(slurm_node_info{node_name=~\"$rack-.*\"}, node_name)",
         "description": "Select as many workers as you need to check their aggregate and separate stats in panels.",
@@ -4273,7 +4335,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(kube_pod_info{pod=~\"$worker\"},node)",
         "hide": 2,
@@ -4299,7 +4361,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "VictoriaMetrics"
+          "uid": "${datasource}"
         },
         "definition": "label_values(node_uname_info{container=\"node-exporter\", nodename=~\"$hostname\"},instance)",
         "hide": 2,

--- a/internal/exporter/collector.go
+++ b/internal/exporter/collector.go
@@ -34,11 +34,14 @@ type MetricsCollector struct {
 	nodeMemoryFreeBytes        *prometheus.Desc
 	nodeMemoryEffectiveBytes   *prometheus.Desc
 	nodePartition              *prometheus.Desc
+	nodeNVLinkInstanceGroup    *prometheus.Desc
 	jobInfo                    *prometheus.Desc
 	jobNode                    *prometheus.Desc
 	jobDuration                *prometheus.Desc
 	jobCPUs                    *prometheus.Desc
 	jobMemoryBytes             *prometheus.Desc
+	nodeTopologySource         NodeTopologySource
+	nodeTopologyTimeout        time.Duration
 	nodeGPUSeconds             *prometheus.CounterVec
 	nodeFails                  *prometheus.CounterVec
 	nodeUnavailabilityDuration *prometheus.HistogramVec
@@ -57,6 +60,8 @@ type MetricsCollector struct {
 	// Monitoring contains self-monitoring metrics
 	Monitoring *MonitoringMetrics
 }
+
+const defaultNodeTopologyCollectionTimeout = time.Minute
 
 // durationBuckets defines histogram buckets for duration metrics ranging from 30 seconds to 30 days
 var durationBuckets = []float64{
@@ -80,6 +85,14 @@ var durationBuckets = []float64{
 
 // NewMetricsCollector creates a new MetricsCollector
 func NewMetricsCollector(slurmAPIClient slurmapi.Client, jobListParams slurmapi.ListJobsParams) *MetricsCollector {
+	return newMetricsCollector(slurmAPIClient, jobListParams, nil)
+}
+
+func newMetricsCollector(
+	slurmAPIClient slurmapi.Client,
+	jobListParams slurmapi.ListJobsParams,
+	nodeTopologySource NodeTopologySource,
+) *MetricsCollector {
 	var nodeInfoLabels = []string{
 		"node_name",
 		"instance_id",
@@ -124,9 +137,11 @@ func NewMetricsCollector(slurmAPIClient slurmapi.Client, jobListParams slurmapi.
 		"finished_time",
 	}
 	collector := &MetricsCollector{
-		slurmAPIClient: slurmAPIClient,
-		jobListParams:  jobListParams,
-		Monitoring:     NewMonitoringMetrics(),
+		slurmAPIClient:      slurmAPIClient,
+		jobListParams:       jobListParams,
+		nodeTopologySource:  nodeTopologySource,
+		nodeTopologyTimeout: defaultNodeTopologyCollectionTimeout,
+		Monitoring:          NewMonitoringMetrics(),
 
 		nodeInfo:                 prometheus.NewDesc("slurm_node_info", "Slurm node info", nodeInfoLabels, nil),
 		nodeCPUTotal:             prometheus.NewDesc("slurm_node_cpus_total", "Total CPUs on the node", []string{"node_name"}, nil),
@@ -138,9 +153,20 @@ func NewMetricsCollector(slurmAPIClient slurmapi.Client, jobListParams slurmapi.
 		nodeMemoryFreeBytes:      prometheus.NewDesc("slurm_node_memory_free_bytes", "Free memory on the node in bytes", []string{"node_name"}, nil),
 		nodeMemoryEffectiveBytes: prometheus.NewDesc("slurm_node_memory_effective_bytes", "Effective memory on the node in bytes", []string{"node_name"}, nil),
 		nodePartition:            prometheus.NewDesc("slurm_node_partition", "Slurm node partition mapping", []string{"node_name", "partition"}, nil),
+		nodeNVLinkInstanceGroup: prometheus.NewDesc(
+			"slurm_node_nvlink_instance_group",
+			"Mapping between Slurm nodes and NVLink instance groups",
+			[]string{"node_name", "instance_id", "nvlink_instance_group", "nodeset_name"},
+			nil,
+		),
 		jobInfo: prometheus.NewDesc(
 			"slurm_job_info", "Slurm job detail information", jobInfoLabels, nil),
-		jobNode:        prometheus.NewDesc("slurm_node_job", "Slurm job node information", []string{"job_id", "node_name"}, nil),
+		jobNode: prometheus.NewDesc(
+			"slurm_node_job",
+			"Slurm job node information",
+			[]string{"job_id", "node_name", "nvlink_instance_group", "nodeset_name"},
+			nil,
+		),
 		jobDuration:    prometheus.NewDesc("slurm_job_duration_seconds", "Slurm job duration in seconds", []string{"job_id"}, nil),
 		jobCPUs:        prometheus.NewDesc("slurm_job_cpus", "CPUs allocated to a Slurm job", []string{"job_id"}, nil),
 		jobMemoryBytes: prometheus.NewDesc("slurm_job_memory_bytes", "Memory allocated to a Slurm job in bytes", []string{"job_id"}, nil),
@@ -315,6 +341,7 @@ func (c *MetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.nodeMemoryFreeBytes
 	ch <- c.nodeMemoryEffectiveBytes
 	ch <- c.nodePartition
+	ch <- c.nodeNVLinkInstanceGroup
 	ch <- c.jobInfo
 	ch <- c.jobNode
 	ch <- c.jobDuration
@@ -373,9 +400,46 @@ func cloneMetricsCollectorState(previousState *metricsCollectorState) *metricsCo
 	newState.jobsCollectionSequence = previousState.jobsCollectionSequence
 	newState.diag = previousState.diag
 	newState.diagCollectionSequence = previousState.diagCollectionSequence
+	newState.nodeTopologies = previousState.nodeTopologies
+	newState.topologyCollectionSequence = previousState.topologyCollectionSequence
 	maps.Copy(newState.nodeUnavailabilityStartTimes, previousState.nodeUnavailabilityStartTimes)
 	maps.Copy(newState.nodeDrainingStartTimes, previousState.nodeDrainingStartTimes)
 	return newState
+}
+
+func (c *MetricsCollector) refreshNodeTopologies(ctx context.Context, sequence uint64) (err error) {
+	start := time.Now()
+	defer func() {
+		c.recordCollectorRun(ctx, "topology", start, err)
+	}()
+
+	if c.nodeTopologySource == nil {
+		return nil
+	}
+	topologyCtx, cancel := context.WithTimeout(ctx, c.nodeTopologyTimeout)
+	defer cancel()
+	topologies, err := c.nodeTopologySource.ListNodeTopologies(topologyCtx)
+	if err != nil {
+		return fmt.Errorf("get Kubernetes node topology: %w", err)
+	}
+
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+
+	previousState := c.state.Load()
+	if previousState == nil {
+		previousState = newMetricsCollectorState()
+	}
+	if sequence != 0 && sequence <= previousState.topologyCollectionSequence {
+		return nil
+	}
+	newState := cloneMetricsCollectorState(previousState)
+	newState.nodeTopologies = topologies
+	if sequence != 0 {
+		newState.topologyCollectionSequence = sequence
+	}
+	c.state.Store(newState)
+	return nil
 }
 
 func (c *MetricsCollector) refreshNodes(ctx context.Context, sequence uint64) (err error) {
@@ -525,7 +589,7 @@ func (c *MetricsCollector) collectImpl(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	for slurmNodeMetric := range c.slurmNodeMetrics(state.nodes) {
+	for slurmNodeMetric := range c.slurmNodeMetrics(state.nodes, state.nodeTopologies) {
 		ch <- slurmNodeMetric
 	}
 
@@ -534,7 +598,7 @@ func (c *MetricsCollector) collectImpl(ch chan<- prometheus.Metric) {
 	c.nodeUnavailabilityDuration.Collect(ch)
 	c.nodeDrainingDuration.Collect(ch)
 
-	for slurmJobMetric := range c.slurmJobMetrics(ctx, state.jobs) {
+	for slurmJobMetric := range c.slurmJobMetrics(ctx, state.jobs, state.nodeTopologies) {
 		ch <- slurmJobMetric
 	}
 
@@ -543,9 +607,26 @@ func (c *MetricsCollector) collectImpl(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (c *MetricsCollector) slurmNodeMetrics(slurmNodes []slurmapi.Node) iter.Seq[prometheus.Metric] {
+func (c *MetricsCollector) slurmNodeMetrics(
+	slurmNodes []slurmapi.Node,
+	nodeTopologies map[string]NodeTopology,
+) iter.Seq[prometheus.Metric] {
 	return func(yield func(prometheus.Metric) bool) {
 		for _, node := range slurmNodes {
+			topology := nodeTopologies[node.Name]
+			if topology.NVLinkInstanceGroup != "" {
+				if !yield(prometheus.MustNewConstMetric(
+					c.nodeNVLinkInstanceGroup,
+					prometheus.GaugeValue,
+					1,
+					node.Name,
+					node.InstanceID,
+					topology.NVLinkInstanceGroup,
+					topology.SlurmNodeSetName,
+				)) {
+					return
+				}
+			}
 			var reason string
 			if node.Reason != nil {
 				reason = node.Reason.Reason
@@ -645,7 +726,11 @@ func boolToLabelValue(b bool) string {
 	return ""
 }
 
-func (c *MetricsCollector) slurmJobMetrics(ctx context.Context, slurmJobs []slurmapi.Job) iter.Seq[prometheus.Metric] {
+func (c *MetricsCollector) slurmJobMetrics(
+	ctx context.Context,
+	slurmJobs []slurmapi.Job,
+	nodeTopologies map[string]NodeTopology,
+) iter.Seq[prometheus.Metric] {
 	return func(yield func(prometheus.Metric) bool) {
 		logger := log.FromContext(ctx).WithName(ControllerName)
 		for _, job := range slurmJobs {
@@ -718,7 +803,13 @@ func (c *MetricsCollector) slurmJobMetrics(ctx context.Context, slurmJobs []slur
 				continue
 			}
 			for _, nodeName := range nodeList {
-				jobNodeLabels := []string{job.GetIDString(), nodeName}
+				topology := nodeTopologies[nodeName]
+				jobNodeLabels := []string{
+					job.GetIDString(),
+					nodeName,
+					topology.NVLinkInstanceGroup,
+					topology.SlurmNodeSetName,
+				}
 				if !yield(prometheus.MustNewConstMetric(c.jobNode, prometheus.GaugeValue, 1, jobNodeLabels...)) {
 					return
 				}

--- a/internal/exporter/collector_test.go
+++ b/internal/exporter/collector_test.go
@@ -223,8 +223,9 @@ func TestMetricsCollector_Describe(t *testing.T) {
 	assert.Contains(t, found, `Desc{fqName: "slurm_node_memory_free_bytes", help: "Free memory on the node in bytes", constLabels: {}, variableLabels: {node_name}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_node_memory_effective_bytes", help: "Effective memory on the node in bytes", constLabels: {}, variableLabels: {node_name}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_node_partition", help: "Slurm node partition mapping", constLabels: {}, variableLabels: {node_name,partition}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_nvlink_instance_group", help: "Mapping between Slurm nodes and NVLink instance groups", constLabels: {}, variableLabels: {node_name,instance_id,nvlink_instance_group,nodeset_name}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_job_info", help: "Slurm job detail information", constLabels: {}, variableLabels: {job_id,job_state,job_state_reason,slurm_partition,job_name,user_name,user_mail,user_id,standard_error,standard_output,array_job_id,array_task_id,submit_time,start_time,end_time,finished_time}}`)
-	assert.Contains(t, found, `Desc{fqName: "slurm_node_job", help: "Slurm job node information", constLabels: {}, variableLabels: {job_id,node_name}}`)
+	assert.Contains(t, found, `Desc{fqName: "slurm_node_job", help: "Slurm job node information", constLabels: {}, variableLabels: {job_id,node_name,nvlink_instance_group,nodeset_name}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_job_duration_seconds", help: "Slurm job duration in seconds", constLabels: {}, variableLabels: {job_id}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_job_cpus", help: "CPUs allocated to a Slurm job", constLabels: {}, variableLabels: {job_id}}`)
 	assert.Contains(t, found, `Desc{fqName: "slurm_job_memory_bytes", help: "Memory allocated to a Slurm job in bytes", constLabels: {}, variableLabels: {job_id}}`)
@@ -237,6 +238,76 @@ func TestMetricsCollector_Describe(t *testing.T) {
 
 	// Controller metrics
 	assert.Contains(t, found, `Desc{fqName: "slurm_controller_server_thread_count", help: "Number of server threads", constLabels: {}, variableLabels: {}}`)
+}
+
+func TestMetricsCollector_NodeTopologyMetrics(t *testing.T) {
+	mockClient := &fake.MockClient{}
+	source := nodeTopologySourceFunc(func(context.Context) (map[string]NodeTopology, error) {
+		return map[string]NodeTopology{
+			"worker-0": {
+				KubernetesNode:      "k8s-node-1",
+				NVLinkInstanceGroup: "nvlig-1",
+				SlurmNodeSetName:    "gpu-workers",
+			},
+		}, nil
+	})
+	collector := newMetricsCollector(mockClient, slurmapi.ListJobsParams{}, source)
+
+	mockClient.EXPECT().ListNodes(mock.Anything).Return([]slurmapi.Node{testNode("worker-0")}, nil).Once()
+	mockClient.EXPECT().ListJobsWithParams(mock.Anything, mock.Anything).Return([]slurmapi.Job{
+		{ID: 123, State: "RUNNING", Nodes: "worker-0"},
+	}, nil).Once()
+	mockClient.EXPECT().GetDiag(mock.Anything).Return(nil, nil).Once()
+
+	require.NoError(t, collectOnce(context.Background(), collector))
+	require.NoError(t, collector.refreshNodeTopologies(context.Background(), 1))
+
+	ch := make(chan prometheus.Metric, 50)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	var metricsText []string
+	for metric := range ch {
+		metricsText = append(metricsText, toPrometheusLikeString(t, metric))
+	}
+
+	assert.Contains(t, metricsText, `GAUGE; slurm_node_nvlink_instance_group{instance_id="worker-0-instance",node_name="worker-0",nodeset_name="gpu-workers",nvlink_instance_group="nvlig-1"} 1`)
+	assert.Contains(t, metricsText, `GAUGE; slurm_node_job{job_id="123",node_name="worker-0",nodeset_name="gpu-workers",nvlink_instance_group="nvlig-1"} 1`)
+}
+
+func TestMetricsCollector_NodeTopologyRefreshRetriesAfterTimeout(t *testing.T) {
+	calls := 0
+	source := nodeTopologySourceFunc(func(ctx context.Context) (map[string]NodeTopology, error) {
+		calls++
+		if calls == 1 {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return map[string]NodeTopology{
+			"worker-0": {
+				KubernetesNode:      "k8s-node-1",
+				NVLinkInstanceGroup: "nvlig-1",
+				SlurmNodeSetName:    "gpu-workers",
+			},
+		}, nil
+	})
+	collector := newMetricsCollector(&fake.MockClient{}, slurmapi.ListJobsParams{}, source)
+	collector.nodeTopologyTimeout = 10 * time.Millisecond
+
+	err := collector.refreshNodeTopologies(context.Background(), 1)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NoError(t, collector.refreshNodeTopologies(context.Background(), 2))
+
+	assert.Equal(t, 2, calls)
+	assert.Equal(t, map[string]NodeTopology{
+		"worker-0": {
+			KubernetesNode:      "k8s-node-1",
+			NVLinkInstanceGroup: "nvlig-1",
+			SlurmNodeSetName:    "gpu-workers",
+		},
+	}, collector.state.Load().nodeTopologies)
 }
 
 func TestMetricsCollector_Collect_Success(t *testing.T) {
@@ -372,8 +443,8 @@ func TestMetricsCollector_Collect_Success(t *testing.T) {
 			`COUNTER; slurm_node_gpu_seconds_total{node_name="node-1",state_base="ALLOCATED",state_is_drain="false",state_is_maintenance="false",state_is_reserved="false"} 20`,
 			`COUNTER; slurm_node_gpu_seconds_total{node_name="node-2",state_base="IDLE",state_is_drain="true",state_is_maintenance="false",state_is_reserved="false"} 10`,
 			`GAUGE; slurm_job_info{array_job_id="",array_task_id="42",end_time="",finished_time="",job_id="12345",job_name="test_job",job_state="RUNNING",job_state_reason="None",slurm_partition="gpu",standard_error="/path/to/stderr",standard_output="/path/to/stdout",start_time="1722697230",submit_time="1722697200",user_id="1000",user_mail="testuser@example.com",user_name="testuser"} 1`,
-			`GAUGE; slurm_node_job{job_id="12345",node_name="node-1"} 1`,
-			`GAUGE; slurm_node_job{job_id="12345",node_name="node-2"} 1`,
+			`GAUGE; slurm_node_job{job_id="12345",node_name="node-1",nodeset_name="",nvlink_instance_group=""} 1`,
+			`GAUGE; slurm_node_job{job_id="12345",node_name="node-2",nodeset_name="",nvlink_instance_group=""} 1`,
 			`GAUGE; slurm_job_cpus{job_id="12345"} 4`,
 			`GAUGE; slurm_job_memory_bytes{job_id="12345"} 6.7108864e+10`,
 			`GAUGE; slurm_controller_server_thread_count 1`,

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -30,6 +30,7 @@ type Params struct {
 	CollectionInterval   time.Duration
 	MaxCollectorInflight int
 	JobListParams        slurmapi.ListJobsParams
+	NodeTopologySource   NodeTopologySource
 }
 
 // Exporter collects metrics from a SLURM cluster and exports them in Prometheus format
@@ -81,7 +82,7 @@ func (c *asyncSubCollector) finish() int32 {
 func NewClusterExporter(slurmAPIClient slurmapi.Client, params Params) *Exporter {
 	registry := prometheus.NewRegistry()
 	monitoringRegistry := prometheus.NewRegistry()
-	collector := NewMetricsCollector(slurmAPIClient, params.JobListParams)
+	collector := newMetricsCollector(slurmAPIClient, params.JobListParams, params.NodeTopologySource)
 
 	return &Exporter{
 		params:             params,
@@ -142,6 +143,9 @@ func (e *Exporter) collectionLoop(ctx context.Context) {
 		{name: "nodes", run: e.collector.refreshNodes},
 		{name: "jobs", run: e.collector.refreshJobs},
 		{name: "diag", run: e.collector.refreshDiag},
+	}
+	if e.collector.nodeTopologySource != nil {
+		collectors = append(collectors, &asyncSubCollector{name: "topology", run: e.collector.refreshNodeTopologies})
 	}
 
 	startCollectors := func() {

--- a/internal/exporter/kubernetes_topology.go
+++ b/internal/exporter/kubernetes_topology.go
@@ -1,0 +1,182 @@
+package exporter
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/rest"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"nebius.ai/slurm-operator/internal/consts"
+)
+
+type kubernetesNodeTopologySource struct {
+	reader      client.Reader
+	namespace   string
+	clusterName string
+}
+
+func topologyNodeSelector() (labels.Selector, error) {
+	nodeSetRequirement, err := labels.NewRequirement(slurmNodeSetNameLabel, selection.Exists, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create Slurm NodeSet label selector: %w", err)
+	}
+	return labels.NewSelector().Add(*nodeSetRequirement), nil
+}
+
+// NewKubernetesNodeTopologyCache creates a list/watch cache scoped to the Kubernetes objects
+// needed to resolve Slurm worker topology.
+func NewKubernetesNodeTopologyCache(
+	cfg *rest.Config,
+	namespace, clusterName string,
+) (ctrlcache.Cache, error) {
+	workerSelector := labels.SelectorFromSet(labels.Set{
+		consts.LabelInstanceKey: clusterName,
+		consts.LabelWorkerKey:   consts.LabelWorkerValue,
+	})
+	nodeSelector, err := topologyNodeSelector()
+	if err != nil {
+		return nil, err
+	}
+
+	topologyCache, err := ctrlcache.New(cfg, ctrlcache.Options{
+		ByObject: map[client.Object]ctrlcache.ByObject{
+			&corev1.Pod{}: {
+				Namespaces: map[string]ctrlcache.Config{
+					namespace: {},
+				},
+				Label:     workerSelector,
+				Transform: transformWorkerPodForTopology,
+			},
+			&corev1.Node{}: {
+				Label:     nodeSelector,
+				Transform: transformNodeForTopology,
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create Kubernetes node topology cache: %w", err)
+	}
+
+	return topologyCache, nil
+}
+
+// RegisterKubernetesNodeTopologyInformers creates the Pod and Node informers before the cache starts.
+func RegisterKubernetesNodeTopologyInformers(ctx context.Context, topologyCache ctrlcache.Cache) error {
+	for _, obj := range []client.Object{&corev1.Pod{}, &corev1.Node{}} {
+		if _, err := topologyCache.GetInformer(ctx, obj, ctrlcache.BlockUntilSynced(false)); err != nil {
+			return fmt.Errorf("register Kubernetes topology informer for %T: %w", obj, err)
+		}
+	}
+	return nil
+}
+
+// NewKubernetesNodeTopologySource creates a topology source backed by worker Pods and Nodes.
+func NewKubernetesNodeTopologySource(
+	reader client.Reader,
+	namespace, clusterName string,
+) NodeTopologySource {
+	if reader == nil {
+		return nil
+	}
+	return &kubernetesNodeTopologySource{
+		reader:      reader,
+		namespace:   namespace,
+		clusterName: clusterName,
+	}
+}
+
+func (s *kubernetesNodeTopologySource) ListNodeTopologies(ctx context.Context) (map[string]NodeTopology, error) {
+	var pods corev1.PodList
+	if err := s.reader.List(
+		ctx,
+		&pods,
+		client.InNamespace(s.namespace),
+		client.MatchingLabels{
+			consts.LabelInstanceKey: s.clusterName,
+			consts.LabelWorkerKey:   consts.LabelWorkerValue,
+		},
+	); err != nil {
+		return nil, fmt.Errorf("list Slurm worker pods: %w", err)
+	}
+
+	topologies := make(map[string]NodeTopology, len(pods.Items))
+	podsByKubernetesNode := make(map[string][]string, len(pods.Items))
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+		podsByKubernetesNode[pod.Spec.NodeName] = append(podsByKubernetesNode[pod.Spec.NodeName], pod.Name)
+	}
+
+	for kubernetesNode, podNames := range podsByKubernetesNode {
+		var node corev1.Node
+		if err := s.reader.Get(ctx, client.ObjectKey{Name: kubernetesNode}, &node); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("get Kubernetes node %q: %w", kubernetesNode, err)
+		}
+
+		topology := NodeTopology{
+			KubernetesNode:      kubernetesNode,
+			NVLinkInstanceGroup: node.Labels[nvlinkInstanceGroupLabel],
+			SlurmNodeSetName:    node.Labels[slurmNodeSetNameLabel],
+		}
+		for _, podName := range podNames {
+			topologies[podName] = topology
+		}
+	}
+
+	return topologies, nil
+}
+
+func transformWorkerPodForTopology(obj any) (any, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+
+	pod.ObjectMeta = metav1.ObjectMeta{
+		Name:            pod.Name,
+		Namespace:       pod.Namespace,
+		UID:             pod.UID,
+		ResourceVersion: pod.ResourceVersion,
+		Labels: map[string]string{
+			consts.LabelInstanceKey: pod.Labels[consts.LabelInstanceKey],
+			consts.LabelWorkerKey:   pod.Labels[consts.LabelWorkerKey],
+		},
+	}
+	pod.Spec = corev1.PodSpec{NodeName: pod.Spec.NodeName}
+	pod.Status = corev1.PodStatus{}
+
+	return pod, nil
+}
+
+func transformNodeForTopology(obj any) (any, error) {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return obj, nil
+	}
+
+	node.ObjectMeta = metav1.ObjectMeta{
+		Name:            node.Name,
+		UID:             node.UID,
+		ResourceVersion: node.ResourceVersion,
+		Labels: map[string]string{
+			nvlinkInstanceGroupLabel: node.Labels[nvlinkInstanceGroupLabel],
+			slurmNodeSetNameLabel:    node.Labels[slurmNodeSetNameLabel],
+		},
+	}
+	node.Spec = corev1.NodeSpec{}
+	node.Status = corev1.NodeStatus{}
+
+	return node, nil
+}

--- a/internal/exporter/kubernetes_topology_test.go
+++ b/internal/exporter/kubernetes_topology_test.go
@@ -1,0 +1,250 @@
+package exporter
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"nebius.ai/slurm-operator/internal/consts"
+)
+
+type nodeTopologySourceFunc func(context.Context) (map[string]NodeTopology, error)
+
+func (f nodeTopologySourceFunc) ListNodeTopologies(ctx context.Context) (map[string]NodeTopology, error) {
+	return f(ctx)
+}
+
+type recordingReader struct {
+	client.Reader
+	getKeys []client.ObjectKey
+}
+
+func (r *recordingReader) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	r.getKeys = append(r.getKeys, key)
+	return r.Reader.Get(ctx, key, obj, opts...)
+}
+
+func TestKubernetesNodeTopologySource(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "worker-0",
+				Namespace: "slurm",
+				Labels: map[string]string{
+					consts.LabelInstanceKey: "cluster-a",
+					consts.LabelWorkerKey:   consts.LabelWorkerValue,
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: "k8s-node-1"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other-worker-0",
+				Namespace: "slurm",
+				Labels: map[string]string{
+					consts.LabelInstanceKey: "cluster-b",
+					consts.LabelWorkerKey:   consts.LabelWorkerValue,
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: "k8s-node-1"},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "k8s-node-1",
+				Labels: map[string]string{
+					nvlinkInstanceGroupLabel: "nvlig-1",
+					slurmNodeSetNameLabel:    "gpu-workers",
+				},
+			},
+		},
+	).Build()
+
+	source := NewKubernetesNodeTopologySource(k8sClient, "slurm", "cluster-a")
+	topologies, err := source.ListNodeTopologies(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]NodeTopology{
+		"worker-0": {
+			KubernetesNode:      "k8s-node-1",
+			NVLinkInstanceGroup: "nvlig-1",
+			SlurmNodeSetName:    "gpu-workers",
+		},
+	}, topologies)
+}
+
+func TestTopologyNodeSelector(t *testing.T) {
+	selector, err := topologyNodeSelector()
+	require.NoError(t, err)
+
+	assert.True(t, selector.Matches(labels.Set{slurmNodeSetNameLabel: "gpu-workers"}))
+	assert.True(t, selector.Matches(labels.Set{slurmNodeSetNameLabel: ""}))
+	assert.False(t, selector.Matches(labels.Set{}))
+}
+
+func TestRegisterKubernetesNodeTopologyInformers(t *testing.T) {
+	topologyCache := &informertest.FakeInformers{}
+
+	require.NoError(t, RegisterKubernetesNodeTopologyInformers(context.Background(), topologyCache))
+	assert.Contains(t, topologyCache.InformersByGVK, corev1.SchemeGroupVersion.WithKind("Pod"))
+	assert.Contains(t, topologyCache.InformersByGVK, corev1.SchemeGroupVersion.WithKind("Node"))
+}
+
+func TestKubernetesNodeTopologySourceGetsEachUsedNodeOnce(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "worker-0",
+				Namespace: "slurm",
+				Labels: map[string]string{
+					consts.LabelInstanceKey: "cluster-a",
+					consts.LabelWorkerKey:   consts.LabelWorkerValue,
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: "k8s-node-1"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "worker-1",
+				Namespace: "slurm",
+				Labels: map[string]string{
+					consts.LabelInstanceKey: "cluster-a",
+					consts.LabelWorkerKey:   consts.LabelWorkerValue,
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: "k8s-node-1"},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "k8s-node-1",
+				Labels: map[string]string{
+					nvlinkInstanceGroupLabel: "nvlig-1",
+					slurmNodeSetNameLabel:    "gpu-workers",
+				},
+			},
+		},
+	).Build()
+	reader := &recordingReader{Reader: k8sClient}
+
+	source := NewKubernetesNodeTopologySource(reader, "slurm", "cluster-a")
+	topologies, err := source.ListNodeTopologies(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, []client.ObjectKey{{Name: "k8s-node-1"}}, reader.getKeys)
+	assert.Equal(t, map[string]NodeTopology{
+		"worker-0": {
+			KubernetesNode:      "k8s-node-1",
+			NVLinkInstanceGroup: "nvlig-1",
+			SlurmNodeSetName:    "gpu-workers",
+		},
+		"worker-1": {
+			KubernetesNode:      "k8s-node-1",
+			NVLinkInstanceGroup: "nvlig-1",
+			SlurmNodeSetName:    "gpu-workers",
+		},
+	}, topologies)
+}
+
+func TestKubernetesNodeTopologySourceSkipsNodeReadsWithoutWorkerPods(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "k8s-node-1"}},
+	).Build()
+	reader := &recordingReader{Reader: k8sClient}
+
+	source := NewKubernetesNodeTopologySource(reader, "slurm", "cluster-a")
+	topologies, err := source.ListNodeTopologies(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, reader.getKeys)
+	assert.Empty(t, topologies)
+}
+
+func TestTransformWorkerPodForTopology(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "worker-0",
+			Namespace:       "slurm",
+			ResourceVersion: "123",
+			Labels: map[string]string{
+				consts.LabelInstanceKey: "cluster-a",
+				consts.LabelWorkerKey:   consts.LabelWorkerValue,
+				"irrelevant":            "value",
+			},
+			Annotations: map[string]string{"irrelevant": "value"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   "k8s-node-1",
+			Containers: []corev1.Container{{Name: "slurmd"}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	transformed, err := transformWorkerPodForTopology(pod)
+	require.NoError(t, err)
+	actual := transformed.(*corev1.Pod)
+
+	assert.Equal(t, "worker-0", actual.Name)
+	assert.Equal(t, "slurm", actual.Namespace)
+	assert.Equal(t, "123", actual.ResourceVersion)
+	assert.Equal(t, map[string]string{
+		consts.LabelInstanceKey: "cluster-a",
+		consts.LabelWorkerKey:   consts.LabelWorkerValue,
+	}, actual.Labels)
+	assert.Equal(t, corev1.PodSpec{NodeName: "k8s-node-1"}, actual.Spec)
+	assert.Empty(t, actual.Status)
+	assert.Empty(t, actual.Annotations)
+}
+
+func TestTransformNodeForTopology(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "k8s-node-1",
+			ResourceVersion: "456",
+			Labels: map[string]string{
+				nvlinkInstanceGroupLabel: "nvlig-1",
+				slurmNodeSetNameLabel:    "gpu-workers",
+				"irrelevant":             "value",
+			},
+			Annotations: map[string]string{"irrelevant": "value"},
+		},
+		Spec:   corev1.NodeSpec{PodCIDR: "10.0.0.0/24"},
+		Status: corev1.NodeStatus{Phase: corev1.NodeRunning},
+	}
+
+	transformed, err := transformNodeForTopology(node)
+	require.NoError(t, err)
+	actual := transformed.(*corev1.Node)
+
+	assert.Equal(t, "k8s-node-1", actual.Name)
+	assert.Equal(t, "456", actual.ResourceVersion)
+	assert.Equal(t, map[string]string{
+		nvlinkInstanceGroupLabel: "nvlig-1",
+		slurmNodeSetNameLabel:    "gpu-workers",
+	}, actual.Labels)
+	assert.Empty(t, actual.Spec)
+	assert.Empty(t, actual.Status)
+	assert.Empty(t, actual.Annotations)
+}

--- a/internal/exporter/state.go
+++ b/internal/exporter/state.go
@@ -17,6 +17,8 @@ type metricsCollectorState struct {
 	jobsCollectionSequence       uint64
 	diag                         *api.V0044OpenapiDiagResp
 	diagCollectionSequence       uint64
+	nodeTopologies               map[string]NodeTopology
+	topologyCollectionSequence   uint64
 	nodeUnavailabilityStartTimes map[string]time.Time
 	nodeDrainingStartTimes       map[string]time.Time
 }
@@ -26,6 +28,7 @@ func newMetricsCollectorState() *metricsCollectorState {
 	return &metricsCollectorState{
 		lastGPUSecondsUpdate:         time.Now(),
 		nodes:                        nil,
+		nodeTopologies:               make(map[string]NodeTopology),
 		nodeUnavailabilityStartTimes: make(map[string]time.Time),
 		nodeDrainingStartTimes:       make(map[string]time.Time),
 	}

--- a/internal/exporter/topology.go
+++ b/internal/exporter/topology.go
@@ -1,0 +1,20 @@
+package exporter
+
+import "context"
+
+const (
+	nvlinkInstanceGroupLabel = "topology.nebius.com/nvl-instance-group-id"
+	slurmNodeSetNameLabel    = "slurm.nebius.ai/nodeset-name"
+)
+
+// NodeTopology describes the Kubernetes placement metadata for a Slurm node.
+type NodeTopology struct {
+	KubernetesNode      string
+	NVLinkInstanceGroup string
+	SlurmNodeSetName    string
+}
+
+// NodeTopologySource resolves Slurm worker names to Kubernetes node topology.
+type NodeTopologySource interface {
+	ListNodeTopologies(ctx context.Context) (map[string]NodeTopology, error)
+}


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
- We need to add NVLink Instance Group as a label for node related metrics
- Grafana dashboards have incorrect and varying values for `datasource`

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
- Added `nvlink_instance_group` as label to `slurm_node_jobs`
- Added new metric `slurm_node_nvlink_instance_group` to join with other metrics for NVLink centric panels and alerts
- Changes all Grafana dashboards to have a `$datasource` template variable that defaults to `VictoriaMetrics` 

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
- Tested in a dev cluster, k8s nodes labels correctly get picked up by exporter

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
