### PR TITLE
SCHED-2328: add node AutoResume option

### DIFF
--- a/api/v1alpha1/nodeset_types.go
+++ b/api/v1alpha1/nodeset_types.go
@@ -522,6 +522,14 @@ type NodeConfig struct {
 	// +kubebuilder:validation:Optional
 	Features []string `json:"features,omitempty"`
 
+	// AutoResume controls whether Slurm automatically resumes the nodes.
+	// Set to false to render AutoResume=Off in the NodeName configuration.
+	// Defaults to true.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=true
+	AutoResume *bool `json:"autoResume,omitempty"`
+
 	// Static provides a possibility to define extra values per Node (e.g. CPU topology).
 	// This line will be provided to the config as is.
 	//

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -760,6 +760,11 @@ func (in *NodeConfig) DeepCopyInto(out *NodeConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AutoResume != nil {
+		in, out := &in.AutoResume, &out.AutoResume
+		*out = new(bool)
+		**out = **in
+	}
 	if in.GRESConfig != nil {
 		in, out := &in.GRESConfig, &out.GRESConfig
 		*out = make([]string, len(*in))

--- a/config/crd/bases/slurm.nebius.ai_nodesets.yaml
+++ b/config/crd/bases/slurm.nebius.ai_nodesets.yaml
@@ -3001,6 +3001,13 @@ spec:
                 description: NodeConfig provides possibility to define extra values
                   set for Node in `slurm.conf`.
                 properties:
+                  autoResume:
+                    default: true
+                    description: |-
+                      AutoResume controls whether Slurm automatically resumes the nodes.
+                      Set to false to render AutoResume=Off in the NodeName configuration.
+                      Defaults to true.
+                    type: boolean
                   dynamic:
                     default: ""
                     description: |-

--- a/helm/nodesets/templates/nodeset.yaml
+++ b/helm/nodesets/templates/nodeset.yaml
@@ -83,6 +83,10 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{- end }}
 
+    {{- if hasKey . "autoResume" }}
+    autoResume: {{ .autoResume }}
+    {{- end }}
+
     {{- with .static }}
     static: {{ . | quote }}
     {{- end }}

--- a/helm/nodesets/tests/custom_values_test.yaml
+++ b/helm/nodesets/tests/custom_values_test.yaml
@@ -35,6 +35,7 @@ tests:
           gpu:
             enabled: false
           nodeConfig:
+            autoResume: false
             features:
               - "custom"
     asserts:
@@ -52,6 +53,9 @@ tests:
       - equal:
           path: spec.updateStrategy
           value: "onDelete"
+      - equal:
+          path: spec.nodeConfig.autoResume
+          value: false
       - equal:
           path: spec.slurmd.image.repository
           value: "custom/slurm"

--- a/helm/nodesets/values.yaml
+++ b/helm/nodesets/values.yaml
@@ -124,6 +124,10 @@ nodesets:
       features:
         - "gpu"
         - "cuda"
+      # Whether Slurm automatically resumes the nodes.
+      # Set to false to render AutoResume=Off in the NodeName configuration.
+      # Optional, defaults to true
+      autoResume: true
       # Static string to be added to the Node's configuration
       # Optional
       static: "Boards=1 SocketsPerBoard=1 CoresPerSocket=8 ThreadsPerCore=1"

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -18251,6 +18251,13 @@ spec:
                 description: NodeConfig provides possibility to define extra values
                   set for Node in `slurm.conf`.
                 properties:
+                  autoResume:
+                    default: true
+                    description: |-
+                      AutoResume controls whether Slurm automatically resumes the nodes.
+                      Set to false to render AutoResume=Off in the NodeName configuration.
+                      Defaults to true.
+                    type: boolean
                   dynamic:
                     default: ""
                     description: |-

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -18251,6 +18251,13 @@ spec:
                 description: NodeConfig provides possibility to define extra values
                   set for Node in `slurm.conf`.
                 properties:
+                  autoResume:
+                    default: true
+                    description: |-
+                      AutoResume controls whether Slurm automatically resumes the nodes.
+                      Set to false to render AutoResume=Off in the NodeName configuration.
+                      Defaults to true.
+                    type: boolean
                   dynamic:
                     default: ""
                     description: |-

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -154,6 +154,9 @@ func AddNodesToSlurmConfig(res *renderutils.PropertiesConfig, cluster *values.Sl
 			fmt.Sprintf("NodeAddr=%s", nodeAddr),
 			fmt.Sprintf("RealMemory=%s", realMemory),
 		)
+		if nodeSet.Spec.NodeConfig.AutoResume != nil && !*nodeSet.Spec.NodeConfig.AutoResume {
+			nodeConfigParts = append(nodeConfigParts, "AutoResume=Off")
+		}
 		if nodeSet.Spec.Slurmd.Port != 0 {
 			nodeConfigParts = append(nodeConfigParts, fmt.Sprintf("Port=%d", nodeSet.Spec.Slurmd.Port))
 		}

--- a/internal/render/common/configmap_test.go
+++ b/internal/render/common/configmap_test.go
@@ -711,14 +711,15 @@ func TestAddNodesToSlurmConfig(t *testing.T) {
 								},
 							},
 							NodeConfig: slurmv1alpha1.NodeConfig{
-								Features: []string{"a", "b"},
-								Static:   "Gres=gpu:nvidia-a100:4 NodeCPUs=64 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=1 Feature=c,d",
+								Features:   []string{"a", "b"},
+								AutoResume: ptr.To(false),
+								Static:     "Gres=gpu:nvidia-a100:4 NodeCPUs=64 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=1 Feature=c,d",
 							},
 						},
 					},
 				},
 			},
-			expected: "NodeName=nodeA-0 State=CLOUD NodeAddr=nodeA-0.slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=2048 Feature=a,b Gres=gpu:nvidia-a100:4 NodeCPUs=64 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=1",
+			expected: "NodeName=nodeA-0 State=CLOUD NodeAddr=nodeA-0.slurm-test-nodeset-svc.soperator.svc.cluster.local RealMemory=2048 AutoResume=Off Feature=a,b Gres=gpu:nvidia-a100:4 NodeCPUs=64 Boards=1 SocketsPerBoard=2 CoresPerSocket=32 ThreadsPerCode=1",
 		},
 		{
 			name: "Single nodeset with multiple replicas",


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
Sometimes it's needed to disable automatic nodes powering up when job is submitted. In patched Slurm `AutoResume=on/off` option is added on node level.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Propagate `AutoResume` option on NodeSet level, but fill it on node level in slurm config.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
Dev cluster.

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Feature: added `AutoResume=on/off` option on node level in Slurm based on corresponding field in NodeSet CR.
