### PR TITLE
SCHED-2383: Add PR-triggered E2E command

### DIFF
--- a/.github/workflows/e2e_pr_command.yml
+++ b/.github/workflows/e2e_pr_command.yml
@@ -1,0 +1,167 @@
+name: PR E2E Command
+
+run-name: "PR #${{ github.event.issue.number }} E2E command by @${{ github.event.comment.user.login }}"
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  dispatch:
+    name: Dispatch E2E
+    if: |
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/e2e')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.issue.number }}
+      COMMENTER: ${{ github.event.comment.user.login }}
+      COMMENT_BODY: ${{ github.event.comment.body }}
+      TERRAFORM_REPOSITORY: nebius/nebius-solution-library
+
+    steps:
+      - name: Authorize requester
+        shell: bash
+        run: |
+          permission=$(gh api \
+            "repos/$REPOSITORY/collaborators/$COMMENTER/permission" \
+            --jq '.permission')
+
+          case "$permission" in
+            admin|maintain|write)
+              ;;
+            *)
+              echo "::error::$COMMENTER is not allowed to trigger E2E"
+              exit 1
+              ;;
+          esac
+
+      - name: Validate request
+        id: request
+        shell: bash
+        run: |
+          fail_with_comment() {
+            local message="$1"
+            gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body "$message"
+            echo "::error::$message"
+            exit 1
+          }
+
+          if [[ "$COMMENT_BODY" =~ ^/e2e([[:blank:]]+([^[:space:]]+))?[[:blank:]]*$ ]]; then
+            terraform_ref="${BASH_REMATCH[2]:-main}"
+          else
+            fail_with_comment 'Usage: `/e2e` or `/e2e <terraform-branch>`.'
+          fi
+
+          if ! git check-ref-format --branch "$terraform_ref" >/dev/null 2>&1; then
+            fail_with_comment "Terraform branch \`$terraform_ref\` is not a valid Git branch name."
+          fi
+
+          pr=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")
+          pr_state=$(jq -r '.state' <<<"$pr")
+          head_ref=$(jq -r '.head.ref' <<<"$pr")
+          head_sha=$(jq -r '.head.sha' <<<"$pr")
+          head_repo=$(jq -r '.head.repo.full_name' <<<"$pr")
+
+          if [[ "$pr_state" != "open" ]]; then
+            fail_with_comment "PR #$PR_NUMBER is not open."
+          fi
+          if [[ "$head_repo" != "$REPOSITORY" ]]; then
+            fail_with_comment 'The `/e2e` command does not support fork PRs.'
+          fi
+
+          if ! git ls-remote --exit-code --heads \
+            "https://github.com/$TERRAFORM_REPOSITORY.git" \
+            "refs/heads/$terraform_ref" >/dev/null; then
+            fail_with_comment \
+              "Terraform branch \`$terraform_ref\` does not exist in \`$TERRAFORM_REPOSITORY\`."
+          fi
+
+          build=$(gh api -X GET \
+            "repos/$REPOSITORY/actions/workflows/one_job.yml/runs" \
+            -F event=pull_request_target \
+            -F head_sha="$head_sha" \
+            -F per_page=1 \
+            --jq '.workflow_runs[0]')
+
+          if [[ -z "$build" || "$build" == "null" ]]; then
+            fail_with_comment \
+              "No Build All run was found for the current PR commit \`${head_sha:0:12}\`."
+          fi
+
+          build_id=$(jq -r '.id' <<<"$build")
+          build_status=$(jq -r '.status' <<<"$build")
+          build_conclusion=$(jq -r '.conclusion' <<<"$build")
+          build_url=$(jq -r '.html_url' <<<"$build")
+
+          if [[ "$build_status" != "completed" || "$build_conclusion" != "success" ]]; then
+            fail_with_comment \
+              "Build All for \`${head_sha:0:12}\` is \`$build_status/$build_conclusion\`. Retry \`/e2e\` after it succeeds: $build_url"
+          fi
+
+          version_artifacts=$(gh api \
+            "repos/$REPOSITORY/actions/runs/$build_id/artifacts" \
+            --jq '[.artifacts[] | select(.name == "version" and .expired == false)] | length')
+          if [[ "$version_artifacts" == "0" ]]; then
+            fail_with_comment \
+              "Build All for \`${head_sha:0:12}\` has no usable \`version\` artifact: $build_url"
+          fi
+
+          {
+            echo "head_ref=$head_ref"
+            echo "head_sha=$head_sha"
+            echo "terraform_ref=$terraform_ref"
+            echo "build_url=$build_url"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch E2E
+        shell: bash
+        env:
+          HEAD_REF: ${{ steps.request.outputs.head_ref }}
+          HEAD_SHA: ${{ steps.request.outputs.head_sha }}
+          TERRAFORM_REF: ${{ steps.request.outputs.terraform_ref }}
+          BUILD_URL: ${{ steps.request.outputs.build_url }}
+        run: |
+          current_head_sha=$(gh api \
+            "repos/$REPOSITORY/pulls/$PR_NUMBER" \
+            --jq '.head.sha')
+          if [[ "$current_head_sha" != "$HEAD_SHA" ]]; then
+            message="The PR head changed while validating \`/e2e\`. Retry the command after Build All succeeds for the new commit."
+            gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body "$message"
+            echo "::error::$message"
+            exit 1
+          fi
+
+          if ! gh workflow run e2e_test.yml \
+            --repo "$REPOSITORY" \
+            --ref "$HEAD_REF" \
+            -f "terraform_repo_ref=$TERRAFORM_REF" \
+            -f "soperator_e2e_repo_branch=$HEAD_REF" \
+            -f profile=@auto-select \
+            -f run_unstable_tests=false \
+            -f is_scheduled=false; then
+            message="Could not dispatch E2E for \`$HEAD_REF\`. See the command workflow logs for details."
+            gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body "$message"
+            exit 1
+          fi
+
+          workflow_url="$GITHUB_SERVER_URL/$REPOSITORY/actions/workflows/e2e_test.yml"
+          message=$(printf '%s\n\n%s\n%s\n%s\n%s\n%s\n\n%s' \
+            'E2E was dispatched with:' \
+            "- Soperator branch: \`$HEAD_REF\`" \
+            "- Terraform branch: \`$TERRAFORM_REF\`" \
+            "- Soperator E2E branch: \`$HEAD_REF\`" \
+            '- Profile: `@auto-select`' \
+            '- Unstable tests: `false`' \
+            "[Build All]($BUILD_URL) · [E2E runs]($workflow_url)")
+          gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body "$message"

--- a/.github/workflows/e2e_test_scheduler.yml
+++ b/.github/workflows/e2e_test_scheduler.yml
@@ -48,9 +48,16 @@ jobs:
 
           # Only scheduled runs count here. A manual run occupies a project, which
           # the selector already accounts for, but it must not affect the schedule.
-          # The actor= query parameter is avoided on purpose: it serves stale results.
+          # PR comment dispatches also run as github-actions[bot], so restrict the
+          # results to branches the scheduler owns. The actor= query parameter is
+          # avoided on purpose: it serves stale results.
+          BRANCHES_JSON=$(printf '%s\n' "${BRANCHES[@]}" | jq -R . | jq -s .)
           RUNS=$(gh api "repos/${{ github.repository }}/actions/workflows/e2e_test.yml/runs?per_page=100" \
-            --jq '[.workflow_runs[] | select(.actor.login == "github-actions[bot]")]')
+            | jq --argjson branches "$BRANCHES_JSON" \
+              '[.workflow_runs[] | select(
+                .actor.login == "github-actions[bot]"
+                and (.head_branch as $branch | $branches | index($branch))
+              )]')
 
           # A run that finds no free profile waits, then fails. Dispatching on every
           # tick regardless would turn a stretch of tight capacity into a stream of


### PR DESCRIPTION
## Problem

E2E tests can currently be started manually only from the GitHub Actions page. This makes it inconvenient to request an E2E run for a specific PR and increases the risk of selecting incorrect branches or parameters.

## Solution

Add a /e2e PR comment command that authorized maintainers can use to trigger E2E tests for the current feature branch.

- /e2e uses the main Terraform branch.
- /e2e terraform-branch uses the specified Terraform branch.
- The PR feature branch is used for Soperator and Soperator E2E.
- The @auto-select profile is used, with unstable tests disabled.
- The command verifies that the current PR build succeeded and that the requested Terraform branch exists before dispatching E2E.
- A confirmation comment reports the selected parameters and links to the workflow runs.
- PR-triggered runs are excluded from scheduled-run accounting.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
