### PR TITLE
SCHED-1326 Add default Slurm config acceptance test

### DIFF
--- a/e2e/acceptance/features.go
+++ b/e2e/acceptance/features.go
@@ -26,6 +26,7 @@ func SharedFeatureSource() FeatureSource {
 func FeaturePaths() []string {
 	return []string{
 		"features/cluster_creation.feature",
+		"features/slurm_config.feature",
 		"features/observability.feature",
 		"features/internal_ssh.feature",
 		"features/package_installation.feature",

--- a/e2e/acceptance/features/slurm_config.feature
+++ b/e2e/acceptance/features/slurm_config.feature
@@ -1,0 +1,18 @@
+Feature: Default Slurm configuration
+
+  @soperator_version_>=4.0.0
+  Scenario: Stable Soperator defaults are applied
+    When the effective Slurm configuration is read
+    Then it contains the following settings:
+      | setting          | value                     |
+      | MpiDefault       | pmix                      |
+      | ProctrackType    | proctrack/cgroup          |
+      | TaskPlugin       | task/cgroup,task/affinity |
+      | SelectType       | select/cons_tres          |
+      | ReturnToService  | 2                         |
+      | SchedulerType    | sched/backfill            |
+      | JobRequeue       | 1                         |
+      | SlurmctldTimeout | 180 sec                   |
+      | SlurmdTimeout    | 180 sec                   |
+    And its cluster name matches the target cluster
+    And main partition smoke job succeeds

--- a/e2e/acceptance/features/slurm_config.feature
+++ b/e2e/acceptance/features/slurm_config.feature
@@ -12,7 +12,6 @@ Feature: Default Slurm configuration
       | ReturnToService  | 2                         |
       | SchedulerType    | sched/backfill            |
       | JobRequeue       | 1                         |
-      | SlurmctldTimeout | 180 sec                   |
       | SlurmdTimeout    | 180 sec                   |
     And its cluster name matches the target cluster
     And main partition smoke job succeeds

--- a/e2e/acceptance/internal/sharedsteps/slurm_config.go
+++ b/e2e/acceptance/internal/sharedsteps/slurm_config.go
@@ -1,0 +1,149 @@
+package sharedsteps
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cucumber/godog"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+type SlurmConfig struct {
+	info          *framework.ClusterInfo
+	runtime       framework.Runtime
+	configuration map[string]string
+}
+
+func NewSlurmConfig(info *framework.ClusterInfo, runtime framework.Runtime) *SlurmConfig {
+	return &SlurmConfig{info: info, runtime: runtime}
+}
+
+func (s *SlurmConfig) RegisterSteps(sc *godog.ScenarioContext) {
+	sc.Step(`^the effective Slurm configuration is read$`, s.readEffectiveSlurmConfiguration)
+	sc.Step(`^it contains the following settings:$`, s.checkEffectiveSlurmSettings)
+	sc.Step(`^its cluster name matches the target cluster$`, s.checkClusterName)
+}
+
+func (s *SlurmConfig) CleanupAndReset(ctx context.Context) {
+	s.configuration = nil
+}
+
+func (s *SlurmConfig) readEffectiveSlurmConfiguration(ctx context.Context) error {
+	output, err := s.runtime.Controller().RunWithDefaultRetry(ctx, "scontrol show config")
+	if err != nil {
+		return fmt.Errorf("read effective Slurm configuration: %w", err)
+	}
+
+	configuration, err := parseSlurmConfiguration(output)
+	if err != nil {
+		return fmt.Errorf("parse effective Slurm configuration: %w", err)
+	}
+	s.configuration = configuration
+	return nil
+}
+
+func (s *SlurmConfig) checkEffectiveSlurmSettings(table *godog.Table) error {
+	if s.configuration == nil {
+		return fmt.Errorf("read effective Slurm configuration before validating settings")
+	}
+
+	expected, err := parseSlurmSettingsTable(table)
+	if err != nil {
+		return fmt.Errorf("parse expected Slurm settings: %w", err)
+	}
+
+	return validateSlurmSettings(s.configuration, expected)
+}
+
+func (s *SlurmConfig) checkClusterName() error {
+	if s.configuration == nil {
+		return fmt.Errorf("read effective Slurm configuration before validating ClusterName")
+	}
+
+	return validateSlurmSettings(s.configuration, map[string]string{
+		"ClusterName": s.info.SlurmClusterName,
+	})
+}
+
+func parseSlurmConfiguration(output string) (map[string]string, error) {
+	configuration := make(map[string]string)
+	for lineNumber, line := range strings.Split(output, "\n") {
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return nil, fmt.Errorf("parse line %d: setting name is empty", lineNumber+1)
+		}
+		if _, found := configuration[key]; found {
+			return nil, fmt.Errorf("parse line %d: setting %q is duplicated", lineNumber+1, key)
+		}
+		configuration[key] = value
+	}
+	if len(configuration) == 0 {
+		return nil, fmt.Errorf("find settings in scontrol output")
+	}
+	return configuration, nil
+}
+
+func parseSlurmSettingsTable(table *godog.Table) (map[string]string, error) {
+	if table == nil || len(table.Rows) == 0 {
+		return nil, fmt.Errorf("find table rows")
+	}
+	if len(table.Rows[0].Cells) != 2 || table.Rows[0].Cells[0].Value != "setting" || table.Rows[0].Cells[1].Value != "value" {
+		return nil, fmt.Errorf(`use the header "setting | value"`)
+	}
+	if len(table.Rows) == 1 {
+		return nil, fmt.Errorf("find settings below the table header")
+	}
+
+	expected := make(map[string]string, len(table.Rows)-1)
+	for rowNumber, row := range table.Rows[1:] {
+		if len(row.Cells) != 2 {
+			return nil, fmt.Errorf("parse row %d: expected 2 cells, got %d", rowNumber+2, len(row.Cells))
+		}
+		setting := strings.TrimSpace(row.Cells[0].Value)
+		value := strings.TrimSpace(row.Cells[1].Value)
+		if setting == "" {
+			return nil, fmt.Errorf("parse row %d: setting name is empty", rowNumber+2)
+		}
+		if value == "" {
+			return nil, fmt.Errorf("parse row %d: value for %q is empty", rowNumber+2, setting)
+		}
+		if _, found := expected[setting]; found {
+			return nil, fmt.Errorf("parse row %d: setting %q is duplicated", rowNumber+2, setting)
+		}
+		expected[setting] = value
+	}
+	return expected, nil
+}
+
+func validateSlurmSettings(configuration, expected map[string]string) error {
+	settings := make([]string, 0, len(expected))
+	for setting := range expected {
+		settings = append(settings, setting)
+	}
+	sort.Strings(settings)
+
+	var problems []string
+	for _, setting := range settings {
+		actual, found := configuration[setting]
+		if !found {
+			problems = append(problems, fmt.Sprintf("%s: missing, expected %q", setting, expected[setting]))
+			continue
+		}
+		if actual != expected[setting] {
+			problems = append(problems, fmt.Sprintf("%s: expected %q, got %q", setting, expected[setting], actual))
+		}
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("validate Slurm settings: %s", strings.Join(problems, "; "))
+	}
+	return nil
+}

--- a/e2e/acceptance/internal/sharedsteps/slurm_config_test.go
+++ b/e2e/acceptance/internal/sharedsteps/slurm_config_test.go
@@ -1,0 +1,108 @@
+package sharedsteps
+
+import (
+	"testing"
+
+	"github.com/cucumber/godog"
+	messages "github.com/cucumber/messages/go/v21"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSlurmConfiguration(t *testing.T) {
+	configuration, err := parseSlurmConfiguration(`Configuration data as of 2026-09-01T15:00:00
+MpiDefault              = pmix
+SlurmctldTimeout        = 180 sec
+PluginOption            = name=value
+`)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"MpiDefault":       "pmix",
+		"PluginOption":     "name=value",
+		"SlurmctldTimeout": "180 sec",
+	}, configuration)
+}
+
+func TestParseSlurmConfigurationRejectsInvalidOutput(t *testing.T) {
+	for name, output := range map[string]string{
+		"no settings":    "Configuration data as of today\n",
+		"empty setting":  " = value\n",
+		"duplicate name": "MpiDefault = pmix\nMpiDefault = none\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseSlurmConfiguration(output)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestParseSlurmSettingsTable(t *testing.T) {
+	table := newSlurmSettingsTable(
+		[]string{"setting", "value"},
+		[]string{" MpiDefault ", " pmix "},
+		[]string{"SlurmctldTimeout", "180 sec"},
+	)
+
+	expected, err := parseSlurmSettingsTable(table)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"MpiDefault":       "pmix",
+		"SlurmctldTimeout": "180 sec",
+	}, expected)
+}
+
+func TestParseSlurmSettingsTableRejectsInvalidTables(t *testing.T) {
+	for name, table := range map[string]*godog.Table{
+		"nil":              nil,
+		"empty":            {},
+		"wrong header":     newSlurmSettingsTable([]string{"name", "expected"}, []string{"MpiDefault", "pmix"}),
+		"header only":      newSlurmSettingsTable([]string{"setting", "value"}),
+		"wrong cell count": newSlurmSettingsTable([]string{"setting", "value"}, []string{"MpiDefault"}),
+		"empty setting":    newSlurmSettingsTable([]string{"setting", "value"}, []string{"", "pmix"}),
+		"empty value":      newSlurmSettingsTable([]string{"setting", "value"}, []string{"MpiDefault", ""}),
+		"duplicate": newSlurmSettingsTable(
+			[]string{"setting", "value"},
+			[]string{"MpiDefault", "pmix"},
+			[]string{"MpiDefault", "none"},
+		),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseSlurmSettingsTable(table)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestValidateSlurmSettingsReportsAllProblemsInOrder(t *testing.T) {
+	err := validateSlurmSettings(
+		map[string]string{"TaskPlugin": "task/none"},
+		map[string]string{
+			"TaskPlugin": "task/cgroup,task/affinity",
+			"MpiDefault": "pmix",
+			"JobRequeue": "1",
+		},
+	)
+
+	require.EqualError(t, err, `validate Slurm settings: JobRequeue: missing, expected "1"; MpiDefault: missing, expected "pmix"; TaskPlugin: expected "task/cgroup,task/affinity", got "task/none"`)
+}
+
+func TestValidateSlurmSettingsAcceptsExactValues(t *testing.T) {
+	configuration := map[string]string{
+		"MpiDefault":       "pmix",
+		"SlurmctldTimeout": "180 sec",
+	}
+
+	assert.NoError(t, validateSlurmSettings(configuration, configuration))
+}
+
+func newSlurmSettingsTable(rows ...[]string) *godog.Table {
+	table := &godog.Table{}
+	for _, values := range rows {
+		row := &messages.PickleTableRow{}
+		for _, value := range values {
+			row.Cells = append(row.Cells, &messages.PickleTableCell{Value: value})
+		}
+		table.Rows = append(table.Rows, row)
+	}
+	return table
+}

--- a/e2e/acceptance/internal/sharedsteps/slurm_config_test.go
+++ b/e2e/acceptance/internal/sharedsteps/slurm_config_test.go
@@ -12,14 +12,14 @@ import (
 func TestParseSlurmConfiguration(t *testing.T) {
 	configuration, err := parseSlurmConfiguration(`Configuration data as of 2026-09-01T15:00:00
 MpiDefault              = pmix
-SlurmctldTimeout        = 180 sec
+SlurmdTimeout           = 180 sec
 PluginOption            = name=value
 `)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
-		"MpiDefault":       "pmix",
-		"PluginOption":     "name=value",
-		"SlurmctldTimeout": "180 sec",
+		"MpiDefault":    "pmix",
+		"PluginOption":  "name=value",
+		"SlurmdTimeout": "180 sec",
 	}, configuration)
 }
 
@@ -40,14 +40,14 @@ func TestParseSlurmSettingsTable(t *testing.T) {
 	table := newSlurmSettingsTable(
 		[]string{"setting", "value"},
 		[]string{" MpiDefault ", " pmix "},
-		[]string{"SlurmctldTimeout", "180 sec"},
+		[]string{"SlurmdTimeout", "180 sec"},
 	)
 
 	expected, err := parseSlurmSettingsTable(table)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
-		"MpiDefault":       "pmix",
-		"SlurmctldTimeout": "180 sec",
+		"MpiDefault":    "pmix",
+		"SlurmdTimeout": "180 sec",
 	}, expected)
 }
 
