### PR TITLE
SCHED-2212: Replace deprecated ctrl.Result{Requeue: true} usages

### DIFF
--- a/internal/controller/clustercontroller/accounting.go
+++ b/internal/controller/clustercontroller/accounting.go
@@ -564,7 +564,7 @@ func (r SlurmClusterReconciler) updateAccountingAvailabilityStatus(
 		return ctrl.Result{}, err
 	}
 	if conditionStatus != metav1.ConditionTrue {
-		return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/clustercontroller/reconcile.go
+++ b/internal/controller/clustercontroller/reconcile.go
@@ -144,7 +144,7 @@ func (r *SlurmClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		// Error reading the object - requeue the request.
 		logger.Error(err, "Failed to get SlurmCluster")
-		return ctrl.Result{Requeue: true}, fmt.Errorf("getting SlurmCluster: %w", err)
+		return ctrl.Result{}, fmt.Errorf("getting SlurmCluster: %w", err)
 	}
 
 	slurmCluster.Spec.PlugStackConfig.Pyxis.SetDefaults()
@@ -490,7 +490,7 @@ func (r *SlurmClusterReconciler) reconcile(ctx context.Context, cluster *slurmv1
 
 	logger.Info("Finished reconciliation of Slurm Cluster")
 
-	if populateJailRes.RequeueAfter > 0 && res.RequeueAfter == 0 && !res.Requeue {
+	if populateJailRes.RequeueAfter > 0 && res.RequeueAfter == 0 {
 		res.RequeueAfter = populateJailRes.RequeueAfter
 	}
 

--- a/internal/controller/nodesetcontroller/controller.go
+++ b/internal/controller/nodesetcontroller/controller.go
@@ -170,7 +170,7 @@ func (r *NodeSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		// Error reading the object - requeue the request.
 		logger.Error(err, "Failed to get resource")
-		return ctrl.Result{Requeue: true}, fmt.Errorf("getting %s: %w", slurmv1alpha1.KindNodeSet, err)
+		return ctrl.Result{}, fmt.Errorf("getting %s: %w", slurmv1alpha1.KindNodeSet, err)
 	}
 
 	// If nodeset is marked for deletion, we have nothing to do

--- a/internal/controller/soperatorchecks/activecheck_jobs_controller.go
+++ b/internal/controller/soperatorchecks/activecheck_jobs_controller.go
@@ -179,7 +179,7 @@ func (r *ActiveCheckJobReconciler) Reconcile(
 			// is still running; processing it too early would be premature.
 			if status := getK8sJobStatus(k8sJob); status != consts.ActiveCheckK8sJobStatusComplete &&
 				status != consts.ActiveCheckK8sJobStatusFailed {
-				return ctrl.Result{Requeue: true, RequeueAfter: r.requeueAfter}, nil
+				return ctrl.Result{RequeueAfter: r.requeueAfter}, nil
 			}
 
 			activeCheck.Status.SlurmJobsStatus = slurmv1alpha1.ActiveCheckSlurmJobsStatus{
@@ -394,7 +394,7 @@ func (r *ActiveCheckJobReconciler) Reconcile(
 		}
 
 		if requeue {
-			return ctrl.Result{Requeue: true, RequeueAfter: r.requeueAfter}, nil
+			return ctrl.Result{RequeueAfter: r.requeueAfter}, nil
 		}
 
 	} else if activeCheck.Spec.CheckType == "k8sJob" {

--- a/internal/controller/soperatorchecks/activecheck_jobs_controller_test.go
+++ b/internal/controller/soperatorchecks/activecheck_jobs_controller_test.go
@@ -162,7 +162,7 @@ func TestActiveCheckJobReconciler_Reconcile_DoesNotFinalizeUntilAllSlurmJobsFini
 
 	firstResult, err := reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
-	assert.True(t, firstResult.Requeue)
+	assert.Equal(t, time.Minute, firstResult.RequeueAfter)
 
 	updatedJob := &batchv1.Job{}
 	require.NoError(t, fakeClient.Get(ctx, req.NamespacedName, updatedJob))
@@ -184,7 +184,7 @@ func TestActiveCheckJobReconciler_Reconcile_DoesNotFinalizeUntilAllSlurmJobsFini
 
 	secondResult, err := reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
-	assert.False(t, secondResult.Requeue)
+	assert.Zero(t, secondResult.RequeueAfter)
 
 	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
 		Namespace: namespace,
@@ -285,7 +285,7 @@ func TestActiveCheckJobReconciler_Reconcile_SlurmJobSubmissionFailureSetsErrorSt
 
 	result, err := reconciler.Reconcile(ctx, newActiveCheckJobRequest(k8sJob))
 	require.NoError(t, err)
-	assert.False(t, result.Requeue)
+	assert.Zero(t, result.RequeueAfter)
 
 	updatedCheck := &slurmv1alpha1.ActiveCheck{}
 	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(activeCheck), updatedCheck))
@@ -349,7 +349,7 @@ func TestActiveCheckJobReconciler_Reconcile_SlurmJobAggregatesTerminalResultsInS
 
 	result, err := reconciler.Reconcile(ctx, newActiveCheckJobRequest(k8sJob))
 	require.NoError(t, err)
-	assert.False(t, result.Requeue)
+	assert.Zero(t, result.RequeueAfter)
 
 	updatedCheck := &slurmv1alpha1.ActiveCheck{}
 	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(activeCheck), updatedCheck))
@@ -431,7 +431,7 @@ func TestActiveCheckJobReconciler_Reconcile_SlurmJobAccumulatesTerminalResultsAc
 
 	firstResult, err := reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
-	assert.True(t, firstResult.Requeue)
+	assert.Equal(t, time.Minute, firstResult.RequeueAfter)
 
 	updatedCheck := &slurmv1alpha1.ActiveCheck{}
 	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(activeCheck), updatedCheck))
