### PR TITLE
SCHED-2332: add worker operation handoff

### DIFF
--- a/images/common/scripts/worker_handoff.py
+++ b/images/common/scripts/worker_handoff.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import socket
+import ssl
+import sys
+import time
+from http.client import HTTPException
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+SERVICE_ACCOUNT_DIR = Path("/var/run/secrets/kubernetes.io/serviceaccount")
+WORKER_OPERATION_ID_LABEL = "slurm.nebius.ai/worker-operation-id"
+WORKER_OPERATION_PHASE_LABEL = "slurm.nebius.ai/worker-operation-phase"
+WORKER_OPERATION_PHASE_STOPPING = "stopping"
+WORKER_OPERATION_PHASE_READY = "ready"
+WORKER_OPERATION_ID_JSON_POINTER = "slurm.nebius.ai~1worker-operation-id"
+WORKER_OPERATION_PHASE_JSON_POINTER = "slurm.nebius.ai~1worker-operation-phase"
+MAX_ATTEMPTS = 5
+REQUEST_TIMEOUT_SECONDS = 10
+
+
+class KubernetesAPI:
+    def __init__(self, pod_name, namespace, token, ca_cert):
+        self.pod_url = (
+            "https://kubernetes.default.svc/api/v1/namespaces/"
+            f"{quote(namespace, safe='')}/pods/{quote(pod_name, safe='')}"
+        )
+        self.token = token
+        self.ssl_context = ssl.create_default_context(cafile=str(ca_cert))
+
+    def get_worker_operation(self):
+        response = self._request("GET")
+        try:
+            pod = json.loads(response)
+            metadata = pod["metadata"]
+            labels = metadata.get("labels") or {}
+            operation_id = labels.get(WORKER_OPERATION_ID_LABEL, "")
+            phase = labels.get(WORKER_OPERATION_PHASE_LABEL, "")
+        except (AttributeError, KeyError, TypeError) as error:
+            raise ValueError("invalid Pod response from Kubernetes API") from error
+
+        if not isinstance(operation_id, str) or not isinstance(phase, str):
+            raise ValueError("invalid worker operation labels in Kubernetes API response")
+        return operation_id, phase
+
+    def mark_ready(self, operation_id):
+        operation_id_path = (
+            f"/metadata/labels/{WORKER_OPERATION_ID_JSON_POINTER}"
+        )
+        phase_path = f"/metadata/labels/{WORKER_OPERATION_PHASE_JSON_POINTER}"
+        patch = [
+            {
+                "op": "test",
+                "path": operation_id_path,
+                "value": operation_id,
+            },
+            {
+                "op": "test",
+                "path": phase_path,
+                "value": WORKER_OPERATION_PHASE_STOPPING,
+            },
+            {
+                "op": "replace",
+                "path": phase_path,
+                "value": WORKER_OPERATION_PHASE_READY,
+            },
+        ]
+        self._request(
+            "PATCH",
+            payload=patch,
+            content_type="application/json-patch+json",
+        )
+
+    def _request(self, method, payload=None, content_type=None):
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.token}",
+        }
+        data = None
+        if payload is not None:
+            data = json.dumps(payload, separators=(",", ":")).encode()
+        if content_type is not None:
+            headers["Content-Type"] = content_type
+
+        request = Request(self.pod_url, data=data, headers=headers, method=method)
+        with urlopen(
+            request,
+            context=self.ssl_context,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        ) as response:
+            return response.read()
+
+
+def handoff_worker_operation(api, namespace, pod_name, sleep=time.sleep):
+    operation_id = None
+
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            current_operation_id, phase = api.get_worker_operation()
+            if not current_operation_id:
+                print(
+                    f"Pod {namespace}/{pod_name} has no active worker operation",
+                    file=sys.stderr,
+                )
+                return False
+
+            if operation_id is None:
+                operation_id = current_operation_id
+            elif current_operation_id != operation_id:
+                print(
+                    f"Worker operation on Pod {namespace}/{pod_name} changed from "
+                    f"{operation_id} to {current_operation_id}",
+                    file=sys.stderr,
+                )
+                return False
+
+            if phase == WORKER_OPERATION_PHASE_READY:
+                return True
+            if phase != WORKER_OPERATION_PHASE_STOPPING:
+                print(
+                    f"Worker operation {operation_id} on Pod {namespace}/{pod_name} "
+                    f"is in unexpected phase {phase!r}",
+                    file=sys.stderr,
+                )
+                return False
+
+            api.mark_ready(operation_id)
+            return True
+        except (
+            HTTPError,
+            URLError,
+            HTTPException,
+            TimeoutError,
+            OSError,
+            ValueError,
+        ) as error:
+            if attempt == MAX_ATTEMPTS:
+                print(
+                    f"Failed to hand off worker operation on {namespace}/{pod_name} "
+                    f"after {MAX_ATTEMPTS} attempts: {error}",
+                    file=sys.stderr,
+                )
+                return False
+
+            print(
+                f"Attempt {attempt}/{MAX_ATTEMPTS} to hand off worker operation on "
+                f"{namespace}/{pod_name} failed: {error}; retrying",
+                file=sys.stderr,
+            )
+            sleep(attempt)
+
+    return False
+
+
+def read_service_account_file(name):
+    value = (SERVICE_ACCOUNT_DIR / name).read_text().strip()
+    if not value:
+        raise ValueError(f"service account {name} is empty")
+    return value
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Hand off this Slurm worker pod to a Soperator worker operation."
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    parse_args(argv)
+    pod_name = socket.gethostname()
+
+    try:
+        namespace = read_service_account_file("namespace")
+        token = read_service_account_file("token")
+        api = KubernetesAPI(
+            pod_name,
+            namespace,
+            token,
+            SERVICE_ACCOUNT_DIR / "ca.crt",
+        )
+    except (OSError, ValueError) as error:
+        print(f"Failed to initialize Kubernetes API client: {error}", file=sys.stderr)
+        return 1
+
+    return 0 if handoff_worker_operation(api, namespace, pod_name) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/images/common/scripts/worker_handoff_test.py
+++ b/images/common/scripts/worker_handoff_test.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+import io
+import json
+import unittest
+from unittest import mock
+from urllib.error import HTTPError, URLError
+
+import worker_handoff
+
+
+class HandoffWorkerOperationTest(unittest.TestCase):
+    def setUp(self):
+        self.api = mock.Mock(spec=worker_handoff.KubernetesAPI)
+        self.sleep = mock.Mock()
+
+    def handoff(self):
+        return worker_handoff.handoff_worker_operation(
+            self.api,
+            "default",
+            "worker-0",
+            sleep=self.sleep,
+        )
+
+    def test_marks_stopping_operation_as_ready(self):
+        self.api.get_worker_operation.return_value = ("revision-1", "stopping")
+
+        self.assertTrue(self.handoff())
+
+        self.api.mark_ready.assert_called_once_with("revision-1")
+        self.sleep.assert_not_called()
+
+    def test_already_ready_is_successful(self):
+        self.api.get_worker_operation.return_value = ("revision-1", "ready")
+
+        self.assertTrue(self.handoff())
+
+        self.api.mark_ready.assert_not_called()
+        self.sleep.assert_not_called()
+
+    def test_missing_operation_id_fails_without_retry(self):
+        self.api.get_worker_operation.return_value = ("", "stopping")
+
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            self.assertFalse(self.handoff())
+
+        self.assertIn("has no active worker operation", stderr.getvalue())
+        self.api.mark_ready.assert_not_called()
+        self.sleep.assert_not_called()
+
+    def test_unexpected_phase_fails_without_retry(self):
+        self.api.get_worker_operation.return_value = ("revision-1", "")
+
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            self.assertFalse(self.handoff())
+
+        self.assertIn("unexpected phase", stderr.getvalue())
+        self.api.mark_ready.assert_not_called()
+        self.sleep.assert_not_called()
+
+    def test_patch_conflict_retries_and_accepts_ready_state(self):
+        self.api.get_worker_operation.side_effect = [
+            ("revision-1", "stopping"),
+            ("revision-1", "ready"),
+        ]
+        self.api.mark_ready.side_effect = HTTPError(
+            "https://kubernetes.default.svc",
+            422,
+            "JSON patch test failed",
+            None,
+            None,
+        )
+
+        with mock.patch("sys.stderr", new_callable=io.StringIO):
+            self.assertTrue(self.handoff())
+
+        self.assertEqual(2, self.api.get_worker_operation.call_count)
+        self.api.mark_ready.assert_called_once_with("revision-1")
+        self.sleep.assert_called_once_with(1)
+
+    def test_changed_operation_id_is_not_acknowledged(self):
+        self.api.get_worker_operation.side_effect = [
+            ("revision-1", "stopping"),
+            ("revision-2", "stopping"),
+        ]
+        self.api.mark_ready.side_effect = HTTPError(
+            "https://kubernetes.default.svc",
+            422,
+            "JSON patch test failed",
+            None,
+            None,
+        )
+
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            self.assertFalse(self.handoff())
+
+        self.assertIn("changed from revision-1 to revision-2", stderr.getvalue())
+        self.api.mark_ready.assert_called_once_with("revision-1")
+        self.sleep.assert_called_once_with(1)
+
+    def test_transient_errors_stop_after_max_attempts(self):
+        self.api.get_worker_operation.side_effect = URLError("unavailable")
+
+        with mock.patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            self.assertFalse(self.handoff())
+
+        self.assertEqual(
+            worker_handoff.MAX_ATTEMPTS,
+            self.api.get_worker_operation.call_count,
+        )
+        self.assertEqual(
+            [mock.call(1), mock.call(2), mock.call(3), mock.call(4)],
+            self.sleep.call_args_list,
+        )
+        self.assertIn("after 5 attempts", stderr.getvalue())
+
+
+class KubernetesAPITest(unittest.TestCase):
+    def setUp(self):
+        ssl_context = mock.Mock()
+        with mock.patch.object(
+            worker_handoff.ssl,
+            "create_default_context",
+            return_value=ssl_context,
+        ):
+            self.api = worker_handoff.KubernetesAPI(
+                "worker-0",
+                "default",
+                "token",
+                "/service-account/ca.crt",
+            )
+
+    def test_reads_worker_operation(self):
+        pod = {
+            "metadata": {
+                "labels": {
+                    worker_handoff.WORKER_OPERATION_ID_LABEL: "revision-1",
+                    worker_handoff.WORKER_OPERATION_PHASE_LABEL: "stopping",
+                }
+            }
+        }
+        with mock.patch.object(
+            self.api, "_request", return_value=json.dumps(pod).encode()
+        ):
+            self.assertEqual(
+                ("revision-1", "stopping"),
+                self.api.get_worker_operation(),
+            )
+
+    def test_mark_ready_uses_json_patch_with_operation_preconditions(self):
+        with mock.patch.object(self.api, "_request") as request:
+            self.api.mark_ready("revision-1")
+
+        operation_id_path = (
+            "/metadata/labels/slurm.nebius.ai~1worker-operation-id"
+        )
+        phase_path = "/metadata/labels/slurm.nebius.ai~1worker-operation-phase"
+        request.assert_called_once_with(
+            "PATCH",
+            payload=[
+                {
+                    "op": "test",
+                    "path": operation_id_path,
+                    "value": "revision-1",
+                },
+                {"op": "test", "path": phase_path, "value": "stopping"},
+                {"op": "replace", "path": phase_path, "value": "ready"},
+            ],
+            content_type="application/json-patch+json",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/images/worker/slurmd.dockerfile
+++ b/images/worker/slurmd.dockerfile
@@ -124,12 +124,14 @@ COPY images/common/scripts/complement_jail.sh /opt/bin/slurm/
 # Copy script for bind-mounting slurm into the jail
 COPY images/common/scripts/bind_slurm_common.sh /opt/bin/slurm/
 
-# Copy script for rebooting K8s nodes
+# Copy scripts for rebooting K8s nodes and handing off worker operations
 COPY images/common/scripts/reboot.sh /opt/bin/slurm/
+COPY images/common/scripts/worker_handoff.py /opt/bin/slurm/
 
 RUN chmod +x /opt/bin/slurm/complement_jail.sh && \
     chmod +x /opt/bin/slurm/bind_slurm_common.sh && \
-    chmod +x /opt/bin/slurm/reboot.sh
+    chmod +x /opt/bin/slurm/reboot.sh && \
+    chmod +x /opt/bin/slurm/worker_handoff.py
 
 # Create single folder with slurm plugins for all architectures
 RUN mkdir -p /usr/lib/slurm && \

--- a/internal/consts/slurm.go
+++ b/internal/consts/slurm.go
@@ -14,6 +14,8 @@ const (
 
 	// SlurmDefaultResumeTimeout mirrors the CRD default of SlurmConfig.ResumeTimeout, in seconds.
 	SlurmDefaultResumeTimeout = 1800
+
+	SlurmPowerActionWorkerHandoff = "soperator-worker-handoff"
 )
 
 var (

--- a/internal/controller/clustercontroller/common.go
+++ b/internal/controller/clustercontroller/common.go
@@ -181,25 +181,6 @@ func (r SlurmClusterReconciler) ReconcileCommon(
 				},
 			},
 			utils.MultiStepExecutionStep{
-				Name: "Slurm Worker ServiceAccount",
-				Func: func(stepCtx context.Context) error {
-					stepLogger := log.FromContext(stepCtx)
-					stepLogger.V(1).Info("Reconciling")
-
-					desired := worker.RenderServiceAccount(clusterValues.Namespace, clusterValues.Name)
-					stepLogger = stepLogger.WithValues(logfield.ResourceKV(&desired)...)
-					stepLogger.V(1).Info("Rendered")
-
-					if err := r.ServiceAccount.Reconcile(stepCtx, cluster, desired); err != nil {
-						stepLogger.Error(err, "Failed to reconcile")
-						return fmt.Errorf("reconciling worker ServiceAccount: %w", err)
-					}
-					stepLogger.V(1).Info("Reconciled")
-
-					return nil
-				},
-			},
-			utils.MultiStepExecutionStep{
 				Name: "Slurm Worker sysctl ConfigMap",
 				Func: func(stepCtx context.Context) error {
 					stepLogger := log.FromContext(stepCtx)

--- a/internal/controller/nodesetcontroller/controller.go
+++ b/internal/controller/nodesetcontroller/controller.go
@@ -24,6 +24,7 @@ import (
 
 	kruisev1b1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -67,9 +68,12 @@ type NodeSetReconciler struct {
 
 	AdvancedStatefulSet *reconciler.AdvancedStatefulSetReconciler
 	Service             *reconciler.ServiceReconciler
+	ServiceAccount      *reconciler.ServiceAccountReconciler
 	Secret              *reconciler.SecretReconciler
 	ConfigMap           *reconciler.ConfigMapReconciler
 	NodeSetPowerState   *reconciler.NodeSetPowerStateReconciler
+	Role                *reconciler.RoleReconciler
+	RoleBinding         *reconciler.RoleBindingReconciler
 }
 
 func NewNodeSetReconciler(client client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) *NodeSetReconciler {
@@ -78,9 +82,12 @@ func NewNodeSetReconciler(client client.Client, scheme *runtime.Scheme, recorder
 		Reconciler:          r,
 		AdvancedStatefulSet: reconciler.NewAdvancedStatefulSetReconciler(r),
 		Service:             reconciler.NewServiceReconciler(r),
+		ServiceAccount:      reconciler.NewServiceAccountReconciler(r),
 		Secret:              reconciler.NewSecretReconciler(r),
 		ConfigMap:           reconciler.NewConfigMapReconciler(r),
 		NodeSetPowerState:   reconciler.NewNodeSetPowerStateReconciler(r),
+		Role:                reconciler.NewRoleReconciler(r),
+		RoleBinding:         reconciler.NewRoleBindingReconciler(r),
 	}
 }
 
@@ -137,6 +144,8 @@ func (r *NodeSetReconciler) createResourceChecks(saPredicate predicate.Funcs) []
 			Objects: []client.Object{
 				&corev1.ConfigMap{},
 				&corev1.Service{},
+				&rbacv1.Role{},
+				&rbacv1.RoleBinding{},
 				&kruisev1b1.StatefulSet{},
 			},
 			Predicate: predicate.GenerationChangedPredicate{},

--- a/internal/controller/nodesetcontroller/reconcile.go
+++ b/internal/controller/nodesetcontroller/reconcile.go
@@ -323,6 +323,63 @@ func (r NodeSetReconciler) executeReconciliation(
 			},
 		},
 		{
+			Name: "Slurm NodeSet ServiceAccount",
+			Func: func(stepCtx context.Context) error {
+				stepLogger := log.FromContext(stepCtx)
+				stepLogger.V(1).Info("Reconciling")
+
+				desired := worker.RenderServiceAccount(nodeSet.Namespace, cluster.Name, nodeSet.Name)
+				stepLogger = stepLogger.WithValues(logfield.ResourceKV(&desired)...)
+				stepLogger.V(1).Info("Rendered")
+
+				if err := r.ServiceAccount.Reconcile(stepCtx, nodeSet, desired); err != nil {
+					stepLogger.Error(err, "Failed to reconcile")
+					return fmt.Errorf("reconciling NodeSet ServiceAccount: %w", err)
+				}
+				stepLogger.V(1).Info("Reconciled")
+
+				return nil
+			},
+		},
+		{
+			Name: "Slurm NodeSet Role",
+			Func: func(stepCtx context.Context) error {
+				stepLogger := log.FromContext(stepCtx)
+				stepLogger.V(1).Info("Reconciling")
+
+				desired := worker.RenderRole(nodeSet.Namespace, cluster.Name, nodeSetValues)
+				stepLogger = stepLogger.WithValues(logfield.ResourceKV(&desired)...)
+				stepLogger.V(1).Info("Rendered")
+
+				if err := r.Role.Reconcile(stepCtx, nodeSet, desired); err != nil {
+					stepLogger.Error(err, "Failed to reconcile")
+					return fmt.Errorf("reconciling NodeSet Role: %w", err)
+				}
+				stepLogger.V(1).Info("Reconciled")
+
+				return nil
+			},
+		},
+		{
+			Name: "Slurm NodeSet RoleBinding",
+			Func: func(stepCtx context.Context) error {
+				stepLogger := log.FromContext(stepCtx)
+				stepLogger.V(1).Info("Reconciling")
+
+				desired := worker.RenderRoleBinding(nodeSet.Namespace, cluster.Name, nodeSet.Name)
+				stepLogger = stepLogger.WithValues(logfield.ResourceKV(&desired)...)
+				stepLogger.V(1).Info("Rendered")
+
+				if err := r.RoleBinding.Reconcile(stepCtx, nodeSet, desired); err != nil {
+					stepLogger.Error(err, "Failed to reconcile")
+					return fmt.Errorf("reconciling NodeSet RoleBinding: %w", err)
+				}
+				stepLogger.V(1).Info("Reconciled")
+
+				return nil
+			},
+		},
+		{
 			Name: "Worker sssd.conf Secret",
 			Func: func(stepCtx context.Context) error {
 				stepLogger := log.FromContext(stepCtx)

--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -246,12 +246,16 @@ func BuildVolumeMountSpoolPath(directory string) string {
 	return path.Join(consts.VolumeMountPathSpool, directory)
 }
 
-func BuildServiceAccountWorkerName(clusterName string) string {
-	return clusterName + "-worker-sa"
+func BuildServiceAccountNodeSetName(clusterName, nodeSetName string) string {
+	return fmt.Sprintf("%s-%s-nodeset-sa", clusterName, nodeSetName)
 }
 
-func BuildRoleWorkerName(clusterName string) string {
-	return clusterName + "-worker-events-role"
+func BuildRoleNodeSetName(clusterName, nodeSetName string) string {
+	return fmt.Sprintf("%s-%s-nodeset-role", clusterName, nodeSetName)
+}
+
+func BuildRoleBindingNodeSetName(clusterName, nodeSetName string) string {
+	return fmt.Sprintf("%s-%s-nodeset-role-binding", clusterName, nodeSetName)
 }
 
 func BuildServiceAccountActiveCheckName(clusterName string) string {

--- a/internal/render/common/configmap.go
+++ b/internal/render/common/configmap.go
@@ -385,6 +385,13 @@ func generateSlurmConfig(cluster *values.SlurmCluster) renderutils.ConfigFile {
 	res.AddComment("")
 
 	res.AddProperty("RebootProgram", "/opt/bin/slurm/reboot.sh")
+	res.AddProperty(
+		"PowerAction",
+		fmt.Sprintf(
+			"%s Location=slurmd Program=/opt/bin/slurm/worker_handoff.py",
+			consts.SlurmPowerActionWorkerHandoff,
+		),
+	)
 	res.AddComment("")
 
 	// Power management for ephemeral nodes.

--- a/internal/render/common/configmap_test.go
+++ b/internal/render/common/configmap_test.go
@@ -378,6 +378,15 @@ func TestRenderSlurmConfigMapResumeFailProgram(t *testing.T) {
 	assert.Contains(t, slurmConfig, "SuspendProgram=/opt/soperator/bin/power_suspend.sh")
 }
 
+func TestRenderSlurmConfigMapRebootPrograms(t *testing.T) {
+	result := RenderConfigMapSlurmConfigs(&values.SlurmCluster{})
+
+	slurmConfig := result.Data[consts.ConfigMapKeySlurmBaseConfig]
+	assert.Contains(t, slurmConfig, "RebootProgram=/opt/bin/slurm/reboot.sh")
+	assert.Contains(t, slurmConfig,
+		"PowerAction=soperator-worker-handoff Location=slurmd Program=/opt/bin/slurm/worker_handoff.py")
+}
+
 func TestRenderConfigMapSlurmConfigs_FileNamesAndWarnings(t *testing.T) {
 	result := RenderConfigMapSlurmConfigs(&values.SlurmCluster{})
 

--- a/internal/render/worker/role.go
+++ b/internal/render/worker/role.go
@@ -1,28 +1,51 @@
 package worker
 
 import (
+	"fmt"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/naming"
 	"nebius.ai/slurm-operator/internal/render/common"
+	"nebius.ai/slurm-operator/internal/values"
 )
 
-func RenderRole(namespace, clusterName string) rbacv1.Role {
-	labels := common.RenderLabels(consts.ComponentTypeWorker, clusterName)
+func RenderRole(namespace, clusterName string, nodeSet *values.SlurmNodeSet) rbacv1.Role {
+	labels := common.RenderLabels(consts.ComponentTypeNodeSet, clusterName)
+
+	ordinals := nodeSetOrdinals(nodeSet)
+	resourceNames := make([]string, 0, len(ordinals))
+	for _, ordinal := range ordinals {
+		resourceNames = append(resourceNames, fmt.Sprintf("%s-%d", nodeSet.StatefulSet.Name, ordinal))
+	}
 
 	return rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      naming.BuildRoleWorkerName(clusterName),
+			Name:      naming.BuildRoleNodeSetName(clusterName, nodeSet.Name),
 			Namespace: namespace,
 			Labels:    labels,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				APIGroups: []string{""},
-				Resources: []string{"events"},
-				Verbs:     []string{"create"},
+				APIGroups:     []string{""},
+				Resources:     []string{"pods"},
+				ResourceNames: resourceNames,
+				Verbs:         []string{"get", "patch"},
 			},
 		},
 	}
+}
+
+func nodeSetOrdinals(nodeSet *values.SlurmNodeSet) []int32 {
+	if nodeSet.EphemeralNodes != nil && *nodeSet.EphemeralNodes {
+		return append([]int32(nil), nodeSet.ActiveNodes...)
+	}
+
+	ordinals := make([]int32, 0, nodeSet.StatefulSet.Replicas)
+	for ordinal := int32(0); ordinal < nodeSet.StatefulSet.Replicas; ordinal++ {
+		ordinals = append(ordinals, ordinal)
+	}
+	return ordinals
 }

--- a/internal/render/worker/role_test.go
+++ b/internal/render/worker/role_test.go
@@ -1,29 +1,75 @@
-package worker
+package worker_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+
+	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/naming"
+	"nebius.ai/slurm-operator/internal/render/worker"
+	"nebius.ai/slurm-operator/internal/values"
 )
 
-func Test_RenderRole(t *testing.T) {
-	namespace := "test-namespace"
-	clusterName := "test-cluster"
-
-	role := RenderRole(namespace, clusterName)
-
-	// Check the name
-	if role.Name != naming.BuildRoleWorkerName(clusterName) {
-		t.Errorf("Unexpected name: got %v, want %v", role.Name, naming.BuildRoleWorkerName(clusterName))
+func TestRenderNodeSetRBAC(t *testing.T) {
+	tests := []struct {
+		name         string
+		nodeSet      *values.SlurmNodeSet
+		expectedPods []string
+	}{
+		{
+			name: "regular NodeSet ordinals",
+			nodeSet: &values.SlurmNodeSet{
+				Name: "workers",
+				StatefulSet: values.StatefulSet{
+					Name:     "workers",
+					Replicas: 3,
+				},
+			},
+			expectedPods: []string{"workers-0", "workers-1", "workers-2"},
+		},
+		{
+			name: "ephemeral NodeSet active ordinals",
+			nodeSet: &values.SlurmNodeSet{
+				Name:           "workers",
+				EphemeralNodes: ptr.To(true),
+				ActiveNodes:    []int32{0, 3, 12},
+				StatefulSet: values.StatefulSet{
+					Name:     "workers",
+					Replicas: 3,
+				},
+			},
+			expectedPods: []string{"workers-0", "workers-3", "workers-12"},
+		},
 	}
 
-	// Check the namespace
-	if role.Namespace != namespace {
-		t.Errorf("Unexpected namespace: got %v, want %v", role.Namespace, namespace)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const namespace = "default"
+			const clusterName = "soperator"
 
-	// Check the rules
-	if len(role.Rules) != 1 || role.Rules[0].APIGroups[0] != "" || role.Rules[0].Resources[0] != "events" || role.Rules[0].Verbs[0] != "create" {
-		t.Errorf("Unexpected rules: got %v, want one rule with apiGroups=[\"\"], resources=[\"events\"], and verbs=[\"create\"]", role.Rules)
+			serviceAccount := worker.RenderServiceAccount(namespace, clusterName, tt.nodeSet.Name)
+			role := worker.RenderRole(namespace, clusterName, tt.nodeSet)
+			roleBinding := worker.RenderRoleBinding(namespace, clusterName, tt.nodeSet.Name)
+
+			expectedServiceAccountName := naming.BuildServiceAccountNodeSetName(clusterName, tt.nodeSet.Name)
+			expectedRoleName := naming.BuildRoleNodeSetName(clusterName, tt.nodeSet.Name)
+
+			assert.Equal(t, expectedServiceAccountName, serviceAccount.Name)
+			assert.Equal(t, consts.ComponentTypeNodeSet.String(), serviceAccount.Labels[consts.LabelComponentKey])
+
+			assert.Equal(t, expectedRoleName, role.Name)
+			assert.Len(t, role.Rules, 1)
+			assert.Equal(t, []string{"pods"}, role.Rules[0].Resources)
+			assert.Equal(t, []string{"get", "patch"}, role.Rules[0].Verbs)
+			assert.Equal(t, tt.expectedPods, role.Rules[0].ResourceNames)
+
+			assert.Equal(t, naming.BuildRoleBindingNodeSetName(clusterName, tt.nodeSet.Name), roleBinding.Name)
+			assert.Len(t, roleBinding.Subjects, 1)
+			assert.Equal(t, expectedServiceAccountName, roleBinding.Subjects[0].Name)
+			assert.Equal(t, namespace, roleBinding.Subjects[0].Namespace)
+			assert.Equal(t, expectedRoleName, roleBinding.RoleRef.Name)
+		})
 	}
 }

--- a/internal/render/worker/rolebinding.go
+++ b/internal/render/worker/rolebinding.go
@@ -1,0 +1,34 @@
+package worker
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"nebius.ai/slurm-operator/internal/consts"
+	"nebius.ai/slurm-operator/internal/naming"
+	"nebius.ai/slurm-operator/internal/render/common"
+)
+
+func RenderRoleBinding(namespace, clusterName, nodeSetName string) rbacv1.RoleBinding {
+	labels := common.RenderLabels(consts.ComponentTypeNodeSet, clusterName)
+
+	return rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      naming.BuildRoleBindingNodeSetName(clusterName, nodeSetName),
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      naming.BuildServiceAccountNodeSetName(clusterName, nodeSetName),
+				Namespace: namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     naming.BuildRoleNodeSetName(clusterName, nodeSetName),
+		},
+	}
+}

--- a/internal/render/worker/serviceaccount.go
+++ b/internal/render/worker/serviceaccount.go
@@ -9,12 +9,12 @@ import (
 	"nebius.ai/slurm-operator/internal/render/common"
 )
 
-func RenderServiceAccount(namespace, clusterName string) corev1.ServiceAccount {
-	labels := common.RenderLabels(consts.ComponentTypeWorker, clusterName)
+func RenderServiceAccount(namespace, clusterName, nodeSetName string) corev1.ServiceAccount {
+	labels := common.RenderLabels(consts.ComponentTypeNodeSet, clusterName)
 
 	return corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      naming.BuildServiceAccountWorkerName(clusterName),
+			Name:      naming.BuildServiceAccountNodeSetName(clusterName, nodeSetName),
 			Namespace: namespace,
 			Labels:    labels,
 		},

--- a/internal/render/worker/sssd_test.go
+++ b/internal/render/worker/sssd_test.go
@@ -11,6 +11,7 @@ import (
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
 	"nebius.ai/slurm-operator/internal/consts"
+	"nebius.ai/slurm-operator/internal/naming"
 	"nebius.ai/slurm-operator/internal/render/worker"
 	"nebius.ai/slurm-operator/internal/values"
 )
@@ -79,6 +80,10 @@ func TestRenderNodeSetStatefulSet_SSSD(t *testing.T) {
 		"",
 	)
 	assert.NoError(t, err)
+	assert.Equal(t,
+		naming.BuildServiceAccountNodeSetName("test-cluster", nodeSet.Name),
+		result.Spec.Template.Spec.ServiceAccountName,
+	)
 
 	assert.Len(t, result.Spec.Template.Spec.InitContainers, 3)
 	assert.Equal(t, consts.ContainerNameSSSD, result.Spec.Template.Spec.InitContainers[1].Name)

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -118,7 +118,7 @@ func RenderNodeSetStatefulSet(
 			},
 		},
 		PriorityClassName:  nodeSet.PriorityClass,
-		ServiceAccountName: naming.BuildServiceAccountWorkerName(nodeSet.ParentalCluster.Name),
+		ServiceAccountName: naming.BuildServiceAccountNodeSetName(nodeSet.ParentalCluster.Name, nodeSet.Name),
 		ImagePullSecrets:   nodeSet.ImagePullSecrets,
 		Affinity:           nodeSet.Affinity,
 		NodeSelector:       nodeSet.NodeSelector,


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

Need to add power action for managing pods corresponding to slurm nodes. Will be used in custom rolling update logic, and maybe others.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

Add power action script, config. Update roles for NodeSet SA and roles.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

Dev cluster.

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->

Feature: add `soperator-worker-handoff` power action that labels corresponding k8s pod. Later on controller will catch this pod and perform necessary actions.
