### PR TITLE
SCHED-1327: add GPU profiling acceptance tests

### DIFF
--- a/e2e/acceptance/features.go
+++ b/e2e/acceptance/features.go
@@ -31,6 +31,7 @@ func FeaturePaths() []string {
 		"features/observability.feature",
 		"features/internal_ssh.feature",
 		"features/package_installation.feature",
+		"features/gpu_profiling.feature",
 		"features/soperator_utils.feature",
 		"features/nodeset_ephemeral_mode_transition.feature",
 		"features/node_replacement.feature",

--- a/e2e/acceptance/features/gpu_profiling.feature
+++ b/e2e/acceptance/features/gpu_profiling.feature
@@ -1,0 +1,16 @@
+Feature: GPU profiling
+
+  Background:
+    Given a GPU worker is available for profiling
+    And the soperatorchecks user is available on the worker
+    And GPU profiling is enabled for non-root users on the worker
+
+  @gpu @soperator_version_>=4.0.0
+  Scenario: A non-root user can profile a GPU workload with Nsight Compute
+    When the soperatorchecks user submits an Nsight Compute profiling job
+    Then the Nsight Compute profiling job succeeds
+
+  @gpu @soperator_version_>=4.0.0
+  Scenario: A non-root user can profile a GPU workload with Nsight Systems
+    When the soperatorchecks user submits a full-node Nsight Systems profiling job
+    Then the Nsight Systems profiling job succeeds and produces a report

--- a/e2e/acceptance/framework/slurm_client.go
+++ b/e2e/acceptance/framework/slurm_client.go
@@ -21,8 +21,8 @@ func NewSlurmClient(runtime Runtime) *SlurmClient {
 }
 
 // SbatchOptions describes a Slurm batch submission from an acceptance test.
-// SubmitBatch always adds -o/-e pointing inside AcceptanceJobOutputDir so the
-// job log ends up in the CI artifact; callers don't set output flags.
+// SubmitBatch adds -o/-e pointing inside OutputDir, which defaults to
+// AcceptanceJobOutputDir.
 type SbatchOptions struct {
 	JobName      string   // required; used in output filename
 	Nodes        int      // -N (omitted if 0)
@@ -31,6 +31,8 @@ type SbatchOptions struct {
 	TasksPerNode int      // --ntasks-per-node (omitted if 0)
 	ExtraFlags   []string // verbatim flags appended before --wrap
 	Wrap         string   // --wrap body
+	RunAsUser    string   // submit through sudo -iu (omitted if empty)
+	OutputDir    string   // defaults to AcceptanceJobOutputDir
 }
 
 // SbatchJob is the handle returned by SubmitBatch. StdoutPath and StderrPath
@@ -60,12 +62,17 @@ func (s *SlurmClient) SubmitBatch(ctx context.Context, opts SbatchOptions) (Sbat
 	if strings.TrimSpace(opts.Wrap) == "" {
 		return SbatchJob{}, fmt.Errorf("sbatch: wrap body is required")
 	}
+	outputDir := strings.TrimSpace(opts.OutputDir)
+	if outputDir == "" {
+		outputDir = AcceptanceJobOutputDir
+	}
+	runAsUser := strings.TrimSpace(opts.RunAsUser)
 
 	var args []string
 	args = append(args, "--parsable")
 	args = append(args, fmt.Sprintf("--job-name=%s", ShellQuote(jobName)))
-	args = append(args, fmt.Sprintf("-o %s/%%x-%%j.out", AcceptanceJobOutputDir))
-	args = append(args, fmt.Sprintf("-e %s/%%x-%%j.err", AcceptanceJobOutputDir))
+	args = append(args, fmt.Sprintf("-o %s", ShellQuote(outputDir+"/%x-%j.out")))
+	args = append(args, fmt.Sprintf("-e %s", ShellQuote(outputDir+"/%x-%j.err")))
 	if opts.Nodes > 0 {
 		args = append(args, fmt.Sprintf("-N %d", opts.Nodes))
 	}
@@ -83,10 +90,14 @@ func (s *SlurmClient) SubmitBatch(ctx context.Context, opts SbatchOptions) (Sbat
 	}
 	args = append(args, fmt.Sprintf("--wrap=%s", ShellQuote(opts.Wrap)))
 
-	command := fmt.Sprintf("mkdir -p %s && sbatch %s",
-		ShellQuote(AcceptanceJobOutputDir),
-		strings.Join(args, " "),
-	)
+	mkdirCommand := fmt.Sprintf("mkdir -p %s", ShellQuote(outputDir))
+	sbatchCommand := fmt.Sprintf("sbatch %s", strings.Join(args, " "))
+	if runAsUser != "" {
+		quotedUser := ShellQuote(runAsUser)
+		mkdirCommand = fmt.Sprintf("sudo -iu %s -- mkdir -p %s", quotedUser, ShellQuote(outputDir))
+		sbatchCommand = fmt.Sprintf("sudo -iu %s -- sbatch %s", quotedUser, strings.Join(args, " "))
+	}
+	command := mkdirCommand + " && " + sbatchCommand
 
 	// TODO: Add safe retries for sbatch without creating duplicate jobs.
 	out, err := s.runtime.Jail().Run(ctx, command)
@@ -100,8 +111,8 @@ func (s *SlurmClient) SubmitBatch(ctx context.Context, opts SbatchOptions) (Sbat
 	return SbatchJob{
 		ID:         jobID,
 		JobName:    jobName,
-		StdoutPath: fmt.Sprintf("%s/%s-%s.out", AcceptanceJobOutputDir, jobName, jobID),
-		StderrPath: fmt.Sprintf("%s/%s-%s.err", AcceptanceJobOutputDir, jobName, jobID),
+		StdoutPath: fmt.Sprintf("%s/%s-%s.out", outputDir, jobName, jobID),
+		StderrPath: fmt.Sprintf("%s/%s-%s.err", outputDir, jobName, jobID),
 	}, nil
 }
 

--- a/e2e/acceptance/framework/slurm_client_test.go
+++ b/e2e/acceptance/framework/slurm_client_test.go
@@ -22,6 +22,28 @@ func TestSubmitBatchQuotesJobName(t *testing.T) {
 	assert.Contains(t, runtime.jailCommand, "--job-name="+ShellQuote(jobName))
 }
 
+func TestSubmitBatchRunsAsUserWithCustomOutputDir(t *testing.T) {
+	runtime := &submitBatchRuntime{}
+	outputDir := "/opt/soperator-home/soperatorchecks/.acceptance/gpu profiling"
+
+	job, err := NewSlurmClient(runtime).SubmitBatch(t.Context(), SbatchOptions{
+		JobName:   "gpu-profile",
+		Wrap:      "true",
+		RunAsUser: "soperatorchecks",
+		OutputDir: outputDir,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, outputDir+"/gpu-profile-123.out", job.StdoutPath)
+	assert.Equal(t, outputDir+"/gpu-profile-123.err", job.StderrPath)
+	assert.Contains(t, runtime.jailCommand,
+		"sudo -iu 'soperatorchecks' -- mkdir -p "+ShellQuote(outputDir))
+	assert.Contains(t, runtime.jailCommand,
+		"sudo -iu 'soperatorchecks' -- sbatch")
+	assert.Contains(t, runtime.jailCommand, "-o "+ShellQuote(outputDir+"/%x-%j.out"))
+	assert.Contains(t, runtime.jailCommand, "-e "+ShellQuote(outputDir+"/%x-%j.err"))
+}
+
 func TestParseSacctJob(t *testing.T) {
 	dump := `
 123.batch|COMPLETED|0:0||

--- a/e2e/acceptance/framework/slurm_node.go
+++ b/e2e/acceptance/framework/slurm_node.go
@@ -14,6 +14,7 @@ var (
 	slurmNodeReasonPattern     = regexp.MustCompile(`\bReason=([^\n]+)`)
 	slurmNodeInstanceIDPattern = regexp.MustCompile(`\bInstanceId=([^\s]+)`)
 	slurmNodeRealMemoryPattern = regexp.MustCompile(`\bRealMemory=(\d+)`)
+	slurmNodeGPUCountPattern   = regexp.MustCompile(`\bCfgTRES=[^\s]*\bgres/gpu=(\d+)`)
 )
 
 type SlurmNodeInfo struct {
@@ -22,6 +23,7 @@ type SlurmNodeInfo struct {
 	Reason        string
 	InstanceID    string
 	RealMemoryMiB uint64
+	GPUCount      int
 }
 
 func ParseSlurmNodeInfo(name, output string) SlurmNodeInfo {
@@ -40,6 +42,11 @@ func ParseSlurmNodeInfo(name, output string) SlurmNodeInfo {
 	if match := slurmNodeRealMemoryPattern.FindStringSubmatch(output); len(match) == 2 {
 		if value, err := strconv.ParseUint(match[1], 10, 64); err == nil {
 			info.RealMemoryMiB = value
+		}
+	}
+	if match := slurmNodeGPUCountPattern.FindStringSubmatch(output); len(match) == 2 {
+		if value, err := strconv.Atoi(match[1]); err == nil {
+			info.GPUCount = value
 		}
 	}
 	return info

--- a/e2e/acceptance/framework/slurm_node_test.go
+++ b/e2e/acceptance/framework/slurm_node_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestParseSlurmNodeInfo(t *testing.T) {
-	output := "NodeName=worker-0 InstanceId=compute-instance-1 State=IDLE+DRAIN ThreadsPerCore=1 RealMemory=191356 Reason=[user_problem] alloc_gpus_busy [root@2026-01-01T00:00:00]"
+	output := "NodeName=worker-0 InstanceId=compute-instance-1 State=IDLE+DRAIN ThreadsPerCore=1 RealMemory=191356 CfgTRES=cpu=128,mem=1436G,billing=128,gres/gpu=8 Reason=[user_problem] alloc_gpus_busy [root@2026-01-01T00:00:00]"
 
 	info := ParseSlurmNodeInfo("worker-0", output)
 
@@ -16,11 +16,29 @@ func TestParseSlurmNodeInfo(t *testing.T) {
 	assert.Equal(t, "IDLE+DRAIN", info.State)
 	assert.Equal(t, "[user_problem] alloc_gpus_busy [root@2026-01-01T00:00:00]", info.Reason)
 	assert.Equal(t, uint64(191356), info.RealMemoryMiB)
+	assert.Equal(t, 8, info.GPUCount)
 	assert.True(t, info.HasStateFlag("DRAIN"))
 	assert.True(t, info.HasStateFlag("idle"))
 	assert.False(t, info.HasStateFlag("DOWN"))
 	assert.True(t, info.ReasonContains("alloc_gpus_busy"))
 	assert.False(t, info.IsUsable())
+}
+
+func TestParseSlurmNodeInfoGPUCount(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		cfgTRES  string
+		expected int
+	}{
+		{name: "GB300", cfgTRES: "CfgTRES=cpu=72,mem=2300G,gres/gpu=4", expected: 4},
+		{name: "H200", cfgTRES: "CfgTRES=cpu=128,mem=1436G,billing=128,gres/gpu=8", expected: 8},
+		{name: "CPU", cfgTRES: "CfgTRES=cpu=32,mem=128G", expected: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			info := ParseSlurmNodeInfo("worker-0", "NodeName=worker-0 "+test.cfgTRES+" State=IDLE")
+			assert.Equal(t, test.expected, info.GPUCount)
+		})
+	}
 }
 
 func TestParseSlurmNodeNames(t *testing.T) {

--- a/e2e/acceptance/internal/sharedsteps/gpu_profiling.go
+++ b/e2e/acceptance/internal/sharedsteps/gpu_profiling.go
@@ -13,7 +13,9 @@ import (
 )
 
 const (
-	gpuProfilingUser       = "soperatorchecks"
+	gpuProfilingUser = "soperatorchecks"
+	// Profiling jobs run as soperatorchecks, so their logs and reports need a
+	// user-writable directory. The E2E cluster teardown removes these artifacts.
 	gpuProfilingOutputDir  = "/opt/soperator-home/soperatorchecks/.acceptance/gpu-profiling"
 	gpuProfilingJobTimeout = 15 * time.Minute
 	gpuProfilingCleanup    = 3 * time.Minute
@@ -51,31 +53,6 @@ func (s *GPUProfiling) CleanupAndReset(ctx context.Context) {
 	if !s.job.IsZero() {
 		if err := s.slurm.CancelJob(ctx, s.job.ID, gpuProfilingCleanup); err != nil {
 			s.runtime.Logf("cleanup: cancel GPU profiling job %s: %v", s.job.ID, err)
-		}
-	}
-
-	var files []string
-	if s.job.StdoutPath != "" {
-		files = append(files, s.job.StdoutPath)
-	}
-	if s.job.StderrPath != "" {
-		files = append(files, s.job.StderrPath)
-	}
-	if s.reportPath != "" {
-		files = append(files, s.reportPath)
-	}
-	if len(files) > 0 {
-		quotedFiles := make([]string, 0, len(files))
-		for _, file := range files {
-			quotedFiles = append(quotedFiles, framework.ShellQuote(file))
-		}
-		command := "rm -f -- " + strings.Join(quotedFiles, " ")
-		if _, err := s.runtime.Jail().Run(ctx, command); err != nil {
-			s.runtime.Logf("cleanup: remove GPU profiling files: %v", err)
-		}
-		if _, err := s.runtime.Jail().Run(ctx,
-			fmt.Sprintf("rmdir %s 2>/dev/null || true", framework.ShellQuote(gpuProfilingOutputDir))); err != nil {
-			s.runtime.Logf("cleanup: remove empty GPU profiling output directory: %v", err)
 		}
 	}
 

--- a/e2e/acceptance/internal/sharedsteps/gpu_profiling.go
+++ b/e2e/acceptance/internal/sharedsteps/gpu_profiling.go
@@ -1,0 +1,208 @@
+package sharedsteps
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+const (
+	gpuProfilingUser       = "soperatorchecks"
+	gpuProfilingOutputDir  = "/opt/soperator-home/soperatorchecks/.acceptance/gpu-profiling"
+	gpuProfilingJobTimeout = 15 * time.Minute
+	gpuProfilingCleanup    = 3 * time.Minute
+)
+
+type GPUProfiling struct {
+	runtime  framework.Runtime
+	slurm    *framework.SlurmClient
+	selector *framework.WorkerSelector
+
+	worker     framework.WorkerInfo
+	job        framework.SbatchJob
+	reportPath string
+}
+
+func NewGPUProfiling(runtime framework.Runtime, slurm *framework.SlurmClient, selector *framework.WorkerSelector) *GPUProfiling {
+	return &GPUProfiling{
+		runtime:  runtime,
+		slurm:    slurm,
+		selector: selector,
+	}
+}
+
+func (s *GPUProfiling) RegisterSteps(sc *godog.ScenarioContext) {
+	sc.Step(`^a GPU worker is available for profiling$`, s.aGPUWorkerIsAvailableForProfiling)
+	sc.Step(`^the soperatorchecks user is available on the worker$`, s.theSoperatorchecksUserIsAvailableOnTheWorker)
+	sc.Step(`^GPU profiling is enabled for non-root users on the worker$`, s.gpuProfilingIsEnabledForNonRootUsersOnTheWorker)
+	sc.Step(`^the soperatorchecks user submits an Nsight Compute profiling job$`, s.theSoperatorchecksUserSubmitsAnNsightComputeProfilingJob)
+	sc.Step(`^the Nsight Compute profiling job succeeds$`, s.theNsightComputeProfilingJobSucceeds)
+	sc.Step(`^the soperatorchecks user submits a full-node Nsight Systems profiling job$`, s.theSoperatorchecksUserSubmitsAFullNodeNsightSystemsProfilingJob)
+	sc.Step(`^the Nsight Systems profiling job succeeds and produces a report$`, s.theNsightSystemsProfilingJobSucceedsAndProducesAReport)
+}
+
+func (s *GPUProfiling) CleanupAndReset(ctx context.Context) {
+	if !s.job.IsZero() {
+		if err := s.slurm.CancelJob(ctx, s.job.ID, gpuProfilingCleanup); err != nil {
+			s.runtime.Logf("cleanup: cancel GPU profiling job %s: %v", s.job.ID, err)
+		}
+	}
+
+	var files []string
+	if s.job.StdoutPath != "" {
+		files = append(files, s.job.StdoutPath)
+	}
+	if s.job.StderrPath != "" {
+		files = append(files, s.job.StderrPath)
+	}
+	if s.reportPath != "" {
+		files = append(files, s.reportPath)
+	}
+	if len(files) > 0 {
+		quotedFiles := make([]string, 0, len(files))
+		for _, file := range files {
+			quotedFiles = append(quotedFiles, framework.ShellQuote(file))
+		}
+		command := "rm -f -- " + strings.Join(quotedFiles, " ")
+		if _, err := s.runtime.Jail().Run(ctx, command); err != nil {
+			s.runtime.Logf("cleanup: remove GPU profiling files: %v", err)
+		}
+		if _, err := s.runtime.Jail().Run(ctx,
+			fmt.Sprintf("rmdir %s 2>/dev/null || true", framework.ShellQuote(gpuProfilingOutputDir))); err != nil {
+			s.runtime.Logf("cleanup: remove empty GPU profiling output directory: %v", err)
+		}
+	}
+
+	s.worker = framework.WorkerInfo{}
+	s.job = framework.SbatchJob{}
+	s.reportPath = ""
+}
+
+func (s *GPUProfiling) aGPUWorkerIsAvailableForProfiling(ctx context.Context) error {
+	workers, err := s.selector.PickGPUWorkers(ctx, 1)
+	if err != nil {
+		return framework.SkipIfInsufficientWorkers(s.runtime, err)
+	}
+	s.worker = workers[0]
+	if s.worker.SlurmNode.GPUCount < 1 {
+		return fmt.Errorf("GPU worker %s has invalid configured GPU count %d", s.worker.Name, s.worker.SlurmNode.GPUCount)
+	}
+	s.runtime.Logf("GPU profiling: selected worker=%s GPUs=%d", s.worker.Name, s.worker.SlurmNode.GPUCount)
+	return nil
+}
+
+func (s *GPUProfiling) theSoperatorchecksUserIsAvailableOnTheWorker(ctx context.Context) error {
+	if s.worker.Name == "" {
+		return fmt.Errorf("GPU profiling worker is not selected")
+	}
+	if _, err := s.runtime.Jail().RunWithDefaultRetry(ctx,
+		"id "+framework.ShellQuote(gpuProfilingUser)+" >/dev/null"); err != nil {
+		return fmt.Errorf("check %s user in the jail: %w", gpuProfilingUser, err)
+	}
+	return waitForSSHTestUserOnWorker(ctx, s.runtime, gpuProfilingUser, s.worker)
+}
+
+func (s *GPUProfiling) gpuProfilingIsEnabledForNonRootUsersOnTheWorker(ctx context.Context) error {
+	if s.worker.Name == "" {
+		return fmt.Errorf("GPU profiling worker is not selected")
+	}
+	output, err := s.runtime.Worker(s.worker).RunWithDefaultRetry(ctx,
+		"grep '^RmProfilingAdminOnly:' /proc/driver/nvidia/params")
+	if err != nil {
+		return fmt.Errorf("read NVIDIA profiling driver parameter on %s: %w", s.worker.Name, err)
+	}
+	fields := strings.Fields(output)
+	if len(fields) != 2 || fields[0] != "RmProfilingAdminOnly:" || fields[1] != "0" {
+		return fmt.Errorf("expected RmProfilingAdminOnly to be 0 on %s, got %q", s.worker.Name, strings.TrimSpace(output))
+	}
+	return nil
+}
+
+func (s *GPUProfiling) theSoperatorchecksUserSubmitsAnNsightComputeProfilingJob(ctx context.Context) error {
+	if s.worker.Name == "" {
+		return fmt.Errorf("GPU profiling worker is not selected")
+	}
+	wrap := fmt.Sprintf(
+		"test \"$(id -u)\" -ne 0 && test \"$(id -un)\" = %s && export NCCL_GRAPH_DISABLE=1 && "+
+			"ncu --target-processes all --profile-from-start on --replay-mode kernel --set base "+
+			"all_reduce_perf -g 1 -b 32M -e 32M -f 1 -w 1 -n 1",
+		framework.ShellQuote(gpuProfilingUser),
+	)
+	job, err := s.slurm.SubmitBatch(ctx, framework.SbatchOptions{
+		JobName:      "e2e-gpu-ncu",
+		Nodes:        1,
+		Nodelist:     []string{s.worker.Name},
+		GPUsPerNode:  1,
+		TasksPerNode: 1,
+		Wrap:         wrap,
+		RunAsUser:    gpuProfilingUser,
+		OutputDir:    gpuProfilingOutputDir,
+	})
+	if err != nil {
+		return err
+	}
+	s.job = job
+	s.runtime.Logf("Nsight Compute: worker=%s job_id=%s stdout=%s stderr=%s",
+		s.worker.Name, job.ID, job.StdoutPath, job.StderrPath)
+	return nil
+}
+
+func (s *GPUProfiling) theNsightComputeProfilingJobSucceeds(ctx context.Context) error {
+	if s.job.IsZero() {
+		return fmt.Errorf("Nsight Compute job ID is empty")
+	}
+	return waitForJobSucceeded(ctx, s.runtime, s.slurm, s.job, gpuProfilingJobTimeout)
+}
+
+func (s *GPUProfiling) theSoperatorchecksUserSubmitsAFullNodeNsightSystemsProfilingJob(ctx context.Context) error {
+	if s.worker.Name == "" {
+		return fmt.Errorf("GPU profiling worker is not selected")
+	}
+	reportBase := path.Join(gpuProfilingOutputDir, fmt.Sprintf("nsys-%d", time.Now().UnixNano()))
+	wrap := fmt.Sprintf(
+		"test \"$(id -u)\" -ne 0 && test \"$(id -un)\" = %s && "+
+			"nsys profile --trace=cuda,nvtx -o %s all_reduce_perf -b 512M -e 8G -f 2 -g %d",
+		framework.ShellQuote(gpuProfilingUser),
+		framework.ShellQuote(reportBase),
+		s.worker.SlurmNode.GPUCount,
+	)
+	job, err := s.slurm.SubmitBatch(ctx, framework.SbatchOptions{
+		JobName:      "e2e-gpu-nsys",
+		Nodes:        1,
+		Nodelist:     []string{s.worker.Name},
+		GPUsPerNode:  s.worker.SlurmNode.GPUCount,
+		TasksPerNode: 1,
+		Wrap:         wrap,
+		RunAsUser:    gpuProfilingUser,
+		OutputDir:    gpuProfilingOutputDir,
+	})
+	if err != nil {
+		return err
+	}
+	s.job = job
+	s.reportPath = reportBase + ".nsys-rep"
+	s.runtime.Logf("Nsight Systems: worker=%s GPUs=%d job_id=%s report=%s stdout=%s stderr=%s",
+		s.worker.Name, s.worker.SlurmNode.GPUCount, job.ID, s.reportPath, job.StdoutPath, job.StderrPath)
+	return nil
+}
+
+func (s *GPUProfiling) theNsightSystemsProfilingJobSucceedsAndProducesAReport(ctx context.Context) error {
+	if s.job.IsZero() {
+		return fmt.Errorf("Nsight Systems job ID is empty")
+	}
+	if err := waitForJobSucceeded(ctx, s.runtime, s.slurm, s.job, gpuProfilingJobTimeout); err != nil {
+		return err
+	}
+	if _, err := s.runtime.Worker(s.worker).RunWithDefaultRetry(ctx,
+		"test -s "+framework.ShellQuote(s.reportPath)); err != nil {
+		return framework.AnnotateWithJobLog(ctx, s.runtime, s.slurm, s.job,
+			fmt.Errorf("expected non-empty Nsight Systems report %s on %s: %w", s.reportPath, s.worker.Name, err))
+	}
+	return nil
+}

--- a/e2e/acceptance/internal/sharedsteps/steps.go
+++ b/e2e/acceptance/internal/sharedsteps/steps.go
@@ -27,6 +27,7 @@ func RegisterAll(sc *godog.ScenarioContext, info *framework.ClusterInfo, runtime
 		NewObservability(kubectl),
 		NewInternalSSH(runtime, selector),
 		NewPackageInstallation(runtime, selector),
+		NewGPUProfiling(runtime, slurm, selector),
 		NewSoperatorUtils(runtime, selector),
 		NewNodeSetEphemeralModeTransition(info, runtime, kubectl),
 		NewNodeReplacement(runtime, slurm, selector),


### PR DESCRIPTION
## Problem

GPU users need to run Nsight Compute and Nsight Systems without root privileges, but this behavior was not covered by automated acceptance tests. Regressions in profiling permissions or GPU allocation could therefore go unnoticed.

## Solution

Added separate acceptance scenarios for Nsight Compute and Nsight Systems profiling as the non-root soperatorchecks user.

The tests verify that non-root profiling is enabled, adapt to the number of GPUs available on the selected worker, and retain generated profiling reports for later inspection.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
