### PR TITLE
SCHED-2370: Ignore POWERED_DOWN nodes in ensure-healthy-nodes check

### DIFF
--- a/helm/soperator-activechecks/scripts/ensure-healthy-nodes.sh
+++ b/helm/soperator-activechecks/scripts/ensure-healthy-nodes.sh
@@ -8,8 +8,8 @@ json=$(scontrol show nodes --json)
 bad_nodes=$(echo "$json" | jq -r '
   .nodes[]
   | select(
-      (.reason // "") != "" 
-      or ((.state? // "") | tostring | test("DOWN|DRAIN|FAIL"))
+      (.reason // "") != ""
+      or ([.state] | flatten | any(IN("DOWN","DRAIN","FAIL","ERROR","INVALID_REG")))
     )
   | {name, reason: (.reason // ""), state: .state}
 ')


### PR DESCRIPTION
## Problem
Active check "ensure-healthy-nodes" fails during cluster provisioning if the initial number of ephemeral nodes is less than the total number.
This is because the POWERED_DOWN node state contains the "DOWN" substring caught by the jq query.

## Solution
Fix the jq query.

## Testing
Will be tested by E2E.

## Release Notes
Fix initial active check failures when the initial number of ephemeral nodes is less than the total number.