@@ -88,8 +88,8 @@ func TestValidateSlurmSettingsReportsAllProblemsInOrder(t *testing.T) {
 
 func TestValidateSlurmSettingsAcceptsExactValues(t *testing.T) {
 	configuration := map[string]string{
-		"MpiDefault":       "pmix",
-		"SlurmctldTimeout": "180 sec",
+		"MpiDefault":    "pmix",
+		"SlurmdTimeout": "180 sec",
 	}
 
 	assert.NoError(t, validateSlurmSettings(configuration, configuration))

--- a/e2e/acceptance/internal/sharedsteps/steps.go
+++ b/e2e/acceptance/internal/sharedsteps/steps.go
@@ -22,6 +22,7 @@ func RegisterAll(sc *godog.ScenarioContext, info *framework.ClusterInfo, runtime
 	selector := framework.NewWorkerSelector(kubectl, slurm, info.SlurmClusterName)
 	for _, family := range []scenarioScopedStepFamily{
 		NewClusterCreation(info, runtime, kubectl, selector),
+		NewSlurmConfig(info, runtime),
 		NewObservability(kubectl),
 		NewInternalSSH(runtime, selector),
 		NewPackageInstallation(runtime, selector),


### PR DESCRIPTION
## Problem

No slurm config acceptance test

## Solution

Added a shared acceptance scenario for Soperator 4.0.0 and later that:

- Verifies required values reported by scontrol show config.
- Confirms the configured Slurm cluster name.
- Runs the existing main-partition smoke job to verify the configuration is operational.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
