### PR TITLE
SCHED-0000: Publish E2E module from Soperator

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -81,7 +81,7 @@ instance removal.
 
 ## Reusable Runner API
 
-Use `nebius.ai/soperator-e2e/acceptance` from another Go runner when you
+Use `github.com/nebius/soperator/e2e/acceptance` from another Go runner when you
 want to reuse the shared Soperator scenarios for a different Soperator cluster
 type.
 
@@ -196,7 +196,7 @@ that need fresh cluster state should query Kubernetes or Slurm through
 
 ## Framework Helpers
 
-External runners can use `nebius.ai/soperator-e2e/acceptance/framework` for
+External runners can use `github.com/nebius/soperator/e2e/acceptance/framework` for
 common Kubernetes, Slurm, and worker primitives:
 
 - `Exec`: command execution interface.

--- a/e2e/acceptance/features_test.go
+++ b/e2e/acceptance/features_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 func TestSharedFeaturesParseWithGherkin(t *testing.T) {

--- a/e2e/acceptance/framework/kubectl_client.go
+++ b/e2e/acceptance/framework/kubectl_client.go
@@ -9,7 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"nebius.ai/soperator-e2e/acceptance/internal/kubeobjects"
+	"github.com/nebius/soperator/e2e/acceptance/internal/kubeobjects"
 )
 
 const SoperatorNamespace = "soperator"

--- a/e2e/acceptance/framework/version.go
+++ b/e2e/acceptance/framework/version.go
@@ -5,7 +5,7 @@ import (
 
 	semver "github.com/Masterminds/semver/v3"
 
-	"nebius.ai/soperator-e2e/acceptance/internal/versionfilter"
+	"github.com/nebius/soperator/e2e/acceptance/internal/versionfilter"
 )
 
 var soperatorFive = semver.MustParse("5.0.0")

