### PR TITLE
SCHED-2397: add per-command retry timeout

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -199,7 +199,8 @@ that need fresh cluster state should query Kubernetes or Slurm through
 External runners can use `github.com/nebius/soperator/e2e/acceptance/framework` for
 common Kubernetes, Slurm, and worker primitives:
 
-- `Exec`: command execution interface.
+- `Exec`: command execution interface. `Run` uses a 10-minute timeout when its context has no deadline,
+  `RunWithDefaultRetry` uses 10 minutes per attempt, and `RunWithRetry` accepts a custom per-attempt timeout.
 - `Runtime`: `Exec` plus polling and logging, used by shared steps and external suites.
 - `ClusterInfo`: static SlurmCluster name and target Soperator version.
 - `KubectlClient`, including `GetJSON`, `NodeSets`, `WorkerPods`, and

--- a/e2e/acceptance/framework/runtime.go
+++ b/e2e/acceptance/framework/runtime.go
@@ -6,19 +6,20 @@ import (
 )
 
 const (
-	DefaultRetryAttempts = 5
-	DefaultRetryDelay    = 10 * time.Second
+	DefaultCommandTimeout = 10 * time.Minute
+	DefaultRetryAttempts  = 5
+	DefaultRetryDelay     = 10 * time.Second
 )
 
 type CommandScope interface {
 	Run(ctx context.Context, command string) (string, error)
-	RunWithRetry(ctx context.Context, command string, attempts int, delay time.Duration) (string, error)
+	RunWithRetry(ctx context.Context, command string, attempts int, delay, timeout time.Duration) (string, error)
 	RunWithDefaultRetry(ctx context.Context, command string) (string, error)
 }
 
 type ArgsScope interface {
 	Run(ctx context.Context, args ...string) (string, error)
-	RunWithRetry(ctx context.Context, attempts int, delay time.Duration, args ...string) (string, error)
+	RunWithRetry(ctx context.Context, attempts int, delay, timeout time.Duration, args ...string) (string, error)
 	RunWithDefaultRetry(ctx context.Context, args ...string) (string, error)
 }
 

--- a/e2e/acceptance/framework/scopes.go
+++ b/e2e/acceptance/framework/scopes.go
@@ -15,17 +15,27 @@ func NewArgsScope(run func(context.Context, ...string) (string, error)) ArgsScop
 }
 
 func (s argsScope) Run(ctx context.Context, args ...string) (string, error) {
-	return s.run(ctx, args...)
+	return runWithDefaultTimeout(ctx, func(commandCtx context.Context) (string, error) {
+		return s.run(commandCtx, args...)
+	})
 }
 
