### PR TITLE
SCHED-2383: Allow E2E command to comment on PRs

### DIFF
--- a/.github/workflows/e2e_pr_command.yml
+++ b/.github/workflows/e2e_pr_command.yml
@@ -9,8 +9,7 @@ on:
 permissions:
   actions: write
   contents: read
-  issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   dispatch:


### PR DESCRIPTION
## Problem

The PR E2E command cannot post validation or confirmation comments because its GitHub token has only read access to pull requests. Failures are reported as `Resource not accessible by integration`, which hides the actual validation result.

## Solution

Grant the command workflow write access to pull requests, matching the existing revert comment workflow. Remove the redundant issue-write permission to keep the token scope minimal.