### PR TITLE
SCHED-2422: Fix worker topology registration and enable topology E2E checks

### DIFF
--- a/e2e/acceptance/features/topology.feature
+++ b/e2e/acceptance/features/topology.feature
@@ -13,8 +13,7 @@ Feature: Slurm named topologies
     When Slurm is asked which topologies it loaded
     Then Slurm loaded exactly the topologies the operator rendered
 
-  # Remove @unstable after worker topology registration is fixed.
-  @multi_topology @unstable @soperator_version_>=5.0.0
+  @multi_topology @soperator_version_>=5.0.0
   Scenario: Partitions and workers use their configured topologies
     Given the operator published the topology config
     When Slurm is asked which topologies it loaded
@@ -27,3 +26,4 @@ Feature: Slurm named topologies
   Scenario: Every configured topology can schedule a job
     Given the operator published the topology config
     Then a job runs in a partition of every topology
+    And eventually no worker is listed under unknown in Slurm topoconf

--- a/e2e/acceptance/features/topology_tree.feature
+++ b/e2e/acceptance/features/topology_tree.feature
@@ -1,7 +1,6 @@
 Feature: Slurm tree-topology scheduling
 
-  # Remove @unstable after worker topology registration is fixed.
-  @gpu @tree_topology @unstable @soperator_version_>=5.0.0
+  @gpu @tree_topology @soperator_version_>=5.0.0
   Scenario: A switch limit rejects a cross-leaf allocation
     Given the cluster is configured with a tree topology spanning multiple leaf switches
     And the operator published the topology config

