### PR TITLE
SCHED-1910: read k8s nodes from the cache instead of paginating the API server

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,6 +56,7 @@ import (
 	"nebius.ai/slurm-operator/internal/controller/soperatorchecks"
 	"nebius.ai/slurm-operator/internal/controller/topologyconfcontroller"
 	"nebius.ai/slurm-operator/internal/controller/updatecontroller"
+	"nebius.ai/slurm-operator/internal/controllerconfig"
 	"nebius.ai/slurm-operator/internal/controllersenabled"
 	metricsopts "nebius.ai/slurm-operator/internal/metrics"
 	"nebius.ai/slurm-operator/internal/slurmapi"
@@ -247,6 +248,7 @@ func main() {
 		// LeaderElectionReleaseOnCancel: true,
 		Cache: cache.Options{
 			DefaultNamespaces: watchNsCacheByName,
+			ByObject:          controllerconfig.NodeCacheByObject(),
 		},
 	})
 	if err != nil {
@@ -341,7 +343,6 @@ func main() {
 			mgr.GetScheme(),
 			soperatorNamespace,
 			topologyLabelPrefix,
-			mgr.GetAPIReader(),
 		).SetupWithManager(mgr, maxConcurrency, cacheSyncTimeout); err != nil {
 			cli.Fail(setupLog, err,
 				"unable to create controller",

--- a/cmd/soperatorchecks/main.go
+++ b/cmd/soperatorchecks/main.go
@@ -47,6 +47,7 @@ import (
 	"nebius.ai/slurm-operator/internal/cli"
 	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/controller/soperatorchecks"
+	"nebius.ai/slurm-operator/internal/controllerconfig"
 	"nebius.ai/slurm-operator/internal/controllersenabled"
 	"nebius.ai/slurm-operator/internal/kubeletclient"
 	metricsopts "nebius.ai/slurm-operator/internal/metrics"
@@ -269,6 +270,7 @@ func main() {
 		// LeaderElectionReleaseOnCancel: true,
 		Cache: cache.Options{
 			DefaultNamespaces: watchNsCacheByName,
+			ByObject:          controllerconfig.NodeCacheByObject(),
 		},
 	})
 	if err != nil {

--- a/internal/consts/pagination.go
+++ b/internal/consts/pagination.go
@@ -1,3 +1,0 @@
-package consts
-
-const DefaultLimit int64 = 64

--- a/internal/controller/soperatorchecks/slurm_nodes_controller.go
+++ b/internal/controller/soperatorchecks/slurm_nodes_controller.go
@@ -35,10 +35,15 @@ const (
 
 type SlurmNodesController struct {
 	*reconciler.Reconciler
-	slurmAPIClients          *slurmapi.ClientSet
-	requeueAfter             time.Duration
-	enabledNodeReplacement   bool
-	apiReader                client.Reader // Direct API reader for pagination
+	slurmAPIClients        *slurmapi.ClientSet
+	requeueAfter           time.Duration
+	enabledNodeReplacement bool
+	// Uncached reader for the worker pod behind getSlurmNodeAssignmentTime. That read decides whether
+	// a drained slurm node has since been reassigned to a fresh compute instance, and this reconcile
+	// is driven by slurm API polling rather than pod events, so nothing guarantees the reassignment
+	// has reached the cache yet. A stale pod there makes the controller suspect hardware issues on a
+	// healthy new instance and replace it for nothing.
+	apiReader                client.Reader
 	MaintenanceConditionType corev1.NodeConditionType
 }
 
@@ -513,38 +518,32 @@ func (c *SlurmNodesController) processKillTaskFailed(
 }
 
 func (c *SlurmNodesController) processK8SNodesMaintenance(ctx context.Context) error {
-	nextToken := ""
+	// Read from the manager cache. This controller already reads Nodes through the cached client
+	// elsewhere, so the Node informer holds the whole set anyway; paginating the same data back out
+	// of the API server every reconcile only added round-trips and client-side throttling.
+	nodes := &corev1.NodeList{}
+	if err := c.Client.List(ctx, nodes); err != nil {
+		return fmt.Errorf("list k8s nodes: %w", err)
+	}
 
-	for {
-		listK8SNodesResp, err := listK8SNodesWithReader(ctx, c.apiReader, consts.DefaultLimit, nextToken)
-		if err != nil {
-			return fmt.Errorf("list k8s nodes: %w", err)
+	for _, k8sNode := range nodes.Items {
+		drainFn := func() error {
+			return c.drainSlurmNodesWithConditionUpdate(
+				ctx,
+				k8sNode.Name,
+				consts.SlurmNodeReasonNodeReplacement,
+				newNodeCondition(
+					consts.SoperatorChecksK8SNodeMaintenance,
+					corev1.ConditionTrue,
+					consts.ReasonNodeDraining,
+					consts.MessageMaintenanceScheduled,
+				),
+			)
 		}
 
-		for _, k8sNode := range listK8SNodesResp.Items {
-			drainFn := func() error {
-				return c.drainSlurmNodesWithConditionUpdate(
-					ctx,
-					k8sNode.Name,
-					consts.SlurmNodeReasonNodeReplacement,
-					newNodeCondition(
-						consts.SoperatorChecksK8SNodeMaintenance,
-						corev1.ConditionTrue,
-						consts.ReasonNodeDraining,
-						consts.MessageMaintenanceScheduled,
-					),
-				)
-			}
-
-			if err := c.processMaintenance(ctx, &k8sNode, drainFn, nil); err != nil {
-				return fmt.Errorf("process maintenance: %w", err)
-			}
+		if err := c.processMaintenance(ctx, &k8sNode, drainFn, nil); err != nil {
+			return fmt.Errorf("process maintenance: %w", err)
 		}
-
-		if listK8SNodesResp.Continue == "" {
-			break
-		}
-		nextToken = listK8SNodesResp.Continue
 	}
 
 	return nil

--- a/internal/controller/soperatorchecks/slurm_nodes_controller_test.go
+++ b/internal/controller/soperatorchecks/slurm_nodes_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -578,4 +579,93 @@ func hasHardwareIssuesSuspected(t *testing.T, ctx context.Context, k8sClient ctr
 		}
 	}
 	return false
+}
+
+func TestSlurmNodesController_processK8SNodesMaintenance_readsNodesFromCache(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	slurmClusterName := types.NamespacedName{Namespace: "test-ns", Name: "test-cluster"}
+
+	newNode := func(name string, conditions ...corev1.NodeCondition) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status:     corev1.NodeStatus{Conditions: conditions},
+		}
+	}
+	newWorkerPod := func(name, nodeName string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: slurmClusterName.Namespace,
+				Name:      name,
+				Labels: map[string]string{
+					consts.LabelWorkerKey:   consts.LabelWorkerValue,
+					consts.LabelInstanceKey: slurmClusterName.Name,
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: nodeName},
+		}
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			newNode("instance-maintenance", corev1.NodeCondition{
+				Type:   consts.DefaultMaintenanceConditionType,
+				Status: corev1.ConditionTrue,
+			}),
+			newNode("instance-healthy"),
+			newWorkerPod("worker-0", "instance-maintenance"),
+			newWorkerPod("worker-1", "instance-healthy"),
+		).
+		WithIndex(&corev1.Pod{}, "spec.nodeName", func(obj ctrlclient.Object) []string {
+			return []string{obj.(*corev1.Pod).Spec.NodeName}
+		}).
+		Build()
+
+	apiClient := slurmapifake.NewMockClient(t)
+	apiClient.On(
+		"SlurmV0044PostNodeWithResponse",
+		ctx,
+		"worker-0",
+		mock.MatchedBy(func(body api.SlurmV0044PostNodeJSONRequestBody) bool {
+			return body.State != nil &&
+				len(*body.State) == 1 &&
+				(*body.State)[0] == api.V0044UpdateNodeMsgStateDRAIN
+		}),
+	).Return(&api.SlurmV0044PostNodeResponse{
+		JSON200: &api.V0044OpenapiResp{Errors: &[]api.V0044OpenapiError{}},
+	}, nil).Once()
+	apiClient.On("GetNode", ctx, "worker-0").Return(slurmapi.Node{
+		Name:   "worker-0",
+		States: map[api.V0044NodeState]struct{}{api.V0044NodeStateIDLE: {}, api.V0044NodeStateDRAIN: {}},
+	}, nil).Once()
+
+	slurmAPIClients := slurmapi.NewClientSet(ctx)
+	slurmAPIClients.AddClient(slurmClusterName, apiClient)
+
+	controller := NewSlurmNodesController(
+		k8sClient,
+		scheme,
+		record.NewFakeRecorder(10),
+		slurmAPIClients,
+		time.Minute,
+		true,
+		// Nodes must come from the cached client, so an empty uncached reader is enough here.
+		fake.NewClientBuilder().WithScheme(scheme).Build(),
+		"",
+	)
+
+	require.NoError(t, controller.processK8SNodesMaintenance(ctx))
+
+	var maintained corev1.Node
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "instance-maintenance"}, &maintained))
+	require.True(t, slices.ContainsFunc(maintained.Status.Conditions, func(c corev1.NodeCondition) bool {
+		return c.Type == consts.SoperatorChecksK8SNodeMaintenance && c.Status == corev1.ConditionTrue
+	}))
+
+	var healthy corev1.Node
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "instance-healthy"}, &healthy))
+	require.Empty(t, healthy.Status.Conditions)
 }

