### PR TITLE
SCHED-1519: add Infrastructure control-plane Deployments schedule onto worker nodes due to missing node affinity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -716,6 +716,9 @@ KIND_CLUSTER_NAME	?= soperator-dev
 KIND_NODES			?= 2
 KIND_K8S_VERSION	?= v1.31.0
 KIND_CONTEXT		?= kind-$(KIND_CLUSTER_NAME)
+# The soperator-fluxcd chart pins its control-plane workloads to the system nodeset, so every kind
+# node carries the label - otherwise those pods stay Pending and their HelmReleases never go Ready.
+KIND_NODESET_LABEL	?= slurm.nebius.ai/nodeset: system
 KUBECTL_CTX			= $(KUBECTL) --context $(KIND_CONTEXT)
 
 .PHONY: kind-create
@@ -729,8 +732,12 @@ kind-create: install-kind ## Create kind cluster with specified number of nodes
 	@echo "apiVersion: kind.x-k8s.io/v1alpha4" >> /tmp/kind-config.yaml
 	@echo "nodes:" >> /tmp/kind-config.yaml
 	@echo "- role: control-plane" >> /tmp/kind-config.yaml
+	@echo "  labels:" >> /tmp/kind-config.yaml
+	@echo "    $(KIND_NODESET_LABEL)" >> /tmp/kind-config.yaml
 	@for i in $$(seq 1 $$(($(KIND_NODES) - 1))); do \
 		echo "- role: worker" >> /tmp/kind-config.yaml; \
+		echo "  labels:" >> /tmp/kind-config.yaml; \
+		echo "    $(KIND_NODESET_LABEL)" >> /tmp/kind-config.yaml; \
 	done
 	@$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config /tmp/kind-config.yaml --image kindest/node:$(KIND_K8S_VERSION)
 	@rm /tmp/kind-config.yaml

--- a/helm/nodeconfigurator/templates/_helpers.tpl
+++ b/helm/nodeconfigurator/templates/_helpers.tpl
@@ -42,6 +42,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Name of the rebooter's priority class. PriorityClass is cluster-scoped, so this defaults to the
+release-derived name to keep two installations in one cluster from colliding.
+*/}}
+{{- define "nodeconfigurator.rebooterPriorityClassName" -}}
+{{- $priorityClass := .Values.rebooter.priorityClass | default dict -}}
+{{- if $priorityClass.name -}}
+{{- $priorityClass.name -}}
+{{- else -}}
+{{- printf "%s-rebooter" (include "nodeconfigurator.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "nodeconfigurator.serviceAccountName" -}}

--- a/helm/nodeconfigurator/templates/priority-class.yaml
+++ b/helm/nodeconfigurator/templates/priority-class.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rebooter.enabled .Values.rebooter.priorityClass.create }}
+{{- $value := int .Values.rebooter.priorityClass.value }}
+{{- if ge $value 100002 }}
+{{- fail (printf "rebooter.priorityClass.value must stay below 100002, the lowest Slurm pod priority (slurm-login); got %d" $value) }}
+{{- end }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ include "nodeconfigurator.rebooterPriorityClassName" . }}
+  labels:
+    {{- include "nodeconfigurator.labels" . | nindent 4 }}
+value: {{ $value }}
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: {{ .Values.rebooter.priorityClass.description | quote }}
+{{- end }}

--- a/helm/nodeconfigurator/tests/priority_class_test.yaml
+++ b/helm/nodeconfigurator/tests/priority_class_test.yaml
@@ -1,0 +1,56 @@
+suite: test rebooter priority class
+templates:
+  - priority-class.yaml
+tests:
+  - it: should render a class that outranks unprioritised pods but no Slurm pod
+    asserts:
+      - isKind:
+          of: PriorityClass
+      # Above the infrastructure Deployments at 0, below slurm-login at 100002 - the lowest of the
+      # Slurm classes. The rebooter runs on every node, so it must never evict a Slurm pod.
+      - isNotNullOrEmpty:
+          path: value
+      - equal:
+          path: value
+          value: 100000
+      - equal:
+          path: preemptionPolicy
+          value: PreemptLowerPriority
+      - equal:
+          path: globalDefault
+          value: false
+
+  - it: should derive the name from the release by default
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rebooter
+
+  - it: should honour an explicit name
+    set:
+      rebooter.priorityClass.name: soperator-rebooter
+    asserts:
+      - equal:
+          path: metadata.name
+          value: soperator-rebooter
+
+  - it: should not render when creation is disabled
+    set:
+      rebooter.priorityClass.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when the rebooter is disabled
+    set:
+      rebooter.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should reject a value that could preempt Slurm pods
+    set:
+      rebooter.priorityClass.value: 100002
+    asserts:
+      - failedTemplate:
+          errorMessage: "rebooter.priorityClass.value must stay below 100002, the lowest Slurm pod priority (slurm-login); got 100002"