--- a/e2e/acceptance/internal/sharedsteps/active_checks.go
+++ b/e2e/acceptance/internal/sharedsteps/active_checks.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
-	"nebius.ai/soperator-e2e/acceptance/internal/kubeobjects"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/internal/kubeobjects"
 )
 
 const (

--- a/e2e/acceptance/internal/sharedsteps/check_helpers.go
+++ b/e2e/acceptance/internal/sharedsteps/check_helpers.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const (

--- a/e2e/acceptance/internal/sharedsteps/check_helpers_test.go
+++ b/e2e/acceptance/internal/sharedsteps/check_helpers_test.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 func TestLoggedCheckOutputPathsNormalizesJailPrefix(t *testing.T) {

--- a/e2e/acceptance/internal/sharedsteps/cluster_creation.go
+++ b/e2e/acceptance/internal/sharedsteps/cluster_creation.go
@@ -12,8 +12,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
-	"nebius.ai/soperator-e2e/acceptance/internal/kubeobjects"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/internal/kubeobjects"
 )
 
 const (

--- a/e2e/acceptance/internal/sharedsteps/container_smoke.go
+++ b/e2e/acceptance/internal/sharedsteps/container_smoke.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const (

--- a/e2e/acceptance/internal/sharedsteps/docker_containers.go
+++ b/e2e/acceptance/internal/sharedsteps/docker_containers.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const (

--- a/e2e/acceptance/internal/sharedsteps/enroot_containers.go
+++ b/e2e/acceptance/internal/sharedsteps/enroot_containers.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const (

--- a/e2e/acceptance/internal/sharedsteps/internal_ssh.go
+++ b/e2e/acceptance/internal/sharedsteps/internal_ssh.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const sshUserName = "bob"

--- a/e2e/acceptance/internal/sharedsteps/node_replacement.go
+++ b/e2e/acceptance/internal/sharedsteps/node_replacement.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const (

--- a/e2e/acceptance/internal/sharedsteps/observability.go
+++ b/e2e/acceptance/internal/sharedsteps/observability.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const observabilityNamespace = "monitoring-system"

--- a/e2e/acceptance/internal/sharedsteps/package_installation.go
+++ b/e2e/acceptance/internal/sharedsteps/package_installation.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 type PackageInstallation struct {

--- a/e2e/acceptance/internal/sharedsteps/passive_checks.go
+++ b/e2e/acceptance/internal/sharedsteps/passive_checks.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const (

--- a/e2e/acceptance/internal/sharedsteps/steps.go
+++ b/e2e/acceptance/internal/sharedsteps/steps.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 type scenarioScopedStepFamily interface {

--- a/e2e/acceptance/internal/sharedsteps/system_checks.go
+++ b/e2e/acceptance/internal/sharedsteps/system_checks.go
@@ -11,8 +11,8 @@ import (
 	"github.com/cucumber/godog"
 	corev1 "k8s.io/api/core/v1"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
-	"nebius.ai/soperator-e2e/acceptance/internal/kubeobjects"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/internal/kubeobjects"
 )
 
 const (

--- a/e2e/acceptance/internal/sharedsteps/topology.go
+++ b/e2e/acceptance/internal/sharedsteps/topology.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const topologyJobTimeout = 10 * time.Minute

--- a/e2e/acceptance/public_api_test.go
+++ b/e2e/acceptance/public_api_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"nebius.ai/soperator-e2e/acceptance"
+	"github.com/nebius/soperator/e2e/acceptance"
 )
 
 func TestPublicRunnerAPIIsImportable(t *testing.T) {

--- a/e2e/acceptance/runner.go
+++ b/e2e/acceptance/runner.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
-	"nebius.ai/soperator-e2e/acceptance/internal/reports"
-	"nebius.ai/soperator-e2e/acceptance/internal/versionfilter"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/internal/reports"
+	"github.com/nebius/soperator/e2e/acceptance/internal/versionfilter"
 )
 
 type timingCtxKey string

--- a/e2e/acceptance/runner_test.go
+++ b/e2e/acceptance/runner_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const testTargetSoperatorVersion = "5.0.0"

--- a/e2e/acceptance/steps.go
+++ b/e2e/acceptance/steps.go
@@ -3,8 +3,8 @@ package acceptance
 import (
 	"github.com/cucumber/godog"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
-	"nebius.ai/soperator-e2e/acceptance/internal/sharedsteps"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/internal/sharedsteps"
 )
 
 // StepRegistrar registers step definitions and scenario hooks for a suite.

--- a/e2e/acceptance/suite.go
+++ b/e2e/acceptance/suite.go
@@ -1,6 +1,6 @@
 package acceptance
 
-import "nebius.ai/soperator-e2e/acceptance/internal/versionfilter"
+import "github.com/nebius/soperator/e2e/acceptance/internal/versionfilter"
 
 const SoperatorVersionTagPrefix = "@soperator_version_"
 

--- a/e2e/acceptance/world.go
+++ b/e2e/acceptance/world.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const (

--- a/e2e/cmd/acceptance/cli/options.go
+++ b/e2e/cmd/acceptance/cli/options.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"nebius.ai/soperator-e2e/acceptance"
+	"github.com/nebius/soperator/e2e/acceptance"
 )
 
 const defaultSlurmClusterName = "soperator"

--- a/e2e/cmd/acceptance/cli/version_discovery.go
+++ b/e2e/cmd/acceptance/cli/version_discovery.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"nebius.ai/soperator-e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 const (

--- a/e2e/cmd/acceptance/main.go
+++ b/e2e/cmd/acceptance/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"nebius.ai/soperator-e2e/cmd/acceptance/cli"
+	"github.com/nebius/soperator/e2e/cmd/acceptance/cli"
 )
 
 func main() {

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,4 +1,4 @@
-module nebius.ai/soperator-e2e
+module github.com/nebius/soperator/e2e
 
 go 1.26.4
 


### PR DESCRIPTION
## Problem

The E2E module inside the Soperator repository still uses the standalone nebius.ai/soperator-e2e module path. External consumers therefore cannot import the framework directly from the public Soperator repository without a replace directive.

## Solution

Rename the nested module and its internal imports to github.com/nebius/soperator/e2e. This allows external runners to depend directly on the framework version published from the Soperator repository.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
