### PR TITLE
SCHED-2241: cap public Cloud Logging exporter batches at 1000 records

### DIFF
--- a/docs/logs-pipeline.md
+++ b/docs/logs-pipeline.md
@@ -194,10 +194,18 @@ observability:
   opentelemetry:
     # Optional. Defaults to dns:///write.logging.eu-north1.nebius.cloud.:443
     publicEndpoint: "dns:///write.logging.eu-north1.nebius.cloud.:443"
+    # Exporter batching for the in-cluster (VictoriaLogs) exporters
     batch:
       timeout: 1s
       sendBatchSize: 2000
       sendBatchMaxSize: 5000
+    # Exporter batching for the public Cloud Logging exporter;
+    # Cloud Logging rejects requests with more than 1000 log records and the collector drops rejected batches,
+    # so keep sendBatchMaxSize <= 1000
+    publicBatch:
+      timeout: 1s
+      sendBatchSize: 500
+      sendBatchMaxSize: 1000
   
   # Storage
   vmLogs:

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-events.yaml
@@ -51,6 +51,7 @@ spec:
   {{- $tokenMountPath := include "soperator-fluxcd.o11yTsaTokenMountPath" . }}
   {{- $tokenHostPathFilename := include "soperator-fluxcd.o11yTsaTokenHostPathFilename" . }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
+  {{- $publicBatch := .Values.observability.opentelemetry.publicBatch | default dict }}
   {{- $sendingQueue := .Values.observability.opentelemetry.sendingQueue | default dict }}
   {{- $eventsValues := .Values.observability.opentelemetry.events.values | default dict }}
   {{- $eventsEnableFileStorage := true }}
@@ -300,7 +301,7 @@ spec:
             initial_interval: 200ms
             max_elapsed_time: 0
           timeout: 5s
-{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $eventsQueueStorage) | indent 10 }}
+{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $publicBatch "queue" $sendingQueue "storage" $eventsQueueStorage) | indent 10 }}
           headers:
             iam-container: {{ .Values.observability.logsProjectId }}
             {{- $extraHeaders := .Values.observability.opentelemetry.extraHeaders }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-jail-logs.yaml
@@ -53,6 +53,7 @@ spec:
   {{- $tokenMountPath := include "soperator-fluxcd.o11yTsaTokenMountPath" . }}
   {{- $tokenHostPathFilename := include "soperator-fluxcd.o11yTsaTokenHostPathFilename" . }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
+  {{- $publicBatch := .Values.observability.opentelemetry.publicBatch | default dict }}
   {{- $sendingQueue := .Values.observability.opentelemetry.sendingQueue | default dict }}
   {{- $logsValues := .Values.observability.opentelemetry.logs.values | default dict }}
   {{- $jailLogsValues := $logsValues.jailLogs | default dict }}
@@ -530,7 +531,7 @@ spec:
             initial_interval: 200ms
             max_elapsed_time: 0
           timeout: 5s
-{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $jailQueueStorage) | indent 10 }}
+{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $publicBatch "queue" $sendingQueue "storage" $jailQueueStorage) | indent 10 }}
           headers:
             iam-container: {{ .Values.observability.logsProjectId }}
             {{- $extraHeaders := .Values.observability.opentelemetry.extraHeaders }}

--- a/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
+++ b/helm/soperator-fluxcd/templates/opentelemetry-collector-logs.yaml
@@ -51,6 +51,7 @@ spec:
   {{- $tokenMountPath := include "soperator-fluxcd.o11yTsaTokenMountPath" . }}
   {{- $tokenHostPathFilename := include "soperator-fluxcd.o11yTsaTokenHostPathFilename" . }}
   {{- $batch := .Values.observability.opentelemetry.batch | default dict }}
+  {{- $publicBatch := .Values.observability.opentelemetry.publicBatch | default dict }}
   {{- $sendingQueue := .Values.observability.opentelemetry.sendingQueue | default dict }}
   {{- $logsValues := .Values.observability.opentelemetry.logs.values | default dict }}
   {{- $logsEnableFileStorage := true }}
@@ -556,7 +557,7 @@ spec:
             initial_interval: 200ms
             max_elapsed_time: 0
           timeout: 5s
-{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $batch "queue" $sendingQueue "storage" $logsQueueStorage) | indent 10 }}
+{{ include "soperator-fluxcd.otelExporterSendingQueue" (dict "batch" $publicBatch "queue" $sendingQueue "storage" $logsQueueStorage) | indent 10 }}
           headers:
             iam-container: {{ .Values.observability.logsProjectId }}
             {{- $extraHeaders := .Values.observability.opentelemetry.extraHeaders }}

--- a/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
+++ b/helm/soperator-fluxcd/tests/opentelemetry_collector_config_test.yaml
@@ -2,7 +2,7 @@ suite: test opentelemetry collector logs config
 templates:
   - templates/opentelemetry-collector-logs.yaml
 tests:
-  - it: should use eu-north public endpoint regardless of observability region and render default queue batch settings
+  - it: should use eu-north public endpoint and cap public exporter batches while keeping large internal batches
     set:
       observability.region: eu-west1
     asserts:
@@ -36,10 +36,22 @@ tests:
           value: 1s
       - equal:
           path: spec.values.config.exporters.otlp.sending_queue.batch.min_size
-          value: 2000
+          value: 500
       - equal:
           path: spec.values.config.exporters.otlp.sending_queue.batch.max_size
