### PR TITLE
SCHED-2007: select E2E builds by commit SHA

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -265,62 +265,92 @@ jobs:
           TARGET_BRANCH: ${{ github.ref_name }}
         run: |
           readonly CANDIDATE_LIMIT=15
+          readonly EMPTY_RESPONSE_RETRY_LIMIT=3
+          readonly RETRY_BACKOFF_SECONDS=5
 
           echo "Looking for a valid successful build run on branch: $TARGET_BRANCH"
 
-          runs=$(.github/workflows/scripts/retry.sh gh api \
-            -H "Cache-Control: no-cache" \
-            -X GET \
-            "/repos/$REPOSITORY/actions/workflows/one_job.yml/runs" \
-            -F branch="$TARGET_BRANCH" \
-            -F status=success \
-            -F per_page="$CANDIDATE_LIMIT")
-
           selected_run=""
           artifact_expires_at=""
-          while IFS= read -r candidate; do
-            run_id=$(jq -r '.id' <<<"$candidate")
-            artifacts=$(.github/workflows/scripts/retry.sh gh api \
-              -H "Cache-Control: no-cache" \
-              -X GET \
-              "/repos/$REPOSITORY/actions/runs/$run_id/artifacts" \
-              -F per_page=100)
+          while IFS= read -r candidate_sha; do
+            echo "Checking build runs for commit: $candidate_sha"
 
-            artifact=$(jq -c '
-              [.artifacts[]
-                | select(
-                    .name == "version"
-                    and .expired == false
-                    and .expires_at != null
-                    and (.expires_at | fromdateiso8601) > now
-                  )
-              ]
-              | sort_by(.expires_at)
-              | last // empty
-            ' <<<"$artifacts")
+            runs=""
+            for ((attempt = 1; attempt <= EMPTY_RESPONSE_RETRY_LIMIT; attempt++)); do
+              runs=$(.github/workflows/scripts/retry.sh gh api \
+                -H "Cache-Control: no-cache" \
+                -X GET \
+                "/repos/$REPOSITORY/actions/workflows/one_job.yml/runs" \
+                -F head_sha="$candidate_sha" \
+                -F per_page=100)
 
-            if [[ -z "$artifact" ]]; then
-              echo "Skipping build $run_id: no non-expired version artifact"
+              if jq -e '.workflow_runs | length > 0' >/dev/null <<<"$runs"; then
+                break
+              fi
+
+              if (( attempt < EMPTY_RESPONSE_RETRY_LIMIT )); then
+                echo "No build runs returned for $candidate_sha; retrying ($attempt/$EMPTY_RESPONSE_RETRY_LIMIT)"
+                sleep $((RETRY_BACKOFF_SECONDS * attempt))
+              fi
+            done
+
+            if ! jq -e '.workflow_runs | length > 0' >/dev/null <<<"$runs"; then
+              echo "Skipping commit $candidate_sha: no build runs returned after $EMPTY_RESPONSE_RETRY_LIMIT attempts"
               continue
             fi
 
-            selected_run="$candidate"
-            artifact_expires_at=$(jq -r '.expires_at' <<<"$artifact")
+            while IFS= read -r candidate; do
+              run_id=$(jq -r '.id' <<<"$candidate")
+              artifacts=$(.github/workflows/scripts/retry.sh gh api \
+                -H "Cache-Control: no-cache" \
+                -X GET \
+                "/repos/$REPOSITORY/actions/runs/$run_id/artifacts" \
+                -F per_page=100)
+
+              artifact=$(jq -c '
+                [.artifacts[]
+                  | select(
+                      .name == "version"
+                      and .expired == false
+                      and .expires_at != null
+                      and (.expires_at | fromdateiso8601) > now
+                    )
+                ]
+                | sort_by(.expires_at)
+                | last // empty
+              ' <<<"$artifacts")
+
+              if [[ -z "$artifact" ]]; then
+                echo "Skipping build $run_id: no non-expired version artifact"
+                continue
+              fi
+
+              selected_run="$candidate"
+              artifact_expires_at=$(jq -r '.expires_at' <<<"$artifact")
+              break
+            done < <(jq -c --arg branch "$TARGET_BRANCH" --arg sha "$candidate_sha" '
+              [.workflow_runs[]
+                | select(
+                    .head_sha == $sha
+                    and .head_branch == $branch
+                    and .status == "completed"
+                    and .conclusion == "success"
+                  )
+              ]
+              | sort_by([.created_at, .id])
+              | reverse[]
+            ' <<<"$runs")
+
+            if [[ -z "$selected_run" ]]; then
+              echo "Skipping commit $candidate_sha: no completed successful build with a valid version artifact"
+              continue
+            fi
+
             break
-          done < <(jq -c --arg branch "$TARGET_BRANCH" '
-            [.workflow_runs[]
-              | select(
-                  .head_branch == $branch
-                  and .status == "completed"
-                  and .conclusion == "success"
-                )
-            ]
-            | sort_by([.created_at, .id])
-            | reverse[]
-          ' <<<"$runs")
+          done < <(git rev-list --first-parent --max-count="$CANDIDATE_LIMIT" "$GITHUB_SHA")
 
           if [[ -z "$selected_run" ]]; then
-            echo "::error::No valid successful build with a non-expired version artifact found among up to $CANDIDATE_LIMIT candidates on branch $TARGET_BRANCH"
+            echo "::error::No valid successful build with a non-expired version artifact found among the latest $CANDIDATE_LIMIT commits on branch $TARGET_BRANCH"
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

GitHub’s branch-filtered workflow-runs API can return a stale but successful response, causing E2E to select an outdated build with incompatible CRDs or artifacts. This caused another SCHED-2007 reproduction in run https://github.com/nebius/soperator/actions/runs/34243545823.

The behavior matches the GitHub Actions API issue described in [this discussion](https://github.com/orgs/community/discussions/206725).

## Solution

Search the latest 15 first-parent commits and query `one_job.yml` runs by exact commit SHA. Retry an empty exact- SHA response up to three attempts, skip running or unsuccessful builds without waiting, and select the first successful build with a non-expired version artifact.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
