### PR TITLE
SCHED-1520, SCHED-1616: only fail acceptance for ActiveCheck errors

### DIFF
--- a/internal/e2e/acceptance/features/cluster_creation.feature
+++ b/internal/e2e/acceptance/features/cluster_creation.feature
@@ -1,13 +1,14 @@
 Feature: Cluster creation
   Scenario: The provisioned cluster is ready for acceptance tests
     Then all non-job pods in soperator are Running and Ready
+    # The soperator-activechecks HelmRelease becomes Ready only after its post-install
+    # hook accepts the initial runAfterCreation ActiveChecks.
     And all HelmReleases are Ready
     And all SlurmCluster CRs are available
     And all NodeSet CRs are ready
     And configured nodesets match the live cluster
     And main and hidden partitions are present and sane
     And all Slurm nodes are healthy
-    And all ActiveChecks completed successfully
     And login welcome output shows cluster information
     And main partition smoke job succeeds
     And hidden partition smoke job succeeds

--- a/internal/e2e/acceptance/features/cluster_creation.feature
+++ b/internal/e2e/acceptance/features/cluster_creation.feature
@@ -1,14 +1,13 @@
 Feature: Cluster creation
   Scenario: The provisioned cluster is ready for acceptance tests
     Then all non-job pods in soperator are Running and Ready
-    # The soperator-activechecks HelmRelease becomes Ready only after its post-install
-    # hook accepts the initial runAfterCreation ActiveChecks.
     And all HelmReleases are Ready
     And all SlurmCluster CRs are available
     And all NodeSet CRs are ready
     And configured nodesets match the live cluster
     And main and hidden partitions are present and sane
     And all Slurm nodes are healthy
+    And no ActiveChecks are Failed or Error
     And login welcome output shows cluster information
     And main partition smoke job succeeds
     And hidden partition smoke job succeeds

--- a/internal/e2e/acceptance/steps/cluster_creation.go
+++ b/internal/e2e/acceptance/steps/cluster_creation.go
@@ -16,6 +16,7 @@ import (
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
+	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
 )
 
@@ -45,6 +46,7 @@ func (s *ClusterCreation) Register(sc *godog.ScenarioContext) {
 	sc.Step(`^configured nodesets match the live cluster$`, s.checkExpectedNodeSets)
 	sc.Step(`^main and hidden partitions are present and sane$`, s.checkPartitions)
 	sc.Step(`^all Slurm nodes are healthy$`, s.checkSlurmNodeHealth)
+	sc.Step(`^no ActiveChecks are Failed or Error$`, s.checkActiveChecks)
 	sc.Step(`^login welcome output shows cluster information$`, s.checkWelcomeOutput)
 	sc.Step(`^main partition smoke job succeeds$`, s.checkMainSmokeJob)
 	sc.Step(`^hidden partition smoke job succeeds$`, s.checkHiddenSmokeJob)
@@ -304,6 +306,59 @@ func (s *ClusterCreation) checkSlurmNodeHealth(ctx context.Context) error {
 	if len(unhealthy) > 0 {
 		sort.Strings(unhealthy)
 		return fmt.Errorf("%s", strings.Join(unhealthy, "; "))
+	}
+	return nil
+}
+
+func (s *ClusterCreation) checkActiveChecks(ctx context.Context) error {
+	var checks slurmv1alpha1.ActiveCheckList
+	if err := kubectlJSON(ctx, s.exec, &checks, "get", "activechecks", "-A", "-o", "json"); err != nil {
+		return fmt.Errorf("list ActiveChecks: %w", err)
+	}
+	if len(checks.Items) == 0 {
+		return fmt.Errorf("no ActiveChecks found")
+	}
+
+	var problems []string
+	checkedCount := 0
+	for _, check := range checks.Items {
+		runAfterCreation := true
+		if check.Spec.RunAfterCreation != nil {
+			runAfterCreation = *check.Spec.RunAfterCreation
+		}
+		if !runAfterCreation {
+			continue
+		}
+		checkedCount++
+
+		checkType := check.Spec.CheckType
+		if checkType == "" {
+			checkType = "k8sJob"
+		}
+
+		switch checkType {
+		case "k8sJob":
+			if check.Status.K8sJobsStatus.LastJobStatus == consts.ActiveCheckK8sJobStatusFailed {
+				problems = append(problems, fmt.Sprintf("%s/%s k8s status=%s", check.Namespace, check.Name, check.Status.K8sJobsStatus.LastJobStatus))
+			}
+		case "slurmJob":
+			status := check.Status.SlurmJobsStatus.LastRunStatus
+			// InProgress is valid here: the HelmRelease hook already gated the initial run,
+			// and this status can belong to a later scheduled execution.
+			if status == consts.ActiveCheckSlurmRunStatusFailed || status == consts.ActiveCheckSlurmRunStatusError {
+				problems = append(problems, fmt.Sprintf("%s/%s slurm status=%s", check.Namespace, check.Name, status))
+			}
+		default:
+			problems = append(problems, fmt.Sprintf("%s/%s unknown checkType=%s", check.Namespace, check.Name, checkType))
+		}
+	}
+
+	if checkedCount == 0 {
+		return fmt.Errorf("no runAfterCreation ActiveChecks found")
+	}
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		return fmt.Errorf("%s", strings.Join(problems, "; "))
 	}
 	return nil
 }

