### PR TITLE
SCHED-1323: test Slurm config updates

### DIFF
--- a/e2e/acceptance/features.go
+++ b/e2e/acceptance/features.go
@@ -28,6 +28,7 @@ func FeaturePaths() []string {
 		"features/cluster_creation.feature",
 		"features/accounting.feature",
 		"features/slurm_config.feature",
+		"features/slurm_config_updates.feature",
 		"features/observability.feature",
 		"features/internal_ssh.feature",
 		"features/package_installation.feature",

--- a/e2e/acceptance/features/slurm_config_updates.feature
+++ b/e2e/acceptance/features/slurm_config_updates.feature
@@ -1,0 +1,12 @@
+Feature: Slurm configuration updates
+
+  @soperator_version_>=4.0.0
+  Scenario: A custom Slurm setting is applied and restored
+    Given the current custom Slurm configuration and worker start times are recorded
+    Then worker start times remain unchanged while the Slurm configuration is unchanged
+    When JobRequeue is overridden to 0 in the SlurmCluster
+    Then the effective JobRequeue value becomes 0
+    And every active worker has been reconfigured
+    When the original custom Slurm configuration is restored
+    Then the effective JobRequeue value is restored
+    And every active worker has been reconfigured again

--- a/e2e/acceptance/features/slurm_config_updates.feature
+++ b/e2e/acceptance/features/slurm_config_updates.feature
@@ -2,7 +2,8 @@ Feature: Slurm configuration updates
 
   @soperator_version_>=4.0.0
   Scenario: A custom Slurm setting is applied and restored
-    Given the current custom Slurm configuration and worker start times are recorded
+    Given at least one active worker is available for Slurm reconfiguration
+    And the current custom Slurm configuration is recorded
     Then worker start times remain unchanged while the Slurm configuration is unchanged
     When JobRequeue is overridden to 0 in the SlurmCluster
     Then the effective JobRequeue value becomes 0

--- a/e2e/acceptance/framework/kubectl_client.go
+++ b/e2e/acceptance/framework/kubectl_client.go
@@ -31,6 +31,7 @@ type SlurmClusterInfo struct {
 	Name              string
 	Namespace         string
 	AccountingEnabled bool
+	CustomSlurmConfig *string
 }
 
 type WorkerPodInfo struct {
@@ -59,7 +60,33 @@ func (c *KubectlClient) SlurmCluster(ctx context.Context, name string) (SlurmClu
 		Name:              cluster.Metadata.Name,
 		Namespace:         cluster.Metadata.Namespace,
 		AccountingEnabled: cluster.Spec.SlurmNodes.Accounting.Enabled,
+		CustomSlurmConfig: cluster.Spec.CustomSlurmConfig,
 	}, nil
+}
+
+func (c *KubectlClient) PatchSlurmClusterCustomConfig(ctx context.Context, name string, value *string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("SlurmCluster name is empty")
+	}
+
+	patch, err := json.Marshal(map[string]any{
+		"spec": map[string]any{
+			"customSlurmConfig": value,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal SlurmCluster custom config patch: %w", err)
+	}
+
+	if _, err := c.exec.Kubectl().RunWithDefaultRetry(ctx,
+		"patch", "slurmcluster", name,
+		"-n", SoperatorNamespace,
+		"--type=merge", "-p", string(patch),
+	); err != nil {
+		return fmt.Errorf("patch SlurmCluster %s/%s custom config: %w", SoperatorNamespace, name, err)
+	}
+	return nil
 }
 
 func (c *KubectlClient) GetJSON(ctx context.Context, out any, args ...string) error {

--- a/e2e/acceptance/framework/kubectl_client_test.go
+++ b/e2e/acceptance/framework/kubectl_client_test.go
@@ -12,10 +12,14 @@ import (
 )
 
 func TestKubectlClientSlurmCluster(t *testing.T) {
+	customConfig := "JobRequeue=0"
 	exec := &kubectlClientTestExec{kubectl: map[string]string{
 		"get\x00slurmcluster\x00soperator\x00-n\x00soperator\x00-o\x00json": `{
 			"metadata": {"name": "soperator", "namespace": "soperator"},
-			"spec": {"slurmNodes": {"accounting": {"enabled": true}}}
+			"spec": {
+				"customSlurmConfig": "JobRequeue=0",
+				"slurmNodes": {"accounting": {"enabled": true}}
+			}
 		}`,
 	}}
 
@@ -25,12 +29,49 @@ func TestKubectlClientSlurmCluster(t *testing.T) {
 		Name:              "soperator",
 		Namespace:         "soperator",
 		AccountingEnabled: true,
+		CustomSlurmConfig: &customConfig,
 	}, cluster)
 }
 
 func TestKubectlClientSlurmClusterRejectsEmptyName(t *testing.T) {
 	_, err := NewKubectlClient(&kubectlClientTestExec{}).SlurmCluster(t.Context(), " ")
 	assert.ErrorContains(t, err, "name is empty")
+}
+
+func TestKubectlClientPatchSlurmClusterCustomConfig(t *testing.T) {
+	for name, test := range map[string]struct {
+		value *string
+		patch string
+	}{
+		"set": {
+			value: ptrTo("JobRequeue=0\n"),
+			patch: `{"spec":{"customSlurmConfig":"JobRequeue=0\n"}}`,
+		},
+		"remove": {
+			patch: `{"spec":{"customSlurmConfig":null}}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			exec := &kubectlClientTestExec{kubectl: map[string]string{
+				strings.Join([]string{
+					"patch", "slurmcluster", "soperator", "-n", "soperator",
+					"--type=merge", "-p", test.patch,
+				}, "\x00"): "",
+			}}
+
+			err := NewKubectlClient(exec).PatchSlurmClusterCustomConfig(t.Context(), "soperator", test.value)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestKubectlClientPatchSlurmClusterCustomConfigRejectsEmptyName(t *testing.T) {
+	err := NewKubectlClient(&kubectlClientTestExec{}).PatchSlurmClusterCustomConfig(t.Context(), " ", nil)
+	assert.ErrorContains(t, err, "name is empty")
+}
+
+func ptrTo[T any](value T) *T {
+	return &value
 }
 
 func TestKubectlClientNodeSetsFiltersByClusterName(t *testing.T) {

--- a/e2e/acceptance/framework/slurm_config.go
+++ b/e2e/acceptance/framework/slurm_config.go
@@ -1,0 +1,44 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+func (s *SlurmClient) Configuration(ctx context.Context) (map[string]string, error) {
+	output, err := s.runtime.Controller().RunWithDefaultRetry(ctx, "scontrol show config")
+	if err != nil {
+		return nil, fmt.Errorf("read effective Slurm configuration: %w", err)
+	}
+
+	configuration, err := parseSlurmConfiguration(output)
+	if err != nil {
+		return nil, fmt.Errorf("parse effective Slurm configuration: %w", err)
+	}
+	return configuration, nil
+}
+
+func parseSlurmConfiguration(output string) (map[string]string, error) {
+	configuration := make(map[string]string)
+	for lineNumber, line := range strings.Split(output, "\n") {
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return nil, fmt.Errorf("parse line %d: setting name is empty", lineNumber+1)
+		}
+		if _, found := configuration[key]; found {
+			return nil, fmt.Errorf("parse line %d: setting %q is duplicated", lineNumber+1, key)
+		}
+		configuration[key] = value
+	}
+	if len(configuration) == 0 {
+		return nil, fmt.Errorf("find settings in scontrol output")
+	}
+	return configuration, nil
+}

--- a/e2e/acceptance/framework/slurm_config_test.go
+++ b/e2e/acceptance/framework/slurm_config_test.go
@@ -1,0 +1,53 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlurmClientConfiguration(t *testing.T) {
+	runtime := &slurmConfigurationRuntime{output: `Configuration data as of 2026-09-01T15:00:00
+MpiDefault              = pmix
+SlurmdTimeout           = 180 sec
+PluginOption            = name=value
+`}
+
+	configuration, err := NewSlurmClient(runtime).Configuration(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"MpiDefault":    "pmix",
+		"PluginOption":  "name=value",
+		"SlurmdTimeout": "180 sec",
+	}, configuration)
+}
+
+func TestParseSlurmConfigurationRejectsInvalidOutput(t *testing.T) {
+	for name, output := range map[string]string{
+		"no settings":    "Configuration data as of today\n",
+		"empty setting":  " = value\n",
+		"duplicate name": "MpiDefault = pmix\nMpiDefault = none\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseSlurmConfiguration(output)
+			assert.Error(t, err)
+		})
+	}
+}
+
+type slurmConfigurationRuntime struct {
+	Runtime
+	output string
+}
+
+func (r *slurmConfigurationRuntime) Controller() CommandScope {
+	return NewCommandScope(func(ctx context.Context, command string) (string, error) {
+		if command != "scontrol show config" {
+			return "", fmt.Errorf("unexpected controller command: %s", command)
+		}
+		return r.output, nil
+	})
+}

--- a/e2e/acceptance/framework/slurm_node.go
+++ b/e2e/acceptance/framework/slurm_node.go
@@ -87,6 +87,32 @@ func (s *SlurmClient) MainPartitionNodeNames(ctx context.Context) ([]string, err
 	return ParseSlurmNodeNames(out), nil
 }
 
+func (s *SlurmClient) ActiveWorkerStartTimes(ctx context.Context) (map[string]time.Time, error) {
+	names, err := s.MainPartitionNodeNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	startTimes := make(map[string]time.Time, len(names))
+	for _, name := range names {
+		node, err := s.NodeInfo(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		if node.HasStateFlag("NOT_RESPONDING") || node.HasStateFlag("POWERING_DOWN") || node.HasStateFlag("POWERED_DOWN") {
+			continue
+		}
+		if node.SlurmdStartTime.IsZero() {
+			return nil, fmt.Errorf("read valid SlurmdStartTime for active worker %s", name)
+		}
+		startTimes[name] = node.SlurmdStartTime
+	}
+	if len(startTimes) == 0 {
+		return nil, fmt.Errorf("find active workers with SlurmdStartTime")
+	}
+	return startTimes, nil
+}
+
 func ParseSlurmNodeNames(output string) []string {
 	seen := make(map[string]struct{})
 	var names []string

--- a/e2e/acceptance/framework/slurm_node.go
+++ b/e2e/acceptance/framework/slurm_node.go
@@ -15,15 +15,19 @@ var (
 	slurmNodeInstanceIDPattern = regexp.MustCompile(`\bInstanceId=([^\s]+)`)
 	slurmNodeRealMemoryPattern = regexp.MustCompile(`\bRealMemory=(\d+)`)
 	slurmNodeGPUCountPattern   = regexp.MustCompile(`\bCfgTRES=[^\s]*\bgres/gpu=(\d+)`)
+	slurmdStartTimePattern     = regexp.MustCompile(`\bSlurmdStartTime=([^\s]+)`)
 )
 
+const slurmTimestampLayout = "2006-01-02T15:04:05"
+
 type SlurmNodeInfo struct {
-	Name          string
-	State         string
-	Reason        string
-	InstanceID    string
-	RealMemoryMiB uint64
-	GPUCount      int
+	Name            string
+	State           string
+	Reason          string
+	InstanceID      string
+	RealMemoryMiB   uint64
+	GPUCount        int
+	SlurmdStartTime time.Time
 }
 
 func ParseSlurmNodeInfo(name, output string) SlurmNodeInfo {
@@ -47,6 +51,11 @@ func ParseSlurmNodeInfo(name, output string) SlurmNodeInfo {
 	if match := slurmNodeGPUCountPattern.FindStringSubmatch(output); len(match) == 2 {
 		if value, err := strconv.Atoi(match[1]); err == nil {
 			info.GPUCount = value
+		}
+	}
+	if match := slurmdStartTimePattern.FindStringSubmatch(output); len(match) == 2 {
+		if value, err := time.Parse(slurmTimestampLayout, match[1]); err == nil {
+			info.SlurmdStartTime = value
 		}
 	}
 	return info

--- a/e2e/acceptance/framework/slurm_node_test.go
+++ b/e2e/acceptance/framework/slurm_node_test.go
@@ -1,10 +1,14 @@
 package framework
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseSlurmNodeInfo(t *testing.T) {
@@ -54,4 +58,46 @@ func TestParseSlurmNodeInfoGPUCount(t *testing.T) {
 
 func TestParseSlurmNodeNames(t *testing.T) {
 	assert.Equal(t, []string{"worker-0", "worker-1"}, ParseSlurmNodeNames("\nworker-0\nworker-1\nworker-0\n"))
+}
+
+func TestSlurmClientActiveWorkerStartTimes(t *testing.T) {
+	runtime := &slurmNodeRuntime{outputs: map[string]string{
+		`sinfo -hN -p main -o '%N'`:     "worker-0\nworker-1\nworker-2\nworker-3\n",
+		`scontrol show node 'worker-0'`: "NodeName=worker-0 State=IDLE SlurmdStartTime=2026-08-28T10:23:44",
+		`scontrol show node 'worker-1'`: "NodeName=worker-1 State=IDLE+NOT_RESPONDING SlurmdStartTime=2026-08-28T10:23:44",
+		`scontrol show node 'worker-2'`: "NodeName=worker-2 State=IDLE+POWERING_DOWN SlurmdStartTime=2026-08-28T10:23:44",
+		`scontrol show node 'worker-3'`: "NodeName=worker-3 State=IDLE+POWERED_DOWN SlurmdStartTime=None",
+	}}
+
+	startTimes, err := NewSlurmClient(runtime).ActiveWorkerStartTimes(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, map[string]time.Time{
+		"worker-0": time.Date(2026, time.August, 28, 10, 23, 44, 0, time.UTC),
+	}, startTimes)
+}
+
+func TestSlurmClientActiveWorkerStartTimesRequiresActiveWorker(t *testing.T) {
+	runtime := &slurmNodeRuntime{outputs: map[string]string{
+		`sinfo -hN -p main -o '%N'`:     "worker-0\n",
+		`scontrol show node 'worker-0'`: "NodeName=worker-0 State=IDLE+POWERED_DOWN SlurmdStartTime=None",
+	}}
+
+	_, err := NewSlurmClient(runtime).ActiveWorkerStartTimes(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "find active workers")
+}
+
+type slurmNodeRuntime struct {
+	Runtime
+	outputs map[string]string
+}
+
+func (r *slurmNodeRuntime) Controller() CommandScope {
+	return NewCommandScope(func(ctx context.Context, command string) (string, error) {
+		output, found := r.outputs[command]
+		if !found {
+			return "", fmt.Errorf("unexpected controller command: %s", strings.TrimSpace(command))
+		}
+		return output, nil
+	})
 }

--- a/e2e/acceptance/framework/slurm_node_test.go
+++ b/e2e/acceptance/framework/slurm_node_test.go
@@ -2,12 +2,13 @@ package framework
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestParseSlurmNodeInfo(t *testing.T) {
-	output := "NodeName=worker-0 InstanceId=compute-instance-1 State=IDLE+DRAIN ThreadsPerCore=1 RealMemory=191356 CfgTRES=cpu=128,mem=1436G,billing=128,gres/gpu=8 Reason=[user_problem] alloc_gpus_busy [root@2026-01-01T00:00:00]"
+	output := "NodeName=worker-0 InstanceId=compute-instance-1 State=IDLE+DRAIN ThreadsPerCore=1 RealMemory=191356 CfgTRES=cpu=128,mem=1436G,billing=128,gres/gpu=8 SlurmdStartTime=2026-08-28T10:23:44 Reason=[user_problem] alloc_gpus_busy [root@2026-01-01T00:00:00]"
 
 	info := ParseSlurmNodeInfo("worker-0", output)
 
@@ -17,11 +18,21 @@ func TestParseSlurmNodeInfo(t *testing.T) {
 	assert.Equal(t, "[user_problem] alloc_gpus_busy [root@2026-01-01T00:00:00]", info.Reason)
 	assert.Equal(t, uint64(191356), info.RealMemoryMiB)
 	assert.Equal(t, 8, info.GPUCount)
+	assert.Equal(t, time.Date(2026, time.August, 28, 10, 23, 44, 0, time.UTC), info.SlurmdStartTime)
 	assert.True(t, info.HasStateFlag("DRAIN"))
 	assert.True(t, info.HasStateFlag("idle"))
 	assert.False(t, info.HasStateFlag("DOWN"))
 	assert.True(t, info.ReasonContains("alloc_gpus_busy"))
 	assert.False(t, info.IsUsable())
+}
+
+func TestParseSlurmNodeInfoLeavesInvalidStartTimeUnset(t *testing.T) {
+	for _, value := range []string{"None", "invalid"} {
+		t.Run(value, func(t *testing.T) {
+			info := ParseSlurmNodeInfo("worker-0", "NodeName=worker-0 SlurmdStartTime="+value)
+			assert.True(t, info.SlurmdStartTime.IsZero())
+		})
+	}
 }
 
 func TestParseSlurmNodeInfoGPUCount(t *testing.T) {

--- a/e2e/acceptance/internal/kubeobjects/types.go
+++ b/e2e/acceptance/internal/kubeobjects/types.go
@@ -50,6 +50,7 @@ type SlurmClusterSpec struct {
 	Topology               *SlurmClusterTopology  `json:"topology"`
 	PartitionConfiguration PartitionConfiguration `json:"partitionConfiguration"`
 	SlurmNodes             SlurmClusterNodes      `json:"slurmNodes"`
+	CustomSlurmConfig      *string                `json:"customSlurmConfig"`
 }
 
 type SlurmClusterNodes struct {

--- a/e2e/acceptance/internal/sharedsteps/slurm_config.go
+++ b/e2e/acceptance/internal/sharedsteps/slurm_config.go
@@ -13,12 +13,12 @@ import (
 
 type SlurmConfig struct {
 	info          *framework.ClusterInfo
-	runtime       framework.Runtime
+	slurm         *framework.SlurmClient
 	configuration map[string]string
 }
 
-func NewSlurmConfig(info *framework.ClusterInfo, runtime framework.Runtime) *SlurmConfig {
-	return &SlurmConfig{info: info, runtime: runtime}
+func NewSlurmConfig(info *framework.ClusterInfo, slurm *framework.SlurmClient) *SlurmConfig {
+	return &SlurmConfig{info: info, slurm: slurm}
 }
 
 func (s *SlurmConfig) RegisterSteps(sc *godog.ScenarioContext) {
@@ -32,14 +32,9 @@ func (s *SlurmConfig) CleanupAndReset(ctx context.Context) {
 }
 
 func (s *SlurmConfig) readEffectiveSlurmConfiguration(ctx context.Context) error {
-	output, err := s.runtime.Controller().RunWithDefaultRetry(ctx, "scontrol show config")
+	configuration, err := s.slurm.Configuration(ctx)
 	if err != nil {
-		return fmt.Errorf("read effective Slurm configuration: %w", err)
-	}
-
-	configuration, err := parseSlurmConfiguration(output)
-	if err != nil {
-		return fmt.Errorf("parse effective Slurm configuration: %w", err)
+		return err
 	}
 	s.configuration = configuration
 	return nil
@@ -66,30 +61,6 @@ func (s *SlurmConfig) checkClusterName() error {
 	return validateSlurmSettings(s.configuration, map[string]string{
 		"ClusterName": s.info.SlurmClusterName,
 	})
-}
-
-func parseSlurmConfiguration(output string) (map[string]string, error) {
-	configuration := make(map[string]string)
-	for lineNumber, line := range strings.Split(output, "\n") {
-		key, value, found := strings.Cut(line, "=")
-		if !found {
-			continue
-		}
-
-		key = strings.TrimSpace(key)
-		value = strings.TrimSpace(value)
-		if key == "" {
-			return nil, fmt.Errorf("parse line %d: setting name is empty", lineNumber+1)
-		}
-		if _, found := configuration[key]; found {
-			return nil, fmt.Errorf("parse line %d: setting %q is duplicated", lineNumber+1, key)
-		}
-		configuration[key] = value
-	}
-	if len(configuration) == 0 {
-		return nil, fmt.Errorf("find settings in scontrol output")
-	}
-	return configuration, nil
 }
 
 func parseSlurmSettingsTable(table *godog.Table) (map[string]string, error) {

--- a/e2e/acceptance/internal/sharedsteps/slurm_config_test.go
+++ b/e2e/acceptance/internal/sharedsteps/slurm_config_test.go
@@ -9,33 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseSlurmConfiguration(t *testing.T) {
-	configuration, err := parseSlurmConfiguration(`Configuration data as of 2026-09-01T15:00:00
-MpiDefault              = pmix
-SlurmdTimeout           = 180 sec
-PluginOption            = name=value
-`)
-	require.NoError(t, err)
-	assert.Equal(t, map[string]string{
-		"MpiDefault":    "pmix",
-		"PluginOption":  "name=value",
-		"SlurmdTimeout": "180 sec",
-	}, configuration)
-}
-
-func TestParseSlurmConfigurationRejectsInvalidOutput(t *testing.T) {
-	for name, output := range map[string]string{
-		"no settings":    "Configuration data as of today\n",
-		"empty setting":  " = value\n",
-		"duplicate name": "MpiDefault = pmix\nMpiDefault = none\n",
-	} {
-		t.Run(name, func(t *testing.T) {
-			_, err := parseSlurmConfiguration(output)
-			assert.Error(t, err)
-		})
-	}
-}
-
 func TestParseSlurmSettingsTable(t *testing.T) {
 	table := newSlurmSettingsTable(
 		[]string{"setting", "value"},

--- a/e2e/acceptance/internal/sharedsteps/slurm_config_updates.go
+++ b/e2e/acceptance/internal/sharedsteps/slurm_config_updates.go
@@ -1,0 +1,293 @@
+package sharedsteps
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+const (
+	slurmConfigStabilityWindow = 30 * time.Second
+	slurmConfigUpdateTimeout   = 5 * time.Minute
+)
+
+type SlurmConfigUpdates struct {
+	info    *framework.ClusterInfo
+	runtime framework.Runtime
+	slurm   *framework.SlurmClient
+	kubectl *framework.KubectlClient
+
+	originalCustomConfig *string
+	originalJobRequeue   string
+	workerStartTimes     map[string]time.Time
+	stateRecorded        bool
+	restoreNeeded        bool
+}
+
+func NewSlurmConfigUpdates(
+	info *framework.ClusterInfo,
+	runtime framework.Runtime,
+	slurm *framework.SlurmClient,
+	kubectl *framework.KubectlClient,
+) *SlurmConfigUpdates {
+	return &SlurmConfigUpdates{
+		info:    info,
+		runtime: runtime,
+		slurm:   slurm,
+		kubectl: kubectl,
+	}
+}
+
+func (s *SlurmConfigUpdates) RegisterSteps(sc *godog.ScenarioContext) {
+	sc.Step(`^the current custom Slurm configuration and worker start times are recorded$`, s.recordCurrentState)
+	sc.Step(`^worker start times remain unchanged while the Slurm configuration is unchanged$`, s.checkWorkerStartTimesStable)
+	sc.Step(`^JobRequeue is overridden to 0 in the SlurmCluster$`, s.overrideJobRequeue)
+	sc.Step(`^the effective JobRequeue value becomes 0$`, s.checkOverriddenJobRequeue)
+	sc.Step(`^every active worker has been reconfigured$`, s.checkWorkersReconfigured)
+	sc.Step(`^the original custom Slurm configuration is restored$`, s.restoreOriginalCustomConfig)
+	sc.Step(`^the effective JobRequeue value is restored$`, s.checkRestoredJobRequeue)
+	sc.Step(`^every active worker has been reconfigured again$`, s.checkWorkersReconfiguredAgain)
+}
+
+func (s *SlurmConfigUpdates) CleanupAndReset(ctx context.Context) {
+	if s.restoreNeeded && s.stateRecorded {
+		cleanupCtx, cancel := context.WithTimeout(ctx, slurmConfigUpdateTimeout)
+		defer cancel()
+
+		if err := s.patchCustomConfig(cleanupCtx, s.originalCustomConfig); err != nil {
+			s.runtime.Logf("cleanup: restore SlurmCluster custom config: %v", err)
+		} else if err := s.waitForJobRequeue(cleanupCtx, s.originalJobRequeue); err != nil {
+			s.runtime.Logf("cleanup: wait for original JobRequeue value: %v", err)
+		}
+	}
+
+	s.originalCustomConfig = nil
+	s.originalJobRequeue = ""
+	s.workerStartTimes = nil
+	s.stateRecorded = false
+	s.restoreNeeded = false
+}
+
+func (s *SlurmConfigUpdates) recordCurrentState(ctx context.Context) error {
+	cluster, err := s.kubectl.SlurmCluster(ctx, s.info.SlurmClusterName)
+	if err != nil {
+		return err
+	}
+	if cluster.CustomSlurmConfig != nil {
+		original := *cluster.CustomSlurmConfig
+		s.originalCustomConfig = &original
+	}
+
+	s.originalJobRequeue, err = s.effectiveSlurmSetting(ctx, "JobRequeue")
+	if err != nil {
+		return err
+	}
+	if s.originalJobRequeue == "0" {
+		return fmt.Errorf("change JobRequeue from 0: scenario requires a different original value")
+	}
+
+	s.workerStartTimes, err = s.activeWorkerStartTimes(ctx)
+	if err != nil {
+		return err
+	}
+	s.stateRecorded = true
+	return nil
+}
+
+func (s *SlurmConfigUpdates) checkWorkerStartTimesStable(ctx context.Context) error {
+	if !s.stateRecorded {
+		return fmt.Errorf("record current Slurm configuration before checking worker start times")
+	}
+
+	timer := time.NewTimer(slurmConfigStabilityWindow)
+	defer timer.Stop()
+	ticker := time.NewTicker(framework.DefaultPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return nil
+		case <-ticker.C:
+			current, err := s.activeWorkerStartTimes(ctx)
+			if err != nil {
+				return err
+			}
+			if err := compareWorkerStartTimes(s.workerStartTimes, current, false); err != nil {
+				return fmt.Errorf("detect worker reconfiguration while Slurm configuration was unchanged: %w", err)
+			}
+		}
+	}
+}
+
+func (s *SlurmConfigUpdates) overrideJobRequeue(ctx context.Context) error {
+	if !s.stateRecorded {
+		return fmt.Errorf("record current Slurm configuration before applying an override")
+	}
+
+	override := customSlurmConfigWithJobRequeue(s.originalCustomConfig, "0")
+	s.restoreNeeded = true
+	return s.patchCustomConfig(ctx, &override)
+}
+
+func (s *SlurmConfigUpdates) checkOverriddenJobRequeue(ctx context.Context) error {
+	return s.waitForJobRequeue(ctx, "0")
+}
+
+func (s *SlurmConfigUpdates) checkWorkersReconfigured(ctx context.Context) error {
+	return s.waitForWorkersReconfigured(ctx)
+}
+
+func (s *SlurmConfigUpdates) restoreOriginalCustomConfig(ctx context.Context) error {
+	if !s.restoreNeeded {
+		return fmt.Errorf("restore original custom Slurm configuration: no override was applied")
+	}
+	return s.patchCustomConfig(ctx, s.originalCustomConfig)
+}
+
+func (s *SlurmConfigUpdates) checkRestoredJobRequeue(ctx context.Context) error {
+	return s.waitForJobRequeue(ctx, s.originalJobRequeue)
+}
+
+func (s *SlurmConfigUpdates) checkWorkersReconfiguredAgain(ctx context.Context) error {
+	if err := s.waitForWorkersReconfigured(ctx); err != nil {
+		return err
+	}
+	s.restoreNeeded = false
+	return nil
+}
+
+func (s *SlurmConfigUpdates) patchCustomConfig(ctx context.Context, value *string) error {
+	if err := s.kubectl.PatchSlurmClusterCustomConfig(ctx, s.info.SlurmClusterName, value); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *SlurmConfigUpdates) effectiveSlurmSetting(ctx context.Context, setting string) (string, error) {
+	output, err := s.runtime.Controller().RunWithDefaultRetry(ctx, "scontrol show config")
+	if err != nil {
+		return "", fmt.Errorf("read effective Slurm configuration: %w", err)
+	}
+	configuration, err := parseSlurmConfiguration(output)
+	if err != nil {
+		return "", fmt.Errorf("parse effective Slurm configuration: %w", err)
+	}
+	value, found := configuration[setting]
+	if !found {
+		return "", fmt.Errorf("find %s in effective Slurm configuration", setting)
+	}
+	return value, nil
+}
+
+func (s *SlurmConfigUpdates) waitForJobRequeue(ctx context.Context, expected string) error {
+	return s.runtime.WaitFor(ctx,
+		fmt.Sprintf("effective JobRequeue value to become %s", expected),
+		slurmConfigUpdateTimeout,
+		framework.DefaultPollInterval,
+		func(waitCtx context.Context) (bool, error) {
+			actual, err := s.effectiveSlurmSetting(waitCtx, "JobRequeue")
+			if err != nil {
+				return false, err
+			}
+			if actual != expected {
+				return false, fmt.Errorf("observe JobRequeue=%q, expected %q", actual, expected)
+			}
+			return true, nil
+		},
+	)
+}
+
+func (s *SlurmConfigUpdates) activeWorkerStartTimes(ctx context.Context) (map[string]time.Time, error) {
+	names, err := s.slurm.MainPartitionNodeNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	startTimes := make(map[string]time.Time, len(names))
+	for _, name := range names {
+		node, err := s.slurm.NodeInfo(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		if node.HasStateFlag("NOT_RESPONDING") || node.HasStateFlag("POWERING_DOWN") || node.HasStateFlag("POWERED_DOWN") {
+			continue
+		}
+		if node.SlurmdStartTime.IsZero() {
+			return nil, fmt.Errorf("read valid SlurmdStartTime for active worker %s", name)
+		}
+		startTimes[name] = node.SlurmdStartTime
+	}
+	if len(startTimes) == 0 {
+		return nil, fmt.Errorf("find active workers with SlurmdStartTime")
+	}
+	return startTimes, nil
+}
+
+func (s *SlurmConfigUpdates) waitForWorkersReconfigured(ctx context.Context) error {
+	if len(s.workerStartTimes) == 0 {
+		return fmt.Errorf("record worker start times before waiting for reconfiguration")
+	}
+
+	var updated map[string]time.Time
+	err := s.runtime.WaitFor(ctx,
+		"every active worker to be reconfigured",
+		slurmConfigUpdateTimeout,
+		framework.DefaultPollInterval,
+		func(waitCtx context.Context) (bool, error) {
+			current, err := s.activeWorkerStartTimes(waitCtx)
+			if err != nil {
+				return false, err
+			}
+			if err := compareWorkerStartTimes(s.workerStartTimes, current, true); err != nil {
+				return false, err
+			}
+			updated = current
+			return true, nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+	s.workerStartTimes = updated
+	return nil
+}
+
+func customSlurmConfigWithJobRequeue(original *string, value string) string {
+	if original == nil || *original == "" {
+		return "JobRequeue=" + value + "\n"
+	}
+
+	config := *original
+	if !strings.HasSuffix(config, "\n") {
+		config += "\n"
+	}
+	return config + "JobRequeue=" + value + "\n"
+}
+
+func compareWorkerStartTimes(expected, actual map[string]time.Time, requireAdvanced bool) error {
+	for name, before := range expected {
+		after, found := actual[name]
+		if !found {
+			return fmt.Errorf("find worker %s among active workers", name)
+		}
+		if requireAdvanced {
+			if !after.After(before) {
+				return fmt.Errorf("observe worker %s SlurmdStartTime still at %s", name, after.Format(time.RFC3339))
+			}
+			continue
+		}
+		if !after.Equal(before) {
+			return fmt.Errorf("observe worker %s SlurmdStartTime change from %s to %s",
+				name, before.Format(time.RFC3339), after.Format(time.RFC3339))
+		}
+	}
+	return nil
+}

--- a/e2e/acceptance/internal/sharedsteps/slurm_config_updates.go
+++ b/e2e/acceptance/internal/sharedsteps/slurm_config_updates.go
@@ -44,7 +44,8 @@ func NewSlurmConfigUpdates(
 }
 
 func (s *SlurmConfigUpdates) RegisterSteps(sc *godog.ScenarioContext) {
-	sc.Step(`^the current custom Slurm configuration and worker start times are recorded$`, s.recordCurrentState)
+	sc.Step(`^at least one active worker is available for Slurm reconfiguration$`, s.recordActiveWorkerStartTimes)
+	sc.Step(`^the current custom Slurm configuration is recorded$`, s.recordCurrentConfig)
 	sc.Step(`^worker start times remain unchanged while the Slurm configuration is unchanged$`, s.checkWorkerStartTimesStable)
 	sc.Step(`^JobRequeue is overridden to 0 in the SlurmCluster$`, s.overrideJobRequeue)
 	sc.Step(`^the effective JobRequeue value becomes 0$`, s.checkOverriddenJobRequeue)
@@ -73,7 +74,20 @@ func (s *SlurmConfigUpdates) CleanupAndReset(ctx context.Context) {
 	s.restoreNeeded = false
 }
 
-func (s *SlurmConfigUpdates) recordCurrentState(ctx context.Context) error {
+func (s *SlurmConfigUpdates) recordActiveWorkerStartTimes(ctx context.Context) error {
+	startTimes, err := s.slurm.ActiveWorkerStartTimes(ctx)
+	if err != nil {
+		return err
+	}
+	s.workerStartTimes = startTimes
+	return nil
+}
+
+func (s *SlurmConfigUpdates) recordCurrentConfig(ctx context.Context) error {
+	if len(s.workerStartTimes) == 0 {
+		return fmt.Errorf("record active worker start times before the Slurm configuration")
+	}
+
 	cluster, err := s.kubectl.SlurmCluster(ctx, s.info.SlurmClusterName)
 	if err != nil {
 		return err
@@ -83,7 +97,11 @@ func (s *SlurmConfigUpdates) recordCurrentState(ctx context.Context) error {
 		s.originalCustomConfig = &original
 	}
 
-	s.originalJobRequeue, err = s.effectiveSlurmSetting(ctx, "JobRequeue")
+	configuration, err := s.slurm.Configuration(ctx)
+	if err != nil {
+		return err
+	}
+	s.originalJobRequeue, err = slurmSetting(configuration, "JobRequeue")
 	if err != nil {
 		return err
 	}
@@ -91,10 +109,6 @@ func (s *SlurmConfigUpdates) recordCurrentState(ctx context.Context) error {
 		return fmt.Errorf("change JobRequeue from 0: scenario requires a different original value")
 	}
 
-	s.workerStartTimes, err = s.activeWorkerStartTimes(ctx)
-	if err != nil {
-		return err
-	}
 	s.stateRecorded = true
 	return nil
 }
@@ -116,7 +130,7 @@ func (s *SlurmConfigUpdates) checkWorkerStartTimesStable(ctx context.Context) er
 		case <-timer.C:
 			return nil
 		case <-ticker.C:
-			current, err := s.activeWorkerStartTimes(ctx)
+			current, err := s.slurm.ActiveWorkerStartTimes(ctx)
 			if err != nil {
 				return err
 			}
@@ -171,15 +185,7 @@ func (s *SlurmConfigUpdates) patchCustomConfig(ctx context.Context, value *strin
 	return nil
 }
 
-func (s *SlurmConfigUpdates) effectiveSlurmSetting(ctx context.Context, setting string) (string, error) {
-	output, err := s.runtime.Controller().RunWithDefaultRetry(ctx, "scontrol show config")
-	if err != nil {
-		return "", fmt.Errorf("read effective Slurm configuration: %w", err)
-	}
-	configuration, err := parseSlurmConfiguration(output)
-	if err != nil {
-		return "", fmt.Errorf("parse effective Slurm configuration: %w", err)
-	}
+func slurmSetting(configuration map[string]string, setting string) (string, error) {
 	value, found := configuration[setting]
 	if !found {
 		return "", fmt.Errorf("find %s in effective Slurm configuration", setting)
@@ -193,7 +199,11 @@ func (s *SlurmConfigUpdates) waitForJobRequeue(ctx context.Context, expected str
 		slurmConfigUpdateTimeout,
 		framework.DefaultPollInterval,
 		func(waitCtx context.Context) (bool, error) {
-			actual, err := s.effectiveSlurmSetting(waitCtx, "JobRequeue")
+			configuration, err := s.slurm.Configuration(waitCtx)
+			if err != nil {
+				return false, err
+			}
+			actual, err := slurmSetting(configuration, "JobRequeue")
 			if err != nil {
 				return false, err
 			}
@@ -203,32 +213,6 @@ func (s *SlurmConfigUpdates) waitForJobRequeue(ctx context.Context, expected str
 			return true, nil
 		},
 	)
-}
-
-func (s *SlurmConfigUpdates) activeWorkerStartTimes(ctx context.Context) (map[string]time.Time, error) {
-	names, err := s.slurm.MainPartitionNodeNames(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	startTimes := make(map[string]time.Time, len(names))
-	for _, name := range names {
-		node, err := s.slurm.NodeInfo(ctx, name)
-		if err != nil {
-			return nil, err
-		}
-		if node.HasStateFlag("NOT_RESPONDING") || node.HasStateFlag("POWERING_DOWN") || node.HasStateFlag("POWERED_DOWN") {
-			continue
-		}
-		if node.SlurmdStartTime.IsZero() {
-			return nil, fmt.Errorf("read valid SlurmdStartTime for active worker %s", name)
-		}
-		startTimes[name] = node.SlurmdStartTime
-	}
-	if len(startTimes) == 0 {
-		return nil, fmt.Errorf("find active workers with SlurmdStartTime")
-	}
-	return startTimes, nil
 }
 
 func (s *SlurmConfigUpdates) waitForWorkersReconfigured(ctx context.Context) error {
@@ -242,7 +226,7 @@ func (s *SlurmConfigUpdates) waitForWorkersReconfigured(ctx context.Context) err
 		slurmConfigUpdateTimeout,
 		framework.DefaultPollInterval,
 		func(waitCtx context.Context) (bool, error) {
-			current, err := s.activeWorkerStartTimes(waitCtx)
+			current, err := s.slurm.ActiveWorkerStartTimes(waitCtx)
 			if err != nil {
 				return false, err
 			}

--- a/e2e/acceptance/internal/sharedsteps/slurm_config_updates.go
+++ b/e2e/acceptance/internal/sharedsteps/slurm_config_updates.go
@@ -101,7 +101,7 @@ func (s *SlurmConfigUpdates) recordCurrentConfig(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	s.originalJobRequeue, err = slurmSetting(configuration, "JobRequeue")
+	s.originalJobRequeue, err = jobRequeue(configuration)
 	if err != nil {
 		return err
 	}
@@ -185,10 +185,10 @@ func (s *SlurmConfigUpdates) patchCustomConfig(ctx context.Context, value *strin
 	return nil
 }
 
-func slurmSetting(configuration map[string]string, setting string) (string, error) {
-	value, found := configuration[setting]
+func jobRequeue(configuration map[string]string) (string, error) {
+	value, found := configuration["JobRequeue"]
 	if !found {
-		return "", fmt.Errorf("find %s in effective Slurm configuration", setting)
+		return "", fmt.Errorf("find JobRequeue in effective Slurm configuration")
 	}
 	return value, nil
 }
@@ -203,7 +203,7 @@ func (s *SlurmConfigUpdates) waitForJobRequeue(ctx context.Context, expected str
 			if err != nil {
 				return false, err
 			}
-			actual, err := slurmSetting(configuration, "JobRequeue")
+			actual, err := jobRequeue(configuration)
 			if err != nil {
 				return false, err
 			}

--- a/e2e/acceptance/internal/sharedsteps/slurm_config_updates_test.go
+++ b/e2e/acceptance/internal/sharedsteps/slurm_config_updates_test.go
@@ -1,0 +1,85 @@
+package sharedsteps
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomSlurmConfigWithJobRequeue(t *testing.T) {
+	for name, test := range map[string]struct {
+		original *string
+		expected string
+	}{
+		"absent": {
+			expected: "JobRequeue=0\n",
+		},
+		"empty": {
+			original: stringPointer(""),
+			expected: "JobRequeue=0\n",
+		},
+		"without trailing newline": {
+			original: stringPointer("MinJobAge=60"),
+			expected: "MinJobAge=60\nJobRequeue=0\n",
+		},
+		"with trailing newline": {
+			original: stringPointer("MinJobAge=60\n"),
+			expected: "MinJobAge=60\nJobRequeue=0\n",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, customSlurmConfigWithJobRequeue(test.original, "0"))
+		})
+	}
+}
+
+func TestCompareWorkerStartTimes(t *testing.T) {
+	before := time.Date(2026, time.August, 28, 10, 23, 44, 0, time.UTC)
+	after := before.Add(time.Minute)
+
+	assert.NoError(t, compareWorkerStartTimes(
+		map[string]time.Time{"worker-0": before},
+		map[string]time.Time{"worker-0": before},
+		false,
+	))
+	assert.NoError(t, compareWorkerStartTimes(
+		map[string]time.Time{"worker-0": before},
+		map[string]time.Time{"worker-0": after},
+		true,
+	))
+}
+
+func TestCompareWorkerStartTimesRejectsUnexpectedState(t *testing.T) {
+	before := time.Date(2026, time.August, 28, 10, 23, 44, 0, time.UTC)
+	after := before.Add(time.Minute)
+
+	err := compareWorkerStartTimes(
+		map[string]time.Time{"worker-0": before},
+		map[string]time.Time{"worker-0": after},
+		false,
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "SlurmdStartTime change")
+
+	err = compareWorkerStartTimes(
+		map[string]time.Time{"worker-0": before},
+		map[string]time.Time{"worker-0": before},
+		true,
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "still at")
+
+	err = compareWorkerStartTimes(
+		map[string]time.Time{"worker-0": before},
+		map[string]time.Time{},
+		true,
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "among active workers")
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/e2e/acceptance/internal/sharedsteps/slurm_config_updates_test.go
+++ b/e2e/acceptance/internal/sharedsteps/slurm_config_updates_test.go
@@ -35,6 +35,16 @@ func TestCustomSlurmConfigWithJobRequeue(t *testing.T) {
 	}
 }
 
+func TestSlurmSetting(t *testing.T) {
+	value, err := slurmSetting(map[string]string{"JobRequeue": "1"}, "JobRequeue")
+	require.NoError(t, err)
+	assert.Equal(t, "1", value)
+
+	_, err = slurmSetting(map[string]string{}, "JobRequeue")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "find JobRequeue")
+}
+
 func TestCompareWorkerStartTimes(t *testing.T) {
 	before := time.Date(2026, time.August, 28, 10, 23, 44, 0, time.UTC)
 	after := before.Add(time.Minute)

--- a/e2e/acceptance/internal/sharedsteps/slurm_config_updates_test.go
+++ b/e2e/acceptance/internal/sharedsteps/slurm_config_updates_test.go
@@ -35,12 +35,12 @@ func TestCustomSlurmConfigWithJobRequeue(t *testing.T) {
 	}
 }
 
-func TestSlurmSetting(t *testing.T) {
-	value, err := slurmSetting(map[string]string{"JobRequeue": "1"}, "JobRequeue")
+func TestJobRequeue(t *testing.T) {
+	value, err := jobRequeue(map[string]string{"JobRequeue": "1"})
 	require.NoError(t, err)
 	assert.Equal(t, "1", value)
 
-	_, err = slurmSetting(map[string]string{}, "JobRequeue")
+	_, err = jobRequeue(map[string]string{})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "find JobRequeue")
 }

--- a/e2e/acceptance/internal/sharedsteps/steps.go
+++ b/e2e/acceptance/internal/sharedsteps/steps.go
@@ -23,7 +23,7 @@ func RegisterAll(sc *godog.ScenarioContext, info *framework.ClusterInfo, runtime
 	for _, family := range []scenarioScopedStepFamily{
 		NewClusterCreation(info, runtime, kubectl, selector),
 		NewAccounting(info, runtime, slurm, kubectl, selector),
-		NewSlurmConfig(info, runtime),
+		NewSlurmConfig(info, slurm),
 		NewSlurmConfigUpdates(info, runtime, slurm, kubectl),
 		NewObservability(kubectl),
 		NewInternalSSH(runtime, selector),

--- a/e2e/acceptance/internal/sharedsteps/steps.go
+++ b/e2e/acceptance/internal/sharedsteps/steps.go
@@ -24,6 +24,7 @@ func RegisterAll(sc *godog.ScenarioContext, info *framework.ClusterInfo, runtime
 		NewClusterCreation(info, runtime, kubectl, selector),
 		NewAccounting(info, runtime, slurm, kubectl, selector),
 		NewSlurmConfig(info, runtime),
+		NewSlurmConfigUpdates(info, runtime, slurm, kubectl),
 		NewObservability(kubectl),
 		NewInternalSSH(runtime, selector),
 		NewPackageInstallation(runtime, selector),


### PR DESCRIPTION
## Problem

Slurm configuration updates were not covered by shared acceptance tests. Regressions could prevent custom settings from being applied, trigger unnecessary worker reconfigurations, or leave workers using stale configuration.

## Solution

Add an acceptance scenario that updates JobRequeue through SlurmCluster.spec.customSlurmConfig, verifies the effective value and worker reconfiguration, and restores the original configuration. The test also confirms workers are not reconfigured while the configuration remains unchanged and provides cleanup on failure.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
