### PR TITLE
SCHED-2127: Derive MariaDB buffer pool size from memory allocation

### DIFF
--- a/internal/consts/mariadb.go
+++ b/internal/consts/mariadb.go
@@ -9,11 +9,12 @@ const (
 	MariaDbSecretName     = "mariadb-password"
 	MariaDbSecretRootName = "mariadb-root"
 	MariaDbPort           = 3306
-	MariaDbDefaultMyCnf   = `[mariadb]
+	// MariaDbMyCnfTemplate is a fmt template; the verb is the innodb_buffer_pool_size value in MiB.
+	MariaDbMyCnfTemplate = `[mariadb]
 bind-address=*
 default_storage_engine=InnoDB
 innodb_default_row_format=DYNAMIC
-innodb_buffer_pool_size=32768M
+innodb_buffer_pool_size=%dM
 innodb_log_file_size=64M
 innodb_lock_wait_timeout=900
 max_allowed_packet=16M`

--- a/internal/controller/reconciler/mariadb.go
+++ b/internal/controller/reconciler/mariadb.go
@@ -104,6 +104,7 @@ func (r *MariaDbReconciler) patch(existing, desired client.Object) (client.Patch
 		dst.Spec.PodSecurityContext = src.Spec.PodSecurityContext
 		dst.Spec.Storage.VolumeClaimTemplate = src.Spec.Storage.VolumeClaimTemplate
 		dst.Spec.Storage.Size = src.Spec.Storage.Size
+		dst.Spec.MyCnf = src.Spec.MyCnf
 
 		return res
 	}

--- a/internal/controller/reconciler/mariadb_test.go
+++ b/internal/controller/reconciler/mariadb_test.go
@@ -1,0 +1,40 @@
+package reconciler
+
+import (
+	"testing"
+
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v25/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestMariaDbReconciler_patch(t *testing.T) {
+	existing := &mariadbv1alpha1.MariaDB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-acct-db",
+			Namespace: "test-namespace",
+		},
+		Spec: mariadbv1alpha1.MariaDBSpec{
+			Image: "mariadb:old",
+			MyCnf: ptr.To("[mariadb]\ninnodb_buffer_pool_size=32768M"),
+		},
+	}
+	desired := &mariadbv1alpha1.MariaDB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-acct-db",
+			Namespace: "test-namespace",
+		},
+		Spec: mariadbv1alpha1.MariaDBSpec{
+			Image: "mariadb:new",
+			MyCnf: ptr.To("[mariadb]\ninnodb_buffer_pool_size=2048M"),
+		},
+	}
+
+	patch, err := (&MariaDbReconciler{}).patch(existing, desired)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, patch)
+	assert.Equal(t, desired.Spec.Image, existing.Spec.Image)
+	assert.Equal(t, desired.Spec.MyCnf, existing.Spec.MyCnf)
+}

--- a/internal/render/accounting/mariadb.go
+++ b/internal/render/accounting/mariadb.go
@@ -2,10 +2,12 @@ package accounting
 
 import (
 	"errors"
+	"fmt"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v25/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -17,6 +19,24 @@ import (
 	"nebius.ai/slurm-operator/internal/utils"
 	"nebius.ai/slurm-operator/internal/values"
 )
+
+const (
+	mariaDbBufferPoolPercent        int64 = 50
+	mariaDbFallbackBufferPoolSizeMi int64 = 32768
+)
+
+// deriveMariaDbBufferPoolSizeMi sizes the InnoDB buffer pool as a share of the container
+// memory allocation, falling back to the legacy fixed size when no allocation is known.
+func deriveMariaDbBufferPoolSizeMi(memory *resource.Quantity) int64 {
+	if memory == nil || memory.Sign() <= 0 {
+		return mariaDbFallbackBufferPoolSizeMi
+	}
+	derived := memory.Value() * mariaDbBufferPoolPercent / 100 / (1 << 20)
+	if derived <= 0 {
+		return mariaDbFallbackBufferPoolSizeMi
+	}
+	return derived
+}
 
 func RenderMariaDb(
 	namespace,
@@ -112,7 +132,7 @@ func RenderMariaDb(
 			Metrics: &mariadbv1alpha1.MariadbMetrics{
 				Enabled: mariaDb.Metrics.Enabled,
 			},
-			MyCnf: ptr.To(consts.MariaDbDefaultMyCnf),
+			MyCnf: ptr.To(fmt.Sprintf(consts.MariaDbMyCnfTemplate, deriveMariaDbBufferPoolSizeMi(mariaDb.Resources.Memory()))),
 		},
 	}, nil
 }

--- a/internal/render/accounting/mariadb_test.go
+++ b/internal/render/accounting/mariadb_test.go
@@ -1,15 +1,58 @@
 package accounting
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/values"
 )
+
+func Test_DeriveMariaDbBufferPoolSizeMi(t *testing.T) {
+	tests := []struct {
+		name     string
+		memory   *resource.Quantity
+		expected int64
+	}{
+		{
+			name:     "nil memory falls back to legacy size",
+			memory:   nil,
+			expected: 32768,
+		},
+		{
+			name:     "zero memory falls back to legacy size",
+			memory:   &resource.Quantity{},
+			expected: 32768,
+		},
+		{
+			name:     "4Gi derives half",
+			memory:   ptr.To(resource.MustParse("4Gi")),
+			expected: 2048,
+		},
+		{
+			name:     "1G floors to whole MiB",
+			memory:   ptr.To(resource.MustParse("1G")),
+			expected: 476,
+		},
+		{
+			name:     "tiny memory falls back to legacy size",
+			memory:   ptr.To(resource.MustParse("1Mi")),
+			expected: 32768,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, deriveMariaDbBufferPoolSizeMi(tt.memory))
+		})
+	}
+}
 
 func Test_GetMariaDbConfig(t *testing.T) {
 	mariaDb := slurmv1.MariaDbOperator{
@@ -84,6 +127,10 @@ func Test_RenderMariaDb(t *testing.T) {
 			NodeContainer: slurmv1.NodeContainer{
 				Image: imageMariaDb,
 				Port:  portMariadb,
+				Resources: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+					corev1.ResourceCPU:    resource.MustParse("1"),
+				},
 			},
 		},
 		SlurmNode: slurmv1.SlurmNode{
@@ -115,4 +162,35 @@ func Test_RenderMariaDb(t *testing.T) {
 	assert.Equal(t, true, mariaDb.Spec.PasswordSecretKeyRef.Generate)
 	assert.Equal(t, consts.MariaDbSecretRootName, mariaDb.Spec.RootPasswordSecretKeyRef.SecretKeySelector.Name)
 	assert.Equal(t, consts.MariaDbPasswordKey, mariaDb.Spec.RootPasswordSecretKeyRef.SecretKeySelector.Key)
+	assert.Equal(t, fmt.Sprintf(consts.MariaDbMyCnfTemplate, int64(2048)), *mariaDb.Spec.MyCnf)
+}
+
+func Test_RenderMariaDb_NoResources(t *testing.T) {
+	nodeFilterName := "cpu"
+	accounting := &values.SlurmAccounting{
+		MariaDb: slurmv1.MariaDbOperator{
+			Enabled: true,
+		},
+		SlurmNode: slurmv1.SlurmNode{
+			K8sNodeFilterName: nodeFilterName,
+		},
+	}
+	nodeFilters := []slurmv1.K8sNodeFilter{
+		{
+			Name: nodeFilterName,
+		},
+	}
+
+	mariaDb, err := RenderMariaDb("test-namespace", "test-cluster", accounting, nodeFilters)
+
+	assert.NoError(t, err)
+	legacyMyCnf := `[mariadb]
+bind-address=*
+default_storage_engine=InnoDB
+innodb_default_row_format=DYNAMIC
+innodb_buffer_pool_size=32768M
+innodb_log_file_size=64M
+innodb_lock_wait_timeout=900
+max_allowed_packet=16M`
+	assert.Equal(t, legacyMyCnf, *mariaDb.Spec.MyCnf)
 }


### PR DESCRIPTION
### Problem

The operator hardcodes `innodb_buffer_pool_size=32768M` in the MariaDB `myCnf` for every cluster, with no override. The 32Gi pool exceeds the acct-db pod memory limit (12Gi in prod today), so once accounting data outgrows the limit, InnoDB caches past the cgroup limit and the DB gets OOM-killed. Memory set in Terraform has no effect on the actual pool size.

### Solution

- Render `innodb_buffer_pool_size` as 50% of the acct-db container memory allocation (floored to whole MiB), falling back to the legacy 32768M when no memory allocation is known.
- Propagate `MyCnf` in the reconciler patch so existing clusters pick up the derived value.

### Testing

Unit tests for the size derivation, rendering with and without resources, and `MyCnf` propagation in the reconciler patch.

### Release Notes

Fix: MariaDB `innodb_buffer_pool_size` is now derived from the accounting DB memory allocation (50% of it) instead of the hardcoded 32Gi.
