### PR TITLE
SCHED-2231: Preserve pods on ephemeral transition

### DIFF
--- a/api/v1alpha1/nodeset_types.go
+++ b/api/v1alpha1/nodeset_types.go
@@ -112,6 +112,8 @@ const (
 	ConditionNodeSetPodsReady = "PodsReady"
 	// ConditionNodeSetStatefulSetTerminated is set when StatefulSet for NodeSet is terminated.
 	ConditionNodeSetStatefulSetTerminated = "StatefulSetTerminated"
+	// ConditionNodeSetEphemeralModeApplied indicates whether the last successfully reconciled mode was ephemeral.
+	ConditionNodeSetEphemeralModeApplied = "EphemeralModeApplied"
 )
 
 // NodeSetSpec defines the desired state of NodeSet

--- a/e2e/acceptance/features.go
+++ b/e2e/acceptance/features.go
@@ -29,6 +29,7 @@ func FeaturePaths() []string {
 		"features/observability.feature",
 		"features/internal_ssh.feature",
 		"features/package_installation.feature",
+		"features/nodeset_ephemeral_mode_transition.feature",
 		"features/node_replacement.feature",
 		"features/docker_containers.feature",
 		"features/enroot_containers.feature",

--- a/e2e/acceptance/features/nodeset_ephemeral_mode_transition.feature
+++ b/e2e/acceptance/features/nodeset_ephemeral_mode_transition.feature
@@ -1,0 +1,8 @@
+Feature: NodeSet ephemeral mode transitions
+  @soperator_version_>=5.0.0
+  Scenario: A static NodeSet can transition to ephemeral mode and back
+    Given a ready static NodeSet is selected for a mode transition
+    When the selected NodeSet is switched to ephemeral mode
+    Then all requested workers remain active without pod recreation
+    When the selected NodeSet is switched back to static mode
+    Then its power state is removed and all static workers are ready

--- a/e2e/acceptance/internal/kubeobjects/types.go
+++ b/e2e/acceptance/internal/kubeobjects/types.go
@@ -1,6 +1,10 @@
 package kubeobjects
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 const (
 	SlurmClusterPhaseAvailable = "Available"
@@ -26,8 +30,9 @@ const (
 )
 
 type ObjectMeta struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace"`
+	Generation int64  `json:"generation"`
 }
 
 type SlurmClusterList struct {
@@ -55,9 +60,11 @@ type NodeSet struct {
 }
 
 type NodeSetSpec struct {
-	ClusterName string         `json:"clusterName"`
-	Replicas    int32          `json:"replicas"`
-	GPU         NodeSetGPUSpec `json:"gpu"`
+	ClusterName                 string         `json:"clusterName"`
+	Replicas                    int32          `json:"replicas"`
+	EphemeralNodes              *bool          `json:"ephemeralNodes"`
+	InitialNumberEphemeralNodes int32          `json:"initialNumberEphemeralNodes"`
+	GPU                         NodeSetGPUSpec `json:"gpu"`
 }
 
 type NodeSetGPUSpec struct {
@@ -65,8 +72,26 @@ type NodeSetGPUSpec struct {
 }
 
 type NodeSetStatus struct {
-	Phase    string `json:"phase"`
-	Replicas int32  `json:"replicas"`
+	Phase      string             `json:"phase"`
+	Replicas   int32              `json:"replicas"`
+	Conditions []metav1.Condition `json:"conditions"`
+}
+
+type NodeSetPowerState struct {
+	Spec NodeSetPowerStateSpec `json:"spec"`
+}
+
+type NodeSetPowerStateSpec struct {
+	ActiveNodes []int32 `json:"activeNodes"`
+}
+
+type KruiseStatefulSet struct {
+	Spec KruiseStatefulSetSpec `json:"spec"`
+}
+
+type KruiseStatefulSetSpec struct {
+	Replicas        *int32            `json:"replicas"`
+	ReserveOrdinals []json.RawMessage `json:"reserveOrdinals"`
 }
 
 type ActiveCheckList struct {

--- a/e2e/acceptance/internal/sharedsteps/nodeset_ephemeral_mode_transition.go
+++ b/e2e/acceptance/internal/sharedsteps/nodeset_ephemeral_mode_transition.go
@@ -1,0 +1,290 @@
+package sharedsteps
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+	"github.com/nebius/soperator/e2e/acceptance/internal/kubeobjects"
+)
+
+const (
+	nodeSetEphemeralModeTransitionTimeout = 15 * time.Minute
+	nodeSetEphemeralModeCleanupTimeout    = 5 * time.Minute
+	nodeSetLabelKey                       = "slurm.nebius.ai/nodeset"
+	ephemeralModeApplied                  = "EphemeralModeApplied"
+)
+
+type NodeSetEphemeralModeTransition struct {
+	info    *framework.ClusterInfo
+	runtime framework.Runtime
+	kubectl *framework.KubectlClient
+
+	initialNodeSet kubeobjects.NodeSet
+	initialPods    map[string]string
+}
+
+func NewNodeSetEphemeralModeTransition(
+	info *framework.ClusterInfo,
+	runtime framework.Runtime,
+	kubectl *framework.KubectlClient,
+) *NodeSetEphemeralModeTransition {
+	return &NodeSetEphemeralModeTransition{
+		info:    info,
+		runtime: runtime,
+		kubectl: kubectl,
+	}
+}
+
+func (s *NodeSetEphemeralModeTransition) RegisterSteps(sc *godog.ScenarioContext) {
+	sc.Step(`^a ready static NodeSet is selected for a mode transition$`, s.selectReadyStaticNodeSet)
+	sc.Step(`^the selected NodeSet is switched to ephemeral mode$`, s.switchToEphemeralMode)
+	sc.Step(`^all requested workers remain active without pod recreation$`, s.checkWorkersPreserved)
+	sc.Step(`^the selected NodeSet is switched back to static mode$`, s.switchToStaticMode)
+	sc.Step(`^its power state is removed and all static workers are ready$`, s.checkStaticModeRestored)
+}
+
+func (s *NodeSetEphemeralModeTransition) CleanupAndReset(ctx context.Context) {
+	if s.initialNodeSet.Metadata.Name != "" {
+		cleanupCtx, cancel := context.WithTimeout(ctx, nodeSetEphemeralModeCleanupTimeout)
+		defer cancel()
+		if err := s.patchNodeSetMode(cleanupCtx, false, s.initialNodeSet.Spec.InitialNumberEphemeralNodes); err != nil {
+			s.runtime.Logf("cleanup: restore static NodeSet %s/%s: %v",
+				s.initialNodeSet.Metadata.Namespace, s.initialNodeSet.Metadata.Name, err)
+		} else if err := s.checkStaticModeRestored(cleanupCtx); err != nil {
+			s.runtime.Logf("cleanup: wait for static NodeSet %s/%s: %v",
+				s.initialNodeSet.Metadata.Namespace, s.initialNodeSet.Metadata.Name, err)
+		}
+	}
+	s.initialNodeSet = kubeobjects.NodeSet{}
+	s.initialPods = nil
+}
+
+func (s *NodeSetEphemeralModeTransition) selectReadyStaticNodeSet(ctx context.Context) error {
+	var nodeSets kubeobjects.NodeSetList
+	if err := s.kubectl.GetJSON(ctx, &nodeSets, "get", "nodesets", "-n", framework.SoperatorNamespace, "-o", "json"); err != nil {
+		return fmt.Errorf("list NodeSets: %w", err)
+	}
+	sort.Slice(nodeSets.Items, func(i, j int) bool {
+		return nodeSets.Items[i].Metadata.Name < nodeSets.Items[j].Metadata.Name
+	})
+
+	for _, nodeSet := range nodeSets.Items {
+		if nodeSet.Spec.ClusterName != "" && nodeSet.Spec.ClusterName != s.info.SlurmClusterName {
+			continue
+		}
+		if nodeSet.Spec.EphemeralNodes != nil && *nodeSet.Spec.EphemeralNodes {
+			continue
+		}
+		if nodeSet.Spec.Replicas == 0 || nodeSet.Status.Replicas != nodeSet.Spec.Replicas {
+			continue
+		}
+		s.initialNodeSet = nodeSet
+		break
+	}
+	if s.initialNodeSet.Metadata.Name == "" {
+		s.runtime.Logf("acceptance: no ready static NodeSet with replicas was found, skipping scenario")
+		return godog.ErrSkip
+	}
+	if err := s.waitForModeApplied(ctx, metav1.ConditionFalse); err != nil {
+		return fmt.Errorf("wait for selected NodeSet static mode: %w", err)
+	}
+
+	pods, err := s.workerPods(ctx)
+	if err != nil {
+		return err
+	}
+	if int32(len(pods)) != s.initialNodeSet.Spec.Replicas {
+		return fmt.Errorf("NodeSet %s/%s has %d worker pods, expected %d",
+			s.initialNodeSet.Metadata.Namespace, s.initialNodeSet.Metadata.Name, len(pods), s.initialNodeSet.Spec.Replicas)
+	}
+	s.initialPods = make(map[string]string, len(pods))
+	for _, pod := range pods {
+		if !kubeobjects.PodReady(pod) {
+			return fmt.Errorf("worker pod %s is not ready", pod.Name)
+		}
+		s.initialPods[pod.Name] = string(pod.UID)
+	}
+	return nil
+}
+
+func (s *NodeSetEphemeralModeTransition) switchToEphemeralMode(ctx context.Context) error {
+	return s.patchNodeSetMode(ctx, true, 0)
+}
+
+func (s *NodeSetEphemeralModeTransition) switchToStaticMode(ctx context.Context) error {
+	return s.patchNodeSetMode(ctx, false, s.initialNodeSet.Spec.InitialNumberEphemeralNodes)
+}
+
+func (s *NodeSetEphemeralModeTransition) patchNodeSetMode(ctx context.Context, enabled bool, initialEphemeralNodes int32) error {
+	patch := fmt.Sprintf(
+		`{"spec":{"ephemeralNodes":%t,"initialNumberEphemeralNodes":%d}}`,
+		enabled,
+		initialEphemeralNodes,
+	)
+	if _, err := s.runtime.Kubectl().RunWithDefaultRetry(ctx,
+		"patch", "nodeset", s.initialNodeSet.Metadata.Name,
+		"-n", s.initialNodeSet.Metadata.Namespace,
+		"--type=merge", "-p", patch,
+	); err != nil {
+		return fmt.Errorf("patch NodeSet mode: %w", err)
+	}
+	return nil
+}
+
+func (s *NodeSetEphemeralModeTransition) checkWorkersPreserved(ctx context.Context) error {
+	if err := s.waitForModeApplied(ctx, metav1.ConditionTrue); err != nil {
+		return err
+	}
+
+	wantActiveNodes := make([]int32, s.initialNodeSet.Spec.Replicas)
+	for ordinal := range s.initialNodeSet.Spec.Replicas {
+		wantActiveNodes[ordinal] = ordinal
+	}
+	if err := s.runtime.WaitFor(ctx, "all requested NodeSet ordinals to become active",
+		nodeSetEphemeralModeTransitionTimeout, framework.DefaultPollInterval,
+		func(waitCtx context.Context) (bool, error) {
+			var powerState kubeobjects.NodeSetPowerState
+			if err := s.kubectl.GetJSON(waitCtx, &powerState,
+				"get", "nodesetpowerstate", s.initialNodeSet.Metadata.Name,
+				"-n", s.initialNodeSet.Metadata.Namespace, "-o", "json",
+			); err != nil {
+				return false, err
+			}
+			return slices.Equal(powerState.Spec.ActiveNodes, wantActiveNodes), nil
+		},
+	); err != nil {
+		return err
+	}
+
+	return s.runtime.WaitFor(ctx, "original worker pods to remain ready",
+		nodeSetEphemeralModeTransitionTimeout, framework.DefaultPollInterval,
+		func(waitCtx context.Context) (bool, error) {
+			pods, err := s.workerPods(waitCtx)
+			if err != nil {
+				return false, err
+			}
+			if len(pods) != len(s.initialPods) {
+				return false, fmt.Errorf("found %d worker pods, expected %d", len(pods), len(s.initialPods))
+			}
+			for _, pod := range pods {
+				uid, exists := s.initialPods[pod.Name]
+				if !exists {
+					return false, fmt.Errorf("unexpected worker pod %s", pod.Name)
+				}
+				if string(pod.UID) != uid {
+					return false, fmt.Errorf("worker pod %s was recreated", pod.Name)
+				}
+				if !kubeobjects.PodReady(pod) {
+					return false, nil
+				}
+			}
+			return true, nil
+		},
+	)
+}
+
+func (s *NodeSetEphemeralModeTransition) checkStaticModeRestored(ctx context.Context) error {
+	if err := s.waitForModeApplied(ctx, metav1.ConditionFalse); err != nil {
+		return err
+	}
+	if err := s.runtime.WaitFor(ctx, "NodeSetPowerState removal",
+		nodeSetEphemeralModeTransitionTimeout, framework.DefaultPollInterval,
+		func(waitCtx context.Context) (bool, error) {
+			out, err := s.runtime.Kubectl().Run(waitCtx,
+				"get", "nodesetpowerstate", s.initialNodeSet.Metadata.Name,
+				"-n", s.initialNodeSet.Metadata.Namespace,
+				"--ignore-not-found", "-o", "name",
+			)
+			return err == nil && strings.TrimSpace(out) == "", err
+		},
+	); err != nil {
+		return err
+	}
+
+	if err := s.runtime.WaitFor(ctx, "static StatefulSet replicas",
+		nodeSetEphemeralModeTransitionTimeout, framework.DefaultPollInterval,
+		func(waitCtx context.Context) (bool, error) {
+			var statefulSet kubeobjects.KruiseStatefulSet
+			if err := s.kubectl.GetJSON(waitCtx, &statefulSet,
+				"get", "statefulsets.apps.kruise.io", s.initialNodeSet.Metadata.Name,
+				"-n", s.initialNodeSet.Metadata.Namespace, "-o", "json",
+			); err != nil {
+				return false, err
+			}
+			return statefulSet.Spec.Replicas != nil &&
+				*statefulSet.Spec.Replicas == s.initialNodeSet.Spec.Replicas &&
+				len(statefulSet.Spec.ReserveOrdinals) == 0, nil
+		},
+	); err != nil {
+		return err
+	}
+
+	return s.runtime.WaitFor(ctx, "all contiguous static worker pods to become ready",
+		nodeSetEphemeralModeTransitionTimeout, framework.DefaultPollInterval,
+		func(waitCtx context.Context) (bool, error) {
+			pods, err := s.workerPods(waitCtx)
+			if err != nil {
+				return false, err
+			}
+			if int32(len(pods)) != s.initialNodeSet.Spec.Replicas {
+				return false, nil
+			}
+			podsByName := make(map[string]corev1.Pod, len(pods))
+			for _, pod := range pods {
+				podsByName[pod.Name] = pod
+			}
+			for ordinal := range s.initialNodeSet.Spec.Replicas {
+				podName := fmt.Sprintf("%s-%d", s.initialNodeSet.Metadata.Name, ordinal)
+				pod, exists := podsByName[podName]
+				if !exists || !kubeobjects.PodReady(pod) {
+					return false, nil
+				}
+			}
+			return true, nil
+		},
+	)
+}
+
+func (s *NodeSetEphemeralModeTransition) waitForModeApplied(ctx context.Context, status metav1.ConditionStatus) error {
+	return s.runtime.WaitFor(ctx, fmt.Sprintf("EphemeralModeApplied=%s", status),
+		nodeSetEphemeralModeTransitionTimeout, framework.DefaultPollInterval,
+		func(waitCtx context.Context) (bool, error) {
+			var nodeSet kubeobjects.NodeSet
+			if err := s.kubectl.GetJSON(waitCtx, &nodeSet,
+				"get", "nodeset", s.initialNodeSet.Metadata.Name,
+				"-n", s.initialNodeSet.Metadata.Namespace, "-o", "json",
+			); err != nil {
+				return false, err
+			}
+			for _, condition := range nodeSet.Status.Conditions {
+				if condition.Type == ephemeralModeApplied &&
+					condition.Status == status &&
+					condition.ObservedGeneration == nodeSet.Metadata.Generation {
+					return true, nil
+				}
+			}
+			return false, nil
+		},
+	)
+}
+
+func (s *NodeSetEphemeralModeTransition) workerPods(ctx context.Context) ([]corev1.Pod, error) {
+	var pods corev1.PodList
+	selector := fmt.Sprintf("%s=%s", nodeSetLabelKey, s.initialNodeSet.Metadata.Name)
+	if err := s.kubectl.GetJSON(ctx, &pods,
+		"get", "pods", "-n", s.initialNodeSet.Metadata.Namespace,
+		"-l", selector, "-o", "json",
+	); err != nil {
+		return nil, fmt.Errorf("list worker pods for NodeSet %s: %w", s.initialNodeSet.Metadata.Name, err)
+	}
+	return pods.Items, nil
+}

--- a/e2e/acceptance/internal/sharedsteps/steps.go
+++ b/e2e/acceptance/internal/sharedsteps/steps.go
@@ -25,6 +25,7 @@ func RegisterAll(sc *godog.ScenarioContext, info *framework.ClusterInfo, runtime
 		NewObservability(kubectl),
 		NewInternalSSH(runtime, selector),
 		NewPackageInstallation(runtime, selector),
+		NewNodeSetEphemeralModeTransition(info, runtime, kubectl),
 		NewNodeReplacement(runtime, slurm, selector),
 		NewDockerContainers(runtime, slurm, selector),
 		NewEnrootContainers(runtime, slurm, selector),

--- a/internal/controller/nodesetcontroller/reconcile.go
+++ b/internal/controller/nodesetcontroller/reconcile.go
@@ -129,6 +129,10 @@ func (r *NodeSetReconciler) reconcile(ctx context.Context, nodeSet *slurmv1alpha
 		return ctrl.Result{}, err
 	}
 
+	if err = r.updateEphemeralModeAppliedCondition(ctx, nodeSet); err != nil {
+		return ctrl.Result{}, fmt.Errorf("updating ephemeral nodes condition: %w", err)
+	}
+
 	// region Maintenance condition
 	{
 		var condition metav1.Condition
@@ -227,6 +231,7 @@ func (r *NodeSetReconciler) setUpConditions(ctx context.Context, nodeSet *slurmv
 		slurmv1alpha1.ConditionNodeSetStatefulSetUpdated,
 		slurmv1alpha1.ConditionNodeSetPodsReady,
 		slurmv1alpha1.ConditionNodeSetStatefulSetTerminated,
+		slurmv1alpha1.ConditionNodeSetEphemeralModeApplied,
 	} {
 		if meta.FindStatusCondition(nodeSet.Status.Conditions, conditionType) != nil {
 			continue
@@ -254,6 +259,28 @@ func (r *NodeSetReconciler) setUpConditions(ctx context.Context, nodeSet *slurmv
 	}
 
 	return nil
+}
+
+func (r *NodeSetReconciler) updateEphemeralModeAppliedCondition(
+	ctx context.Context,
+	nodeSet *slurmv1alpha1.NodeSet,
+) error {
+	condition := metav1.Condition{
+		Type:               slurmv1alpha1.ConditionNodeSetEphemeralModeApplied,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: nodeSet.Generation,
+		Reason:             "StaticModeApplied",
+		Message:            "Static nodes mode is applied",
+	}
+	if nodeSet.Spec.EphemeralNodes != nil && *nodeSet.Spec.EphemeralNodes {
+		condition.Status = metav1.ConditionTrue
+		condition.Reason = "EphemeralModeApplied"
+		condition.Message = "Ephemeral nodes mode is applied"
+	}
+
+	return r.patchStatus(ctx, nodeSet, func(status *slurmv1alpha1.NodeSetStatus) bool {
+		return meta.SetStatusCondition(&status.Conditions, condition)
+	})
 }
 
 // executeReconciliation reconciles all resources necessary for deploying Slurm NodeSet workers
@@ -705,11 +732,7 @@ func (r *NodeSetReconciler) reconcileNodeSetPowerState(
 
 	if apierrors.IsNotFound(err) {
 		logger.V(1).Info("NodeSetPowerState not found, it will be created")
-		activeNodes := make([]int32, nodeSet.Spec.InitialNumberEphemeralNodes)
-		for i := int32(0); i < nodeSet.Spec.InitialNumberEphemeralNodes; i++ {
-			activeNodes[i] = i
-		}
-		desired.Spec.ActiveNodes = activeNodes
+		desired.Spec.ActiveNodes = buildActiveNodesForNewPowerState(nodeSet)
 	}
 
 	if err := r.NodeSetPowerState.Reconcile(ctx, nodeSet, desired); err != nil {
@@ -759,4 +782,23 @@ func (r *NodeSetReconciler) reconcileNodeSetPowerState(
 	)
 
 	return existing.Spec.ActiveNodes, nil
+}
+
+func buildActiveNodesForNewPowerState(nodeSet *slurmv1alpha1.NodeSet) []int32 {
+	activeCount := nodeSet.Spec.InitialNumberEphemeralNodes
+	appliedMode := meta.FindStatusCondition(
+		nodeSet.Status.Conditions,
+		slurmv1alpha1.ConditionNodeSetEphemeralModeApplied,
+	)
+
+	// On a static-to-ephemeral transition, activate all spec replicas instead of applying the initial ephemeral count
+	if appliedMode != nil && appliedMode.Status == metav1.ConditionFalse {
+		activeCount = nodeSet.Spec.Replicas
+	}
+
+	activeNodes := make([]int32, activeCount)
+	for i := int32(0); i < activeCount; i++ {
+		activeNodes[i] = i
+	}
+	return activeNodes
 }

--- a/internal/controller/nodesetcontroller/reconcile.go
+++ b/internal/controller/nodesetcontroller/reconcile.go
@@ -115,7 +115,8 @@ func (r *NodeSetReconciler) reconcile(ctx context.Context, nodeSet *slurmv1alpha
 	clusterWithGPU := values.BuildClusterWithGPUFromNodeSets(nodeSets)
 
 	// region Ephemeral nodes power state
-	if nodeSetValues.EphemeralNodes != nil && *nodeSetValues.EphemeralNodes {
+	ephemeralNodesEnabled := nodeSetValues.EphemeralNodes != nil && *nodeSetValues.EphemeralNodes
+	if ephemeralNodesEnabled {
 		activeNodes, err := r.reconcileNodeSetPowerState(ctx, nodeSet)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("reconciling NodeSetPowerState: %w", err)
@@ -129,8 +130,16 @@ func (r *NodeSetReconciler) reconcile(ctx context.Context, nodeSet *slurmv1alpha
 		return ctrl.Result{}, err
 	}
 
+	// Remove any stale NodeSetPowerState after the NodeSet becomes static.
+	// Apply static replicas and clear reserved ordinals before removing the power state.
+	if !ephemeralNodesEnabled {
+		if err = r.deleteNodeSetPowerState(ctx, nodeSet); err != nil {
+			return ctrl.Result{}, fmt.Errorf("deleting NodeSetPowerState: %w", err)
+		}
+	}
+
 	if err = r.updateEphemeralModeAppliedCondition(ctx, nodeSet); err != nil {
-		return ctrl.Result{}, fmt.Errorf("updating ephemeral nodes condition: %w", err)
+		return ctrl.Result{}, fmt.Errorf("updating ephemeral mode applied condition: %w", err)
 	}
 
 	// region Maintenance condition
@@ -782,6 +791,19 @@ func (r *NodeSetReconciler) reconcileNodeSetPowerState(
 	)
 
 	return existing.Spec.ActiveNodes, nil
+}
+
+func (r *NodeSetReconciler) deleteNodeSetPowerState(
+	ctx context.Context,
+	nodeSet *slurmv1alpha1.NodeSet,
+) error {
+	powerState := &slurmv1alpha1.NodeSetPowerState{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodeSet.Name,
+			Namespace: nodeSet.Namespace,
+		},
+	}
+	return client.IgnoreNotFound(r.Delete(ctx, powerState))
 }
 
 func buildActiveNodesForNewPowerState(nodeSet *slurmv1alpha1.NodeSet) []int32 {

--- a/internal/controller/nodesetcontroller/reconcile_test.go
+++ b/internal/controller/nodesetcontroller/reconcile_test.go
@@ -157,6 +157,143 @@ func TestReconcileNodeSetPowerState_AllowsZeroInitialEphemeralNodes(t *testing.T
 	assert.Equal(t, metav1.ConditionTrue, readyCondition.Status)
 }
 
+func TestBuildActiveNodesForNewPowerState(t *testing.T) {
+	tests := []struct {
+		name            string
+		condition       *metav1.Condition
+		replicas        int32
+		initial         int32
+		wantActiveNodes []int32
+	}{
+		{
+			name:            "new ephemeral NodeSet uses initial count",
+			replicas:        10,
+			initial:         2,
+			wantActiveNodes: []int32{0, 1},
+		},
+		{
+			name: "unknown previous mode uses initial count",
+			condition: &metav1.Condition{
+				Type:   slurmv1alpha1.ConditionNodeSetEphemeralModeApplied,
+				Status: metav1.ConditionUnknown,
+			},
+			replicas:        10,
+			initial:         2,
+			wantActiveNodes: []int32{0, 1},
+		},
+		{
+			name: "previously static NodeSet keeps all replicas active",
+			condition: &metav1.Condition{
+				Type:   slurmv1alpha1.ConditionNodeSetEphemeralModeApplied,
+				Status: metav1.ConditionFalse,
+			},
+			replicas:        10,
+			initial:         2,
+			wantActiveNodes: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+		{
+			name: "previously ephemeral NodeSet uses initial count when power state is absent",
+			condition: &metav1.Condition{
+				Type:   slurmv1alpha1.ConditionNodeSetEphemeralModeApplied,
+				Status: metav1.ConditionTrue,
+			},
+			replicas:        10,
+			initial:         2,
+			wantActiveNodes: []int32{0, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeSet := &slurmv1alpha1.NodeSet{
+				Spec: slurmv1alpha1.NodeSetSpec{
+					Replicas:                    tt.replicas,
+					InitialNumberEphemeralNodes: tt.initial,
+				},
+			}
+			if tt.condition != nil {
+				nodeSet.Status.Conditions = []metav1.Condition{*tt.condition}
+			}
+
+			assert.Equal(t, tt.wantActiveNodes, buildActiveNodesForNewPowerState(nodeSet))
+		})
+	}
+}
+
+func TestUpdateEphemeralModeAppliedCondition(t *testing.T) {
+	tests := []struct {
+		name            string
+		ephemeralNodes  bool
+		conditionStatus metav1.ConditionStatus
+	}{
+		{
+			name:            "static mode",
+			conditionStatus: metav1.ConditionFalse,
+		},
+		{
+			name:            "ephemeral mode",
+			ephemeralNodes:  true,
+			conditionStatus: metav1.ConditionTrue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, slurmv1alpha1.AddToScheme(scheme))
+			previousStatus := metav1.ConditionTrue
+			if tt.ephemeralNodes {
+				previousStatus = metav1.ConditionFalse
+			}
+
+			nodeSet := &slurmv1alpha1.NodeSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-nodeset",
+					Namespace:  "test-namespace",
+					Generation: 7,
+				},
+				Spec: slurmv1alpha1.NodeSetSpec{
+					EphemeralNodes: ptr.To(tt.ephemeralNodes),
+				},
+				Status: slurmv1alpha1.NodeSetStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               slurmv1alpha1.ConditionNodeSetEphemeralModeApplied,
+							Status:             previousStatus,
+							ObservedGeneration: 6,
+						},
+					},
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(nodeSet).
+				WithStatusSubresource(&slurmv1alpha1.NodeSet{}).
+				Build()
+			r := &NodeSetReconciler{
+				Reconciler: reconciler.NewReconciler(fakeClient, scheme, record.NewFakeRecorder(10)),
+			}
+
+			require.NoError(t, r.updateEphemeralModeAppliedCondition(context.Background(), nodeSet))
+
+			var updated slurmv1alpha1.NodeSet
+			require.NoError(t, fakeClient.Get(
+				context.Background(),
+				client.ObjectKeyFromObject(nodeSet),
+				&updated,
+			))
+			condition := meta.FindStatusCondition(
+				updated.Status.Conditions,
+				slurmv1alpha1.ConditionNodeSetEphemeralModeApplied,
+			)
+			require.NotNil(t, condition)
+			assert.Equal(t, tt.conditionStatus, condition.Status)
+			assert.Equal(t, nodeSet.Generation, condition.ObservedGeneration)
+		})
+	}
+}
+
 func TestExpectedReplicas(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/controller/nodesetcontroller/reconcile_test.go
+++ b/internal/controller/nodesetcontroller/reconcile_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -292,6 +293,45 @@ func TestUpdateEphemeralModeAppliedCondition(t *testing.T) {
 			assert.Equal(t, nodeSet.Generation, condition.ObservedGeneration)
 		})
 	}
+}
+
+func TestDeleteNodeSetPowerState(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, slurmv1alpha1.AddToScheme(scheme))
+
+	nodeSet := &slurmv1alpha1.NodeSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-nodeset",
+			Namespace: "test-namespace",
+		},
+	}
+	powerState := &slurmv1alpha1.NodeSetPowerState{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodeSet.Name,
+			Namespace: nodeSet.Namespace,
+		},
+		Spec: slurmv1alpha1.NodeSetPowerStateSpec{
+			NodeSetRef:  nodeSet.Name,
+			ActiveNodes: []int32{0, 2},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(nodeSet, powerState).
+		Build()
+	r := &NodeSetReconciler{
+		Reconciler: reconciler.NewReconciler(fakeClient, scheme, record.NewFakeRecorder(10)),
+	}
+
+	require.NoError(t, r.deleteNodeSetPowerState(context.Background(), nodeSet))
+	require.NoError(t, r.deleteNodeSetPowerState(context.Background(), nodeSet))
+
+	err := fakeClient.Get(
+		context.Background(),
+		client.ObjectKeyFromObject(powerState),
+		&slurmv1alpha1.NodeSetPowerState{},
+	)
+	assert.True(t, apierrors.IsNotFound(err))
 }
 
 func TestExpectedReplicas(t *testing.T) {


### PR DESCRIPTION
## Problem

Switching a static NodeSet to ephemeral mode could reduce its active workers to `initialNumberEphemeralNodes`, causing existing worker pods to be deleted and recreated.

Switching an ephemeral NodeSet back to static mode also left an obsolete `NodeSetPowerState` and did not provide a complete transition back to static StatefulSet management.

## Solution

Track the last successfully applied NodeSet mode in its status conditions.

When transitioning from static to ephemeral mode, initialize the power state with all workers requested by `spec.replicas`. This preserves the existing requested worker pods instead of shrinking the NodeSet to `initialNumberEphemeralNodes`.

When transitioning from ephemeral to static mode, reconcile the StatefulSet in static mode and remove the obsolete `NodeSetPowerState`. Ephemeral ordinals are not preserved, so some worker pods may be recreated.

Mode transitions reset the effective autoscaling state. Previous scale-up and scale-down decisions are not carried across modes.

## Testing

Added unit tests covering:

- Initialization of `NodeSetPowerState.activeNodes` from `spec.replicas` during a static-to-ephemeral transition.
- Updates to the applied-mode status condition.
- Idempotent removal of `NodeSetPowerState` in static mode.

Ran unit tests and static analysis:

- `GOTOOLCHAIN=go1.26.4 go test ./...`
- `GOTOOLCHAIN=go1.26.4 go vet ./...`
- `GOTOOLCHAIN=go1.26.4 go -C e2e test ./...`
- `GOTOOLCHAIN=go1.26.4 go -C e2e vet ./...`

Automated E2E acceptance test on the `MAN_H200` profile: [GitHub Actions job](https://github.com/nebius/soperator/actions/runs/32974493971/job/98196110508).

The E2E test covers:

- Static-to-ephemeral transition without recreating existing requested worker pods.
- Ephemeral-to-static transition with `NodeSetPowerState` removal.
- Readiness of all expected static workers after switching back.

## Release Notes

Fix: Switching a NodeSet from static to ephemeral mode no longer recreates existing requested worker pods, and switching it back to static mode is now supported.