### PR TITLE
SCHED-2422: Reconcile Slurm node topology registrations

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -568,6 +568,17 @@ jobs:
           kubectl exec -n soperator ${SLURM_CLUSTER_NAME}-controller-0 -- sacct --format=JobID,JobName,Partition,Account,AllocCPUS,State,ExitCode -S now-6hours || true
           kubectl exec -n soperator ${SLURM_CLUSTER_NAME}-controller-0 -- sacct --parsable2 --allusers --starttime=now-6hours | column -t -s'|'
 
+      - name: Slurm Topology State
+        if: always()
+        shell: bash
+        run: |
+          echo "=== Slurm control show nodes ==="
+          kubectl exec -n soperator ${SLURM_CLUSTER_NAME}-controller-0 -- scontrol show nodes || true
+          echo "=== Slurm control show topoconf ==="
+          kubectl exec -n soperator ${SLURM_CLUSTER_NAME}-controller-0 -- scontrol show topoconf || true
+          echo "=== Slurm control show topology tree-ib ==="
+          kubectl exec -n soperator ${SLURM_CLUSTER_NAME}-controller-0 -- scontrol show topology tree-ib || true
+
       - name: Collect Full Kubernetes Cluster Info
         if: always()
         shell: bash

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -313,7 +313,9 @@ func main() {
 
 	slurmAPIClients := slurmapi.NewClientSet(context.Background())
 
-	if controllersSet.Enabled("rollingupdate") {
+	// Set up whenever anything downstream needs to talk to Slurm: it is what populates the client
+	// set and starts the shared node cache.
+	if controllersSet.Enabled("rollingupdate") || controllersSet.Enabled("topology") {
 		if err = soperatorchecks.NewSlurmAPIClientsController(
 			mgr.GetClient(),
 			mgr.GetScheme(),
@@ -322,7 +324,9 @@ func main() {
 		).SetupWithManager(mgr, maxConcurrency, cacheSyncTimeout); err != nil {
 			cli.Fail(setupLog, err, "unable to create slurm api clients controller", "controller", soperatorchecks.SlurmAPIClientsControllerName)
 		}
+	}
 
+	if controllersSet.Enabled("rollingupdate") {
 		if err = updatecontroller.NewRollingUpdateReconciler(
 			mgr.GetClient(),
 			mgr.GetScheme(),
@@ -354,6 +358,7 @@ func main() {
 			mgr.GetScheme(),
 			soperatorNamespace,
 			mgr.GetEventRecorder(topologyconfcontroller.WorkerTopologyReconcilerName),
+			slurmAPIClients,
 		).SetupWithManager(mgr, maxConcurrency, cacheSyncTimeout); err != nil {
 			cli.Fail(setupLog, err,
 				"unable to create controller",

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -447,6 +447,21 @@ content would otherwise read as confirming the new one.
 
 #### Watching it happen
 
+Every published change to `topology.yaml` is recorded on the SlurmCluster, in its own namespace and
+under its own name, with a summary of how node membership moved:
+
+```
+kubectl -n <ns> describe slurmcluster <name>
+...
+Events:
+  Type    Reason             Age   From                     Message
+  Normal  TopologyRendered   2m    workertopology-reconciler Published topology.yaml: +block-nvl72 (2 nodes); tree-ib 6 nodes (+0 -2)
+```
+
+This is the only signal for a node moved between topologies: membership is not part of the structure
+fingerprint, so such an edit asks for no reconfigure. The operator log carries the same change with
+the node names spelled out, under `Topology config changed, publishing it`.
+
 Every performed reconfigure is recorded as a Kubernetes event on each `JailedConfig` it covered, so
 it is visible without reading operator logs:
 
@@ -458,7 +473,16 @@ Events:
   Normal  Reconfigured   1m    jailedconfig-controller slurmctld re-read the configs written for this JailedConfig
 ```
 
-A failed one is recorded as a `Warning` with reason `ReconfigureFailed` and the error.
+A failed one is recorded as a `Warning` with reason `ReconfigureFailed`, naming the config that
+triggered the reconfigure, why it was due, and the error. When the failure is nodes not coming back,
+the error names them:
+
+```
+nodes did not restart within 5m0s: worker-[3-5]: context deadline exceeded
+```
+
+Repeated failures aggregate into one event with a count, so `kubectl get events` shows how long a
+request has been failing without comparing timestamps by hand.
 
 #### Misconfigurations reported as events
 
@@ -472,18 +496,58 @@ them without digging through operator logs:
 | `UnresolvedTopologyRef` | A partition's `topologyRef` names a topology that is not in the rendered config. The binding is dropped and the partition falls back to the cluster default. |
 | `ClusterDefaultConflict` | Several topologies set `clusterDefault`. The first one stays the default, the rest are cleared. |
 
+`TopologyRendered` is emitted on the same object but is not a problem report: it records a normal
+publish.
+
 #### What a reconfigure does not do
 
 It does not move already-registered nodes between topologies. Re-reading the file lays the nodes out
 as written, but slurmctld then applies each node's own `Topology=` registration on top, and treats
 that registration as the complete list: a node is removed from every topology its registration does
-not name. Workers compute that registration once, in their init container.
+not name.
 
-So a node that was running before a topology was added stays out of it until its pod restarts, no
-matter how many times the cluster is reconfigured. Adding a topology and expecting existing nodes to
-join it is the one case where the file and the running cluster legitimately disagree — check
-`scontrol show node <name> | grep -i topology` against the file before assuming the config failed to
-arrive.
+### How a node's registration is kept correct
+
+The `Topology=` field of `scontrol show node` is the node's own registration, not a view of the
+file. Two things maintain it, and they divide the work:
+
+- The worker registers itself when its pod starts, from its init container. This is the fast path,
+  and it is the only one that runs before slurmd does.
+- The operator converges it. On every reconcile it compares the rendered config against what
+  slurmctld reports and corrects the difference, so a registration that was lost or is out of date
+  heals within a reconcile.
+
+The converging half exists because the fast path is fragile in one specific way: a worker registers
+before its slurmd comes up, which means Slurm still considers the node powered down. If a
+reconfigure lands in that window, slurmctld discards the registration while restoring node state —
+it deliberately does not preserve dynamic topology for a powered-down node — and nothing in the pod
+recomputes it. That is a race a worker cannot win on its own, and it is why the file alone is not
+enough either: a node's own registration overrides whatever the file says about it.
+
+The push is cheap by construction. The desired side comes from the file, the current side from the
+node cache the operator already refreshes, and nodes needing the same value are sent as one hostlist
+request — so a steady cluster costs no request at all, and a re-render costs one request per changed
+switch rather than one per node. It never triggers a reconfigure: `scontrol update` changes the live
+tree in place.
+
+When a managed node loses its last tree/block binding, the operator sends an explicit empty
+registration to clear its previous placement. This also applies when only flat topologies remain.
+
+Two cases are deliberately left alone. Nodes that are powered down are skipped, because a
+registration written to them would be discarded exactly as described above; they are picked up once
+they come up. Nodes the config places in the catch-all `unknown` unit are skipped too, since that
+unit means the placement is not known yet, and asserting it into slurmctld would replace "no answer"
+with a wrong one.
+
+| Reason | Meaning |
+| --- | --- |
+| `NodeTopologyPushed` | The operator corrected one or more registrations to match the config. |
+| `NodeTopologyPushFailed` | A registration could not be written. The note names the nodes, the value and the error. |
+
+A push waits until the reconfigure for the current structure has been confirmed. Registering a node
+into a topology slurmctld has not read yet fails for every node in it, because the set of named
+topologies is fixed when the process starts and only a reconfigure — which re-execs slurmctld — can
+extend it.
 
 ## Troubleshooting
 

--- a/e2e/acceptance/features/topology.feature
+++ b/e2e/acceptance/features/topology.feature
@@ -13,8 +13,7 @@ Feature: Slurm named topologies
     When Slurm is asked which topologies it loaded
     Then Slurm loaded exactly the topologies the operator rendered
 
-  # Remove @unstable after worker topology registration is fixed.
-  @multi_topology @unstable @soperator_version_>=5.0.0
+  @multi_topology @soperator_version_>=5.0.0
   Scenario: Partitions and workers use their configured topologies
     Given the operator published the topology config
     When Slurm is asked which topologies it loaded

--- a/e2e/acceptance/features/topology_tree.feature
+++ b/e2e/acceptance/features/topology_tree.feature
@@ -1,7 +1,6 @@
 Feature: Slurm tree-topology scheduling
 
-  # Remove @unstable after worker topology registration is fixed.
-  @gpu @tree_topology @unstable @soperator_version_>=5.0.0
+  @gpu @tree_topology @soperator_version_>=5.0.0
   Scenario: A switch limit rejects a cross-leaf allocation
     Given the cluster is configured with a tree topology spanning multiple leaf switches
     And the operator published the topology config

--- a/images/worker/worker_init_test.py
+++ b/images/worker/worker_init_test.py
@@ -718,6 +718,30 @@ class TestWaitForController(unittest.TestCase):
 
 
 
+class TestApplyNodeTopology(unittest.TestCase):
+    """Tests for applying the prepared topology after controller readiness."""
+
+    @mock.patch("worker_init.get_node_addr", return_value="nodeaddr=worker.service.svc")
+    @mock.patch("subprocess.run")
+    def test_updates_node_without_another_ping(self, mock_run, mock_node_addr):
+        mock_run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+
+        worker_init.apply_node_topology("worker-0", "topology=default:root:leaf-0")
+
+        mock_run.assert_called_once_with(
+            [
+                "scontrol",
+                "update",
+                "nodename=worker-0",
+                "nodeaddr=worker.service.svc",
+                "topology=default:root:leaf-0",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+
 class TestIsGpuEnabled(unittest.TestCase):
     """Tests for is_gpu_enabled function."""
 
@@ -1043,16 +1067,26 @@ class TestMainArgparse(unittest.TestCase):
             worker_init.main()
         mock_wait.assert_called_once()
 
-    @mock.patch("worker_init.wait_for_topology")
-    @mock.patch("worker_init.wait_for_controller")
-    def test_main_both_commands(self, mock_controller, mock_topology):
-        """Main runs both commands sequentially."""
-        with mock.patch(
-            "sys.argv", ["worker_init.py", "wait-controller", "wait-topology"]
+    def test_main_both_commands(self):
+        """Delay precedes the controller wait, even when topology is requested first."""
+        for commands in (
+            ["wait-controller", "wait-topology"],
+            ["wait-topology", "wait-controller"],
         ):
-            worker_init.main()
-        mock_controller.assert_called_once()
-        mock_topology.assert_called_once()
+            with self.subTest(commands=commands):
+                parent = mock.Mock()
+                with mock.patch("worker_init.wait_for_topology") as topology, \
+                    mock.patch("worker_init.wait_for_controller") as controller, \
+                    mock.patch("worker_init.apply_random_startup_delay") as delay, \
+                    mock.patch("sys.argv", ["worker_init.py", *commands]):
+                    parent.attach_mock(delay, "delay")
+                    parent.attach_mock(controller, "controller")
+                    parent.attach_mock(topology, "topology")
+                    worker_init.main()
+                self.assertEqual(
+                    parent.mock_calls,
+                    [mock.call.delay(), mock.call.controller(), mock.call.topology()],
+                )
 
     def test_main_no_command(self):
         """Main exits with error when no command is given."""
@@ -1293,6 +1327,46 @@ class TestTopologyHostnameWait(unittest.TestCase):
 
         mock_wait_hostname.assert_called_once_with("worker-0", 180, 5, config_path)
         mock_apply.assert_called_once_with("worker-0", "")
+
+
+class TestRegistrationMatchesTheOperator(unittest.TestCase):
+    """Pin the exact registration strings the worker produces.
+
+    The operator computes the same values from the rendered topology.yaml and pushes them through
+    slurmrestd to correct a registration that was lost. If the two ever disagree they overwrite each
+    other on every reconcile, so the expected strings here are duplicated verbatim in
+    TestDesiredRegistrations* in internal/controller/topologyconfcontroller/node_registration_test.go
+    and the two sets must be changed together.
+    """
+
+    FABRIC = "fab"
+    LABELS = '{"tier-1": "leaf-a", "tier-2": "spine", "tier-0": "block-0"}'
+
+    def test_tree_registration(self):
+        result = worker_init.build_bound_topology(
+            self.LABELS, [("tree-ib", "tree")], self.FABRIC
+        )
+        self.assertEqual(result, "topology=tree-ib:fab:spine:leaf-a")
+
+    def test_block_registration(self):
+        result = worker_init.build_bound_topology(
+            self.LABELS, [("block-nvl72", "block")], self.FABRIC
+        )
+        self.assertEqual(result, "topology=block-nvl72:block-0")
+
+    def test_several_topologies_are_joined_in_config_order(self):
+        result = worker_init.build_bound_topology(
+            self.LABELS, [("tree-ib", "tree"), ("block-nvl72", "block")], self.FABRIC
+        )
+        self.assertEqual(
+            result, "topology=tree-ib:fab:spine:leaf-a,block-nvl72:block-0"
+        )
+
+    def test_flat_contributes_nothing(self):
+        result = worker_init.build_bound_topology(
+            self.LABELS, [("flat", "flat")], self.FABRIC
+        )
+        self.assertEqual(result, "")
 
 
 if __name__ == "__main__":

--- a/internal/controller/sconfigcontroller/aggregation_reconfigure_test.go
+++ b/internal/controller/sconfigcontroller/aggregation_reconfigure_test.go
@@ -24,6 +24,7 @@ import (
 	"nebius.ai/slurm-operator/internal/consts"
 	fakes "nebius.ai/slurm-operator/internal/controller/sconfigcontroller/fake"
 	slurmapifake "nebius.ai/slurm-operator/internal/slurmapi/fake"
+	slurmpattern "nebius.ai/slurm-operator/internal/utils/slurm/pattern"
 )
 
 const (
@@ -242,4 +243,71 @@ func TestReconfigureEmitsEvent(t *testing.T) {
 
 		assert.Empty(t, g.recorder.Events, "no reconfigure ran, so there is nothing to report")
 	})
+}
+
+// TestReconfigureIsDueReportsWhy pins that the trigger is nameable. A reconfigure restarts
+// slurmctld, so an unexpected one must be explainable from the default logs and the event, without
+// turning on debug after the fact.
+func TestReconfigureIsDueReportsWhy(t *testing.T) {
+	withRequest := func(hash string, generation int64) *slurmv1alpha1.JailedConfig {
+		jc := &slurmv1alpha1.JailedConfig{}
+		jc.Generation = generation
+		jc.Spec.UpdateActions = []slurmv1alpha1.UpdateAction{slurmv1alpha1.UpdateActionReconfigure}
+		jc.Status.AppliedHash = hash
+		return jc
+	}
+
+	t.Run("a config that asks for nothing is not due and needs no reason", func(t *testing.T) {
+		due, reason := reconfigureIsDue(&slurmv1alpha1.JailedConfig{}, "h1")
+
+		assert.False(t, due)
+		assert.Empty(t, reason)
+	})
+
+	t.Run("changed content names itself", func(t *testing.T) {
+		due, reason := reconfigureIsDue(withRequest("h1", 1), "h2")
+
+		assert.True(t, due)
+		assert.Equal(t, reconfigureReasonContentChanged, reason)
+	})
+
+	t.Run("an unsatisfied request names itself", func(t *testing.T) {
+		// Same content, but no reconfigure has been confirmed for this generation yet.
+		due, reason := reconfigureIsDue(withRequest("h1", 1), "h1")
+
+		assert.True(t, due)
+		assert.Equal(t, reconfigureReasonUnsatisfied, reason)
+	})
+
+	t.Run("a satisfied request over unchanged content is not due", func(t *testing.T) {
+		jc := withRequest("h1", 7)
+		jc.Status.Conditions = []metav1.Condition{{
+			Type:               string(slurmv1alpha1.ReconfigurePerformed),
+			Status:             metav1.ConditionTrue,
+			Reason:             slurmv1alpha1.ReasonSuccess,
+			ObservedGeneration: 7,
+		}}
+
+		due, reason := reconfigureIsDue(jc, "h1")
+
+		assert.False(t, due)
+		assert.Empty(t, reason)
+	})
+}
+
+// The nodes that never restarted are the point of the timeout error: without them it says only
+// that something, somewhere, did not come back.
+func TestPendingNodeNamesAreSortedForTheTimeoutError(t *testing.T) {
+	names := pendingNodeNames(map[string]int64{
+		"worker-2": 3,
+		"worker-0": 1,
+		"worker-1": 2,
+	})
+
+	assert.Equal(t, []string{"worker-0", "worker-1", "worker-2"}, names)
+	assert.Equal(t, "worker-[0-2]", slurmpattern.Merge(names))
+}
+
+func TestPendingNodeNamesOfAnEmptyMap(t *testing.T) {
+	assert.Empty(t, pendingNodeNames(map[string]int64{}))
 }

--- a/internal/controller/sconfigcontroller/jailedconfig_controller.go
+++ b/internal/controller/sconfigcontroller/jailedconfig_controller.go
@@ -52,6 +52,7 @@ import (
 	"nebius.ai/slurm-operator/internal/controllerconfig"
 	"nebius.ai/slurm-operator/internal/logfield"
 	"nebius.ai/slurm-operator/internal/slurmapi"
+	slurmpattern "nebius.ai/slurm-operator/internal/utils/slurm/pattern"
 )
 
 const (
@@ -340,7 +341,8 @@ func (r *JailedConfigReconciler) reconcileIndividual(ctx context.Context, jailed
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("setting conditions: %w", err)
 		}
-	} else if reconfigureIsDue(jailedConfig, hash) {
+	} else if due, reason := reconfigureIsDue(jailedConfig, hash); due {
+		logger.Info("Reconfiguring Slurm", "config", jailedConfig.Name, "reason", reason)
 		err = r.reconfigureCluster(ctx)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("reconfiguring Slurm cluster: %w", err)
@@ -531,26 +533,35 @@ func (r *JailedConfigReconciler) reconcileWithAggregation(ctx context.Context, j
 	// check the group reconfigures on every pass, because the slurm configs member carries the
 	// action permanently -- so a topology-only edit would restart slurmd across the cluster.
 	needsReconfigure := false
+	var reconfigureTrigger, reconfigureReason string
 	for i := range jailedConfigs.Items {
 		jailedConfig := &jailedConfigs.Items[i]
 		if _, written := writtenHashes[jailedConfig.Name]; !written {
 			continue
 		}
-		if reconfigureIsDue(jailedConfig, writtenHashes[jailedConfig.Name]) {
+		if due, reason := reconfigureIsDue(jailedConfig, writtenHashes[jailedConfig.Name]); due {
 			needsReconfigure = true
+			reconfigureTrigger, reconfigureReason = jailedConfig.Name, reason
 			break
 		}
 	}
 
 	if needsReconfigure {
-		logger.V(1).Info("Performing reconfigure for aggregated group", "aggregationKey", aggregationKey)
+		// Reported at info level on purpose: a reconfigure restarts slurmctld, so an unexpected one
+		// has to be explainable from the default logs, without turning on debug after the fact.
+		logger.Info("Reconfiguring Slurm",
+			"aggregationKey", aggregationKey,
+			"triggeredBy", reconfigureTrigger,
+			"reason", reconfigureReason)
 		if err = r.reconfigureCluster(ctx); err != nil {
-			r.recordReconfigure(jailedConfigs.Items, writtenHashes, corev1.EventTypeWarning,
-				reasonReconfigureFailed, fmt.Sprintf("Slurm reconfigure failed: %v", err))
+			r.recordReconfigure(jailedConfigs.Items, writtenHashes, corev1.EventTypeWarning, reasonReconfigureFailed,
+				fmt.Sprintf("Slurm reconfigure failed, triggered by %s because %s: %v",
+					reconfigureTrigger, reconfigureReason, err))
 			return ctrl.Result{}, fmt.Errorf("reconfiguring Slurm cluster for aggregated group: %w", err)
 		}
-		r.recordReconfigure(jailedConfigs.Items, writtenHashes, corev1.EventTypeNormal,
-			reasonReconfigured, "slurmctld re-read the configs written for this JailedConfig")
+		r.recordReconfigure(jailedConfigs.Items, writtenHashes, corev1.EventTypeNormal, reasonReconfigured,
+			fmt.Sprintf("slurmctld re-read the configs written for this JailedConfig; triggered by %s because %s",
+				reconfigureTrigger, reconfigureReason))
 
 		// Report it against each config's own generation, so whoever asked for the action can tell
 		// this reconfigure from one that ran for an earlier version of the spec.
@@ -600,12 +611,21 @@ func (r *JailedConfigReconciler) reconcileWithAggregation(ctx context.Context, j
 	return ctrl.Result{}, nil
 }
 
-// reconfigureIsDue reports whether this config needs slurmctld to re-read what was just written.
+// Why a reconfigure was due, reported in logs and in the event so the trigger is nameable after the
+// fact. A reconfigure restarts slurmctld, so "which config asked, and why" is the first question
+// asked of any unexpected one.
+const (
+	reconfigureReasonContentChanged = "the written content differs from the last applied one"
+	reconfigureReasonUnsatisfied    = "the request has not been satisfied for the current generation"
+)
+
+// reconfigureIsDue reports whether this config needs slurmctld to re-read what was just written, and
+// why.
 //
 // It is due when the content changed, and also when the request itself is new: a config can ask for
 // a reconfigure over content that renders identically -- a topology gaining an entry that reaches no
 // node yet, say -- and gating on the hash alone would leave that request permanently unsatisfied.
-func reconfigureIsDue(jailedConfig *slurmv1alpha1.JailedConfig, writtenHash string) bool {
+func reconfigureIsDue(jailedConfig *slurmv1alpha1.JailedConfig, writtenHash string) (bool, string) {
 	requested := false
 	for _, action := range jailedConfig.Spec.UpdateActions {
 		if action == slurmv1alpha1.UpdateActionReconfigure {
@@ -614,16 +634,21 @@ func reconfigureIsDue(jailedConfig *slurmv1alpha1.JailedConfig, writtenHash stri
 		}
 	}
 	if !requested {
-		return false
+		return false, ""
 	}
 
 	if writtenHash != jailedConfig.Status.AppliedHash {
-		return true
+		return true, reconfigureReasonContentChanged
 	}
 
 	condition := meta.FindStatusCondition(jailedConfig.Status.Conditions, string(slurmv1alpha1.ReconfigurePerformed))
-	return condition == nil || condition.Status != metav1.ConditionTrue ||
+	unsatisfied := condition == nil || condition.Status != metav1.ConditionTrue ||
 		condition.ObservedGeneration != jailedConfig.Generation
+	if unsatisfied {
+		return true, reconfigureReasonUnsatisfied
+	}
+
+	return false, ""
 }
 
 // hasFailedFilesWrittenCondition checks if the JailedConfig has a failed FilesWritten condition.
@@ -952,13 +977,16 @@ func (r *JailedConfigReconciler) pollSlurmNodesRestart(ctx context.Context, node
 func (r *JailedConfigReconciler) reconfigureCluster(ctx context.Context) error {
 	logger := logf.FromContext(ctx)
 
-	logger.V(1).Info("Reconfiguring cluster")
+	started := time.Now()
 
 	logger.V(1).Info("Storing nodes start times before reconfigure")
 	nodeToStartBefore, err := r.getNodesStartTime(ctx)
 	if err != nil {
-		return err
+		// The phase is named because each one fails for its own reason: this one only ever means
+		// the Slurm API was unreachable or unhealthy, before anything was asked of slurmctld.
+		return fmt.Errorf("read node start times before reconfigure: %w", err)
 	}
+	watchedNodes := len(nodeToStartBefore)
 
 	logger.V(1).Info("Requesting Slurm API to reconfigure nodes")
 	reconfigureResponse, err := r.slurmAPIClient.SlurmV0044GetReconfigureWithResponse(ctx)
@@ -976,10 +1004,34 @@ func (r *JailedConfigReconciler) reconfigureCluster(ctx context.Context) error {
 	defer cancel()
 	err = r.pollSlurmNodesRestart(pollCtx, nodeToStartBefore)
 	if errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Errorf("nodes did not restart: %w", err)
+		// pollSlurmNodesRestart drops each node as it comes back, so what is left names exactly the
+		// nodes that never restarted. Reported because the deadline alone cannot tell one stuck
+		// slurmd from a cluster that never got the message.
+		return fmt.Errorf("nodes did not restart within %s: %s: %w",
+			r.reconfigureWaitTimeout, slurmpattern.Merge(pendingNodeNames(nodeToStartBefore)), err)
+	}
+	if err != nil {
+		// Not treated as a failure, because slurmctld re-execs on reconfigure and the API is
+		// expected to blink out from under the poll. Logged rather than dropped: the same error
+		// also covers a poll that gave up for a reason worth knowing about.
+		logger.Info("Stopped waiting for nodes to restart before all of them came back",
+			"cause", err.Error(),
+			"nodesLeft", slurmpattern.Merge(pendingNodeNames(nodeToStartBefore)))
 	}
 
+	logger.Info("Slurm reconfigure finished",
+		"elapsed", time.Since(started).String(), "nodesWatched", watchedNodes)
+
 	return nil
+}
+
+func pendingNodeNames(nodeToStart map[string]int64) []string {
+	names := make([]string, 0, len(nodeToStart))
+	for name := range nodeToStart {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 type statusPatcher func(status *slurmv1alpha1.JailedConfigStatus)

--- a/internal/controller/soperatorchecks/slurm_api_clients_controller.go
+++ b/internal/controller/soperatorchecks/slurm_api_clients_controller.go
@@ -28,6 +28,11 @@ var (
 	SlurmAPIClientsControllerName = "soperatorchecks.slurmapiclients"
 )
 
+// nodeCacheRefreshInterval bounds how stale the shared view of Slurm nodes can be. Consumers read
+// from the cache instead of asking slurmrestd, so this is the only node-listing traffic the
+// operator generates no matter how many of them there are.
+const nodeCacheRefreshInterval = 30 * time.Second
+
 type SlurmAPIClientsController struct {
 	*reconciler.Reconciler
 
@@ -85,6 +90,16 @@ func (c *SlurmAPIClientsController) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	c.slurmAPIClients.AddClient(req.NamespacedName, slurmAPIClient)
+
+	// Started with the client rather than by whoever reads it first: several controllers depend on
+	// the cache, and tying its lifetime to any one of them makes their availability depend on which
+	// optional feature happens to be enabled.
+	if nc := c.slurmAPIClients.EnsureNodeCache(
+		req.NamespacedName, nodeCacheRefreshInterval,
+		log.Log.WithName("NodeCache").WithValues("cluster", req.NamespacedName),
+	); nc == nil {
+		logger.Info("Could not start the Slurm node cache", "cluster", req.NamespacedName)
+	}
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/topologyconfcontroller/node_push.go
+++ b/internal/controller/topologyconfcontroller/node_push.go
@@ -1,0 +1,184 @@
+package topologyconfcontroller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	api "github.com/SlinkyProject/slurm-client/api/v0044"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	slurmv1 "nebius.ai/slurm-operator/api/v1"
+	"nebius.ai/slurm-operator/api/v1alpha1"
+	"nebius.ai/slurm-operator/internal/consts"
+	"nebius.ai/slurm-operator/internal/slurmapi"
+	slurmpattern "nebius.ai/slurm-operator/internal/utils/slurm/pattern"
+)
+
+// unsettableStates name the power states in which a registration does not survive.
+//
+// slurmctld drops a node's dynamic topology when it restores state for a node that is powered down,
+// so a registration written now would be silently discarded by the next reconfigure. The node is
+// left alone and picked up once it is up, which is the same condition Slurm itself checks before
+// preserving the value.
+var unsettableStates = []api.V0044NodeState{
+	api.V0044NodeStatePOWEREDDOWN,
+	api.V0044NodeStatePOWERINGDOWN,
+}
+
+// pushNodeRegistrations makes the topology slurmctld holds for each node match the rendered config.
+//
+// Workers register themselves when their pod starts, but that registration is lost whenever a
+// reconfigure lands while the node is still powered down, and nothing recomputes it afterwards.
+// This is the converging half: it compares what the file says against what slurmctld reports and
+// corrects the difference, so a lost or stale registration heals on the next reconcile.
+//
+// It is deliberately cheap. The desired side comes from the file, the current side from the node
+// cache the operator already refreshes, and nodes are grouped by identical registration -- so a
+// steady cluster costs no request at all, and a re-render costs one request per changed unit
+// rather than one per node.
+func (r *WorkerTopologyReconciler) pushNodeRegistrations(
+	ctx context.Context, slurmCluster *slurmv1.SlurmCluster, jailedConfig *v1alpha1.JailedConfig,
+	rendered, structure string, managedNodes []string,
+) error {
+	logger := log.FromContext(ctx)
+
+	if !topologyLoaded(jailedConfig, structure) {
+		// Pushing a topology slurmctld has not read yet fails with
+		// ESLURM_REQUESTED_TOPO_CONFIG_UNAVAILABLE for every node in it, so the wait is not
+		// politeness -- it is the difference between converging and hammering a doomed request.
+		logger.V(1).Info("Waiting for the reconfigure to land before pushing registrations",
+			"structure", structure)
+		return nil
+	}
+
+	desired, err := desiredRegistrations(rendered, managedNodes...)
+	if err != nil {
+		return fmt.Errorf("compute desired node registrations: %w", err)
+	}
+	if len(desired) == 0 {
+		return nil
+	}
+
+	clusterKey := types.NamespacedName{Namespace: slurmCluster.Namespace, Name: slurmCluster.Name}
+	nodeCache, found := r.slurmAPIClients.GetNodeCache(clusterKey)
+	if !found {
+		logger.V(1).Info("No Slurm node cache yet, skipping the registration push")
+		return nil
+	}
+	slurmClient, found := r.slurmAPIClients.GetClient(clusterKey)
+	if !found {
+		logger.V(1).Info("No Slurm API client yet, skipping the registration push")
+		return nil
+	}
+
+	byRegistration := diffRegistrations(desired, nodeCache)
+	if len(byRegistration) == 0 {
+		return nil
+	}
+
+	var pushed []string
+	for _, registration := range sortedKeys(byRegistration) {
+		nodes := slurmpattern.Merge(byRegistration[registration])
+		if err := slurmClient.SetNodeTopology(ctx, nodes, registration); err != nil {
+			if errors.Is(err, slurmapi.ErrTopologyUnavailable) {
+				// The reconfigure was confirmed but this topology is still missing, which means
+				// slurmctld is running older content than the JailedConfig believes. Retrying is
+				// the whole remedy, and the node keeps whatever it had.
+				logger.Info("Slurm has not loaded the topology yet, will retry",
+					"nodes", nodes, "registration", registration)
+				return nil
+			}
+			r.recordNodeTopologyPushFailed(slurmCluster, nodes, registration, err)
+			return fmt.Errorf("register %s into %q: %w", nodes, registration, err)
+		}
+		pushed = append(pushed, fmt.Sprintf("%s=%s", nodes, registration))
+	}
+
+	summary := strings.Join(pushed, "; ")
+	logger.Info("Registered workers into their topologies", "registrations", summary)
+	r.recordNodeTopologyPushed(slurmCluster, summary)
+	return nil
+}
+
+// nodeLookup is the part of the shared Slurm node cache the diff needs.
+type nodeLookup interface {
+	GetNode(name string) (slurmapi.Node, bool)
+}
+
+// diffRegistrations groups the nodes whose registration disagrees with the config by the value they
+// need, so each group becomes one hostlist request.
+func diffRegistrations(desired map[string]string, nodeCache nodeLookup) map[string][]string {
+	byRegistration := make(map[string][]string)
+
+	for _, name := range sortedKeys(desired) {
+		registration := desired[name]
+
+		node, known := nodeCache.GetNode(name)
+		if !known {
+			// Rendered from the NodeSet replica range, so the config can name a node Slurm has no
+			// record of yet.
+			continue
+		}
+		if slices.ContainsFunc(unsettableStates, func(state api.V0044NodeState) bool {
+			_, has := node.States[state]
+			return has
+		}) {
+			continue
+		}
+		if node.Topology == registration {
+			continue
+		}
+
+		byRegistration[registration] = append(byRegistration[registration], name)
+	}
+
+	return byRegistration
+}
+
+// topologyLoaded reports whether slurmctld is running the topology structure being rendered.
+//
+// The annotation holds the structure a confirmed reconfigure was performed for: ensureJailedConfig
+// keeps the previous value there while a request is outstanding, so it only reaches the desired
+// structure once slurmctld has actually re-read the file.
+func topologyLoaded(jailedConfig *v1alpha1.JailedConfig, structure string) bool {
+	if jailedConfig == nil {
+		return false
+	}
+	if jailedConfig.Annotations[consts.AnnotationTopologyStructure] != structure {
+		return false
+	}
+	return !hasReconfigureRequest(jailedConfig) || reconfigureConfirmed(jailedConfig)
+}
+
+func (r *WorkerTopologyReconciler) recordNodeTopologyPushed(slurmCluster *slurmv1.SlurmCluster, summary string) {
+	if r.recorder == nil {
+		return
+	}
+	r.recorder.Eventf(slurmCluster, nil, corev1.EventTypeNormal, reasonNodeTopologyPushed,
+		actionRegisterNodeTopology, "Registered workers into their topologies: %s", summary)
+}
+
+func (r *WorkerTopologyReconciler) recordNodeTopologyPushFailed(
+	slurmCluster *slurmv1.SlurmCluster, nodes, registration string, cause error,
+) {
+	if r.recorder == nil {
+		return
+	}
+	r.recorder.Eventf(slurmCluster, nil, corev1.EventTypeWarning, reasonNodeTopologyPushFailed,
+		actionRegisterNodeTopology, "Failed to register %s into %s: %s", nodes, registration, cause.Error())
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/controller/topologyconfcontroller/node_push_test.go
+++ b/internal/controller/topologyconfcontroller/node_push_test.go
@@ -1,0 +1,129 @@
+package topologyconfcontroller
+
+import (
+	"testing"
+
+	api "github.com/SlinkyProject/slurm-client/api/v0044"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"nebius.ai/slurm-operator/api/v1alpha1"
+	"nebius.ai/slurm-operator/internal/consts"
+	"nebius.ai/slurm-operator/internal/slurmapi"
+)
+
+type fakeNodes map[string]slurmapi.Node
+
+func (f fakeNodes) GetNode(name string) (slurmapi.Node, bool) {
+	node, found := f[name]
+	return node, found
+}
+
+func node(states ...api.V0044NodeState) slurmapi.Node {
+	stateSet := make(map[api.V0044NodeState]struct{}, len(states))
+	for _, state := range states {
+		stateSet[state] = struct{}{}
+	}
+	return slurmapi.Node{States: stateSet}
+}
+
+func withTopology(n slurmapi.Node, topology string) slurmapi.Node {
+	n.Topology = topology
+	return n
+}
+
+func TestDiffRegistrations(t *testing.T) {
+	desired := map[string]string{
+		"worker-0": "tree-ib:fab:leaf-a",
+		"worker-1": "tree-ib:fab:leaf-a",
+		"worker-2": "tree-ib:fab:leaf-b",
+	}
+
+	t.Run("nodes needing the same value are grouped", func(t *testing.T) {
+		diff := diffRegistrations(desired, fakeNodes{
+			"worker-0": node(api.V0044NodeStateIDLE),
+			"worker-1": node(api.V0044NodeStateIDLE),
+			"worker-2": node(api.V0044NodeStateIDLE),
+		})
+
+		assert.Equal(t, map[string][]string{
+			"tree-ib:fab:leaf-a": {"worker-0", "worker-1"},
+			"tree-ib:fab:leaf-b": {"worker-2"},
+		}, diff)
+	})
+
+	t.Run("a node already carrying the value is left alone", func(t *testing.T) {
+		diff := diffRegistrations(desired, fakeNodes{
+			"worker-0": withTopology(node(api.V0044NodeStateIDLE), "tree-ib:fab:leaf-a"),
+			"worker-1": withTopology(node(api.V0044NodeStateIDLE), "tree-ib:fab:leaf-a"),
+			"worker-2": withTopology(node(api.V0044NodeStateIDLE), "tree-ib:fab:leaf-b"),
+		})
+
+		assert.Empty(t, diff)
+	})
+
+	// The whole point of the exercise: a node that lost its registration gets it back.
+	t.Run("a node that lost its registration is corrected", func(t *testing.T) {
+		diff := diffRegistrations(desired, fakeNodes{
+			"worker-0": node(api.V0044NodeStateIDLE),
+			"worker-1": withTopology(node(api.V0044NodeStateIDLE), "tree-ib:fab:leaf-a"),
+			"worker-2": withTopology(node(api.V0044NodeStateIDLE), "tree-ib:fab:leaf-b"),
+		})
+
+		assert.Equal(t, map[string][]string{"tree-ib:fab:leaf-a": {"worker-0"}}, diff)
+	})
+
+	// Writing to a powered-down node is exactly what gets discarded by the next reconfigure.
+	t.Run("powered down nodes are skipped", func(t *testing.T) {
+		diff := diffRegistrations(desired, fakeNodes{
+			"worker-0": node(api.V0044NodeStateIDLE, api.V0044NodeStatePOWEREDDOWN),
+			"worker-1": node(api.V0044NodeStateIDLE, api.V0044NodeStatePOWERINGDOWN),
+			"worker-2": node(api.V0044NodeStateIDLE),
+		})
+
+		assert.Equal(t, map[string][]string{"tree-ib:fab:leaf-b": {"worker-2"}}, diff)
+	})
+
+	// Slurm preserves the registration of a node that is powering up, so it is safe to write.
+	t.Run("powering up nodes are written", func(t *testing.T) {
+		diff := diffRegistrations(map[string]string{"worker-0": "tree-ib:fab:leaf-a"}, fakeNodes{
+			"worker-0": node(api.V0044NodeStateIDLE, api.V0044NodeStatePOWERINGUP),
+		})
+
+		assert.Equal(t, map[string][]string{"tree-ib:fab:leaf-a": {"worker-0"}}, diff)
+	})
+
+	t.Run("nodes Slurm does not know are skipped", func(t *testing.T) {
+		diff := diffRegistrations(desired, fakeNodes{"worker-2": node(api.V0044NodeStateIDLE)})
+
+		assert.Equal(t, map[string][]string{"tree-ib:fab:leaf-b": {"worker-2"}}, diff)
+	})
+}
+
+func TestTopologyLoaded(t *testing.T) {
+	const structure = "tree-ib=tree:[]:false"
+
+	jailedConfig := func(annotation string, actions ...v1alpha1.UpdateAction) *v1alpha1.JailedConfig {
+		return &v1alpha1.JailedConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{consts.AnnotationTopologyStructure: annotation},
+			},
+			Spec: v1alpha1.JailedConfigSpec{UpdateActions: actions},
+		}
+	}
+
+	t.Run("open once the committed structure is the rendered one", func(t *testing.T) {
+		assert.True(t, topologyLoaded(jailedConfig(structure), structure))
+	})
+
+	// While a reconfigure is outstanding the annotation still holds the previous structure, so
+	// slurmctld has not read the new topology and a push would be rejected for every node in it.
+	t.Run("closed while a reconfigure is outstanding", func(t *testing.T) {
+		assert.False(t, topologyLoaded(
+			jailedConfig("tree-ib=tree:[]:true", v1alpha1.UpdateActionReconfigure), structure))
+	})
+
+	t.Run("closed without a JailedConfig", func(t *testing.T) {
+		assert.False(t, topologyLoaded(nil, structure))
+	})
+}

--- a/internal/controller/topologyconfcontroller/node_registration.go
+++ b/internal/controller/topologyconfcontroller/node_registration.go
@@ -1,0 +1,137 @@
+package topologyconfcontroller
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	slurmpattern "nebius.ai/slurm-operator/internal/utils/slurm/pattern"
+)
+
+// unknownSwitchSuffix marks the catch-all unit a node lands in while its tier labels are still
+// missing. Registrations are never pushed for it: the catch-all is a statement that the placement
+// is not known yet, and pinning it into slurmctld would assert an answer the operator does not have.
+const unknownSwitchSuffix = "unknown"
+
+// desiredRegistrations maps every node the rendered topology.yaml places to the registration string
+// that puts it there -- the same value a worker computes for itself in its init container.
+//
+// The format is Slurm's dynamic topology syntax: comma-separated "<name>:<unit>" specs, where a
+// tree unit is the switch path from the root down to the node's leaf and a block unit is the block
+// name. Flat topologies are left out: they list no node, so there is nothing to register into.
+//
+// https://slurm.schedmd.com/topology.html#dynamic_topo
+func desiredRegistrations(rendered string, managedNodes ...string) (map[string]string, error) {
+	entries, err := parseTopologyEntries(rendered)
+	if err != nil {
+		return nil, err
+	}
+
+	specs := make(map[string][]string)
+	for _, entry := range entries {
+		var units map[string]string
+		switch {
+		case entry.Tree != nil:
+			units, err = treeUnits(entry)
+			if err != nil {
+				return nil, err
+			}
+		case entry.Block != nil:
+			units = blockUnits(entry)
+		default:
+			continue
+		}
+
+		for node, unit := range units {
+			specs[node] = append(specs[node], fmt.Sprintf("%s:%s", entry.Topology, unit))
+		}
+	}
+
+	registrations := make(map[string]string, len(specs))
+	for node, nodeSpecs := range specs {
+		registrations[node] = strings.Join(nodeSpecs, ",")
+	}
+	// A managed node absent from every node list has no remaining binding. Keep an
+	// explicit empty value so the push clears its old registration. Nodes listed
+	// under unknown are still covered and must wait for their placement instead.
+	membership, err := topologyMembership(rendered)
+	if err != nil {
+		return nil, err
+	}
+	covered := make(map[string]struct{})
+	for _, nodes := range membership {
+		for _, node := range nodes {
+			covered[node] = struct{}{}
+		}
+	}
+	for _, node := range managedNodes {
+		if _, found := covered[node]; !found {
+			registrations[node] = ""
+		}
+	}
+	return registrations, nil
+}
+
+// treeUnits maps each node of a tree topology to its switch path, root first, leaf last.
+func treeUnits(entry topologyYAMLEntry) (map[string]string, error) {
+	parents := make(map[string]string)
+	for _, networkSwitch := range entry.Tree.Switches {
+		for _, child := range slurmpattern.Expand(networkSwitch.Children) {
+			parents[child] = networkSwitch.Switch
+		}
+	}
+
+	units := make(map[string]string)
+	for _, networkSwitch := range entry.Tree.Switches {
+		if networkSwitch.Nodes == "" || isUnknownUnit(networkSwitch.Switch) {
+			continue
+		}
+		path, err := switchPath(networkSwitch.Switch, parents)
+		if err != nil {
+			return nil, fmt.Errorf("topology %q: %w", entry.Topology, err)
+		}
+		for _, node := range slurmpattern.Expand(networkSwitch.Nodes) {
+			units[node] = path
+		}
+	}
+	return units, nil
+}
+
+// switchPath walks from a leaf up to the root and returns the switches root first.
+func switchPath(leaf string, parents map[string]string) (string, error) {
+	path := []string{leaf}
+	seen := map[string]struct{}{leaf: {}}
+
+	for current := leaf; ; {
+		parent, ok := parents[current]
+		if !ok {
+			break
+		}
+		if _, looped := seen[parent]; looped {
+			return "", fmt.Errorf("switch %q sits in a cycle", leaf)
+		}
+		seen[parent] = struct{}{}
+		path = append(path, parent)
+		current = parent
+	}
+
+	slices.Reverse(path)
+	return strings.Join(path, ":"), nil
+}
+
+func blockUnits(entry topologyYAMLEntry) map[string]string {
+	units := make(map[string]string)
+	for _, block := range entry.Block.Blocks {
+		if block.Nodes == "" || isUnknownUnit(block.Block) {
+			continue
+		}
+		for _, node := range slurmpattern.Expand(block.Nodes) {
+			units[node] = block.Block
+		}
+	}
+	return units
+}
+
+func isUnknownUnit(name string) bool {
+	return name == unknownSwitchSuffix || strings.HasSuffix(name, "."+unknownSwitchSuffix)
+}

--- a/internal/controller/topologyconfcontroller/node_registration_test.go
+++ b/internal/controller/topologyconfcontroller/node_registration_test.go
@@ -1,0 +1,154 @@
+package topologyconfcontroller
+
+import (
+	"strings"
+	"testing"
+
+	api "github.com/SlinkyProject/slurm-client/api/v0044"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The registration strings asserted here are the ones a worker computes for itself in its init
+// container. Both sides write into the same field, so a disagreement makes them overwrite each
+// other on every reconcile. The same expectations are pinned from the worker's side in
+// TestRegistrationMatchesTheOperator in images/worker/worker_init_test.py, and the two sets must be
+// changed together.
+
+// goldenTreeConfig is one fabric with two leaves under a spine, plus a catch-all for the nodes
+// whose labels have not arrived.
+const goldenTreeConfig = `- topology: flat
+  cluster_default: true
+  flat: true
+- topology: tree-ib
+  cluster_default: false
+  tree:
+    switches:
+      - switch: fab
+        children: spine,fab.unknown
+      - switch: spine
+        children: leaf-a,leaf-b
+      - switch: leaf-a
+        nodes: worker-[0-1]
+      - switch: leaf-b
+        nodes: worker-2
+      - switch: fab.unknown
+        nodes: worker-3
+`
+
+func TestDesiredRegistrations(t *testing.T) {
+	registrations, err := desiredRegistrations(goldenTreeConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{
+		"worker-0": "tree-ib:fab:spine:leaf-a",
+		"worker-1": "tree-ib:fab:spine:leaf-a",
+		"worker-2": "tree-ib:fab:spine:leaf-b",
+	}, registrations)
+}
+
+// A node in the catch-all is a node whose placement is not known yet. Registering it would assert
+// an answer the operator does not have, and the file already puts it there anyway.
+func TestDesiredRegistrationsSkipsTheCatchAll(t *testing.T) {
+	registrations, err := desiredRegistrations(goldenTreeConfig)
+	require.NoError(t, err)
+
+	assert.NotContains(t, registrations, "worker-3")
+}
+
+func TestDesiredRegistrationsOfABlockTopology(t *testing.T) {
+	config := `- topology: block-nvl72
+  cluster_default: false
+  block:
+    block_sizes: [2]
+    blocks:
+      - block: block-0
+        nodes: worker-[0-1]
+      - block: unknown
+        nodes: worker-2
+`
+	registrations, err := desiredRegistrations(config)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{
+		"worker-0": "block-nvl72:block-0",
+		"worker-1": "block-nvl72:block-0",
+	}, registrations)
+}
+
+// A node described by two topologies registers into both, in the order the file declares them.
+func TestDesiredRegistrationsJoinsSeveralTopologies(t *testing.T) {
+	config := goldenTreeConfig + `- topology: block-nvl72
+  cluster_default: false
+  block:
+    block_sizes: [2]
+    blocks:
+      - block: block-0
+        nodes: worker-[0-1]
+`
+	registrations, err := desiredRegistrations(config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "tree-ib:fab:spine:leaf-a,block-nvl72:block-0", registrations["worker-0"])
+	assert.Equal(t, "tree-ib:fab:spine:leaf-b", registrations["worker-2"])
+}
+
+// Flat lists no node, so it contributes no registration -- matching what the worker does.
+func TestDesiredRegistrationsIgnoresFlat(t *testing.T) {
+	registrations, err := desiredRegistrations("- topology: flat\n  cluster_default: true\n  flat: true\n")
+	require.NoError(t, err)
+
+	assert.Empty(t, registrations)
+}
+
+func TestDesiredRegistrationsOfAMalformedConfig(t *testing.T) {
+	_, err := desiredRegistrations("not: [a, yaml, list")
+
+	assert.Error(t, err)
+}
+
+// A leaf that is its own ancestor would otherwise walk forever.
+func TestDesiredRegistrationsRejectsACycle(t *testing.T) {
+	config := `- topology: tree-ib
+  cluster_default: false
+  tree:
+    switches:
+      - switch: a
+        children: b
+      - switch: b
+        children: a
+      - switch: a
+        nodes: worker-0
+`
+	_, err := desiredRegistrations(config)
+
+	assert.ErrorContains(t, err, "cycle")
+}
+
+func TestRemovedLastBindingClearsRegistration(t *testing.T) {
+	before := goldenTreeConfig
+	after := strings.ReplaceAll(before, "worker-[0-1]", "worker-0")
+	managed := []string{"worker-0", "worker-1", "worker-2", "worker-3"}
+
+	previous, err := desiredRegistrations(before, managed...)
+	require.NoError(t, err)
+	current, err := desiredRegistrations(after, managed...)
+	require.NoError(t, err)
+
+	cache := make(fakeNodes)
+	for name, registration := range previous {
+		cache[name] = withTopology(node(api.V0044NodeStateIDLE), registration)
+	}
+	cache["worker-3"] = withTopology(node(api.V0044NodeStateIDLE), "tree-ib:old:leaf")
+	cache["unmanaged-0"] = withTopology(node(api.V0044NodeStateIDLE), "tree-ib:old:leaf")
+	assert.Equal(t, map[string][]string{"": {"worker-1"}}, diffRegistrations(current, cache))
+
+	cache["worker-1"] = node(api.V0044NodeStateIDLE)
+	assert.Empty(t, diffRegistrations(current, cache))
+}
+
+func TestFlatOnlyClearsManagedRegistrations(t *testing.T) {
+	registrations, err := desiredRegistrations("- topology: flat\n  flat: true\n", "worker-0")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"worker-0": ""}, registrations)
+}

--- a/internal/controller/topologyconfcontroller/topology_diff.go
+++ b/internal/controller/topologyconfcontroller/topology_diff.go
@@ -1,0 +1,146 @@
+package topologyconfcontroller
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	slurmpattern "nebius.ai/slurm-operator/internal/utils/slurm/pattern"
+)
+
+// maxTopologyChangeSummary bounds the summary so it fits an event note, which Kubernetes caps at
+// 1024 characters.
+const maxTopologyChangeSummary = 800
+
+// topologyChange describes how a re-render moved nodes between topologies.
+//
+// It exists because the structure fingerprint deliberately omits node membership: moving a node
+// from one topology to another changes neither the fingerprint nor the request for a reconfigure,
+// so without this the only trace of that edit is the ConfigMap itself.
+type topologyChange struct {
+	// Summary is short enough for an event note.
+	Summary string
+	// Detail names the nodes that moved, for the log, where length is not a concern.
+	Detail string
+}
+
+// parseTopologyEntries reads back a rendered topology.yaml.
+func parseTopologyEntries(rendered string) ([]topologyYAMLEntry, error) {
+	var entries []topologyYAMLEntry
+	if err := yaml.Unmarshal([]byte(rendered), &entries); err != nil {
+		return nil, fmt.Errorf("unmarshal topology.yaml: %w", err)
+	}
+	return entries, nil
+}
+
+// topologyMembership maps every topology in a rendered topology.yaml to the nodes it covers.
+//
+// Flat topologies map to no node: they list none by design, and every node not named elsewhere
+// belongs to them.
+func topologyMembership(rendered string) (map[string][]string, error) {
+	entries, err := parseTopologyEntries(rendered)
+	if err != nil {
+		return nil, err
+	}
+
+	membership := make(map[string][]string, len(entries))
+	for _, entry := range entries {
+		var nodes []string
+		switch {
+		case entry.Tree != nil:
+			for _, networkSwitch := range entry.Tree.Switches {
+				nodes = append(nodes, slurmpattern.Expand(networkSwitch.Nodes)...)
+			}
+		case entry.Block != nil:
+			for _, block := range entry.Block.Blocks {
+				nodes = append(nodes, slurmpattern.Expand(block.Nodes)...)
+			}
+		}
+		slices.Sort(nodes)
+		membership[entry.Topology] = slices.Compact(nodes)
+	}
+
+	return membership, nil
+}
+
+// summarizeTopologyChange reports how membership differs between two renderings of topology.yaml.
+//
+// Content that cannot be parsed is reported as such rather than raising an error: the summary is
+// there to explain a change that is being published either way, and a hand-edited ConfigMap must
+// not stop it.
+func summarizeTopologyChange(before, after string) topologyChange {
+	beforeMembership, err := topologyMembership(before)
+	if err != nil {
+		return topologyChange{Summary: "previous topology.yaml could not be parsed"}
+	}
+	afterMembership, err := topologyMembership(after)
+	if err != nil {
+		return topologyChange{Summary: "rendered topology.yaml could not be parsed"}
+	}
+
+	names := make([]string, 0, len(beforeMembership)+len(afterMembership))
+	for name := range beforeMembership {
+		names = append(names, name)
+	}
+	for name := range afterMembership {
+		if _, ok := beforeMembership[name]; !ok {
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names)
+
+	var summaries, details []string
+	for _, name := range names {
+		previous, existed := beforeMembership[name]
+		current, remains := afterMembership[name]
+
+		switch {
+		case !existed:
+			summaries = append(summaries, fmt.Sprintf("+%s (%d nodes)", name, len(current)))
+			details = append(details, fmt.Sprintf("+%s=%s", name, slurmpattern.Merge(current)))
+		case !remains:
+			summaries = append(summaries, fmt.Sprintf("-%s", name))
+			details = append(details, fmt.Sprintf("-%s=%s", name, slurmpattern.Merge(previous)))
+		case !slices.Equal(previous, current):
+			added, removed := membershipDelta(previous, current)
+			summaries = append(summaries, fmt.Sprintf("%s %d nodes (+%d -%d)",
+				name, len(current), len(added), len(removed)))
+			details = append(details, fmt.Sprintf("%s +[%s] -[%s]",
+				name, slurmpattern.Merge(added), slurmpattern.Merge(removed)))
+		}
+	}
+
+	if len(summaries) == 0 {
+		// Reached whenever the edit touched something other than membership: a block size, a
+		// cluster default, a switch renamed with the same nodes under it.
+		return topologyChange{Summary: "node membership unchanged"}
+	}
+
+	return topologyChange{
+		Summary: truncateSummary(strings.Join(summaries, "; ")),
+		Detail:  strings.Join(details, "; "),
+	}
+}
+
+func membershipDelta(previous, current []string) (added, removed []string) {
+	for _, node := range current {
+		if !slices.Contains(previous, node) {
+			added = append(added, node)
+		}
+	}
+	for _, node := range previous {
+		if !slices.Contains(current, node) {
+			removed = append(removed, node)
+		}
+	}
+	return added, removed
+}
+
+func truncateSummary(summary string) string {
+	if len(summary) <= maxTopologyChangeSummary {
+		return summary
+	}
+	return summary[:maxTopologyChangeSummary] + "... (see the operator log for the rest)"
+}

--- a/internal/controller/topologyconfcontroller/topology_diff_test.go
+++ b/internal/controller/topologyconfcontroller/topology_diff_test.go
@@ -1,0 +1,150 @@
+package topologyconfcontroller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+
+	slurmv1 "nebius.ai/slurm-operator/api/v1"
+)
+
+const treeBefore = `- topology: tree-ib
+  cluster_default: true
+  tree:
+    switches:
+      - switch: root
+        children: leaf-[0-1]
+      - switch: leaf-0
+        nodes: worker-[0-3]
+      - switch: leaf-1
+        nodes: worker-[4-7]
+`
+
+func TestTopologyMembership(t *testing.T) {
+	membership, err := topologyMembership(treeBefore)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string][]string{
+		"tree-ib": {
+			"worker-0", "worker-1", "worker-2", "worker-3",
+			"worker-4", "worker-5", "worker-6", "worker-7",
+		},
+	}, membership)
+}
+
+// A flat topology names no node, so it must not be mistaken for one that lost all of them.
+func TestTopologyMembershipFlatCoversNoNode(t *testing.T) {
+	membership, err := topologyMembership("- topology: flat\n  cluster_default: false\n  flat: true\n")
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string][]string{"flat": nil}, membership)
+}
+
+func TestSummarizeTopologyChange(t *testing.T) {
+	tests := []struct {
+		name            string
+		before, after   string
+		expectedSummary string
+		expectedDetail  string
+	}{
+		{
+			name:            "nodes moved to another topology",
+			before:          treeBefore,
+			after:           strings.Replace(treeBefore, "nodes: worker-[4-7]", "nodes: worker-[4-5]", 1) + blockEntry,
+			expectedSummary: "+block-nvl72 (2 nodes); tree-ib 6 nodes (+0 -2)",
+			expectedDetail:  "+block-nvl72=worker-[6-7]; tree-ib +[] -[worker-[6-7]]",
+		},
+		{
+			name:            "topology added",
+			before:          treeBefore,
+			after:           treeBefore + blockEntry,
+			expectedSummary: "+block-nvl72 (2 nodes)",
+			expectedDetail:  "+block-nvl72=worker-[6-7]",
+		},
+		{
+			name:            "topology removed",
+			before:          treeBefore + blockEntry,
+			after:           treeBefore,
+			expectedSummary: "-block-nvl72",
+			expectedDetail:  "-block-nvl72=worker-[6-7]",
+		},
+		{
+			name:            "membership untouched",
+			before:          treeBefore,
+			after:           strings.Replace(treeBefore, "cluster_default: true", "cluster_default: false", 1),
+			expectedSummary: "node membership unchanged",
+			expectedDetail:  "",
+		},
+		{
+			name:            "previous content is not topology.yaml",
+			before:          "not: [a, yaml, list",
+			after:           treeBefore,
+			expectedSummary: "previous topology.yaml could not be parsed",
+			expectedDetail:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			change := summarizeTopologyChange(tt.before, tt.after)
+			assert.Equal(t, tt.expectedSummary, change.Summary)
+			assert.Equal(t, tt.expectedDetail, change.Detail)
+		})
+	}
+}
+
+const blockEntry = `- topology: block-nvl72
+  cluster_default: false
+  block:
+    block_sizes: [2]
+    blocks:
+      - block: block-0
+        nodes: worker-[6-7]
+`
+
+func TestSummarizeTopologyChangeTruncatesForTheEventNote(t *testing.T) {
+	var before, after strings.Builder
+	for i := range 200 {
+		before.WriteString(renderTinyTree(i, "worker-0"))
+		after.WriteString(renderTinyTree(i, "worker-1"))
+	}
+
+	change := summarizeTopologyChange(before.String(), after.String())
+
+	assert.LessOrEqual(t, len(change.Summary), maxTopologyChangeSummary+64)
+	assert.Contains(t, change.Summary, "see the operator log for the rest")
+	assert.Greater(t, len(change.Detail), len(change.Summary))
+}
+
+func renderTinyTree(index int, node string) string {
+	return strings.NewReplacer("INDEX", string(rune('a'+index%26))+string(rune('a'+index/26)), "NODE", node).Replace(
+		"- topology: tree-INDEX\n  cluster_default: false\n  tree:\n    switches:\n      - switch: leaf-INDEX\n        nodes: NODE\n",
+	)
+}
+
+func TestRecordTopologyRenderedGoesToTheCluster(t *testing.T) {
+	recorder := events.NewFakeRecorder(10)
+	reconciler := &WorkerTopologyReconciler{recorder: recorder}
+	cluster := &slurmv1.SlurmCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "test-namespace"},
+	}
+
+	reconciler.recordTopologyRendered(cluster, summarizeTopologyChange(treeBefore, treeBefore+blockEntry))
+
+	captured := drainEvents(recorder)
+	require.Len(t, captured, 1)
+	assert.Contains(t, captured[0], reasonTopologyRendered)
+	assert.Contains(t, captured[0], "+block-nvl72 (2 nodes)")
+}
+
+func TestRecordTopologyRenderedWithoutARecorder(t *testing.T) {
+	reconciler := &WorkerTopologyReconciler{}
+
+	assert.NotPanics(t, func() {
+		reconciler.recordTopologyRendered(&slurmv1.SlurmCluster{}, topologyChange{})
+	})
+}

--- a/internal/controller/topologyconfcontroller/workertopology_controller.go
+++ b/internal/controller/topologyconfcontroller/workertopology_controller.go
@@ -35,6 +35,7 @@ import (
 	"nebius.ai/slurm-operator/internal/controllerconfig"
 	"nebius.ai/slurm-operator/internal/render/common"
 	renderutils "nebius.ai/slurm-operator/internal/render/utils"
+	"nebius.ai/slurm-operator/internal/slurmapi"
 	"nebius.ai/slurm-operator/internal/utils/resourcegetter"
 )
 
@@ -53,8 +54,9 @@ var (
 
 type WorkerTopologyReconciler struct {
 	BaseReconciler
-	namespace string
-	recorder  events.EventRecorder
+	namespace       string
+	recorder        events.EventRecorder
+	slurmAPIClients *slurmapi.ClientSet
 }
 
 // Event reasons reported against the SlurmCluster whose topology is misconfigured. They exist
@@ -65,7 +67,19 @@ const (
 	reasonUnresolvedTopologyRef  = "UnresolvedTopologyRef"
 	reasonClusterDefaultConflict = "ClusterDefaultConflict"
 
-	actionRenderTopology = "RenderTopology"
+	// reasonTopologyRendered reports a published change to topology.yaml. Unlike the reasons above
+	// it is not a problem report: it exists so that a node moved between topologies leaves a trace
+	// outside the ConfigMap, since such a move changes neither the structure fingerprint nor
+	// anything else the operator logs.
+	reasonTopologyRendered = "TopologyRendered"
+
+	// reasonNodeTopologyPushed and reasonNodeTopologyPushFailed report the converging half: the
+	// operator correcting a worker's registration in slurmctld to match the rendered config.
+	reasonNodeTopologyPushed     = "NodeTopologyPushed"
+	reasonNodeTopologyPushFailed = "NodeTopologyPushFailed"
+
+	actionRenderTopology       = "RenderTopology"
+	actionRegisterNodeTopology = "RegisterNodeTopology"
 )
 
 // Link represents a connection in the topology
@@ -77,14 +91,16 @@ type Link struct {
 
 func NewWorkerTopologyReconciler(
 	client client.Client, scheme *runtime.Scheme, namespace string, recorder events.EventRecorder,
+	slurmAPIClients *slurmapi.ClientSet,
 ) *WorkerTopologyReconciler {
 	return &WorkerTopologyReconciler{
 		BaseReconciler: BaseReconciler{
 			Client: client,
 			Scheme: scheme,
 		},
-		namespace: namespace,
-		recorder:  recorder,
+		namespace:       namespace,
+		recorder:        recorder,
+		slurmAPIClients: slurmAPIClients,
 	}
 }
 
@@ -96,6 +112,16 @@ func (r *WorkerTopologyReconciler) recordTopologyIssue(
 		return
 	}
 	r.recorder.Eventf(slurmCluster, nil, corev1.EventTypeWarning, reason, actionRenderTopology, note, args...)
+}
+
+// recordTopologyRendered reports a published topology.yaml change against the SlurmCluster it was
+// rendered for, which puts the event in that cluster's namespace under that cluster's name.
+func (r *WorkerTopologyReconciler) recordTopologyRendered(slurmCluster *slurmv1.SlurmCluster, change topologyChange) {
+	if r.recorder == nil {
+		return
+	}
+	r.recorder.Eventf(slurmCluster, nil, corev1.EventTypeNormal, reasonTopologyRendered, actionRenderTopology,
+		"Published topology.yaml: %s", change.Summary)
 }
 
 func (r *WorkerTopologyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -161,8 +187,23 @@ func (r *WorkerTopologyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if err := r.ensureJailedConfig(ctx, req.Namespace, topoConfigName, slurmCluster.Name, configKey, desiredStructure); err != nil {
 			return ctrl.Result{}, fmt.Errorf("ensure JailedConfig: %w", err)
 		}
+		// Reached on every quiet reconcile, and that is the point: this is where a registration
+		// lost to a reconfigure gets noticed and put back.
+		if err := r.convergeNodeRegistrations(
+			ctx, req.Namespace, topoConfigName, slurmCluster, desiredTopology, desiredStructure, collectAllNodeNames(nodeSetList),
+		); err != nil {
+			return ctrl.Result{}, err
+		}
 		return DefaultRequeueResult, nil
 	}
+
+	change := summarizeTopologyChange(existingTopology, renderedDesiredTopology)
+	// Reported at info level and as an event on purpose. Node membership is left out of the
+	// structure fingerprint, so moving nodes between topologies asks for no reconfigure and would
+	// otherwise be published without a single line saying so.
+	logger.Info("Topology config changed, publishing it",
+		"change", change.Summary, "nodes", change.Detail, "structure", desiredStructure)
+	r.recordTopologyRendered(slurmCluster, change)
 
 	// The content is published before the request, on purpose: requesting first would let
 	// sconfigcontroller reconfigure the old content and satisfy the request against it. Publishing
@@ -178,8 +219,39 @@ func (r *WorkerTopologyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, fmt.Errorf("ensure JailedConfig: %w", err)
 	}
 
+	if err := r.convergeNodeRegistrations(
+		ctx, req.Namespace, topoConfigName, slurmCluster, desiredTopology, desiredStructure, collectAllNodeNames(nodeSetList),
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	logger.Info("Reconciliation completed successfully")
 	return DefaultRequeueResult, nil
+}
+
+// convergeNodeRegistrations reads back the JailedConfig the reconcile just wrote and pushes the
+// node registrations it now allows. The read is a cache hit, and it is needed because the
+// annotation that says whether slurmctld has this structure is only settled by ensureJailedConfig.
+func (r *WorkerTopologyReconciler) convergeNodeRegistrations(
+	ctx context.Context, namespace, topoConfigName string, slurmCluster *slurmv1.SlurmCluster,
+	desiredTopology, desiredStructure string, managedNodes []string,
+) error {
+	if r.slurmAPIClients == nil {
+		return nil
+	}
+
+	jailedConfig := &v1alpha1.JailedConfig{}
+	key := client.ObjectKey{Namespace: namespace, Name: topoConfigName}
+	if err := r.Client.Get(ctx, key, jailedConfig); err != nil {
+		return fmt.Errorf("get JailedConfig %s: %w", topoConfigName, err)
+	}
+
+	if err := r.pushNodeRegistrations(
+		ctx, slurmCluster, jailedConfig, renderManagedTopologyConfig(desiredTopology), desiredStructure, managedNodes,
+	); err != nil {
+		return fmt.Errorf("push node registrations: %w", err)
+	}
+	return nil
 }
 
 // isClusterReconciliationNeeded reports whether the cluster describes a network topology at all.

--- a/internal/controller/topologyconfcontroller/workertopology_controller_test.go
+++ b/internal/controller/topologyconfcontroller/workertopology_controller_test.go
@@ -156,7 +156,7 @@ func TestCollectWorkerPods(t *testing.T) {
 		WithObjects(objects...).
 		Build()
 
-	reconciler := tc.NewWorkerTopologyReconciler(fakeClient, scheme, namespace, events.NewFakeRecorder(10))
+	reconciler := tc.NewWorkerTopologyReconciler(fakeClient, scheme, namespace, events.NewFakeRecorder(10), nil)
 
 	pods, err := reconciler.CollectWorkerPods(context.Background(), nodeSetList, clusterName, namespace)
 	require.NoError(t, err)

--- a/internal/slurmapi/fake/mock_client.go
+++ b/internal/slurmapi/fake/mock_client.go
@@ -420,6 +420,54 @@ func (_c *MockClient_RebootNodes_Call) RunAndReturn(run func(context.Context, sl
 	return _c
 }
 
+// SetNodeTopology provides a mock function with given fields: ctx, nodes, topologyStr
+func (_m *MockClient) SetNodeTopology(ctx context.Context, nodes string, topologyStr string) error {
+	ret := _m.Called(ctx, nodes, topologyStr)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetNodeTopology")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, nodes, topologyStr)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockClient_SetNodeTopology_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetNodeTopology'
+type MockClient_SetNodeTopology_Call struct {
+	*mock.Call
+}
+
+// SetNodeTopology is a helper method to define mock.On call
+//   - ctx context.Context
+//   - nodes string
+//   - topologyStr string
+func (_e *MockClient_Expecter) SetNodeTopology(ctx interface{}, nodes interface{}, topologyStr interface{}) *MockClient_SetNodeTopology_Call {
+	return &MockClient_SetNodeTopology_Call{Call: _e.mock.On("SetNodeTopology", ctx, nodes, topologyStr)}
+}
+
+func (_c *MockClient_SetNodeTopology_Call) Run(run func(ctx context.Context, nodes string, topologyStr string)) *MockClient_SetNodeTopology_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockClient_SetNodeTopology_Call) Return(_a0 error) *MockClient_SetNodeTopology_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClient_SetNodeTopology_Call) RunAndReturn(run func(context.Context, string, string) error) *MockClient_SetNodeTopology_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SlurmV0044DeleteJobWithResponse provides a mock function with given fields: ctx, jobId, params, reqEditors
 func (_m *MockClient) SlurmV0044DeleteJobWithResponse(ctx context.Context, jobId string, params *v0044.SlurmV0044DeleteJobParams, reqEditors ...v0044.RequestEditorFn) (*v0044.SlurmV0044DeleteJobResponse, error) {
 	_va := make([]interface{}, len(reqEditors))

--- a/internal/slurmapi/interface.go
+++ b/internal/slurmapi/interface.go
@@ -12,6 +12,7 @@ type Client interface {
 	GetNode(ctx context.Context, nodeName string) (Node, error)
 	RebootNodes(ctx context.Context, request RebootNodesRequest) error
 	UndrainNode(ctx context.Context, nodeName string) error
+	SetNodeTopology(ctx context.Context, nodes, topologyStr string) error
 	GetJobsByIDFromAccounting(ctx context.Context, jobID string) ([]Job, error)
 	ListJobs(ctx context.Context) ([]Job, error)
 	ListJobsWithParams(ctx context.Context, params ListJobsParams) ([]Job, error)

--- a/internal/slurmapi/node.go
+++ b/internal/slurmapi/node.go
@@ -20,6 +20,11 @@ type Node struct {
 	Comment     string
 	Reservation string
 
+	// Topology is the node's dynamic topology registration, as set by `scontrol update
+	// nodename=... topology=...`. It is empty for a node placed only by topology.yaml: Slurm
+	// prints the field solely from the node's own registration, never from the file.
+	Topology string
+
 	// Resource-related fields (nullable to detect missing data)
 	CPUs                *int32
 	AllocCPUs           *int32
@@ -108,6 +113,10 @@ func NodeFromAPI(node api.V0044Node) (Node, error) {
 
 	if node.Reservation != nil {
 		res.Reservation = *node.Reservation
+	}
+
+	if node.Topology != nil {
+		res.Topology = *node.Topology
 	}
 
 	return res, nil

--- a/internal/slurmapi/topology.go
+++ b/internal/slurmapi/topology.go
@@ -1,0 +1,95 @@
+package slurmapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	api "github.com/SlinkyProject/slurm-client/api/v0044"
+)
+
+// ErrTopologyUnavailable reports that slurmctld does not know one of the topologies named in the
+// registration.
+//
+// It means the running slurmctld has not loaded the topology yet, not that the request was wrong:
+// topology_g_init parses topology.yaml once per process, so a newly declared topology only exists
+// after a reconfigure re-execs the controller. Slurm rolls the node's previous registration back
+// before answering, so a caller can simply retry once the reconfigure lands.
+var ErrTopologyUnavailable = errors.New("requested topology is not loaded by slurmctld")
+
+// slurmErrTopologyUnavailable is the short form Slurm reports for
+// ESLURM_REQUESTED_TOPO_CONFIG_UNAVAILABLE (2178). Matched by name rather than by number because
+// the numeric values shift whenever an entry is inserted into the errno enum.
+const slurmErrTopologyUnavailable = "ESLURM_REQUESTED_TOPO_CONFIG_UNAVAILABLE"
+
+// SetNodeTopology registers nodes into the topologies named by topologyStr.
+//
+// nodes is a Slurm hostlist expression, so one call covers every node sharing a registration --
+// which is every node of one leaf switch or one block. slurmrestd passes the path segment straight
+// into the update request, and slurmctld expands it, so the cost to the controller is one RPC per
+// distinct registration rather than one per node.
+//
+// The registration is exhaustive: slurmctld removes the nodes from every topology topologyStr does
+// not name. Callers must pass the complete set of topologies a node belongs to.
+func (c *client) SetNodeTopology(ctx context.Context, nodes, topologyStr string) error {
+	if nodes == "" {
+		return fmt.Errorf("set node topology: node expression is required")
+	}
+
+	response, err := c.SlurmV0044PostNodeWithResponse(ctx, nodes, api.V0044UpdateNodeMsg{
+		TopologyStr: &topologyStr,
+	})
+	if err != nil {
+		return fmt.Errorf("post topology for %s: %w", nodes, err)
+	}
+	if response.StatusCode() < http.StatusOK || response.StatusCode() >= http.StatusMultipleChoices {
+		if topologyUnavailable(response.Body) {
+			return fmt.Errorf("set topology %q for %s: %w", topologyStr, nodes, ErrTopologyUnavailable)
+		}
+		return fmt.Errorf(
+			"set topology for %s failed: status=%d %s",
+			nodes, response.StatusCode(), summarizeSlurmRESTBody(response.Body),
+		)
+	}
+	if len(bytes.TrimSpace(response.Body)) == 0 {
+		return nil
+	}
+
+	// A rejected update also comes back as 200 with the failure in the envelope, so the body is
+	// checked even on success.
+	var responseEnvelope api.V0044OpenapiResp
+	if err := json.Unmarshal(response.Body, &responseEnvelope); err != nil {
+		return fmt.Errorf("decode set topology response for %s: %w", nodes, err)
+	}
+	if responseEnvelope.Errors != nil && len(*responseEnvelope.Errors) > 0 {
+		if topologyUnavailable(response.Body) {
+			return fmt.Errorf("set topology %q for %s: %w", topologyStr, nodes, ErrTopologyUnavailable)
+		}
+		return fmt.Errorf(
+			"set topology for %s responded with errors: %s",
+			nodes, summarizeSlurmRESTBody(response.Body),
+		)
+	}
+
+	return nil
+}
+
+func topologyUnavailable(body []byte) bool {
+	var parsed struct {
+		Errors []struct {
+			Error string `json:"error"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return false
+	}
+	for _, e := range parsed.Errors {
+		if e.Error == slurmErrTopologyUnavailable {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/slurmapi/topology_test.go
+++ b/internal/slurmapi/topology_test.go
@@ -1,0 +1,105 @@
+package slurmapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetNodeTopologyPostsTheRegistration(t *testing.T) {
+	var gotBody map[string]any
+	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodPost, request.Method)
+		// One request covers every node sharing the registration, so the path carries a hostlist.
+		assert.Equal(t, "/slurm/v0.0.44/node/worker-[0-3]", request.URL.Path)
+
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&gotBody))
+		return undrainJSONResponse(http.StatusOK, `{"errors":[]}`), nil
+	})}
+
+	client, err := NewClient("http://slurmrestd/", staticTokenIssuer("token-value"), httpClient)
+	require.NoError(t, err)
+
+	require.NoError(t, client.SetNodeTopology(
+		context.Background(), "worker-[0-3]", "tree-ib:fab:leaf-a"))
+	assert.Equal(t, "tree-ib:fab:leaf-a", gotBody["topology_str"])
+}
+
+func TestSetNodeTopologyRejectsAnEmptyNodeExpression(t *testing.T) {
+	client, err := NewClient("http://slurmrestd", nil, nil)
+	require.NoError(t, err)
+
+	assert.ErrorContains(t,
+		client.SetNodeTopology(context.Background(), "", "tree-ib:fab:leaf-a"),
+		"node expression is required")
+}
+
+// Slurm reports an unloaded topology as a plain rejection, but for the operator it means "not yet":
+// the reconfigure that would load it has not landed. It has to be distinguishable so the caller
+// retries instead of reporting a failure.
+func TestSetNodeTopologyReportsAnUnloadedTopology(t *testing.T) {
+	const envelope = `{"errors":[{"error":"ESLURM_REQUESTED_TOPO_CONFIG_UNAVAILABLE",` +
+		`"description":"Requested topology configuration is not available","error_number":2178}]}`
+
+	for name, status := range map[string]int{
+		"rejected outright":      http.StatusBadRequest,
+		"reported inside the OK": http.StatusOK,
+	} {
+		t.Run(name, func(t *testing.T) {
+			httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return undrainJSONResponse(status, envelope), nil
+			})}
+			client, err := NewClient("http://slurmrestd", nil, httpClient)
+			require.NoError(t, err)
+
+			err = client.SetNodeTopology(context.Background(), "worker-0", "tree-ib:fab:leaf-a")
+			assert.ErrorIs(t, err, ErrTopologyUnavailable)
+		})
+	}
+}
+
+func TestSetNodeTopologyOtherErrorsAreNotRetryable(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return undrainJSONResponse(http.StatusUnprocessableEntity,
+			`{"errors":[{"error":"ESLURM_INVALID_NODE_NAME","description":"Invalid node name"}]}`), nil
+	})}
+
+	client, err := NewClient("http://slurmrestd", nil, httpClient)
+	require.NoError(t, err)
+
+	err = client.SetNodeTopology(context.Background(), "worker-0", "tree-ib:fab:leaf-a")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrTopologyUnavailable)
+}
+
+func TestSetNodeTopologyAcceptsEmptySuccessResponse(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		// Without a JSON content type the generated client leaves the body unparsed, which is how
+		// slurmrestd answers an update it had nothing to say about.
+		response := undrainJSONResponse(http.StatusOK, "")
+		response.Header.Del("Content-Type")
+		return response, nil
+	})}
+
+	client, err := NewClient("http://slurmrestd", nil, httpClient)
+	require.NoError(t, err)
+
+	assert.NoError(t, client.SetNodeTopology(context.Background(), "worker-0", "tree-ib:fab:leaf-a"))
+}
+
+func TestSetNodeTopologySendsExplicitEmptyRegistration(t *testing.T) {
+	var body map[string]any
+	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&body))
+		return undrainJSONResponse(http.StatusOK, `{"errors":[]}`), nil
+	})}
+	client, err := NewClient("http://slurmrestd/", nil, httpClient)
+	require.NoError(t, err)
+	require.NoError(t, client.SetNodeTopology(context.Background(), "worker-0", ""))
+	assert.Contains(t, body, "topology_str")
+	assert.Equal(t, "", body["topology_str"])
+}

--- a/internal/utils/slurm/pattern/expand.go
+++ b/internal/utils/slurm/pattern/expand.go
@@ -1,0 +1,98 @@
+package pattern
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Expand is the inverse of Merge: it turns a merged hostlist expression back into the individual
+// entity names it stands for.
+//
+// Anything it cannot read as a range -- an entity Merge passed through untouched, or a
+// hand-written expression -- comes back as itself, so a caller counting entities never loses one to
+// a parse it did not expect.
+func Expand(merged string) []string {
+	if strings.TrimSpace(merged) == "" {
+		return nil
+	}
+
+	var entities []string
+	for _, part := range splitTopLevel(merged) {
+		entities = append(entities, expandPart(part)...)
+	}
+	return entities
+}
+
+// splitTopLevel splits on the commas separating entities, leaving the ones inside a range
+// expression alone.
+func splitTopLevel(merged string) []string {
+	var parts []string
+	var current strings.Builder
+	depth := 0
+
+	flush := func() {
+		if trimmed := strings.TrimSpace(current.String()); trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+		current.Reset()
+	}
+
+	for _, char := range merged {
+		switch {
+		case char == '[':
+			depth++
+		case char == ']':
+			depth--
+		case char == ',' && depth == 0:
+			flush()
+			continue
+		}
+		current.WriteRune(char)
+	}
+	flush()
+
+	return parts
+}
+
+func expandPart(part string) []string {
+	open := strings.Index(part, "[")
+	if open == -1 || !strings.HasSuffix(part, "]") {
+		return []string{part}
+	}
+
+	prefix := part[:open]
+	ranges := part[open+1 : len(part)-1]
+
+	var entities []string
+	for _, item := range strings.Split(ranges, ",") {
+		item = strings.TrimSpace(item)
+		start, end, width, ok := parseRangeItem(item)
+		if !ok {
+			return []string{part}
+		}
+		for number := start; number <= end; number++ {
+			entities = append(entities, prefix+formatPatternNumber(number, width))
+		}
+	}
+
+	return entities
+}
+
+func parseRangeItem(item string) (start, end, width int, ok bool) {
+	bounds := strings.SplitN(item, "-", 2)
+
+	start, err := strconv.Atoi(bounds[0])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	end = start
+
+	if len(bounds) == 2 {
+		end, err = strconv.Atoi(bounds[1])
+		if err != nil || end < start {
+			return 0, 0, 0, false
+		}
+	}
+
+	return start, end, len(bounds[0]), true
+}

--- a/internal/utils/slurm/pattern/expand_test.go
+++ b/internal/utils/slurm/pattern/expand_test.go
@@ -1,0 +1,68 @@
+package pattern
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpand(t *testing.T) {
+	tests := []struct {
+		name     string
+		merged   string
+		expected []string
+	}{
+		{name: "empty", merged: "", expected: nil},
+		{name: "blank", merged: "   ", expected: nil},
+		{name: "single entity", merged: "worker-0", expected: []string{"worker-0"}},
+		{name: "range", merged: "worker-[0-2]", expected: []string{"worker-0", "worker-1", "worker-2"}},
+		{
+			name:     "range with gaps",
+			merged:   "worker-[0-1,5]",
+			expected: []string{"worker-0", "worker-1", "worker-5"},
+		},
+		{
+			name:     "several prefixes",
+			merged:   "cpu-[0-1],gpu-0",
+			expected: []string{"cpu-0", "cpu-1", "gpu-0"},
+		},
+		{
+			name:     "padded range keeps its width",
+			merged:   "worker-[08-10]",
+			expected: []string{"worker-08", "worker-09", "worker-10"},
+		},
+		{
+			name:     "unparsable range is kept whole",
+			merged:   "worker-[a-b]",
+			expected: []string{"worker-[a-b]"},
+		},
+		{
+			name:     "entity without a numeric suffix",
+			merged:   "login",
+			expected: []string{"login"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, Expand(tt.merged))
+		})
+	}
+}
+
+// Expand has to read back everything Merge writes, since the two are used on the two sides of the
+// same comparison.
+func TestExpandRoundTripsMerge(t *testing.T) {
+	tests := [][]string{
+		{"worker-0"},
+		{"worker-0", "worker-1", "worker-2"},
+		{"worker-0", "worker-1", "worker-5", "worker-6"},
+		{"cpu-0", "cpu-1", "gpu-0", "gpu-3"},
+		{"worker-08", "worker-09", "worker-10"},
+	}
+
+	for _, entities := range tests {
+		merged := Merge(entities)
+		assert.Equal(t, entities, Expand(merged), "merged as %q", merged)
+	}
+}


### PR DESCRIPTION
## Problem

Node topology registrations can become stale or disappear after reconfiguration.

## Solution

Reconcile registrations through Slurm REST API, clear removed bindings, and add topology diagnostics.

## Testing

Go tests, 110 Python tests, and lint pass. Topology E2E scenarios re-enabled; not run locally.

## Release Notes

Automatically restore and update worker topology registrations without restarting pods.