### PR TITLE
SCHED-2331: add Slurm node reboot client

### DIFF
--- a/internal/slurmapi/client.go
+++ b/internal/slurmapi/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"strings"
 	"time"
 
 	api "github.com/SlinkyProject/slurm-client/api/v0044"
@@ -91,6 +92,9 @@ type client struct {
 	 */
 	api.ClientWithResponsesInterface
 
+	server     string
+	httpClient *http.Client
+
 	tokenIssuer tokenIssuer
 }
 
@@ -107,6 +111,8 @@ func NewClient(server string, tokenIssuer tokenIssuer, httpClient *http.Client) 
 	}
 
 	apiClient := &client{
+		server:      strings.TrimRight(server, "/"),
+		httpClient:  httpClient,
 		tokenIssuer: normalizeIssuer(tokenIssuer),
 	}
 

--- a/internal/slurmapi/fake/mock_client.go
+++ b/internal/slurmapi/fake/mock_client.go
@@ -373,6 +373,53 @@ func (_c *MockClient_ListNodes_Call) RunAndReturn(run func(context.Context) ([]s
 	return _c
 }
 
+// RebootNodes provides a mock function with given fields: ctx, request
+func (_m *MockClient) RebootNodes(ctx context.Context, request slurmapi.RebootNodesRequest) error {
+	ret := _m.Called(ctx, request)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RebootNodes")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, slurmapi.RebootNodesRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockClient_RebootNodes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RebootNodes'
+type MockClient_RebootNodes_Call struct {
+	*mock.Call
+}
+
+// RebootNodes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - request slurmapi.RebootNodesRequest
+func (_e *MockClient_Expecter) RebootNodes(ctx interface{}, request interface{}) *MockClient_RebootNodes_Call {
+	return &MockClient_RebootNodes_Call{Call: _e.mock.On("RebootNodes", ctx, request)}
+}
+
+func (_c *MockClient_RebootNodes_Call) Run(run func(ctx context.Context, request slurmapi.RebootNodesRequest)) *MockClient_RebootNodes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(slurmapi.RebootNodesRequest))
+	})
+	return _c
+}
+
+func (_c *MockClient_RebootNodes_Call) Return(_a0 error) *MockClient_RebootNodes_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClient_RebootNodes_Call) RunAndReturn(run func(context.Context, slurmapi.RebootNodesRequest) error) *MockClient_RebootNodes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SlurmV0044DeleteJobWithResponse provides a mock function with given fields: ctx, jobId, params, reqEditors
 func (_m *MockClient) SlurmV0044DeleteJobWithResponse(ctx context.Context, jobId string, params *v0044.SlurmV0044DeleteJobParams, reqEditors ...v0044.RequestEditorFn) (*v0044.SlurmV0044DeleteJobResponse, error) {
 	_va := make([]interface{}, len(reqEditors))

--- a/internal/slurmapi/interface.go
+++ b/internal/slurmapi/interface.go
@@ -10,6 +10,7 @@ type Client interface {
 	api.ClientWithResponsesInterface
 	ListNodes(ctx context.Context) ([]Node, error)
 	GetNode(ctx context.Context, nodeName string) (Node, error)
+	RebootNodes(ctx context.Context, request RebootNodesRequest) error
 	GetJobsByIDFromAccounting(ctx context.Context, jobID string) ([]Job, error)
 	ListJobs(ctx context.Context) ([]Job, error)
 	ListJobsWithParams(ctx context.Context, params ListJobsParams) ([]Job, error)

--- a/internal/slurmapi/reboot.go
+++ b/internal/slurmapi/reboot.go
@@ -1,0 +1,90 @@
+package slurmapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	api "github.com/SlinkyProject/slurm-client/api/v0044"
+)
+
+const slurmV0044RebootNodesPath = "/slurm/v0.0.44/nodes/reboot"
+
+// RebootNextState is the state Slurm assigns to a node after rebooting it.
+type RebootNextState string
+
+const (
+	// RebootNextStateDown leaves the node in DOWN state after the reboot.
+	RebootNextStateDown RebootNextState = "DOWN"
+	// RebootNextStateResume resumes the node after the reboot.
+	RebootNextStateResume RebootNextState = "RESUME"
+)
+
+// RebootNodesRequest contains the options supported by scontrol reboot.
+type RebootNodesRequest struct {
+	NodeList    string            `json:"nodes"`
+	ASAP        bool              `json:"asap,omitempty"`
+	Force       bool              `json:"force,omitempty"`
+	NextState   []RebootNextState `json:"next_state,omitempty"`
+	Reason      string            `json:"reason,omitempty"`
+	PowerAction string            `json:"power_action,omitempty"`
+}
+
+// RebootNodes schedules a reboot for a Slurm node list through slurmrestd.
+func (c *client) RebootNodes(ctx context.Context, request RebootNodesRequest) error {
+	if request.NodeList == "" {
+		return fmt.Errorf("reboot nodes: nodes field is required")
+	}
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("marshal reboot nodes request: %w", err)
+	}
+
+	httpRequest, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.server+slurmV0044RebootNodesPath,
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return fmt.Errorf("create reboot nodes request: %w", err)
+	}
+	if err := c.setHeaders(ctx, httpRequest); err != nil {
+		return fmt.Errorf("set reboot nodes request headers: %w", err)
+	}
+
+	response, err := c.httpClient.Do(httpRequest)
+	if err != nil {
+		return fmt.Errorf("post reboot nodes request: %w", err)
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("read reboot nodes response: %w", err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf(
+			"reboot nodes request failed: status=%d %s",
+			response.StatusCode,
+			summarizeSlurmRESTBody(responseBody),
+		)
+	}
+	if len(bytes.TrimSpace(responseBody)) == 0 {
+		return nil
+	}
+
+	var responseEnvelope api.V0044OpenapiResp
+	if err := json.Unmarshal(responseBody, &responseEnvelope); err != nil {
+		return fmt.Errorf("decode reboot nodes response: %w", err)
+	}
+	if responseEnvelope.Errors != nil && len(*responseEnvelope.Errors) > 0 {
+		return fmt.Errorf("reboot nodes responded with errors: %s", summarizeSlurmRESTBody(responseBody))
+	}
+
+	return nil
+}