--- a/helm/nodeconfigurator/values.yaml
+++ b/helm/nodeconfigurator/values.yaml
@@ -36,7 +36,17 @@ rebooter:
   readinessProbe: {}
   tolerations: []
   affinity: {}
+  # Set to the chart's own class name to let the rebooter preempt the unprioritised infrastructure
+  # Deployments competing for a node's spare CPU. Leave empty to run at priority 0.
   priorityClassName: ""
+  # The rebooter is a DaemonSet on every node, so its value sits below every Slurm pod class
+  # (the lowest is slurm-login at 100002) and above the unprioritised Deployments at 0.
+  priorityClass:
+    create: true
+    # Defaults to "<release>-rebooter".
+    name: ""
+    value: 100000
+    description: "Priority class for the soperator rebooter DaemonSet. Above unprioritised infrastructure Deployments, below every Slurm pod."
   serviceAccountName: ""
 initContainers:
   - name: node-sysctl-params

--- a/helm/soperator-fluxcd-bootstrap/values.yaml
+++ b/helm/soperator-fluxcd-bootstrap/values.yaml
@@ -17,13 +17,21 @@ helmRelease:
     name: helm-soperator-fluxcd
     version: "5.0.0"
     interval: 5m
+  # This release renders nothing but the HelmReleases of the Soperator stack.
+  # helm-controller v1.5 (Flux v2.8) assesses readiness with kstatus, which waits
+  # for custom resources as well, so waiting here means waiting for the whole
+  # stack to install. That never fits into the timeout, and the resulting failure
+  # is remediated with an uninstall that wipes the entire tree. The children
+  # track their own readiness, in dependsOn order.
   install:
     createNamespace: true
     crds: Skip
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
     crds: Skip
+    disableWait: true
     remediation:
       retries: 3
   valuesFrom:

--- a/helm/soperator-fluxcd/templates/backup.yaml
+++ b/helm/soperator-fluxcd/templates/backup.yaml
@@ -38,6 +38,19 @@ spec:
   {{- if .Values.backup.overrideValues }}
     {{- toYaml .Values.backup.overrideValues | nindent 4 }}
   {{- else }}
+  {{- $backup := .Values.backup.values | default dict }}
+    {{- with $backup.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $backup.affinity }}
+    affinity:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $backup.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     k8up:
       backupImage:
         repository: cr.eu-north1.nebius.cloud/soperator-proxy-ghcr-io/k8up-io/k8up

--- a/helm/soperator-fluxcd/templates/cert-manager.yaml
+++ b/helm/soperator-fluxcd/templates/cert-manager.yaml
@@ -35,9 +35,33 @@ spec:
   {{- if .Values.certManager.overrideValues }}
     {{- toYaml .Values.certManager.overrideValues | nindent 4 }}
   {{- else }}
+  {{- $certManager := .Values.certManager.values | default dict }}
     enableCertificateOwnerRef: true
+    {{- with $certManager.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $certManager.affinity }}
+    affinity:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $certManager.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     startupapicheck:
       enabled: true
+      {{- with $certManager.startupapicheck }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- with $certManager.webhook }}
+    webhook:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $certManager.cainjector }}
+    cainjector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     crds:
       enabled: true
     global:

--- a/helm/soperator-fluxcd/templates/mariadb-operator.yaml
+++ b/helm/soperator-fluxcd/templates/mariadb-operator.yaml
@@ -34,11 +34,31 @@ spec:
   {{- if .Values.mariadbOperator.overrideValues }}
     {{- toYaml .Values.mariadbOperator.overrideValues | nindent 4 }}
   {{- else }}
+  {{- $mariadbOperator := .Values.mariadbOperator.values | default dict }}
+    {{- with $mariadbOperator.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $mariadbOperator.affinity }}
+    affinity:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $mariadbOperator.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     webhook:
       cert:
         certManager:
           enabled: true
       enabled: true
+      {{- with $mariadbOperator.webhook }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- with $mariadbOperator.certController }}
+    certController:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- end }}
   valuesFrom:
   - kind: ConfigMap

--- a/helm/soperator-fluxcd/templates/nodeconfigurator.yaml
+++ b/helm/soperator-fluxcd/templates/nodeconfigurator.yaml
@@ -34,11 +34,19 @@ spec:
   {{- else }}
     nodeConfigurator:
       enabled: false
