### PR TITLE
SCHED-2378: Login user isolation enabled

### DIFF
--- a/api/v1/login_user_isolation_validation_test.go
+++ b/api/v1/login_user_isolation_validation_test.go
@@ -1,0 +1,108 @@
+package v1_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
+	"sigs.k8s.io/yaml"
+)
+
+func TestLoginUserIsolationCRDValidation(t *testing.T) {
+	data, err := os.ReadFile("../../config/crd/bases/slurm.nebius.ai_slurmclusters.yaml")
+	require.NoError(t, err)
+
+	var crd apiextensionsv1.CustomResourceDefinition
+	require.NoError(t, yaml.Unmarshal(data, &crd))
+
+	var isolationSchema apiextensions.JSONSchemaProps
+	for _, version := range crd.Spec.Versions {
+		if version.Name != "v1" {
+			continue
+		}
+		login := version.Schema.OpenAPIV3Schema.Properties["spec"].Properties["slurmNodes"].Properties["login"]
+		isolation := login.Properties["userIsolation"]
+		require.NoError(t, apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(
+			&isolation,
+			&isolationSchema,
+			nil,
+		))
+	}
+	require.Len(t, isolationSchema.XValidations, 2)
+
+	structural, err := schema.NewStructural(&isolationSchema)
+	require.NoError(t, err)
+	celValidator := cel.NewValidator(structural, false, celconfig.PerCallLimit)
+	require.NotNil(t, celValidator)
+	schemaValidator, _, err := validation.NewSchemaValidator(&isolationSchema)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		isolation map[string]any
+		wantErr   string
+	}{
+		{
+			name:      "both limits omitted",
+			isolation: map[string]any{"enabled": true},
+		},
+		{
+			name: "both limits specified",
+			isolation: map[string]any{
+				"enabled": true, "memoryHigh": "4Gi", "memoryMax": "5Gi",
+			},
+		},
+		{
+			name: "only memoryHigh specified",
+			isolation: map[string]any{
+				"enabled": true, "memoryHigh": "4Gi",
+			},
+			wantErr: "memoryHigh and memoryMax must be specified together or both omitted",
+		},
+		{
+			name: "only memoryMax specified",
+			isolation: map[string]any{
+				"enabled": true, "memoryMax": "5Gi",
+			},
+			wantErr: "memoryHigh and memoryMax must be specified together or both omitted",
+		},
+		{
+			name: "memoryHigh exceeds memoryMax",
+			isolation: map[string]any{
+				"enabled": true, "memoryHigh": "6Gi", "memoryMax": "5Gi",
+			},
+			wantErr: "memoryHigh must not exceed memoryMax",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defaulting.Default(tt.isolation, structural)
+			path := field.NewPath("spec", "slurmNodes", "login", "userIsolation")
+			errs := validation.ValidateCustomResource(path, tt.isolation, schemaValidator)
+			celErrs, _ := celValidator.Validate(
+				context.Background(),
+				path,
+				structural,
+				tt.isolation,
+				nil,
+				celconfig.RuntimeCELCostBudget,
+			)
+			errs = append(errs, celErrs...)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, errs.ToAggregate(), tt.wantErr)
+			} else {
+				require.Empty(t, errs)
+			}
+		})
+	}
+}

