### PR TITLE
SCHED-2368: Dummy change to learn PR workflow and soperator deployment

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -177,6 +177,9 @@ func main() {
 	klog.SetLogger(zapLogger.WithName("klog"))
 
 	setupLog := ctrl.Log.WithName("setup")
+
+	setupLog.Info("SCHED-2368 dummy validation log")
+
 	var err error
 	controllersSpec := os.Getenv("SLURM_OPERATOR_CONTROLLERS")
 	controllersSource := "env"


### PR DESCRIPTION
## Problem

New contributors need hands-on practice with the Soperator contribution workflow, including creating a correctly named branch, opening a pull request, selecting a PR build artifact, and validating it on a real test cluster.

This is a training-only change and does not address a production issue.

## Solution

Added a harmless startup log message containing `SCHED-2368` to the main Soperator binary. The marker makes it easy to confirm that the PR-built operator image is running on a test cluster.

This dummy change is not intended to be merged into `main`.

## Testing

Local validation:

- Ran `go test ./cmd`.
- Ran `git diff --check`.
- Both commands completed successfully.

Real-cluster validation is pending. After deploying the image built by this PR, verify the marker in the operator logs:

```bash
kubectl logs -n <namespace> deployment/soperator-controller-manager \
  | rg 'SCHED-2368 dummy validation log'
```

## Release Notes

No user-facing change. This PR adds a temporary log message solely for onboarding and workflow validation.