@@ -445,7 +445,7 @@ func TestActiveCheckJobReconciler_Reconcile_SlurmJobAccumulatesTerminalResultsAc
 
 	secondResult, err := reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
-	assert.False(t, secondResult.Requeue)
+	assert.Zero(t, secondResult.RequeueAfter)
 
 	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(activeCheck), updatedCheck))
 	assert.Equal(t, consts.ActiveCheckSlurmRunStatusFailed, updatedCheck.Status.SlurmJobsStatus.LastRunStatus)
@@ -488,7 +488,7 @@ func TestActiveCheckJobReconciler_Reconcile_FailedSlurmJobWithoutReactionsOnlyUp
 
 	result, err := reconciler.Reconcile(ctx, newActiveCheckJobRequest(k8sJob))
 	require.NoError(t, err)
-	assert.False(t, result.Requeue)
+	assert.Zero(t, result.RequeueAfter)
 
 	updatedCheck := &slurmv1alpha1.ActiveCheck{}
 	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(activeCheck), updatedCheck))
@@ -519,7 +519,7 @@ func TestActiveCheckJobReconciler_Reconcile_SlurmJobNotYetVisibleInAccountingReq
 
 	result, err := reconciler.Reconcile(ctx, newActiveCheckJobRequest(k8sJob))
 	require.NoError(t, err)
-	assert.True(t, result.Requeue)
+	assert.Equal(t, time.Minute, result.RequeueAfter)
 
 	updatedCheck := &slurmv1alpha1.ActiveCheck{}
 	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(activeCheck), updatedCheck))
@@ -582,7 +582,7 @@ func TestActiveCheckJobReconciler_Reconcile_FailedSlurmJobExecutesCommentReactio
 
 	result, err := reconciler.Reconcile(ctx, newActiveCheckJobRequest(k8sJob))
 	require.NoError(t, err)
-	assert.False(t, result.Requeue)
+	assert.Zero(t, result.RequeueAfter)
 
 	updatedCheck := &slurmv1alpha1.ActiveCheck{}
 	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(activeCheck), updatedCheck))
@@ -613,7 +613,7 @@ func TestActiveCheckJobReconciler_Reconcile_K8sJobUpdatesStatus(t *testing.T) {
 
 	result, err := reconciler.Reconcile(ctx, newActiveCheckJobRequest(k8sJob))
 	require.NoError(t, err)
-	assert.False(t, result.Requeue)
+	assert.Zero(t, result.RequeueAfter)
 
 	updatedCheck := &slurmv1alpha1.ActiveCheck{}
 	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(activeCheck), updatedCheck))
@@ -644,7 +644,7 @@ func TestActiveCheckJobReconciler_Reconcile_K8sJobNoopWhenStatusDidNotChange(t *
 
 	result, err := reconciler.Reconcile(ctx, newActiveCheckJobRequest(k8sJob))
 	require.NoError(t, err)
-	assert.False(t, result.Requeue)
+	assert.Zero(t, result.RequeueAfter)
 
 	updatedCheck := &slurmv1alpha1.ActiveCheck{}
 	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(activeCheck), updatedCheck))

