### PR TITLE
check_runner: do not quote scontrol Reason= and Comment= values

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/check_runner.py
+++ b/helm/slurm-cluster/slurm_scripts/check_runner.py
@@ -565,7 +565,7 @@ def drain_node(reason):
     try:
 
         subprocess.run(
-            ["scontrol", "update", f"NodeName={SLURMD_NODENAME}", "State=drain", f"Reason=\"{reason}\""],
+            ["scontrol", "update", f"NodeName={SLURMD_NODENAME}", "State=drain", f"Reason={reason}"],
             check=False, stderr=subprocess.DEVNULL
         )
         # Invalidate cache for the Slurm node info
@@ -591,7 +591,7 @@ def comment_node(comment):
     logging.info(f"Comment Slurm node {SLURMD_NODENAME}: {comment}")
     try:
         subprocess.run(
-            ["scontrol", "update", f"NodeName={SLURMD_NODENAME}", f"Comment=\"{comment}\""],
+            ["scontrol", "update", f"NodeName={SLURMD_NODENAME}", f"Comment={comment}"],
             check=False, stderr=subprocess.DEVNULL
         )
         # Invalidate cache for the Slurm node info
@@ -604,7 +604,7 @@ def uncomment_node():
     logging.info(f"Uncomment Slurm node {SLURMD_NODENAME}")
     try:
         subprocess.run(
-            ["scontrol", "update", f"NodeName={SLURMD_NODENAME}", "Comment=\"\""],
+            ["scontrol", "update", f"NodeName={SLURMD_NODENAME}", "Comment="],
             check=False, stderr=subprocess.DEVNULL
         )
         # Invalidate cache for the Slurm node info


### PR DESCRIPTION
## Problem

The scontrol calls in `drain_node`, `comment_node` and `uncomment_node` pass a list to `subprocess.run`, so the quotes around the value are stored in Slurm as part of it. `on_ok: undrain` / `uncomment` compare with `startswith(reason_base)` and never match a value that starts with `"`, and `Comment=""` stores `""` instead of clearing the field. Nodes keep their `[node_problem] ...` reason and comment after the check starts passing.

## Solution

Drop the quotes from the three scontrol arguments: `Reason={reason}`, `Comment={comment}`, `Comment=`.

## Testing

On a production cluster a node kept its `[node_problem] ib_link_check` comment after the IB link came back and the check passed on every run. With the quotes removed, the next hc_program run logged `Check ib_link_check: OK` and `Uncomment Slurm node worker-gpu-29`, and the comment was cleared.

## Release Notes

Fix: `on_ok: undrain` and `on_ok: uncomment` now clear the drain reason and node comment set by a check, instead of leaving the node marked forever.

Fixes #2954.