--- a/e2e/acceptance/internal/sharedsteps/topology.go
+++ b/e2e/acceptance/internal/sharedsteps/topology.go
@@ -139,6 +139,7 @@ func (s *Topology) RegisterSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^every partition is bound to a topology Slurm loaded$`, s.partitionsAreBound)
 	sc.Step(`^every running worker is registered into the topologies that list it$`, s.registrationsMatchTheConfig)
 	sc.Step(`^a job runs in a partition of every topology$`, s.jobRunsInEveryTopology)
+	sc.Step(`^eventually no worker is listed under unknown in Slurm topoconf$`, s.noWorkersUnderUnknown)
 
 	sc.Step(`^Slurm loaded the tree topology$`, s.slurmLoadedTheTreeTopology)
 	sc.Step(`^two configured workers on different leaf switches are requested without a switch limit$`, s.requestCrossLeafWorkers)
@@ -501,6 +502,20 @@ func (s *Topology) loadedMatchesRendered() error {
 		return fmt.Errorf("slurmctld loaded %q, the operator rendered %q", got, want)
 	}
 	return nil
+}
+
+func (s *Topology) noWorkersUnderUnknown(ctx context.Context) error {
+	return s.runtime.WaitFor(ctx, "Slurm topoconf to list no workers under unknown",
+		topologyConvergeTimeout, framework.DefaultPollInterval,
+		func(waitCtx context.Context) (bool, error) {
+			if err := s.readLoadedTopologies(waitCtx); err != nil {
+				return false, err
+			}
+			if err := validateNoWorkersUnderUnknown(s.loaded); err != nil {
+				return false, err
+			}
+			return true, nil
+		})
 }
 
 func (s *Topology) partitionsAreBound(ctx context.Context) error {

--- a/e2e/acceptance/internal/sharedsteps/topology_parse.go
+++ b/e2e/acceptance/internal/sharedsteps/topology_parse.go
@@ -174,6 +174,31 @@ func topologyStructure(entries []topologyEntry) string {
 	return strings.Join(parts, ",")
 }
 
+func validateNoWorkersUnderUnknown(entries []topologyEntry) error {
+	var problems []string
+	check := func(topology, name, nodes string) {
+		if name != "unknown" && !strings.HasSuffix(name, ".unknown") {
+			return
+		}
+		if len(splitSlurmList(nodes)) > 0 {
+			problems = append(problems, fmt.Sprintf("%s/%s: %s", topology, name, nodes))
+		}
+	}
+	for _, entry := range entries {
+		for _, sw := range entry.Switches {
+			check(entry.Name, sw.Name, sw.Nodes)
+		}
+		for _, block := range entry.Blocks {
+			check(entry.Name, block.Name, block.Nodes)
+		}
+	}
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		return fmt.Errorf("workers remain under unknown in Slurm topoconf: %s", strings.Join(problems, "; "))
+	}
+	return nil
+}
+
 func topologyByName(entries []topologyEntry, name string) (topologyEntry, bool) {
 	for _, entry := range entries {
 		if entry.Name == name {

--- a/e2e/acceptance/internal/sharedsteps/topology_test.go
+++ b/e2e/acceptance/internal/sharedsteps/topology_test.go
@@ -165,6 +165,46 @@ func TestParseTopologyEntriesReadsTopoconfTheSameWay(t *testing.T) {
 	assert.Equal(t, topologyStructure(rendered), topologyStructure(loaded))
 }
 
+func TestValidateNoWorkersUnderUnknown(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		unit    string
+		nodes   string
+		wantErr bool
+	}{
+		{name: "bare unknown", unit: "unknown", nodes: "worker-0", wantErr: true},
+		{name: "fabric unknown hostlist", unit: "fabric.unknown", nodes: "worker-[0-3]", wantErr: true},
+		{name: "empty unknown", unit: "unknown"},
+		{name: "null unknown", unit: "fabric.unknown", nodes: "(null)"},
+		{name: "whitespace unknown", unit: "unknown", nodes: "  "},
+		{name: "known unit", unit: "leaf-a", nodes: "worker-0"},
+		{name: "unknown substring", unit: "unknown-leaf", nodes: "worker-0"},
+	} {
+		for _, kind := range []string{topologyKindTree, topologyKindBlock} {
+			t.Run(tt.name+"/"+kind, func(t *testing.T) {
+				entry := topologyEntry{Name: "fabric", Kind: kind}
+				if kind == topologyKindTree {
+					entry.Switches = []topologySwitch{{Name: tt.unit, Nodes: tt.nodes}}
+				} else {
+					entry.Blocks = []topologyUnit{{Name: tt.unit, Nodes: tt.nodes}}
+				}
+				err := validateNoWorkersUnderUnknown([]topologyEntry{entry})
+				if tt.wantErr {
+					require.ErrorContains(t, err, "fabric/"+tt.unit+": "+tt.nodes)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		}
+	}
+
+	t.Run("loaded topoconf", func(t *testing.T) {
+		entries, err := parseTopologyEntries(loadedTopologyConfig)
+		require.NoError(t, err)
+		require.ErrorContains(t, validateNoWorkersUnderUnknown(entries), "tree-ib/fabric.unknown: worker-2")
+	})
+}
+
 func TestParseTopologyEntriesRejectsMalformedConfigs(t *testing.T) {
 	for name, raw := range map[string]string{
 		"empty":         "",

--- a/images/worker/worker_init.py
+++ b/images/worker/worker_init.py
@@ -671,6 +671,7 @@ def apply_node_topology(hostname: str, topology: str) -> None:
         # covered only by flat topologies.
         if topology:
             cmd.append(f"{topology}")
+        cmd.append("State=POWER_UP")
         logger.info("Running: %s", " ".join(cmd))
         result: subprocess.CompletedProcess[str] = subprocess.run(
             cmd,


### PR DESCRIPTION
## Problem

Worker topology registration did not explicitly request the POWER_UP state. Topology registration and tree scheduling E2E scenarios were marked unstable and excluded from default runs, while workers remaining under unknown in Slurm topoconf went unchecked.

## Solution

- Include State=POWER_UP when applying worker topology through scontrol.
- Enable topology registration and tree switch-limit scenarios in default E2E runs.
- After topology scheduling checks, wait up to 10 minutes for all unknown and <fabric>.unknown switches and blocks in Slurm topoconf to contain no workers.
- Report topology names and affected workers if the check fails.
- Keep the block topology reconfiguration scenario outside the default suite.

## Testing

- Passed: go test ./acceptance/... from e2e/.
- Added unit coverage for unknown switches and blocks, hostlists, empty node lists, and parsed topoconf output.
- Passed: git diff --check.
- Cluster E2E tests have not been run locally.

## Release Notes

Fixed worker initialization to request POWER_UP when applying topology. Enabled topology E2E checks by default and added detection of workers remaining under unknown topology units.