+  {{- $rebooter := .Values.soperator.nodeConfigurator.values.rebooter | default dict }}
     rebooter:
       enabled: true
-      {{- if and .Values.soperator.nodeConfigurator.values.rebooter .Values.soperator.nodeConfigurator.values.rebooter.resources }}
-      resources: 
-      {{- toYaml .Values.soperator.nodeConfigurator.values.rebooter.resources | nindent 8 }}
+      {{- with $rebooter.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with $rebooter.priorityClass }}
+      priorityClass:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $rebooter.resources }}
+      resources:
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       generateRBAC: true
       logFormat: json

--- a/helm/soperator-fluxcd/templates/o11y-tsa-token-writer.yaml
+++ b/helm/soperator-fluxcd/templates/o11y-tsa-token-writer.yaml
@@ -114,6 +114,19 @@ spec:
             hostNetwork: true
             dnsPolicy: ClusterFirstWithHostNet
             {{- end }}
+            {{- with $writer.nodeSelector }}
+            nodeSelector:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            affinity:
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      topologyKey: kubernetes.io/hostname
+                      labelSelector:
+                        matchLabels:
+                          app.kubernetes.io/name: {{ $name }}
             containers:
               - name: tsa-token-writer
                 image: {{ printf "%s:%s" $repo $tag | quote }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -96,6 +96,14 @@ spec:
       tag: 2.0.10
 
     mode: deployment
+    {{- with $eventsValues.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $eventsValues.affinity }}
+    affinity:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 
     rollout:
       rollingUpdate:

--- a/helm/soperator-fluxcd/templates/security-profiles-operator.yaml
+++ b/helm/soperator-fluxcd/templates/security-profiles-operator.yaml
@@ -53,6 +53,14 @@ spec:
     resources:
       {{- toYaml .Values.securityProfilesOperator.values.resources | nindent 6 }}
     {{- end }}
+    {{- with .Values.securityProfilesOperator.values.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.securityProfilesOperator.values.affinity }}
+    affinity:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- end }}
   valuesFrom:
   - kind: ConfigMap

--- a/helm/soperator-fluxcd/templates/soperator.yaml
+++ b/helm/soperator-fluxcd/templates/soperator.yaml
@@ -45,6 +45,14 @@ spec:
       enabled: true
     {{- end }}
     controllerManager:
+      {{- with (.Values.soperator.values.controllerManager | default dict).nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.soperator.values.controllerManager | default dict).affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       manager:
         {{- if and .Values.soperator.values .Values.soperator.values.manager .Values.soperator.values.manager.resources }}
         resources: {{- toYaml .Values.soperator.values.manager.resources | nindent 10 }}

--- a/helm/soperator-fluxcd/templates/vm-logs.yaml
+++ b/helm/soperator-fluxcd/templates/vm-logs.yaml
@@ -35,6 +35,14 @@ spec:
       labels:
         grafana_dashboard: "1"
     server:
+      {{- with .Values.observability.vmLogs.values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.observability.vmLogs.values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.observability.vmLogs.values.resources }}
       resources:
         {{- toYaml .Values.observability.vmLogs.values.resources | nindent 8 }}

--- a/helm/soperator-fluxcd/templates/vm-stack.yaml
+++ b/helm/soperator-fluxcd/templates/vm-stack.yaml
@@ -44,7 +44,8 @@ spec:
   {{- if .Values.observability.vmStack.overrideValues }}
     {{- toYaml .Values.observability.vmStack.overrideValues | nindent 4 }}
   {{- else }}
-  {{- $kubeStateMetrics := .Values.observability.vmStack.values.kubeStateMetrics | default dict }}
+  {{- $vmStackValues := .Values.observability.vmStack.values | default dict }}
+  {{- $kubeStateMetrics := $vmStackValues.kubeStateMetrics | default dict }}
       alertmanager:
         enabled: false
       crds:
@@ -66,6 +67,9 @@ spec:
             create: false
       grafana:
         enabled: true
+        {{- with $vmStackValues.grafana }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.observability.vmStack.values.grafanaIni }}
         grafana.ini: {{- toYaml .Values.observability.vmStack.values.grafanaIni | nindent 10 }}
         {{- end }}
@@ -79,15 +83,10 @@ spec:
           datasources:
             searchNamespace: {{- toYaml .Values.observability.vmStack.values.dashboardNamespaces | nindent 12 }}
       kube-state-metrics:
+        {{- with $kubeStateMetrics.affinity }}
         affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: slurm.nebius.ai/nodeset