--- a/internal/e2e/acceptance/steps/cluster_creation.go
+++ b/internal/e2e/acceptance/steps/cluster_creation.go
@@ -16,7 +16,6 @@ import (
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
-	"nebius.ai/slurm-operator/internal/consts"
 	"nebius.ai/slurm-operator/internal/e2e/acceptance/framework"
 )
 
@@ -46,7 +45,6 @@ func (s *ClusterCreation) Register(sc *godog.ScenarioContext) {
 	sc.Step(`^configured nodesets match the live cluster$`, s.checkExpectedNodeSets)
 	sc.Step(`^main and hidden partitions are present and sane$`, s.checkPartitions)
 	sc.Step(`^all Slurm nodes are healthy$`, s.checkSlurmNodeHealth)
-	sc.Step(`^all ActiveChecks completed successfully$`, s.checkActiveChecks)
 	sc.Step(`^login welcome output shows cluster information$`, s.checkWelcomeOutput)
 	sc.Step(`^main partition smoke job succeeds$`, s.checkMainSmokeJob)
 	sc.Step(`^hidden partition smoke job succeeds$`, s.checkHiddenSmokeJob)
@@ -306,56 +304,6 @@ func (s *ClusterCreation) checkSlurmNodeHealth(ctx context.Context) error {
 	if len(unhealthy) > 0 {
 		sort.Strings(unhealthy)
 		return fmt.Errorf("%s", strings.Join(unhealthy, "; "))
-	}
-	return nil
-}
-
-func (s *ClusterCreation) checkActiveChecks(ctx context.Context) error {
-	var checks slurmv1alpha1.ActiveCheckList
-	if err := kubectlJSON(ctx, s.exec, &checks, "get", "activechecks", "-A", "-o", "json"); err != nil {
-		return fmt.Errorf("list ActiveChecks: %w", err)
-	}
-	if len(checks.Items) == 0 {
-		return fmt.Errorf("no ActiveChecks found")
-	}
-
-	var problems []string
-	checkedCount := 0
-	for _, check := range checks.Items {
-		runAfterCreation := true
-		if check.Spec.RunAfterCreation != nil {
-			runAfterCreation = *check.Spec.RunAfterCreation
-		}
-		if !runAfterCreation {
-			continue
-		}
-		checkedCount++
-
-		checkType := check.Spec.CheckType
-		if checkType == "" {
-			checkType = "k8sJob"
-		}
-
-		switch checkType {
-		case "k8sJob":
-			if check.Status.K8sJobsStatus.LastJobStatus != consts.ActiveCheckK8sJobStatusComplete {
-				problems = append(problems, fmt.Sprintf("%s/%s k8s status=%s", check.Namespace, check.Name, check.Status.K8sJobsStatus.LastJobStatus))
-			}
-		case "slurmJob":
-			if check.Status.SlurmJobsStatus.LastRunStatus != consts.ActiveCheckSlurmRunStatusComplete {
-				problems = append(problems, fmt.Sprintf("%s/%s slurm status=%s", check.Namespace, check.Name, check.Status.SlurmJobsStatus.LastRunStatus))
-			}
-		default:
-			problems = append(problems, fmt.Sprintf("%s/%s unknown checkType=%s", check.Namespace, check.Name, checkType))
-		}
-	}
-
-	if checkedCount == 0 {
-		return fmt.Errorf("no runAfterCreation ActiveChecks found")
-	}
-	if len(problems) > 0 {
-		sort.Strings(problems)
-		return fmt.Errorf("%s", strings.Join(problems, "; "))
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

SCHED-1520: The cluster-creation acceptance scenario requires every `runAfterCreation` ActiveCheck's mutable latest status to be `Complete`. A later scheduled run can legitimately change that status to `InProgress`, causing acceptance to fail even though Terraform already validated the initial run.

SCHED-1616: The same assertion rejects the legitimate `Skipped` status for an inapplicable ActiveCheck.

## Solution

Change the acceptance assertion to reject only actual failure states: `Failed` for Kubernetes jobs and `Failed` or `Error` for Slurm jobs.

Allow transient and accepted states such as `InProgress`, `Skipped`, and `Cancelled`. Document beside the status predicate that `InProgress` may belong to a later scheduled execution because the ActiveChecks HelmRelease hook already gated the initial run.

Apply the fix to release 4.0 and carry it through the merge-back chain to release 4.1 and main.