-func (s argsScope) RunWithRetry(ctx context.Context, attempts int, delay time.Duration, args ...string) (string, error) {
+func (s argsScope) RunWithRetry(
+	ctx context.Context,
+	attempts int,
+	delay time.Duration,
+	timeout time.Duration,
+	args ...string,
+) (string, error) {
 	return retry(ctx, attempts, delay, func(attemptCtx context.Context) (string, error) {
-		return s.Run(attemptCtx, args...)
+		return runWithTimeout(attemptCtx, timeout, func(commandCtx context.Context) (string, error) {
+			return s.run(commandCtx, args...)
+		})
 	})
 }
 
 func (s argsScope) RunWithDefaultRetry(ctx context.Context, args ...string) (string, error) {
-	return s.RunWithRetry(ctx, DefaultRetryAttempts, DefaultRetryDelay, args...)
+	return s.RunWithRetry(ctx, DefaultRetryAttempts, DefaultRetryDelay, DefaultCommandTimeout, args...)
 }
 
 type commandScope struct {
@@ -38,17 +48,46 @@ func NewCommandScope(run func(context.Context, string) (string, error)) CommandS
 }
 
 func (s commandScope) Run(ctx context.Context, command string) (string, error) {
-	return s.run(ctx, command)
+	return runWithDefaultTimeout(ctx, func(commandCtx context.Context) (string, error) {
+		return s.run(commandCtx, command)
+	})
 }
 
-func (s commandScope) RunWithRetry(ctx context.Context, command string, attempts int, delay time.Duration) (string, error) {
+func (s commandScope) RunWithRetry(
+	ctx context.Context,
+	command string,
+	attempts int,
+	delay time.Duration,
+	timeout time.Duration,
+) (string, error) {
 	return retry(ctx, attempts, delay, func(attemptCtx context.Context) (string, error) {
-		return s.Run(attemptCtx, command)
+		return runWithTimeout(attemptCtx, timeout, func(commandCtx context.Context) (string, error) {
+			return s.run(commandCtx, command)
+		})
 	})
 }
 
 func (s commandScope) RunWithDefaultRetry(ctx context.Context, command string) (string, error) {
-	return s.RunWithRetry(ctx, command, DefaultRetryAttempts, DefaultRetryDelay)
+	return s.RunWithRetry(ctx, command, DefaultRetryAttempts, DefaultRetryDelay, DefaultCommandTimeout)
+}
+
+func runWithDefaultTimeout(ctx context.Context, run func(context.Context) (string, error)) (string, error) {
+	if _, ok := ctx.Deadline(); ok {
+		return run(ctx)
+	}
+
+	return runWithTimeout(ctx, DefaultCommandTimeout, run)
+}
+
+func runWithTimeout(
+	ctx context.Context,
+	timeout time.Duration,
+	run func(context.Context) (string, error),
+) (string, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return run(commandCtx)
 }
 
 func retry(ctx context.Context, attempts int, delay time.Duration, run func(context.Context) (string, error)) (string, error) {

--- a/e2e/acceptance/framework/scopes_test.go
+++ b/e2e/acceptance/framework/scopes_test.go
@@ -5,21 +5,26 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestNewArgsScopeRetries(t *testing.T) {
+	const commandTimeout = 2 * time.Minute
+
 	var calls int
 	var gotArgs []string
+	var deadlines []time.Time
 	scope := NewArgsScope(func(ctx context.Context, args ...string) (string, error) {
 		calls++
 		gotArgs = append([]string(nil), args...)
+		deadlines = append(deadlines, requireContextTimeout(t, ctx, commandTimeout))
 		if calls == 1 {
 			return "", errors.New("temporary")
 		}
 		return "ok", nil
 	})
 
-	out, err := scope.RunWithRetry(t.Context(), 2, 0, "get", "pods")
+	out, err := scope.RunWithRetry(t.Context(), 2, 0, commandTimeout, "get", "pods")
 	if err != nil {
 		t.Fatalf("RunWithRetry returned error: %v", err)
 	}
@@ -32,21 +37,27 @@ func TestNewArgsScopeRetries(t *testing.T) {
 	if want := []string{"get", "pods"}; !reflect.DeepEqual(gotArgs, want) {
 		t.Fatalf("args=%v, want %v", gotArgs, want)
 	}
+	if !deadlines[1].After(deadlines[0]) {
+		t.Fatalf("retry deadline %s is not after first attempt deadline %s", deadlines[1], deadlines[0])
+	}
 }
 
 func TestNewCommandScopeRetries(t *testing.T) {
+	const commandTimeout = 2 * time.Minute
+
 	var calls int
 	var gotCommand string
 	scope := NewCommandScope(func(ctx context.Context, command string) (string, error) {
 		calls++
 		gotCommand = command
+		requireContextTimeout(t, ctx, commandTimeout)
 		if calls == 1 {
 			return "", errors.New("temporary")
 		}
 		return "ok", nil
 	})
 
-	out, err := scope.RunWithRetry(t.Context(), "sinfo", 2, 0)
+	out, err := scope.RunWithRetry(t.Context(), "sinfo", 2, 0, commandTimeout)
 	if err != nil {
 		t.Fatalf("RunWithRetry returned error: %v", err)
 	}
@@ -59,4 +70,76 @@ func TestNewCommandScopeRetries(t *testing.T) {
 	if gotCommand != "sinfo" {
 		t.Fatalf("command=%q, want sinfo", gotCommand)
 	}
+}
+
+func TestRunUsesDefaultCommandTimeout(t *testing.T) {
+	scope := NewArgsScope(func(ctx context.Context, args ...string) (string, error) {
+		requireContextTimeout(t, ctx, DefaultCommandTimeout)
+		return "ok", nil
+	})
+
+	if _, err := scope.Run(t.Context(), "get", "pods"); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+func TestRunWithDefaultRetryUsesDefaultCommandTimeout(t *testing.T) {
+	scope := NewCommandScope(func(ctx context.Context, command string) (string, error) {
+		requireContextTimeout(t, ctx, DefaultCommandTimeout)
+		return "ok", nil
+	})
+
+	out, err := scope.RunWithDefaultRetry(t.Context(), "sinfo")
+	if err != nil {
+		t.Fatalf("RunWithDefaultRetry returned error: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("out=%q, want ok", out)
+	}
+}
+
+func TestNestedScopePreservesCustomTimeout(t *testing.T) {
+	const commandTimeout = 30 * time.Minute
+
+	inner := NewArgsScope(func(ctx context.Context, args ...string) (string, error) {
+		requireContextTimeout(t, ctx, commandTimeout)
+		return "ok", nil
+	})
+	outer := NewArgsScope(func(ctx context.Context, args ...string) (string, error) {
+		return inner.Run(ctx, args...)
+	})
+
+	if _, err := outer.RunWithRetry(t.Context(), 1, 0, commandTimeout, "operation", "wait"); err != nil {
+		t.Fatalf("RunWithRetry returned error: %v", err)
+	}
+}
+
+func TestRunPreservesExistingDeadline(t *testing.T) {
+	const parentTimeout = time.Minute
+
+	ctx, cancel := context.WithTimeout(t.Context(), parentTimeout)
+	defer cancel()
+
+	scope := NewArgsScope(func(ctx context.Context, args ...string) (string, error) {
+		requireContextTimeout(t, ctx, parentTimeout)
+		return "ok", nil
+	})
+
+	if _, err := scope.Run(ctx, "operation", "wait"); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+func requireContextTimeout(t *testing.T, ctx context.Context, want time.Duration) time.Time {
+	t.Helper()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("command context has no deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining > want || remaining < want-time.Second {
+		t.Fatalf("command timeout=%s, want approximately %s", remaining, want)
+	}
+	return deadline
 }

--- a/e2e/acceptance/internal/sharedsteps/package_installation.go
+++ b/e2e/acceptance/internal/sharedsteps/package_installation.go
@@ -95,7 +95,13 @@ func (s *PackageInstallation) logInstallFailureDiagnostics(ctx context.Context, 
 	}
 
 	for _, command := range commands {
-		output, err := s.runtime.Jail().RunWithRetry(ctx, command, 2, 10*time.Second)
+		output, err := s.runtime.Jail().RunWithRetry(
+			ctx,
+			command,
+			2,
+			10*time.Second,
+			framework.DefaultCommandTimeout,
+		)
 		if err != nil {
 			s.runtime.Logf("package installation debug command failed (%s): %v", command, err)
 			continue

--- a/e2e/acceptance/internal/sharedsteps/soperator_utils.go
+++ b/e2e/acceptance/internal/sharedsteps/soperator_utils.go
@@ -146,7 +146,13 @@ func (s *SoperatorUtils) queryWorkerHostByNameAndInstanceID(ctx context.Context)
 			framework.ShellQuote(query.value),
 			framework.ShellQuote(`grep -l '^kubelet$' /proc/[0-9]*/comm`),
 		)
-		output, err := s.runtime.Jail().RunWithRetry(ctx, command, 2, 2*time.Second)
+		output, err := s.runtime.Jail().RunWithRetry(
+			ctx,
+			command,
+			2,
+			2*time.Second,
+			framework.DefaultCommandTimeout,
+		)
 		if err != nil {
 			return fmt.Errorf("query worker host by %s: %w", query.label, err)
 		}

--- a/e2e/acceptance/world.go
+++ b/e2e/acceptance/world.go
@@ -13,10 +13,6 @@ import (
 	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
-const (
-	commandTimeout = 10 * time.Minute
-)
-
 type world struct {
 	logPrefix string
 
@@ -78,12 +74,9 @@ func (w *world) WorkerPod(pod framework.WorkerPodInfo) framework.CommandScope {
 }
 
 func (w *world) Run(ctx context.Context, name string, args ...string) (string, error) {
-	cmdCtx, cancel := context.WithTimeout(ctx, commandTimeout)
-	defer cancel()
-
 	w.logf("run: %s %s", name, strings.Join(args, " "))
 
-	cmd := exec.CommandContext(cmdCtx, name, args...)
+	cmd := exec.CommandContext(ctx, name, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
## Problem

The reusable acceptance runtime imposes a fixed 10-minute timeout on every external command. Consumers cannot extend it for legitimately long operations, such as managed cluster topology updates, without retrying commands based on process error text.

## Solution

Add a per-attempt timeout argument to both RunWithRetry scope methods. RunWithDefaultRetry uses a fresh 10-minute timeout for every attempt. Run supplies a 10-minute timeout when its context has no deadline and otherwise respects the caller-provided deadline

## Testing

## Release Notes