--- a/internal/slurmapi/reboot_test.go
+++ b/internal/slurmapi/reboot_test.go
@@ -1,0 +1,102 @@
+package slurmapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type staticTokenIssuer string
+
+func (s staticTokenIssuer) Issue(context.Context) (string, error) {
+	return string(s), nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func rebootJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func TestRebootNodesPostsV0044PayloadAndHeaders(t *testing.T) {
+	var gotBody map[string]any
+	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, slurmV0044RebootNodesPath, request.URL.Path)
+		assert.Equal(t, headerApplicationJson, request.Header.Get(headerContentType))
+		assert.Equal(t, "token-value", request.Header.Get(headerSlurmUserToken))
+
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&gotBody))
+		return rebootJSONResponse(http.StatusOK, `{"errors":[]}`), nil
+	})}
+
+	client, err := NewClient("http://slurmrestd/", staticTokenIssuer("token-value"), httpClient)
+	require.NoError(t, err)
+
+	err = client.RebootNodes(context.Background(), RebootNodesRequest{
+		NodeList:    "worker-[1-2]",
+		ASAP:        true,
+		Force:       true,
+		NextState:   []RebootNextState{RebootNextStateResume},
+		Reason:      "rolling update",
+		PowerAction: "restart-slurmd",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "worker-[1-2]", gotBody["nodes"])
+	assert.Equal(t, true, gotBody["asap"])
+	assert.Equal(t, true, gotBody["force"])
+	assert.Equal(t, []any{"RESUME"}, gotBody["next_state"])
+	assert.Equal(t, "rolling update", gotBody["reason"])
+	assert.Equal(t, "restart-slurmd", gotBody["power_action"])
+}
+
+func TestRebootNodesRejectsEmptyNodeList(t *testing.T) {
+	client, err := NewClient("http://slurmrestd", nil, nil)
+	require.NoError(t, err)
+
+	err = client.RebootNodes(context.Background(), RebootNodesRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nodes field is required")
+}
+
+func TestRebootNodesStatusErrorSummarizesSlurmEnvelope(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return rebootJSONResponse(http.StatusUnprocessableEntity, `{"errors":[{"description":"Invalid next_state"}]}`), nil
+	})}
+
+	client, err := NewClient("http://slurmrestd", nil, httpClient)
+	require.NoError(t, err)
+
+	err = client.RebootNodes(context.Background(), RebootNodesRequest{NodeList: "worker-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status=422")
+	assert.Contains(t, err.Error(), "Invalid next_state")
+}
+
+func TestRebootNodesDetectsSlurmErrorsOnOK(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return rebootJSONResponse(http.StatusOK, `{"errors":[{"error":"ESLURM_INVALID_NODE_STATE"}]}`), nil
+	})}
+
+	client, err := NewClient("http://slurmrestd", nil, httpClient)
+	require.NoError(t, err)
+
+	err = client.RebootNodes(context.Background(), RebootNodesRequest{NodeList: "worker-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ESLURM_INVALID_NODE_STATE")
+}


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

`scontrol reboot` is missing in the rest API. The corresponding endpoint was added in patched Slurm.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

Add endpoint (not autogenerated, since it's a separate repo) for `scontrol reboot`.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
Dev cluster.

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->

Feature: add `scontrol reboot` endpoint in slurm rest client.