-                      operator: In
-                      values:
-                        - system
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- with $kubeStateMetrics.resources }}
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -399,6 +398,9 @@ spec:
         extraArgs:
           {{- toYaml .Values.observability.vmStack.values.prometheusNodeExporter.extraArgs | nindent 10 }}
       victoria-metrics-operator:
+        {{- with $vmStackValues.victoriaMetricsOperator }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         admissionWebhooks:
           enable: true
         crd:
@@ -421,6 +423,14 @@ spec:
           {{- $useHostPathToken := and $hasPublicEndpoint (eq $tokenKind "hostPath") }}
           {{- $hasHostNetwork := and $hasVmagentSpec (hasKey $hasVmagentSpec "hostNetwork") }}
           {{- $hasDnsPolicy := and $hasVmagentSpec (hasKey $hasVmagentSpec "dnsPolicy") }}
+          {{- with $hasVmagentSpec.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $hasVmagentSpec.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if $hasHostNetwork }}
           hostNetwork: {{ $hasVmagentSpec.hostNetwork }}
           {{- end }}

--- a/helm/soperator-fluxcd/tests/control_plane_placement_test.yaml
+++ b/helm/soperator-fluxcd/tests/control_plane_placement_test.yaml
@@ -1,0 +1,211 @@
+suite: test control-plane placement
+templates:
+  - templates/cert-manager.yaml
+  - templates/mariadb-operator.yaml
+  - templates/backup.yaml
+  - templates/security-profiles-operator.yaml
+  - templates/csi-driver-nfs.yaml
+  - templates/kruise.yaml
+  - templates/soperator.yaml
+  - templates/soperatorchecks.yaml
+  - templates/vm-logs.yaml
+  - templates/vm-stack.yaml
+  - templates/opentelemetry-collector-events.yaml
+tests:
+  - it: should pin cert-manager and its companions to system nodes
+    template: templates/cert-manager.yaml
+    asserts:
+      - equal:
+          path: spec.values.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      # The chart's own Windows guard must survive the merge.
+      - equal:
+          path: spec.values.nodeSelector["kubernetes.io/os"]
+          value: linux
+      - equal:
+          path: spec.values.webhook.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.cainjector.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.startupapicheck.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+
+  - it: should spread cert-manager replicas across nodes
+    template: templates/cert-manager.yaml
+    asserts:
+      - equal:
+          path: spec.values.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100
+      - equal:
+          path: spec.values.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
+          value: kubernetes.io/hostname
+      - equal:
+          path: spec.values.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: cert-manager
+      - equal:
+          path: spec.values.webhook.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: webhook
+
+  - it: should not give the one-shot startupapicheck job an anti-affinity term
+    template: templates/cert-manager.yaml
+    asserts:
+      - notExists:
+          path: spec.values.startupapicheck.affinity
+
+  - it: should pin the mariadb operator, its webhook and its cert controller
+    template: templates/mariadb-operator.yaml
+    asserts:
+      - equal:
+          path: spec.values.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.webhook.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.certController.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      # The placement must not displace the webhook settings the chart already sets.
+      - equal:
+          path: spec.values.webhook.cert.certManager.enabled
+          value: true
+
+  - it: should pin k8up
+    template: templates/backup.yaml
+    asserts:
+      - equal:
+          path: spec.values.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+
+  - it: should pin the security profiles operator but leave its DaemonSet alone
+    template: templates/security-profiles-operator.yaml
+    asserts:
+      - equal:
+          path: spec.values.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels.app
+          value: security-profiles-operator
+      - notExists:
+          path: spec.values.daemon.nodeSelector
+
+  - it: should pin only the csi-driver-nfs controller, never the node plugin
+    template: templates/csi-driver-nfs.yaml
+    asserts:
+      - equal:
+          path: spec.values.controller.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - notExists:
+          path: spec.values.node
+
+  - it: should pin the kruise manager without an anti-affinity term
+    template: templates/kruise.yaml
+    asserts:
+      - equal:
+          path: spec.values.manager.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      # The kruise chart has no manager.affinity value to set.
+      - notExists:
+          path: spec.values.manager.affinity
+      - equal:
+          path: spec.values.manager.replicas
+          value: 2
+
+  - it: should pin the soperator controller manager
+    template: templates/soperator.yaml
+    asserts:
+      - equal:
+          path: spec.values.controllerManager.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.controllerManager.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels["control-plane"]
+          value: controller-manager
+      - equal:
+          path: spec.values.controllerManager.manager.resources.requests.cpu
+          value: 500m
+
+  - it: should pin soperatorchecks
+    template: templates/soperatorchecks.yaml
+    asserts:
+      - equal:
+          path: spec.values.checks.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.checks.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels["control-plane"]
+          value: soperatorchecks
+
+  - it: should pin the vm-logs server
+    template: templates/vm-logs.yaml
+    asserts:
+      - equal:
+          path: spec.values.server.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.server.resources.requests.cpu
+          value: 1000m
+
+  - it: should pin the events collector
+    template: templates/opentelemetry-collector-events.yaml
+    asserts:
+      - equal:
+          path: spec.values.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.mode
+          value: deployment
+
+  - it: should pin grafana, the vm operator, vmagent and vmsingle
+    template: templates/vm-stack.yaml
+    asserts:
+      - equal:
+          path: spec.values.grafana.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.victoria-metrics-operator.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.vmagent.spec.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.values.vmsingle.spec.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      # The rest of the vmsingle spec must still be there.
+      - equal:
+          path: spec.values.vmsingle.spec.retentionPeriod
+          value: 30d
+
+  - it: should add an anti-affinity term to kube-state-metrics without dropping its node affinity
+    template: templates/vm-stack.yaml
+    asserts:
+      - equal:
+          path: spec.values.kube-state-metrics.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: slurm.nebius.ai/nodeset
+      - equal:
+          path: spec.values.kube-state-metrics.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: kube-state-metrics
+
+  # csi-driver-nfs carries its placement in overrideValues, which the template renders verbatim,
+  # so clearing them is how you opt out.
+  - it: should drop the csi-driver-nfs placement when its overrideValues are cleared
+    template: templates/csi-driver-nfs.yaml
+    set:
+      csiDriverNfs.overrideValues: null
+    asserts:
+      - notExists:
+          path: spec.values.controller
+
+  # overrideValues is the documented full escape hatch, so it drops the pin along with
+  # everything else the template would have rendered.
+  - it: should let overrideValues replace the placement
+    template: templates/backup.yaml
+    set:
+      backup.overrideValues:
+        k8up:
+          skipWithoutAnnotation: false
+    asserts:
+      - notExists:
+          path: spec.values.nodeSelector
+      - equal:
+          path: spec.values.k8up.skipWithoutAnnotation
+          value: false

--- a/helm/soperator-fluxcd/tests/control_plane_resources_test.yaml
+++ b/helm/soperator-fluxcd/tests/control_plane_resources_test.yaml
@@ -1,0 +1,121 @@
+suite: test control-plane cpu requests
+templates:
+  - templates/cert-manager.yaml
+  - templates/mariadb-operator.yaml
+  - templates/backup.yaml
+  - templates/vm-stack.yaml
+  - templates/o11y-tsa-token-writer.yaml
+  - templates/nodeconfigurator.yaml
+tests:
+  # Without a cpu request these pods are scored as free and bin-pack onto whatever node has
+  # room, so every control-plane workload carries a floor.
+  - it: should request a cpu floor for cert-manager and its companions
+    template: templates/cert-manager.yaml
+    asserts:
+      - equal:
+          path: spec.values.resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.values.webhook.resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.values.cainjector.resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.values.startupapicheck.resources.requests.cpu
+          value: 100m
+
+  - it: should request a cpu floor for the mariadb operator, its webhook and cert controller
+    template: templates/mariadb-operator.yaml
+    asserts:
+      - equal:
+          path: spec.values.resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.values.webhook.resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.values.certController.resources.requests.cpu
+          value: 100m
+
+  - it: should request a smaller cpu floor for k8up
+    template: templates/backup.yaml
+    asserts:
+      - equal:
+          path: spec.values.resources.requests.cpu
+          value: 50m
+
+  - it: should request a cpu floor for grafana and the vm operator
+    template: templates/vm-stack.yaml
+    asserts:
+      - equal:
+          path: spec.values.grafana.resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.values.victoria-metrics-operator.resources.requests.cpu
+          value: 100m
+
+  - it: should request a smaller cpu floor for the tsa token writer
+    template: templates/o11y-tsa-token-writer.yaml
+    asserts:
+      # The raw chart takes a list: ServiceAccount, a Role/RoleBinding pair per namespace,
+      # then the Deployment.
+      - equal:
+          path: spec.values.resources[5].kind
+          value: Deployment
+      - equal:
+          path: spec.values.resources[5].spec.template.spec.containers[0].resources.requests.cpu
+          value: 50m
+      - equal:
+          path: spec.values.resources[5].spec.template.spec.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+
+  - it: should set no memory floor alongside the cpu request
+    template: templates/backup.yaml
+    asserts:
+      - notExists:
+          path: spec.values.resources.requests.memory
+      - notExists:
+          path: spec.values.resources.limits
+
+  - it: should let the cpu floor be overridden
+    template: templates/backup.yaml
+    set:
+      backup.values.resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.values.resources.requests.cpu
+          value: 250m
+      - equal:
+          path: spec.values.resources.requests.memory
+          value: 256Mi
+
+  # The rebooter competes for the sliver of node cpu left over after the Slurm pod, so it needs to
+  # preempt whatever else lands there - but it runs on every node, so its class must stay below
+  # every Slurm class (the lowest is slurm-login at 100002).
+  - it: should give the rebooter a class that outranks infra pods but no Slurm pod
+    template: templates/nodeconfigurator.yaml
+    asserts:
+      - equal:
+          path: spec.values.rebooter.priorityClassName
+          value: soperator-rebooter
+      - equal:
+          path: spec.values.rebooter.priorityClass.name
+          value: soperator-rebooter
+      - equal:
+          path: spec.values.rebooter.priorityClass.value
+          value: 100000
+      - equal:
+          path: spec.values.rebooter.resources.requests.cpu
+          value: 100m
+
+  - it: should omit the rebooter priority class when unset
+    template: templates/nodeconfigurator.yaml
+    set:
+      soperator.nodeConfigurator.values.rebooter.priorityClassName: ""
+    asserts:
+      - notExists:
+          path: spec.values.rebooter.priorityClassName

--- a/helm/soperator-fluxcd/tests/kube_state_metrics_test.yaml
+++ b/helm/soperator-fluxcd/tests/kube_state_metrics_test.yaml
@@ -30,12 +30,15 @@ tests:
           path: spec.values.kube-state-metrics.vmScrape.spec.endpoints[0].max_scrape_size
           value: "150554432"
 
-  - it: should not set kube-state-metrics resources by default
+  - it: should request a cpu floor for kube-state-metrics by default
     asserts:
       - hasDocuments:
           count: 1
+      - equal:
+          path: spec.values.kube-state-metrics.resources.requests.cpu
+          value: 100m
       - notExists:
-          path: spec.values.kube-state-metrics.resources
+          path: spec.values.kube-state-metrics.resources.limits
 
   - it: should pin kube-state-metrics to system nodes
     asserts:

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -50,7 +50,67 @@ certManager:
   version: v1.20.*
   namespace: cert-manager-system
   releaseName: cert-manager
-  values: null
+  values:
+    # kubernetes.io/os is the chart's own default and has to be repeated here: setting
+    # nodeSelector replaces it wholesale.
+    nodeSelector:
+      kubernetes.io/os: linux
+      slurm.nebius.ai/nodeset: system
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: cert-manager
+                  app.kubernetes.io/component: controller
+    resources:
+      requests:
+        cpu: 100m
+    webhook:
+      nodeSelector:
+        kubernetes.io/os: linux
+        slurm.nebius.ai/nodeset: system
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: webhook
+                    app.kubernetes.io/component: webhook
+      resources:
+        requests:
+          cpu: 100m
+    cainjector:
+      nodeSelector:
+        kubernetes.io/os: linux
+        slurm.nebius.ai/nodeset: system
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: cainjector
+                    app.kubernetes.io/component: cainjector
+      resources:
+        requests:
+          cpu: 100m
+    startupapicheck:
+      # A one-shot Job, so it gets the pin but no anti-affinity term.
+      nodeSelector:
+        kubernetes.io/os: linux
+        slurm.nebius.ai/nodeset: system
+      resources:
+        requests:
+          cpu: 100m
   overrideValues: null
   install:
     crds: CreateReplace
@@ -78,6 +138,20 @@ backup:
       registry: cr.eu-north1.nebius.cloud/soperator-proxy-docker-io
       repository: alpine/k8s
       tag: 1.34.0
+    nodeSelector:
+      slurm.nebius.ai/nodeset: system
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: k8up
+    resources:
+      requests:
+        cpu: 50m
   overrideValues: null
   install:
     crds: CreateReplace
@@ -116,7 +190,51 @@ mariadbOperator:
   version: 25.10.2
   namespace: mariadb-operator-system
   releaseName: mariadb-operator
-  values: null
+  values:
+    nodeSelector:
+      slurm.nebius.ai/nodeset: system
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: mariadb-operator
+    resources:
+      requests:
+        cpu: 100m
+    webhook:
+      nodeSelector:
+        slurm.nebius.ai/nodeset: system
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: mariadb-operator-webhook
+      resources:
+        requests:
+          cpu: 100m
+    certController:
+      nodeSelector:
+        slurm.nebius.ai/nodeset: system
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: mariadb-operator-cert-controller
+      resources:
+        requests:
+          cpu: 100m
   overrideValues: null
   install:
     crds: Skip
@@ -178,7 +296,13 @@ observability:
       tokenExpiryFile: ""
       refreshSafetyMarginSeconds: 900
       pollIntervalSeconds: 300
-      resources: {}
+      nodeSelector:
+        slurm.nebius.ai/nodeset: system
+      # No affinity here: this Deployment is rendered inline and its pod label carries the
+      # release name, so the anti-affinity selector is built in the template.
+      resources:
+        requests:
+          cpu: 50m
   opentelemetry:
     enabled: true
     publicEndpoint: dns:///write.logging.eu-north1.nebius.cloud.:443
@@ -263,6 +387,18 @@ observability:
       values:
         enableFileStorage: true
         useGoMemLimit: true
+        nodeSelector:
+          slurm.nebius.ai/nodeset: system
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: opentelemetry-collector
+                      component: standalone-collector
         resources:
           requests:
             memory: 128Mi
@@ -312,6 +448,57 @@ observability:
         retries: 6
         remediateLastFailure: true
     values:
+      kubeStateMetrics:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: slurm.nebius.ai/nodeset
+                      operator: In
+                      values:
+                        - system
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: kube-state-metrics
+        resources:
+          requests:
+            cpu: 100m
+      grafana:
+        nodeSelector:
+          slurm.nebius.ai/nodeset: system
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: grafana
+        resources:
+          requests:
+            cpu: 100m
+      victoriaMetricsOperator:
+        nodeSelector:
+          slurm.nebius.ai/nodeset: system
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: victoria-metrics-operator
+        resources:
+          requests:
+            cpu: 100m
       dashboardNamespaces:
         - soperator
         - soperator-system
@@ -329,6 +516,17 @@ observability:
           org_role: Admin
       vmagent:
         spec:
+          nodeSelector:
+            slurm.nebius.ai/nodeset: system
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    topologyKey: kubernetes.io/hostname
+                    labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: vmagent
           extraArgs:
             promscrape.maxScrapeSize: "33554432"
             promscrape.dropOriginalLabels: "true"
@@ -348,6 +546,17 @@ observability:
           volumes: []
       vmsingle:
         spec:
+          nodeSelector:
+            slurm.nebius.ai/nodeset: system
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    topologyKey: kubernetes.io/hostname
+                    labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: vmsingle
           extraArgs:
             dedup.minScrapeInterval: 30s
             maxLabelsPerTimeseries: "40"
@@ -393,6 +602,17 @@ observability:
         enabled: true
         size: 30Gi
         accessMode: ReadWriteOnce
+      nodeSelector:
+        slurm.nebius.ai/nodeset: system
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: victoria-logs-single
       resources:
         requests:
           memory: 2Gi
@@ -513,6 +733,19 @@ securityProfilesOperator:
         requests:
           cpu: 100m
           memory: 128Mi
+    # The operator's own webhook Deployment is created by the operator rather than by its chart,
+    # so its placement cannot be set from here.
+    nodeSelector:
+      slurm.nebius.ai/nodeset: system
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: security-profiles-operator
     resources:
       limits:
         cpu: 500m
@@ -618,6 +851,18 @@ soperator:
   values:
     serviceMonitor:
       enabled: true
+    controllerManager:
+      nodeSelector:
+        slurm.nebius.ai/nodeset: system
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    control-plane: controller-manager
     manager:
       resources:
         limits:
@@ -649,6 +894,10 @@ soperator:
         image:
           repository: cr.eu-north1.nebius.cloud/soperator/kruise-manager
           tag: v1.8.3
+        # The chart exposes no manager.affinity, so the two replicas get the pin but no
+        # anti-affinity term.
+        nodeSelector:
+          slurm.nebius.ai/nodeset: system
         resources:
           limits:
             memory: 2Gi
@@ -674,7 +923,19 @@ soperator:
       remediation:
         retries: 3
         remediateLastFailure: true
-    values: null
+    values:
+      checks:
+        nodeSelector:
+          slurm.nebius.ai/nodeset: system
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      control-plane: soperatorchecks
     overrideValues: null
     driftDetection:
       mode: warn
@@ -694,6 +955,15 @@ soperator:
         remediateLastFailure: true
     values:
       rebooter:
+        # Without a priority class the rebooter runs at 0 and loses a node's spare CPU budget to
+        # whatever infrastructure Deployment lands there first, with no way to preempt it. The
+        # class sits below every Slurm pod (the lowest is slurm-login at 100002) because this is a
+        # DaemonSet on every node, not just the worker ones - it must never evict Slurm workloads.
+        priorityClassName: soperator-rebooter
+        priorityClass:
+          create: true
+          name: soperator-rebooter
+          value: 100000
         resources:
           requests:
             memory: 200Mi
@@ -748,8 +1018,19 @@ csiDriverNfs:
   version: 4.11.0
   namespace: nfs-system
   releaseName: csi-driver-nfs
-  overrideValues: null
-  values: null
+  overrideValues:
+    controller:
+      nodeSelector:
+        slurm.nebius.ai/nodeset: system
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: csi-nfs-controller
   install:
     crds: Skip
     remediation:

--- a/helm/soperatorchecks/templates/deployment.yaml
+++ b/helm/soperatorchecks/templates/deployment.yaml
@@ -68,4 +68,13 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- if .Values.checks.tolerations }}
+      tolerations: {{- toYaml .Values.checks.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.checks.affinity }}
+      affinity: {{- toYaml .Values.checks.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.checks.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.checks.nodeSelector | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10

--- a/helm/soperatorchecks/tests/placement_test.yaml
+++ b/helm/soperatorchecks/tests/placement_test.yaml
@@ -1,0 +1,42 @@
+suite: test checks deployment placement
+release:
+  name: test-soperatorchecks
+  namespace: soperator-system
+templates:
+  - templates/deployment.yaml
+
+tests:
+  - it: should not constrain placement by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+      - notExists:
+          path: spec.template.spec.affinity
+      - notExists:
+          path: spec.template.spec.tolerations
+
+  - it: should render nodeSelector, affinity and tolerations when set
+    set:
+      checks.nodeSelector:
+        slurm.nebius.ai/nodeset: system
+      checks.affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    control-plane: soperatorchecks
+      checks.tolerations:
+        - operator: Exists
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector["slurm.nebius.ai/nodeset"]
+          value: system
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
+          value: kubernetes.io/hostname
+      - equal:
+          path: spec.template.spec.tolerations[0].operator
+          value: Exists

--- a/helm/soperatorchecks/values.yaml
+++ b/helm/soperatorchecks/values.yaml
@@ -47,6 +47,9 @@ checks:
   replicas: 1
   serviceAccount:
     annotations: {}
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
 kubernetesClusterDomain: cluster.local
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
## Problem

Non-soperator control-plane Deployments installed via the soperator-fluxcd umbrella chart carried no
nodeSelector or affinity, so the scheduler was free to bin-pack them onto worker nodes — and did,
preferring the large worker-64vcpu nodes. A worker node has only ~900m of CPU left for non-worker
pods, most of it already taken by the base DaemonSets. On bfl-me-west1-cpu-dataprocessing this left
3 of 5 worker-64vcpu nodes unable to schedule the node-configurator (rebooter) DaemonSet.

## Solution

Pin every control-plane workload the chart installs to the system nodeset via
`nodeSelector: slurm.nebius.ai/nodeset=system`, plus a soft pod anti-affinity so a Deployment's
replicas spread across nodes. All of it lives in `values.yaml`, so it stays visible and overridable.

Give the rebooter `priorityClassName: system-node-critical` so it can preempt whatever else lands on
a packed worker node.

Add a CPU request floor where there was none (100m; 50m for k8up and the tsa-token-writer) —
without a request these pods score as free and bin-pack anywhere.

Add `affinity`/`nodeSelector`/`tolerations` to the `soperatorchecks` chart, which had no scheduling
fields at all.

## Testing

`make helmtest` (388 tests, 17 charts) and `make test` pass. New suites cover the placement, the CPU
floors and the rebooter priority class; verified the rendered HelmReleases against each sub-chart's
actual value schema (`helm show values`) and pod labels (`helm template`). `make sync-version-from-scratch`
produces no drift.

Not verified on a live cluster. `make lint` fails on a pre-existing toolchain mismatch (`bin/golangci-lint`
built with go1.25 vs the repo's 1.26.4 target) — reproduces on a clean `main`; no Go code changed here.

## Release Notes

Fix: control-plane components installed by soperator-fluxcd now run on system nodes instead of
competing for the worker nodes' reserved CPU budget, and the rebooter DaemonSet is guaranteed a slot
on every node.

Risk: the pin is a hard `nodeSelector`. A cluster with no `slurm.nebius.ai/nodeset=system` nodes will
leave these pods Pending — clear the component's `values` block or set `overrideValues` to opt out.
The SPO webhook, kruise manager anti-affinity, nfs-server and notifier are out of scope.
