### PR TITLE
SCHED-1158: wait for namespace before installing SPO

### DIFF
--- a/helm/soperator-fluxcd/templates/security-profiles-operator.yaml
+++ b/helm/soperator-fluxcd/templates/security-profiles-operator.yaml
@@ -18,6 +18,8 @@ spec:
         kind: HelmRepository
         name: {{ include "soperator-fluxcd.fullname" . }}-security-profiles-operator
       version: {{ .Values.securityProfilesOperator.version }}
+  dependsOn:
+  - name: {{ include "soperator-fluxcd.fullname" . }}-ns
   install:
     {{- toYaml .Values.securityProfilesOperator.install | nindent 4 }}
   upgrade:

--- a/helm/soperator-fluxcd/tests/soperator_dependency_test.yaml
+++ b/helm/soperator-fluxcd/tests/soperator_dependency_test.yaml
@@ -23,6 +23,23 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-soperator
 ---
+suite: test security profiles operator dependencies
+templates:
+  - templates/security-profiles-operator.yaml
+tests:
+  - it: should depend on the namespace HelmRelease
+    set:
+      securityProfilesOperator.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HelmRelease
+      - contains:
+          path: spec.dependsOn
+          content:
+            name: RELEASE-NAME-ns
+---
 suite: test soperatorchecks dependencies
 templates:
   - templates/soperatorchecks.yaml


### PR DESCRIPTION
## Problem

During cluster deployment, the Security Profiles Operator HelmRelease can reconcile before its target namespace exists. The installation then fails and may stall after exhausting remediation attempts, preventing dependent components such as the Slurm cluster from progressing.

## Solution

Make the Security Profiles Operator HelmRelease depend on the namespace HelmRelease. This guarantees the managed namespace is ready before SPO installation begins and follows the existing dependency pattern used by other components.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