--- a/internal/controller/soperatorchecks/k8s_nodes_controller_test.go
+++ b/internal/controller/soperatorchecks/k8s_nodes_controller_test.go
@@ -246,7 +246,6 @@ func TestK8SNodesController_Reconcile_NotReadyFlow(t *testing.T) {
 	tests := []struct {
 		name               string
 		node               *corev1.Node
-		expectRequeue      bool
 		expectRequeueAfter bool
 		expectNodeDeletion bool
 	}{
@@ -265,7 +264,6 @@ func TestK8SNodesController_Reconcile_NotReadyFlow(t *testing.T) {
 					},
 				},
 			},
-			expectRequeue:      false,
 			expectRequeueAfter: false,
 			expectNodeDeletion: false,
 		},
@@ -285,7 +283,6 @@ func TestK8SNodesController_Reconcile_NotReadyFlow(t *testing.T) {
 					},
 				},
 			},
-			expectRequeue:      true,
 			expectRequeueAfter: true,
 			expectNodeDeletion: false,
 		},
@@ -305,7 +302,6 @@ func TestK8SNodesController_Reconcile_NotReadyFlow(t *testing.T) {
 					},
 				},
 			},
-			expectRequeue:      false,
 			expectRequeueAfter: false,
 			expectNodeDeletion: true,
 		},
@@ -331,13 +327,9 @@ func TestK8SNodesController_Reconcile_NotReadyFlow(t *testing.T) {
 			result, err := controller.Reconcile(ctx, req)
 			assert.NoError(t, err)
 
-			if tt.expectRequeue && tt.expectRequeueAfter {
-				assert.True(t, result.Requeue || result.RequeueAfter > 0, "Should requeue")
-				if result.RequeueAfter > 0 {
-					assert.Greater(t, result.RequeueAfter, time.Duration(0), "RequeueAfter should be positive")
-				}
+			if tt.expectRequeueAfter {
+				assert.Greater(t, result.RequeueAfter, time.Duration(0), "RequeueAfter should be positive")
 			} else {
-				assert.False(t, result.Requeue, "Should not requeue")
 				assert.Equal(t, time.Duration(0), result.RequeueAfter, "RequeueAfter should be zero")
 			}
 

--- a/internal/controller/topologyconfcontroller/workertopology_controller.go
+++ b/internal/controller/topologyconfcontroller/workertopology_controller.go
@@ -39,7 +39,6 @@ var (
 	WorkerTopologyReconcilerName = "workerTopologyReconciler"
 	DefaultRequeueResult         = ctrl.Result{
 		RequeueAfter: 1 * time.Minute,
-		Requeue:      true,
 	}
 )
 

--- a/internal/rebooter/reconcile.go
+++ b/internal/rebooter/reconcile.go
@@ -11,7 +11,6 @@ import (
 	"github.com/mackerelio/go-osstat/uptime"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -108,10 +107,6 @@ func (r *RebooterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	logger.V(1).Info("Starting handling node reboot")
 	if err := r.handleNodeReboot(ctx, node, nodeActions); err != nil {
-		if apierrors.IsConflict(err) {
-			logger.V(1).Info("Conflict during reboot handling, requeueing")
-			return ctrl.Result{Requeue: true}, nil
-		}
 		return ctrl.Result{}, err
 	}
 
@@ -188,6 +183,8 @@ func (r *RebooterReconciler) handleNodeDrain(ctx context.Context, node *corev1.N
 }
 
 // handleDrainError handles the error that occurred during the node draining process.
+// Only failed pod eviction gets a fixed retry cadence; any other error, conflicts included,
+// is returned so the request is re-enqueued through the rate limiter's backoff.
 func (r *RebooterReconciler) handleDrainError(ctx context.Context, err error) (ctrl.Result, error) {
 	var podErr *PodNotEvictableError
 	// If some pods are not evicted, requeue the reconciliation.
@@ -195,10 +192,6 @@ func (r *RebooterReconciler) handleDrainError(ctx context.Context, err error) (c
 	if errors.As(err, &podErr) {
 		log.FromContext(ctx).V(1).Info("Reenqueueing reconciliation due to failed pod eviction")
 		return ctrl.Result{RequeueAfter: r.reconcileTimeout}, nil
-	}
-	if apierrors.IsConflict(err) {
-		log.FromContext(ctx).V(1).Info("Conflict during drain handling, requeueing")
-		return ctrl.Result{Requeue: true}, nil
 	}
 	return ctrl.Result{}, fmt.Errorf("failed to drain node: %w", err)
 }


### PR DESCRIPTION
## Problem
controller-runtime v0.24 deprecated `Result.Requeue`.

## Solution
Removed all `Requeue` usages; rebooter conflict paths return the error instead, keeping rate-limited backoff.

## Testing
`make test`, `make helmtest`, `go vet` pass.

## Release Notes
Internal refactor. Rebooter drain/reboot conflicts now retry with backoff and count into `reconcile_errors_total`.