+          value: 1000
+      - equal:
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.batch.flush_timeout
+          value: 1s
+      - equal:
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.batch.min_size
+          value: 2000
+      - equal:
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.batch.max_size
           value: 5000
+      - equal:
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.queue_size
+          value: 30000
 
   - it: should prefer explicit public endpoint override
     set:
@@ -77,7 +89,7 @@ tests:
           path: spec.values.config.extensions.bearertokenauth.filename
           value: /var/run/o11y-token/token
 
-  - it: should fall back to default batch settings when batch config is empty
+  - it: should fall back to default internal batch settings and keep the public cap when batch config is empty
     set:
       observability.opentelemetry.batch: null
     asserts:
@@ -86,14 +98,20 @@ tests:
       - notExists:
           path: spec.values.config.processors.batch
       - equal:
-          path: spec.values.config.exporters.otlp.sending_queue.batch.flush_timeout
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.batch.flush_timeout
           value: 1s
       - equal:
-          path: spec.values.config.exporters.otlp.sending_queue.batch.min_size
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.batch.min_size
           value: 2000
       - equal:
-          path: spec.values.config.exporters.otlp.sending_queue.batch.max_size
+          path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.batch.max_size
           value: 5000
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.batch.min_size
+          value: 500
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.batch.max_size
+          value: 1000
 
   - it: should omit file storage when log file storage is disabled
     set:
@@ -142,6 +160,9 @@ tests:
       observability.opentelemetry.batch.timeout: 2s
       observability.opentelemetry.batch.sendBatchSize: 3000
       observability.opentelemetry.batch.sendBatchMaxSize: 7000
+      observability.opentelemetry.publicBatch.timeout: 3s
+      observability.opentelemetry.publicBatch.sendBatchSize: 400
+      observability.opentelemetry.publicBatch.sendBatchMaxSize: 800
       observability.opentelemetry.sendingQueue.queueSize: 9000
       observability.opentelemetry.sendingQueue.numConsumers: 3
     asserts:
@@ -167,6 +188,15 @@ tests:
       - equal:
           path: spec.values.config.exporters["otlp_http/victoriametrics"].sending_queue.batch.max_size
           value: 7000
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.batch.flush_timeout
+          value: 3s
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.batch.min_size
+          value: 400
+      - equal:
+          path: spec.values.config.exporters.otlp.sending_queue.batch.max_size
+          value: 800
 
   - it: should mount the shared token secret with custom name key and namespace
     set:
@@ -252,9 +282,15 @@ tests:
           value: 1s
       - equal:
           path: spec.values.config.exporters.otlp.sending_queue.batch.min_size
-          value: 2000
+          value: 500
       - equal:
           path: spec.values.config.exporters.otlp.sending_queue.batch.max_size
+          value: 1000
+      - equal:
+          path: spec.values.config.exporters["otlp_http/victorialogs"].sending_queue.batch.min_size
+          value: 2000
+      - equal:
+          path: spec.values.config.exporters["otlp_http/victorialogs"].sending_queue.batch.max_size
           value: 5000
       - equal:
           path: spec.values.extraVolumeMounts[0].readOnly

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -308,13 +308,20 @@ observability:
     publicEndpoint: dns:///write.logging.eu-north1.nebius.cloud.:443
     namespace: logs-system
     extraHeaders: {}
-    # These values are rendered as exporter sending_queue.batch settings.
+    # These values are rendered as sending_queue.batch settings for the in-cluster (VictoriaLogs) exporters.
     # The chart intentionally does not use the batch processor for collector pipelines.
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44845#issuecomment-3877056774
     batch:
       timeout: 1s
       sendBatchSize: 2000
       sendBatchMaxSize: 5000
+    # Batch settings for the public Cloud Logging exporter only.
+    # Cloud Logging rejects requests with more than 1000 log records and the
+    # collector drops rejected batches, so keep sendBatchMaxSize <= 1000.
+    publicBatch:
+      timeout: 1s
+      sendBatchSize: 500
+      sendBatchMaxSize: 1000
     # Exporter queue sizing shared by logs, events, and jail logs collectors.
     # queueSize is measured in telemetry items because exporter queues use sizer: items
     # (log records for logs/events), and it applies separately to each exporter.


### PR DESCRIPTION
## Problem

Since #2641 batching moved from the batch processor to exporter-level `sending_queue.batch`, and the public Cloud Logging exporter shares the same settings as the VictoriaLogs exporters (min 2000 / max 5000 records). Cloud
Logging rejects requests with more than 1000 log records as a permanent error, so the collector drops these batches instead of retrying and they never reach public Cloud Logging.

## Solution

- Add `observability.opentelemetry.publicBatch` (timeout 1s, sendBatchSize 500, sendBatchMaxSize 1000) to `soperator-fluxcd` values
- Use it for the public `otlp` exporter in the logs, events, and jail-logs collectors; the in-cluster VictoriaLogs exporters keep the existing `batch` settings
- Document the new setting in `docs/logs-pipeline.md`

## Testing

- Helm unit tests cover the split: public exporter capped at 500/1000 while VictoriaLogs exporters keep 2000/5000, defaults when `batch` is null, and `publicBatch` overrides.
- https://github.com/nebius/soperator/actions/runs/31810477203

## Release Notes

Fix: public Cloud Logging exporter batches are capped at 1000 records, so they are no longer rejected and dropped by Cloud Logging.