--- a/internal/controller/soperatorchecks/soperatorchecks.go
+++ b/internal/controller/soperatorchecks/soperatorchecks.go
@@ -45,17 +45,16 @@ func setK8SNodeCondition(
 		return err
 	}
 
-	// The field node.Status.Conditions belongs to the status of the Node resource.
-	// In Kubernetes, the status is considered a "system-owned" object and cannot be
-	// modified using a regular Update call.
-	// Instead, changes to the status must be made using the Status().Update method.
+	// node.Status.Conditions belongs to the status subresource, so it is written through
+	// Status(), and by patch rather than update: the node comes from the manager cache, whose
+	// transform drops fields no controller reads, and an update would write that back wholesale.
 	for i, cond := range node.Status.Conditions {
 		if cond.Type == condition.Type {
 
 			if cond.Status == condition.Status && cond.Reason == string(condition.Reason) {
 				logger.Info("Node already has condition, updating LastHeartbeatTime")
-				node.Status.Conditions[i].LastHeartbeatTime = metav1.Now()
 				patch := client.MergeFrom(node.DeepCopy())
+				node.Status.Conditions[i].LastHeartbeatTime = metav1.Now()
 				return c.Status().Patch(ctx, node, patch)
 			}
 
@@ -68,9 +67,13 @@ func setK8SNodeCondition(
 	}
 
 	logger.Info("Adding new condition to node")
+	// Patch rather than update: the node was read from the manager cache, which trims fields the
+	// controllers never read, and a status update would write that truncated status back wholesale.
+	// The optimistic lock keeps a concurrent condition write from being lost to the array replacement.
+	patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	node.Status.Conditions = append(node.Status.Conditions, condition)
-	if err := c.Status().Update(ctx, node); err != nil {
-		return fmt.Errorf("failed to update object status: %w", err)
+	if err := c.Status().Patch(ctx, node, patch); err != nil {
+		return fmt.Errorf("patch object status: %w", err)
 	}
 
 	return nil
@@ -116,15 +119,4 @@ func getK8SNode(ctx context.Context, c client.Client, nodeName string) (*corev1.
 		return nil, err
 	}
 	return node, nil
-}
-
-func listK8SNodesWithReader(ctx context.Context, reader client.Reader, limit int64, nextToken string) (corev1.NodeList, error) {
-	nodes := &corev1.NodeList{}
-	if err := reader.List(ctx, nodes, &client.ListOptions{
-		Limit:    limit,
-		Continue: nextToken,
-	}); err != nil {
-		return corev1.NodeList{}, fmt.Errorf("list nodes: %w", err)
-	}
-	return *nodes, nil
 }

--- a/internal/controller/soperatorchecks/soperatorchecks_test.go
+++ b/internal/controller/soperatorchecks/soperatorchecks_test.go
@@ -1,0 +1,113 @@
+package soperatorchecks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"nebius.ai/slurm-operator/internal/consts"
+	"nebius.ai/slurm-operator/internal/controllerconfig"
+)
+
+// newTrimmedCacheClient mimics the manager client in soperatorchecks: reads come back with the
+// Node cache transform already applied, so a caller that writes the object back must not carry
+// the truncation to the API server. stopTrimming lifts the transform so assertions can observe
+// what the write actually stored.
+func newTrimmedCacheClient(t *testing.T, objects ...ctrlclient.Object) (c ctrlclient.Client, stopTrimming func()) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	trim := true
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(&corev1.Node{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(
+				ctx context.Context,
+				c ctrlclient.WithWatch,
+				key ctrlclient.ObjectKey,
+				obj ctrlclient.Object,
+				opts ...ctrlclient.GetOption,
+			) error {
+				if err := c.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				if !trim {
+					return nil
+				}
+				_, err := controllerconfig.TrimNodeForCache(obj)
+				return err
+			},
+		}).
+		Build(), func() { trim = false }
+}
+
+func nodeWithImages(conditions ...corev1.NodeCondition) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-node"},
+		Status: corev1.NodeStatus{
+			Conditions: conditions,
+			Images: []corev1.ContainerImage{
+				{Names: []string{"cr.eu-north1.nebius.cloud/soperator:1.0.0"}, SizeBytes: 1024},
+			},
+		},
+	}
+}
+
+func TestSetK8SNodeCondition_addingConditionKeepsTrimmedStatusFields(t *testing.T) {
+	ctx := context.Background()
+	k8sClient, stopTrimming := newTrimmedCacheClient(t, nodeWithImages())
+
+	require.NoError(t, setK8SNodeCondition(ctx, k8sClient, "worker-node", newNodeCondition(
+		consts.SoperatorChecksK8SNodeMaintenance,
+		corev1.ConditionTrue,
+		consts.ReasonNodeDraining,
+		consts.MessageMaintenanceScheduled,
+	)))
+
+	stopTrimming()
+	var stored corev1.Node
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "worker-node"}, &stored))
+	require.Len(t, stored.Status.Conditions, 1)
+	require.Equal(t, consts.SoperatorChecksK8SNodeMaintenance, stored.Status.Conditions[0].Type)
+	require.Len(t, stored.Status.Images, 1, "status.images must survive a condition write")
+}
+
+func TestSetK8SNodeCondition_unchangedConditionUpdatesHeartbeat(t *testing.T) {
+	ctx := context.Background()
+	staleHeartbeat := metav1.NewTime(time.Date(2026, time.April, 7, 10, 0, 0, 0, time.UTC))
+	condition := newNodeCondition(
+		consts.SoperatorChecksK8SNodeMaintenance,
+		corev1.ConditionTrue,
+		consts.ReasonNodeDraining,
+		consts.MessageMaintenanceScheduled,
+	)
+
+	existing := condition
+	existing.LastHeartbeatTime = staleHeartbeat
+	k8sClient, stopTrimming := newTrimmedCacheClient(t, nodeWithImages(existing))
+
+	require.NoError(t, setK8SNodeCondition(ctx, k8sClient, "worker-node", condition))
+
+	stopTrimming()
+	var stored corev1.Node
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "worker-node"}, &stored))
+	require.Len(t, stored.Status.Conditions, 1)
+	require.True(t,
+		stored.Status.Conditions[0].LastHeartbeatTime.After(staleHeartbeat.Time),
+		"LastHeartbeatTime must actually reach the API server",
+	)
+}