--- a/api/v1/slurmcluster_types.go
+++ b/api/v1/slurmcluster_types.go
@@ -1173,6 +1173,7 @@ type LoginAutoscaling struct {
 // so one user cannot exhaust the memory or monopolize the CPU of the whole login node.
 // Requires cgroup v2 on the Kubernetes node.
 // +kubebuilder:validation:XValidation:rule="!has(self.memoryHigh) || !has(self.memoryMax) || quantity(self.memoryHigh).compareTo(quantity(self.memoryMax)) <= 0",message="memoryHigh must not exceed memoryMax"
+// +kubebuilder:validation:XValidation:rule="has(self.memoryHigh) == has(self.memoryMax)",message="memoryHigh and memoryMax must be specified together or both omitted"
 type LoginUserIsolation struct {
 	// Enabled turns on placement of each SSH session into a per-user cgroup
 	//
@@ -1183,7 +1184,8 @@ type LoginUserIsolation struct {
 	// MemoryHigh is the per-user memory throttling threshold (cgroup v2 memory.high).
 	// The kernel throttles and reclaims a user's memory above this value before OOM.
 	// Must be lower than the sshd container memory limit.
-	// When unset, it is derived as 80% of the sshd container memory limit
+	// Must be specified together with memoryMax.
+	// When unset, it is derived as 40% of the sshd container memory limit
 	//
 	// +kubebuilder:validation:Optional
 	MemoryHigh *resource.Quantity `json:"memoryHigh,omitempty"`
@@ -1191,9 +1193,8 @@ type LoginUserIsolation struct {
 	// MemoryMax is the per-user hard memory limit (cgroup v2 memory.max).
 	// The OOM killer is scoped to the user's own cgroup when this limit is hit.
 	// Must be lower than the sshd container memory limit.
-	// When unset, it is derived as 90% of the sshd container memory limit,
-	// which keeps OOM events scoped to a single user without restricting
-	// how much of the container's memory a lone user may use
+	// Must be specified together with memoryHigh.
+	// When unset, it is derived as 50% of the sshd container memory limit
 	//
 	// +kubebuilder:validation:Optional
 	MemoryMax *resource.Quantity `json:"memoryMax,omitempty"`

--- a/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
+++ b/config/crd/bases/slurm.nebius.ai_slurmclusters.yaml
@@ -20122,7 +20122,8 @@ spec:
                               MemoryHigh is the per-user memory throttling threshold (cgroup v2 memory.high).
                               The kernel throttles and reclaims a user's memory above this value before OOM.
                               Must be lower than the sshd container memory limit.
-                              When unset, it is derived as 80% of the sshd container memory limit
+                              Must be specified together with memoryMax.
+                              When unset, it is derived as 40% of the sshd container memory limit
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           memoryMax:
@@ -20133,9 +20134,8 @@ spec:
                               MemoryMax is the per-user hard memory limit (cgroup v2 memory.max).
                               The OOM killer is scoped to the user's own cgroup when this limit is hit.
                               Must be lower than the sshd container memory limit.
-                              When unset, it is derived as 90% of the sshd container memory limit,
-                              which keeps OOM events scoped to a single user without restricting
-                              how much of the container's memory a lone user may use
+                              Must be specified together with memoryHigh.
+                              When unset, it is derived as 50% of the sshd container memory limit
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                         type: object
@@ -20144,6 +20144,9 @@ spec:
                           rule: '!has(self.memoryHigh) || !has(self.memoryMax) ||
                             quantity(self.memoryHigh).compareTo(quantity(self.memoryMax))
                             <= 0'
+                        - message: memoryHigh and memoryMax must be specified together
+                            or both omitted
+                          rule: has(self.memoryHigh) == has(self.memoryMax)
                       volumes:
                         description: Volumes represents the volume configurations
                           for the login node

--- a/e2e/acceptance/features.go
+++ b/e2e/acceptance/features.go
@@ -32,6 +32,7 @@ func FeaturePaths() []string {
 		"features/login_autoscaling.feature",
 		"features/observability.feature",
 		"features/internal_ssh.feature",
+		"features/login_user_isolation.feature",
 		"features/package_installation.feature",
 		"features/gpu_profiling.feature",
 		"features/soperator_utils.feature",

--- a/e2e/acceptance/features/login_user_isolation.feature
+++ b/e2e/acceptance/features/login_user_isolation.feature
@@ -1,0 +1,8 @@
+Feature: Login user isolation
+  @soperator_version_>=5.0.0
+  Scenario: Additional processes do not increase a login user's CPU share
+    Given two regular users can SSH to the login node for CPU isolation testing
+    When both users run workloads at twice the login CPU capacity
+    And the first user runs at login CPU capacity while the second runs at four times capacity
+    Then both users complete similar amounts of work in both cases
+    And the first user's amount of completed work remains stable

--- a/e2e/acceptance/internal/sharedsteps/login_user_isolation.go
+++ b/e2e/acceptance/internal/sharedsteps/login_user_isolation.go
@@ -1,0 +1,381 @@
+package sharedsteps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cucumber/godog"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+const (
+	loginCPUFirstUser  = "soperatorcpua"
+	loginCPUSecondUser = "soperatorcpub"
+
+	loginCPUBurnMarker = "soperator-e2e-login-cpu-burn"
+
+	loginCPUWorkloadDuration = 8 * time.Second
+	loginCPUCommandTimeout   = 20 * time.Second
+
+	loginCPUMinShare            = 0.35
+	loginCPUMaxShare            = 0.65
+	loginCPUMaxWorkRelativeDiff = 0.20
+)
+
+type loginCPUWork struct {
+	first  uint64
+	second uint64
+}
+
+type loginCPUWorkloadResult struct {
+	userName string
+	work     uint64
+	err      error
+}
+
+type LoginUserIsolation struct {
+	info    *framework.ClusterInfo
+	runtime framework.Runtime
+
+	capacity       int
+	balancedWork   loginCPUWork
+	unbalancedWork loginCPUWork
+	workloadActive bool
+}
+
+func NewLoginUserIsolation(info *framework.ClusterInfo, runtime framework.Runtime) *LoginUserIsolation {
+	return &LoginUserIsolation{info: info, runtime: runtime}
+}
+
+func (s *LoginUserIsolation) RegisterSteps(sc *godog.ScenarioContext) {
+	sc.Step(`^two regular users can SSH to the login node for CPU isolation testing$`, s.twoRegularUsersCanSSHToTheLoginNode)
+	sc.Step(`^both users run workloads at twice the login CPU capacity$`, s.bothUsersRunAtTwiceCapacity)
+	sc.Step(`^the first user runs at login CPU capacity while the second runs at four times capacity$`, s.usersRunAtDifferentLoads)
+	sc.Step(`^both users complete similar amounts of work in both cases$`, s.bothUsersCompleteSimilarAmountsOfWork)
+	sc.Step(`^the first user's amount of completed work remains stable$`, s.firstUsersAmountOfWorkRemainsStable)
+}
+
+func (s *LoginUserIsolation) CleanupAndReset(ctx context.Context) {
+	if s.workloadActive {
+		if err := s.stopCPUWorkloads(ctx); err != nil {
+			s.runtime.Logf("cleanup: stop login CPU isolation workloads: %v", err)
+		}
+	}
+	s.capacity = 0
+	s.balancedWork = loginCPUWork{}
+	s.unbalancedWork = loginCPUWork{}
+	s.workloadActive = false
+}
+
+func (s *LoginUserIsolation) twoRegularUsersCanSSHToTheLoginNode(ctx context.Context) error {
+	enabled, err := s.loginUserIsolationIsEnabled(ctx)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		s.runtime.Logf("acceptance: login user isolation is disabled, skipping scenario")
+		return godog.ErrSkip
+	}
+
+	for _, userName := range []string{loginCPUFirstUser, loginCPUSecondUser} {
+		if err := ensureSSHTestUser(ctx, s.runtime, userName); err != nil {
+			return err
+		}
+		if err := s.verifyUserCanSSH(ctx, userName); err != nil {
+			return err
+		}
+	}
+
+	capacity, err := s.loginCPUCapacity(ctx)
+	if err != nil {
+		return err
+	}
+	s.capacity = capacity
+	s.runtime.Logf("login CPU capacity: %d", capacity)
+	return nil
+}
+
+func (s *LoginUserIsolation) loginUserIsolationIsEnabled(ctx context.Context) (bool, error) {
+	output, err := s.runtime.Kubectl().RunWithDefaultRetry(
+		ctx,
+		"get",
+		"slurmcluster",
+		s.info.SlurmClusterName,
+		"-n",
+		framework.SoperatorNamespace,
+		"-o",
+		"jsonpath={.spec.slurmNodes.login.userIsolation.enabled}",
+	)
+	if err != nil {
+		return false, fmt.Errorf("read login user isolation configuration: %w", err)
+	}
+	return strings.TrimSpace(output) == "true", nil
+}
+
+func (s *LoginUserIsolation) bothUsersRunAtTwiceCapacity(ctx context.Context) error {
+	if s.capacity < 1 {
+		return fmt.Errorf("run balanced login CPU load: CPU capacity is not initialized")
+	}
+
+	work, err := s.runCPUContention(ctx, 2*s.capacity, 2*s.capacity)
+	if err != nil {
+		return fmt.Errorf("run balanced login CPU load: %w", err)
+	}
+	s.balancedWork = work
+	return nil
+}
+
+func (s *LoginUserIsolation) usersRunAtDifferentLoads(ctx context.Context) error {
+	if s.capacity < 1 {
+		return fmt.Errorf("run unbalanced login CPU load: CPU capacity is not initialized")
+	}
+
+	work, err := s.runCPUContention(ctx, s.capacity, 4*s.capacity)
+	if err != nil {
+		return fmt.Errorf("run unbalanced login CPU load: %w", err)
+	}
+	s.unbalancedWork = work
+	return nil
+}
+
+func (s *LoginUserIsolation) bothUsersCompleteSimilarAmountsOfWork() error {
+	phases := []struct {
+		name string
+		work loginCPUWork
+	}{
+		{name: "balanced", work: s.balancedWork},
+		{name: "unbalanced", work: s.unbalancedWork},
+	}
+	for _, phase := range phases {
+		share, err := firstCPUWorkShare(phase.work)
+		if err != nil {
+			return fmt.Errorf("validate %s login CPU shares: %w", phase.name, err)
+		}
+		s.runtime.Logf(
+			"%s login CPU work: first=%d second=%d first_share=%.3f",
+			phase.name,
+			phase.work.first,
+			phase.work.second,
+			share,
+		)
+		if share < loginCPUMinShare || share > loginCPUMaxShare {
+			return fmt.Errorf(
+				"validate %s login CPU shares: first user share %.3f is outside [%.2f, %.2f]",
+				phase.name,
+				share,
+				loginCPUMinShare,
+				loginCPUMaxShare,
+			)
+		}
+	}
+	return nil
+}
+
+func (s *LoginUserIsolation) firstUsersAmountOfWorkRemainsStable() error {
+	difference, err := relativeDifference(s.balancedWork.first, s.unbalancedWork.first)
+	if err != nil {
+		return fmt.Errorf("compare first user's login CPU work: %w", err)
+	}
+	s.runtime.Logf("first user login CPU work relative difference: %.3f", difference)
+	if difference > loginCPUMaxWorkRelativeDiff {
+		return fmt.Errorf(
+			"compare first user's login CPU work: relative difference %.3f exceeds %.2f",
+			difference,
+			loginCPUMaxWorkRelativeDiff,
+		)
+	}
+	return nil
+}
+
+func (s *LoginUserIsolation) verifyUserCanSSH(ctx context.Context, userName string) error {
+	command := fmt.Sprintf(
+		"su - %s -c %s",
+		framework.ShellQuote(userName),
+		framework.ShellQuote(loginCPUSSHCommand("true")),
+	)
+	if _, err := s.runtime.Jail().Run(ctx, command); err != nil {
+		return fmt.Errorf("verify login CPU isolation SSH connectivity for %s: %w", userName, err)
+	}
+	return nil
+}
+
+func (s *LoginUserIsolation) stopCPUWorkloads(ctx context.Context) error {
+	command := fmt.Sprintf(
+		"pkill -u %s -f %s 2>/dev/null || true; pkill -u %s -f %s 2>/dev/null || true",
+		framework.ShellQuote(loginCPUFirstUser),
+		framework.ShellQuote(loginCPUBurnMarker),
+		framework.ShellQuote(loginCPUSecondUser),
+		framework.ShellQuote(loginCPUBurnMarker),
+	)
+	_, err := s.runtime.Jail().Run(ctx, command)
+	return err
+}
+
+func (s *LoginUserIsolation) loginCPUCapacity(ctx context.Context) (int, error) {
+	output, err := s.runtime.Jail().Run(ctx, "nproc")
+	if err != nil {
+		return 0, fmt.Errorf("read effective login CPU capacity: %w", err)
+	}
+	value := strings.TrimSpace(output)
+	capacity, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse effective login CPU capacity %q: %w", value, err)
+	}
+	if capacity <= 0 {
+		return 0, fmt.Errorf("parse effective login CPU capacity %q: must be positive", value)
+	}
+	return capacity, nil
+}
+
+func (s *LoginUserIsolation) runCPUContention(ctx context.Context, firstBurners, secondBurners int) (loginCPUWork, error) {
+	workloadCtx, cancelWorkloads := context.WithCancel(ctx)
+	defer cancelWorkloads()
+	results := make(chan loginCPUWorkloadResult, 2)
+
+	s.workloadActive = true
+	s.startCPUWorkload(workloadCtx, loginCPUFirstUser, firstBurners, results)
+	s.startCPUWorkload(workloadCtx, loginCPUSecondUser, secondBurners, results)
+
+	work, err := waitForLoginCPUWorkloads(ctx, results)
+	if err != nil {
+		return loginCPUWork{}, err
+	}
+	s.workloadActive = false
+	return work, nil
+}
+
+func (s *LoginUserIsolation) startCPUWorkload(
+	ctx context.Context,
+	userName string,
+	burners int,
+	results chan<- loginCPUWorkloadResult,
+) {
+	go func() {
+		output, err := s.runtime.Jail().Run(ctx, loginCPUWorkloadCommand(userName, burners))
+		if err != nil {
+			err = fmt.Errorf("run login CPU workload for %s: %w", userName, err)
+		}
+		var work uint64
+		if err == nil {
+			work, err = parseLoginCPUWork(output)
+			if err != nil {
+				err = fmt.Errorf("read completed login CPU work for %s: %w", userName, err)
+			}
+		}
+		results <- loginCPUWorkloadResult{userName: userName, work: work, err: err}
+	}()
+}
+
+func waitForLoginCPUWorkloads(ctx context.Context, results <-chan loginCPUWorkloadResult) (loginCPUWork, error) {
+	var work loginCPUWork
+	var workloadErrors []error
+	for range 2 {
+		select {
+		case <-ctx.Done():
+			return loginCPUWork{}, ctx.Err()
+		case result := <-results:
+			if result.err != nil {
+				workloadErrors = append(workloadErrors, result.err)
+				continue
+			}
+			switch result.userName {
+			case loginCPUFirstUser:
+				work.first = result.work
+			case loginCPUSecondUser:
+				work.second = result.work
+			default:
+				workloadErrors = append(workloadErrors, fmt.Errorf("read completed login CPU work for unknown user %q", result.userName))
+			}
+		}
+	}
+	if err := errors.Join(workloadErrors...); err != nil {
+		return loginCPUWork{}, err
+	}
+	return work, nil
+}
+
+func loginCPUWorkloadCommand(userName string, burners int) string {
+	burnScript := fmt.Sprintf(`
+marker=%s
+count=0
+deadline=$((SECONDS + %.0f))
+while ((SECONDS < deadline)); do
+    ((count += 1))
+done
+printf '%%s\n' "${count}"
+`, framework.ShellQuote(loginCPUBurnMarker), loginCPUWorkloadDuration.Seconds())
+	remoteScript := fmt.Sprintf(`
+set -euo pipefail
+workdir="$(mktemp -d /tmp/soperator-e2e-login-cpu.XXXXXX)"
+trap 'rm -r -- "${workdir}"' EXIT
+pids=()
+for ((i = 0; i < %d; i++)); do
+    bash -c %s >"${workdir}/${i}" &
+    pids+=("$!")
+done
+worker_failed=0
+for i in "${!pids[@]}"; do
+    if ! wait "${pids[$i]}"; then
+        printf 'login CPU worker %%d failed\n' "${i}" >&2
+        worker_failed=1
+    fi
+done
+if ((worker_failed)); then
+    exit 1
+fi
+awk '{total += $1} END {printf "SOPERATOR_E2E_LOGIN_CPU_WORK %%.0f\n", total}' "${workdir}"/*
+`, burners, framework.ShellQuote(burnScript))
+	return fmt.Sprintf(
+		"su - %s -c %s",
+		framework.ShellQuote(userName),
+		framework.ShellQuote(loginCPUSSHCommand(framework.BashLC(remoteScript))),
+	)
+}
+
+func loginCPUSSHCommand(command string) string {
+	return fmt.Sprintf(
+		"timeout %.0f ssh -i ~/.ssh/id_ecdsa -o IdentitiesOnly=yes -o BatchMode=yes -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null localhost %s",
+		loginCPUCommandTimeout.Seconds(),
+		framework.ShellQuote(command),
+	)
+}
+
+func parseLoginCPUWork(output string) (uint64, error) {
+	for line := range strings.SplitSeq(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 || fields[0] != "SOPERATOR_E2E_LOGIN_CPU_WORK" {
+			continue
+		}
+		if len(fields) != 2 {
+			return 0, fmt.Errorf("parse login CPU work line %q", line)
+		}
+		work, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse login CPU work %q: %w", fields[1], err)
+		}
+		return work, nil
+	}
+	return 0, fmt.Errorf("parse login CPU work: marker line not found in %q", strings.TrimSpace(output))
+}
+
+func firstCPUWorkShare(work loginCPUWork) (float64, error) {
+	total := work.first + work.second
+	if total == 0 {
+		return 0, fmt.Errorf("combined CPU work is zero")
+	}
+	return float64(work.first) / float64(total), nil
+}
+
+func relativeDifference(first, second uint64) (float64, error) {
+	maximum := max(first, second)
+	if maximum == 0 {
+		return 0, fmt.Errorf("both CPU work values are zero")
+	}
+	minimum := min(first, second)
+	return float64(maximum-minimum) / float64(maximum), nil
+}

--- a/e2e/acceptance/internal/sharedsteps/steps.go
+++ b/e2e/acceptance/internal/sharedsteps/steps.go
@@ -28,6 +28,7 @@ func RegisterAll(sc *godog.ScenarioContext, info *framework.ClusterInfo, runtime
 		NewLoginAutoscaling(info, runtime, kubectl),
 		NewObservability(kubectl),
 		NewInternalSSH(runtime, selector),
+		NewLoginUserIsolation(info, runtime),
 		NewPackageInstallation(runtime, selector),
 		NewGPUProfiling(runtime, slurm, selector),
 		NewSoperatorUtils(runtime, selector),

--- a/helm/slurm-cluster/tests/user_isolation_test.yaml
+++ b/helm/slurm-cluster/tests/user_isolation_test.yaml
@@ -2,50 +2,52 @@ suite: test login user isolation rendering
 templates:
   - templates/slurm-cluster-cr.yaml
 tests:
-  - it: should render user isolation disabled by default
-    asserts:
-      - equal:
-          path: spec.slurmNodes.login.userIsolation.enabled
-          value: false
-      - equal:
-          path: spec.slurmNodes.login.userIsolation.cpuWeight
-          value: 100
-      # Memory limits are unset by default: when the feature is enabled, the
-      # operator derives them from the sshd container memory limit (80% high /
-      # 90% max).
-      - notExists:
-          path: spec.slurmNodes.login.userIsolation.memoryHigh
-      - notExists:
-          path: spec.slurmNodes.login.userIsolation.memoryMax
-
-  - it: should render user isolation enabled with derived memory limits when turned on
-    set:
-      slurmNodes:
-        login:
-          userIsolation:
-            enabled: true
+  - it: should render user isolation enabled by default
     asserts:
       - equal:
           path: spec.slurmNodes.login.userIsolation.enabled
           value: true
+      - equal:
+          path: spec.slurmNodes.login.userIsolation.cpuWeight
+          value: 100
+      # Memory limits are unset by default: when the feature is enabled, the
+      # operator derives them from the sshd container memory limit (40% high /
+      # 50% max).
       - notExists:
           path: spec.slurmNodes.login.userIsolation.memoryHigh
       - notExists:
           path: spec.slurmNodes.login.userIsolation.memoryMax
 
-  - it: should render user isolation with memory limits when enabled
+  - it: should not render memoryHigh, memoryMax and cpuWeight if unset
     set:
       slurmNodes:
         login:
           userIsolation:
             enabled: true
+            memoryHigh: null
+            memoryMax: null
+            cpuWeight: null
+    asserts:
+      - notExists:
+          path: spec.slurmNodes.login.userIsolation.memoryHigh
+      - notExists:
+          path: spec.slurmNodes.login.userIsolation.memoryMax
+      - notExists:
+          path: spec.slurmNodes.login.userIsolation.cpuWeight
+
+  - it: should render user isolation settings as is
+    set:
+      slurmNodes:
+        login:
+          userIsolation:
+            enabled: false
             memoryHigh: "2Gi"
             memoryMax: "3Gi"
             cpuWeight: 250
     asserts:
       - equal:
           path: spec.slurmNodes.login.userIsolation.enabled
-          value: true
+          value: false
       - equal:
           path: spec.slurmNodes.login.userIsolation.memoryHigh
           value: "2Gi"

--- a/helm/slurm-cluster/values.yaml
+++ b/helm/slurm-cluster/values.yaml
@@ -631,20 +631,18 @@ slurmNodes:
     # user cannot exhaust the memory or monopolize the CPU of the login node.
     # Requires cgroup v2 on the Kubernetes node.
     # When memory values are unset, safe defaults are derived from
-    # sshd.resources.memory: memoryHigh = 80%, memoryMax = 90% of it. The
-    # derived memoryMax keeps OOM events scoped to a single user's cgroup
-    # without restricting how much a lone user may use. Set explicit values
-    # to give users tighter budgets; they must stay below
-    # sshd.resources.memory.
-    # Disabled by default for the initial release; planned to default to
-    # enabled in a future release.
+    # sshd.resources.memory: memoryHigh = 40%, memoryMax = 50% of it. Set
+    # explicit values to give users different budgets; they must stay below
+    # sshd.resources.memory. memoryHigh and memoryMax must be specified
+    # together or both omitted.
     userIsolation:
-      enabled: false
+      # Enabled by default
+      enabled: true
       # Throttling threshold per user (cgroup v2 memory.high), e.g. "2Gi".
-      # Unset = derived (80% of sshd.resources.memory).
+      # Unset = derived (40% of sshd.resources.memory).
       # memoryHigh: "2Gi"
       # Hard memory limit per user (cgroup v2 memory.max), e.g. "3Gi".
-      # Unset = derived (90% of sshd.resources.memory).
+      # Unset = derived (50% of sshd.resources.memory).
       # memoryMax: "3Gi"
       # CPU weight per user (cgroup v2 cpu.weight, 1-10000). CPU is shared
       # proportionally between users under contention; idle CPU stays usable.

--- a/helm/soperator-crds/templates/slurmcluster-crd.yaml
+++ b/helm/soperator-crds/templates/slurmcluster-crd.yaml
@@ -47699,7 +47699,8 @@ spec:
                               MemoryHigh is the per-user memory throttling threshold (cgroup v2 memory.high).
                               The kernel throttles and reclaims a user's memory above this value before OOM.
                               Must be lower than the sshd container memory limit.
-                              When unset, it is derived as 80% of the sshd container memory limit
+                              Must be specified together with memoryMax.
+                              When unset, it is derived as 40% of the sshd container memory limit
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           memoryMax:
@@ -47710,9 +47711,8 @@ spec:
                               MemoryMax is the per-user hard memory limit (cgroup v2 memory.max).
                               The OOM killer is scoped to the user's own cgroup when this limit is hit.
                               Must be lower than the sshd container memory limit.
-                              When unset, it is derived as 90% of the sshd container memory limit,
-                              which keeps OOM events scoped to a single user without restricting
-                              how much of the container's memory a lone user may use
+                              Must be specified together with memoryHigh.
+                              When unset, it is derived as 50% of the sshd container memory limit
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                         type: object
@@ -47721,6 +47721,9 @@ spec:
                           rule: '!has(self.memoryHigh) || !has(self.memoryMax) ||
                             quantity(self.memoryHigh).compareTo(quantity(self.memoryMax))
                             <= 0'
+                        - message: memoryHigh and memoryMax must be specified together
+                            or both omitted
+                          rule: has(self.memoryHigh) == has(self.memoryMax)
                       volumes:
                         description: Volumes represents the volume configurations
                           for the login node

--- a/helm/soperator/crds/slurmcluster-crd.yaml
+++ b/helm/soperator/crds/slurmcluster-crd.yaml
@@ -47699,7 +47699,8 @@ spec:
                               MemoryHigh is the per-user memory throttling threshold (cgroup v2 memory.high).
                               The kernel throttles and reclaims a user's memory above this value before OOM.
                               Must be lower than the sshd container memory limit.
-                              When unset, it is derived as 80% of the sshd container memory limit
+                              Must be specified together with memoryMax.
+                              When unset, it is derived as 40% of the sshd container memory limit
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           memoryMax:
@@ -47710,9 +47711,8 @@ spec:
                               MemoryMax is the per-user hard memory limit (cgroup v2 memory.max).
                               The OOM killer is scoped to the user's own cgroup when this limit is hit.
                               Must be lower than the sshd container memory limit.
-                              When unset, it is derived as 90% of the sshd container memory limit,
-                              which keeps OOM events scoped to a single user without restricting
-                              how much of the container's memory a lone user may use
+                              Must be specified together with memoryHigh.
+                              When unset, it is derived as 50% of the sshd container memory limit
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                         type: object
@@ -47721,6 +47721,9 @@ spec:
                           rule: '!has(self.memoryHigh) || !has(self.memoryMax) ||
                             quantity(self.memoryHigh).compareTo(quantity(self.memoryMax))
                             <= 0'
+                        - message: memoryHigh and memoryMax must be specified together
+                            or both omitted
+                          rule: has(self.memoryHigh) == has(self.memoryMax)
                       volumes:
                         description: Volumes represents the volume configurations
                           for the login node

--- a/internal/render/login/configmap_test.go
+++ b/internal/render/login/configmap_test.go
@@ -107,9 +107,9 @@ func TestGenerateUserIsolationConfig_DerivedMemoryDefaults(t *testing.T) {
 	rendered := generateUserIsolationConfig(cluster).Render()
 	assert.Contains(t, rendered, "SOPERATOR_USER_ISOLATION_ENABLED=true")
 	// Unset memory limits are derived from the sshd container memory limit (10Gi):
-	// memory.high = 80%, memory.max = 90%.
-	assert.Contains(t, rendered, "SOPERATOR_USER_ISOLATION_MEMORY_HIGH=8589934592")
-	assert.Contains(t, rendered, "SOPERATOR_USER_ISOLATION_MEMORY_MAX=9663676416")
+	// memory.high = 40%, memory.max = 50%.
+	assert.Contains(t, rendered, "SOPERATOR_USER_ISOLATION_MEMORY_HIGH=4294967296")
+	assert.Contains(t, rendered, "SOPERATOR_USER_ISOLATION_MEMORY_MAX=5368709120")
 	// CPUWeight falls back to 100 when the CRD default was not applied.
 	assert.Contains(t, rendered, "SOPERATOR_USER_ISOLATION_CPU_WEIGHT=100")
 }

--- a/internal/values/login_user_isolation.go
+++ b/internal/values/login_user_isolation.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	loginUserIsolationMemoryHighPercent int64 = 80
-	loginUserIsolationMemoryMaxPercent  int64 = 90
+	loginUserIsolationMemoryHighPercent int64 = 40
+	loginUserIsolationMemoryMaxPercent  int64 = 50
 )
 
 // ResolveLoginUserIsolationMemoryLimits returns the effective limits after applying derived defaults.

--- a/internal/webhook/v1/slurmcluster_webhook_test.go
+++ b/internal/webhook/v1/slurmcluster_webhook_test.go
@@ -85,55 +85,45 @@ func TestValidateSlurmClusterUserIsolation(t *testing.T) {
 	}
 
 	t.Run("admits limits below the container memory limit", func(t *testing.T) {
+		memoryHigh := resource.MustParse("4Gi")
 		memoryMax := resource.MustParse("8Gi")
 		_, err := validator.ValidateCreate(context.Background(), clusterWith(&slurmv1.LoginUserIsolation{
-			Enabled:   ptr.To(true),
-			MemoryMax: &memoryMax,
+			Enabled:    ptr.To(true),
+			MemoryHigh: &memoryHigh,
+			MemoryMax:  &memoryMax,
 		}))
 		assert.NoError(t, err)
 	})
 
-	t.Run("admits explicit memoryHigh below derived memoryMax", func(t *testing.T) {
-		memoryHigh := resource.MustParse("8Gi")
+	t.Run("rejects memoryHigh above memoryMax", func(t *testing.T) {
+		memoryHigh := resource.MustParse("4Gi")
+		memoryMax := resource.MustParse("3Gi")
 		_, err := validator.ValidateCreate(context.Background(), clusterWith(&slurmv1.LoginUserIsolation{
 			Enabled:    ptr.To(true),
 			MemoryHigh: &memoryHigh,
-		}))
-		assert.NoError(t, err)
-	})
-
-	t.Run("rejects explicit memoryMax below derived memoryHigh", func(t *testing.T) {
-		memoryMax := resource.MustParse("7Gi")
-		_, err := validator.ValidateCreate(context.Background(), clusterWith(&slurmv1.LoginUserIsolation{
-			Enabled:   ptr.To(true),
-			MemoryMax: &memoryMax,
-		}))
-		assert.ErrorContains(t, err, "must not exceed memoryMax")
-	})
-
-	t.Run("rejects explicit memoryHigh above derived memoryMax", func(t *testing.T) {
-		memoryHigh := resource.MustParse("8500Mi")
-		_, err := validator.ValidateCreate(context.Background(), clusterWith(&slurmv1.LoginUserIsolation{
-			Enabled:    ptr.To(true),
-			MemoryHigh: &memoryHigh,
+			MemoryMax:  &memoryMax,
 		}))
 		assert.ErrorContains(t, err, "must not exceed memoryMax")
 	})
 
 	t.Run("rejects memoryMax at or above the container memory limit", func(t *testing.T) {
+		memoryHigh := resource.MustParse("4Gi")
 		memoryMax := resource.MustParse("9Gi")
 		_, err := validator.ValidateCreate(context.Background(), clusterWith(&slurmv1.LoginUserIsolation{
-			Enabled:   ptr.To(true),
-			MemoryMax: &memoryMax,
+			Enabled:    ptr.To(true),
+			MemoryHigh: &memoryHigh,
+			MemoryMax:  &memoryMax,
 		}))
 		assert.ErrorContains(t, err, "memoryMax")
 	})
 
 	t.Run("rejects memoryHigh at or above the container memory limit", func(t *testing.T) {
 		memoryHigh := resource.MustParse("10Gi")
+		memoryMax := resource.MustParse("10Gi")
 		_, err := validator.ValidateCreate(context.Background(), clusterWith(&slurmv1.LoginUserIsolation{
 			Enabled:    ptr.To(true),
 			MemoryHigh: &memoryHigh,
+			MemoryMax:  &memoryMax,
 		}))
 		assert.ErrorContains(t, err, "memoryHigh")
 	})
@@ -141,7 +131,13 @@ func TestValidateSlurmClusterUserIsolation(t *testing.T) {
 	for _, field := range []string{"memoryHigh", "memoryMax"} {
 		t.Run("rejects non-positive "+field, func(t *testing.T) {
 			quantity := resource.MustParse("-1Gi")
-			isolation := &slurmv1.LoginUserIsolation{Enabled: ptr.To(true)}
+			memoryHigh := resource.MustParse("1Gi")
+			memoryMax := resource.MustParse("8Gi")
+			isolation := &slurmv1.LoginUserIsolation{
+				Enabled:    ptr.To(true),
+				MemoryHigh: &memoryHigh,
+				MemoryMax:  &memoryMax,
+			}
 			switch field {
 			case "memoryHigh":
 				isolation.MemoryHigh = &quantity
@@ -155,10 +151,12 @@ func TestValidateSlurmClusterUserIsolation(t *testing.T) {
 	}
 
 	t.Run("ignores limits when isolation is disabled", func(t *testing.T) {
+		memoryHigh := resource.MustParse("100Gi")
 		memoryMax := resource.MustParse("100Gi")
 		_, err := validator.ValidateCreate(context.Background(), clusterWith(&slurmv1.LoginUserIsolation{
-			Enabled:   ptr.To(false),
-			MemoryMax: &memoryMax,
+			Enabled:    ptr.To(false),
+			MemoryHigh: &memoryHigh,
+			MemoryMax:  &memoryMax,
 		}))
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
## Problem

Login user isolation is available, but it is disabled by default. Unless operators explicitly enable it, one user can monopolize login-node CPU or exhaust the memory available to the `sshd` container, affecting every other logged-in user.

The previous derived per-user memory defaults (`memory.high = 80%` and `memory.max = 90%` of the `sshd` container memory) also allow one user to consume nearly all login-node memory and do not leave useful capacity for a second user.

## Solution

- Enable `slurmNodes.login.userIsolation` by default.
- Derive `memory.high` at 40% and `memory.max` at 50% of the `sshd` container memory when explicit values are not provided.
- Add a black-box acceptance scenario that creates two regular login users and compares completed CPU work under two contention patterns:
  - both users run workloads at twice the login CPU capacity;
  - the first user runs at login CPU capacity while the second runs at four times capacity.
- Skip the acceptance scenario once at the top level when login user isolation is disabled.

## Testing

- `go test ./...`, `go vet ./...` — passed.
- [Build All in one job](https://github.com/nebius/soperator/actions/runs/33881965250) — passed, including lint, E2E build, images, Helm charts, and Helm integration tests.
- Manual validation on a personal dev cluster. Usage is each user's share of the total completed CPU work:

  | Isolation | First user workload | Second user workload | First user usage | Second user usage |
  | --- | ---: | ---: | ---: | ---: |
  | Enabled | `2x` login CPU capacity | `2x` login CPU capacity | `49.2%` | `50.8%` |
  | Enabled | `1x` login CPU capacity | `4x` login CPU capacity | `45.9%` | `54.1%` |
  | Disabled | `1x` login CPU capacity | `4x` login CPU capacity | `20.4%` | `79.6%` |

  The disabled-isolation row was a negative control run with the scenario skip bypassed only in the local runner; it failed as expected because the first user's share was outside the accepted `[35%, 65%]` range.
- [Full GitHub E2E](https://github.com/nebius/soperator/actions/runs/33886548071) — passed on the `MDC_B200` profile.

## Release Notes

Login-node user isolation is now enabled by default, with per-user memory thresholds derived at 40%/50% of the `sshd` container memory and proportional CPU sharing under contention. This changes the default behavior; clusters that need the previous behavior can explicitly set `slurmNodes.login.userIsolation.enabled: false`.