--- a/internal/controller/topologyconfcontroller/nodetopology_controller.go
+++ b/internal/controller/topologyconfcontroller/nodetopology_controller.go
@@ -43,12 +43,10 @@ type NodeTopologyReconciler struct {
 	BaseReconciler
 	Namespace           string
 	topologyLabelPrefix string
-	// https://github.com/kubernetes-sigs/controller-runtime/issues/3044
-	APIReader client.Reader // Direct API reader for pagination
 }
 
 func NewNodeTopologyReconciler(
-	client client.Client, scheme *runtime.Scheme, namespace, topologyLabelPrefix string, apiReader client.Reader) *NodeTopologyReconciler {
+	client client.Client, scheme *runtime.Scheme, namespace, topologyLabelPrefix string) *NodeTopologyReconciler {
 	return &NodeTopologyReconciler{
 		BaseReconciler: BaseReconciler{
 			Client: client,
@@ -56,7 +54,6 @@ func NewNodeTopologyReconciler(
 		},
 		Namespace:           namespace,
 		topologyLabelPrefix: topologyLabelPrefix,
-		APIReader:           apiReader,
 	}
 }
 
@@ -375,40 +372,25 @@ func (r *NodeTopologyReconciler) initializeResourceDistributionWithAllNodes(ctx 
 
 	configMapData := make(map[string]string)
 
+	// Read from the manager cache: this controller already watches every Node, so the informer
+	// holds them all regardless. Paginating the same data back out of the API server bought no
+	// memory and only added round-trips and client-side throttling.
 	nodeList := &corev1.NodeList{}
-	continueToken := ""
+	if err := r.Client.List(ctx, nodeList); err != nil {
+		return fmt.Errorf("list nodes: %w", err)
+	}
 
-	for {
-		listOptions := []client.ListOption{
-			client.Limit(consts.DefaultLimit),
-		}
-		if continueToken != "" {
-			listOptions = append(listOptions, client.Continue(continueToken))
-		}
-
-		// Use APIReader instead of cached client for pagination support
-		// https://github.com/kubernetes-sigs/controller-runtime/issues/3044
-		if err := r.APIReader.List(ctx, nodeList, listOptions...); err != nil {
-			return fmt.Errorf("list nodes: %w", err)
-		}
-
-		for _, node := range nodeList.Items {
-			if _, hasTierLabel := node.Labels[r.tierOneLabel()]; hasTierLabel {
-				tierData := ExtractTierLabels(node.Labels, r.topologyLabelPrefix)
-				if len(tierData) > 0 {
-					tierDataJSON, err := json.Marshal(tierData)
-					if err != nil {
-						logger.Error(err, "Failed to serialize tier data for node", "node", node.Name)
-						continue
-					}
-					configMapData[node.Name] = string(tierDataJSON)
+	for _, node := range nodeList.Items {
+		if _, hasTierLabel := node.Labels[r.tierOneLabel()]; hasTierLabel {
+			tierData := ExtractTierLabels(node.Labels, r.topologyLabelPrefix)
+			if len(tierData) > 0 {
+				tierDataJSON, err := json.Marshal(tierData)
+				if err != nil {
+					logger.Error(err, "Failed to serialize tier data for node", "node", node.Name)
+					continue
 				}
+				configMapData[node.Name] = string(tierDataJSON)
 			}
-		}
-
-		continueToken = nodeList.Continue
-		if continueToken == "" {
-			break
 		}
 	}
 

--- a/internal/controller/topologyconfcontroller/nodetopology_controller_test.go
+++ b/internal/controller/topologyconfcontroller/nodetopology_controller_test.go
@@ -58,8 +58,6 @@ func TestUpdateTopologyConfigMap(t *testing.T) {
 			Scheme: scheme,
 		},
 		Namespace: "default",
-		// Use the same fakeClient as APIReader for tests
-		APIReader: fakeClient,
 	}
 
 	ctx := context.TODO()
@@ -123,8 +121,6 @@ func TestRemoveTopologyConfigMap(t *testing.T) {
 			Scheme: scheme,
 		},
 		Namespace: "default",
-		// Use the same fakeClient as APIReader for tests
-		APIReader: fakeClient,
 	}
 
 	ctx := context.TODO()

--- a/internal/controllerconfig/cache.go
+++ b/internal/controllerconfig/cache.go
@@ -1,0 +1,31 @@
+package controllerconfig
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NodeCacheByObject trims Node objects on their way into the manager cache.
+//
+// Managers that watch Nodes hold every Node in the cluster, and at a few thousand nodes the two
+// heaviest fields on a Node object are status.images (the kubelet reports every image on disk, with
+// all of its tags) and metadata.managedFields. Nothing in soperator reads either, so dropping them
+// before the object is stored keeps the Node cache to the parts controllers actually use.
+func NodeCacheByObject() map[client.Object]cache.ByObject {
+	return map[client.Object]cache.ByObject{
+		&corev1.Node{}: {Transform: TrimNodeForCache},
+	}
+}
+
+func TrimNodeForCache(obj any) (any, error) {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return obj, nil
+	}
+
+	node.ManagedFields = nil
+	node.Status.Images = nil
+
+	return node, nil
+}

--- a/internal/controllerconfig/cache_test.go
+++ b/internal/controllerconfig/cache_test.go
@@ -1,0 +1,46 @@
+package controllerconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTrimNodeForCache(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "worker-0",
+			Labels:        map[string]string{"topology.nebius.com/tier-1": "switch-1"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubelet"}},
+		},
+		Spec: corev1.NodeSpec{Unschedulable: true},
+		Status: corev1.NodeStatus{
+			Images:     []corev1.ContainerImage{{Names: []string{"cr.eu-north1.nebius.cloud/soperator:1.0.0"}}},
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+
+	trimmed, err := TrimNodeForCache(node)
+	require.NoError(t, err)
+
+	trimmedNode, ok := trimmed.(*corev1.Node)
+	require.True(t, ok)
+	require.Empty(t, trimmedNode.ManagedFields)
+	require.Empty(t, trimmedNode.Status.Images)
+
+	// Everything the controllers actually read must survive.
+	require.Equal(t, "worker-0", trimmedNode.Name)
+	require.Equal(t, "switch-1", trimmedNode.Labels["topology.nebius.com/tier-1"])
+	require.True(t, trimmedNode.Spec.Unschedulable)
+	require.Equal(t, corev1.NodeReady, trimmedNode.Status.Conditions[0].Type)
+}
+
+func TestTrimNodeForCache_passesThroughNonNodes(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "worker-0"}}
+
+	trimmed, err := TrimNodeForCache(pod)
+	require.NoError(t, err)
+	require.Same(t, pod, trimmed)
+}


### PR DESCRIPTION
## Problem

Two controllers listed Kubernetes Nodes page by page through an uncached reader to save memory. Both managers already cache every Node, so this saved nothing and added ~32 throttled API calls per reconcile in `SlurmNodesController` — every 3 minutes, forever.

## Solution

Read Nodes from the manager cache and drop the pagination. To pay for the cache that was already there, a transformer strips `status.images` and `managedFields` from Nodes before they are stored — nothing in soperator reads either.

The uncached worker pod `Get` in `getSlurmNodeAssignmentTime` stays: it guards against replacing a healthy new instance on a stale read.

## Testing

`make lint`, `make test`, `make helmtest` all pass. Added unit coverage for `processK8SNodesMaintenance` (previously untested) and for the cache transformer.

## Release Notes

Improvement: soperator and soperatorchecks no longer paginate Node lists against kube-apiserver, removing recurring API load and client-side throttling on large clusters. Node cache footprint is reduced by dropping unused fields. No config changes.
