### PR TITLE
SCHED-2009 Show exact node state combinations in dashboards

### DIFF
--- a/docs/metrics-pipeline.md
+++ b/docs/metrics-pipeline.md
@@ -204,7 +204,18 @@ kubectl port-forward -n monitoring-system svc/metrics-grafana 3000:80
 ```
 
 Pre-configured Dashboards:
+
 - Victoria Metrics K8s Stack: Grafana, Kubelet, Kubernetes system, Node Exporter, VictoriaMetrics health
-- Soperator Custom: Cluster health, Jobs overview, Workers stats and overview
+- Soperator Custom: Cluster Health & Overview, Slurm Controller, Jobs overview, Workers stats and overview
+
+Cluster Health & Overview and Slurm Controller each include **Nodes by Categories**
+and **Nodes by State** panels. They share mutually exclusive category definitions
+and stacking order: the first shows category totals, while the second shows exact
+Slurm state combinations within each category, including cloud and power-state
+flags. Powered down groups DOWN, POWERED_DOWN, POWER_UP, and POWERING_UP;
+Other/error includes ERROR, NOT_RESPONDING, INVALID, FAIL, and otherwise
+unclassified nodes.
+See [Grafana Dashboards](slurm-exporter.md#grafana-dashboards) for definitions
+and example legends.
 
 Dashboards are auto-discovered from ConfigMaps with label `grafana_dashboard: "1"` in monitored namespaces.

--- a/docs/slurm-exporter.md
+++ b/docs/slurm-exporter.md
@@ -94,10 +94,10 @@ Boolean state flag label convention:
 
 | Metric Name & Type | Description & Labels |
 |-------------------|---------------------|
-| **slurm_node_info**<br>*Gauge* | Provides detailed information about SLURM nodes<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node<br>• `instance_id` - Kubernetes instance identifier<br>• `nodeset_name` - Name of the Soperator NodeSet from the worker Pod's `slurm.nebius.ai/nodeset` label, including for pending Pods; empty when the worker Pod is unavailable<br>• `state_base` - Base node state (IDLE, ALLOCATED, DOWN, ERROR, MIXED, UNKNOWN)<br>• `state_is_drain` - Whether node is in drain state ("true"/"false")<br>• `state_is_maintenance` - Whether node is in maintenance state ("true"/"false")<br>• `state_is_reserved` - Whether node is in reserved state ("true"/"false")<br>• `state_is_completing` - Whether node is in completing state ("true" or empty)<br>• `state_is_fail` - Whether node is in fail state ("true" or empty)<br>• `state_is_planned` - Whether node is in planned state ("true" or empty)<br>• `state_is_not_responding` - Whether the node is marked as not responding ("true" or empty)<br>• `state_is_invalid` - Whether the node state is considered invalid by SLURM ("true" or empty)<br>• `state_is_cloud` - Whether the node is a cloud node powered on/off dynamically via Slurm power saving ("true" or empty)<br>• `state_is_power_down` - Whether the node is pending power down ("true" or empty)<br>• `state_is_power_drain` - Whether the node is draining as part of power down ("true" or empty)<br>• `state_is_powered_down` - Whether the node is currently powered down ("true" or empty)<br>• `state_is_powering_down` - Whether the node is transitioning to powered down ("true" or empty)<br>• `state_is_powering_up` - Whether the node is transitioning to powered up ("true" or empty)<br>• `state_is_power_up` - Whether the node is pending power up ("true" or empty)<br>• `is_unavailable` - Computed by the exporter: "true" when the node is considered unavailable (DOWN+* or IDLE+DRAIN+*), empty string otherwise. Power-managed nodes (powering up/down or powered down) are never reported as unavailable<br>• `reservation_name` - Reservation that currently includes the node (trimmed to 50 characters)<br>• `address` - IP address of the node<br>• `reason` - Reason for current node state (empty string if node has no reason set)<br>• `comment` - Comment set on the node (e.g., by active checks when GPU health check fails) |
+| **slurm_node_info**<br>*Gauge* | Provides detailed information about SLURM nodes<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node<br>• `instance_id` - Kubernetes instance identifier<br>• `nodeset_name` - Name of the Soperator NodeSet from the worker Pod's `slurm.nebius.ai/nodeset` label, including for pending Pods; empty when the worker Pod is unavailable<br>• `state_base` - Base node state (for example, IDLE, ALLOCATED, DOWN, ERROR, MIXED, UNKNOWN)<br>• `state_is_drain` - Whether node is in drain state ("true"/"false")<br>• `state_is_maintenance` - Whether node is in maintenance state ("true"/"false")<br>• `state_is_reserved` - Whether node is in reserved state ("true"/"false")<br>• `state_is_completing` - Whether node is in completing state ("true" or empty)<br>• `state_is_fail` - Whether node is in fail state ("true" or empty)<br>• `state_is_planned` - Whether node is in planned state ("true" or empty)<br>• `state_is_not_responding` - Whether the node is marked as not responding ("true" or empty)<br>• `state_is_invalid` - Whether the node state is considered invalid by SLURM ("true" or empty)<br>• `state_is_cloud` - Whether the node is a cloud node powered on/off dynamically via Slurm power saving ("true" or empty)<br>• `state_is_power_down` - Whether the node is pending power down ("true" or empty)<br>• `state_is_power_drain` - Whether the node is draining as part of power down ("true" or empty)<br>• `state_is_powered_down` - Whether the node is currently powered down ("true" or empty)<br>• `state_is_powering_down` - Whether the node is transitioning to powered down ("true" or empty)<br>• `state_is_powering_up` - Whether the node is transitioning to powered up ("true" or empty)<br>• `state_is_power_up` - Whether the node is pending power up ("true" or empty)<br>• `is_unavailable` - Computed by the exporter: "true" for DOWN, UNKNOWN, ERROR, NOT_RESPONDING, FAIL, INVALID, or IDLE+DRAIN, empty string otherwise. Power-managed nodes (powering up/down or powered down) are never reported as unavailable<br>• `reservation_name` - Reservation that currently includes the node (trimmed to 50 characters)<br>• `address` - IP address of the node<br>• `reason` - Reason for current node state (empty string if node has no reason set)<br>• `comment` - Comment set on the node (e.g., by active checks when GPU health check fails) |
 | **slurm_node_gpu_seconds_total**<br>*Counter* | Total GPU seconds accumulated on SLURM nodes<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node<br>• `state_base` - Base node state<br>• `state_is_drain` - Drain state flag<br>• `state_is_maintenance` - Maintenance state flag<br>• `state_is_reserved` - Reserved state flag |
 | **slurm_node_fails_total**<br>*Counter* | Total number of node state transitions to failed states (DOWN/DRAIN). Power-managed nodes (powering up/down or powered down) are excluded, since their DOWN/DRAIN states are part of the normal cloud lifecycle<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node<br>• `state_base` - Base node state at time of failure<br>• `state_is_drain` - Drain state flag<br>• `state_is_maintenance` - Maintenance state flag<br>• `state_is_reserved` - Reserved state flag<br>• `reason` - Reason for the node failure |
-| **slurm_node_unavailability_duration_seconds**<br>*Histogram* | Duration of completed node unavailability events (DOWN+* or IDLE+DRAIN+*). Power-managed nodes (powering up/down or powered down) are excluded, since their DOWN/DRAIN states are part of the normal cloud lifecycle<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node<br><br>**Note:** Observations are recorded when unavailability events complete. Duration tracking is reset on exporter restarts, which may affect accuracy |
+| **slurm_node_unavailability_duration_seconds**<br>*Histogram* | Duration of completed node unavailability events, using the exporter’s `is_unavailable` definition. Power-managed nodes (powering up/down or powered down) are excluded, since their DOWN/DRAIN states are part of the normal cloud lifecycle<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node<br><br>**Note:** Observations are recorded when unavailability events complete. Duration tracking is reset on exporter restarts, which may affect accuracy |
 | **slurm_node_draining_duration_seconds**<br>*Histogram* | Duration of completed node draining events (DRAIN+ALLOCATED or DRAIN+MIXED)<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node<br><br>**Note:** Observations are recorded when draining events complete. Duration tracking is reset on exporter restarts, which may affect accuracy |
 | **slurm_node_cpus_total**<br>*Gauge* | Total number of CPUs on the node<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node |
 | **slurm_node_cpus_allocated**<br>*Gauge* | Number of CPUs currently allocated on the node<br><br>**Labels:**<br>• `node_name` - Name of the SLURM node |
@@ -214,6 +214,46 @@ go run ./cmd/exporter/main.go --cluster-name=soperator --kubeconfig-path=$HOME/.
 curl localhost:8080/metrics
 ```
 
-## Grafana Dashboard Example
+## Grafana Dashboards
 
-The SLURM Exporter integrates with existing Grafana dashboards. Here's an example based on the production dashboard from [nebius-solutions-library](https://github.com/nebius/nebius-solutions-library/blob/release/soperator/soperator/modules/monitoring/templates/dashboards/cluster_health.json).
+The [Cluster Health & Overview](../helm/soperator-monitoring-dashboards/dashboards/cluster_health.json)
+and [Slurm Controller](../helm/soperator-monitoring-dashboards/dashboards/slurm_controller.json)
+dashboards include two complementary panels based on `slurm_node_info`:
+
+- **Nodes by Categories** shows totals for mutually exclusive categories.
+- **Nodes by State** breaks each category down into exact combinations of
+  `state_base` and exported `state_is_*` flags. Legends include the category and
+  only flags set to `"true"`, for example `Busy: MIXED+CLOUD` or
+  `Powered down: IDLE+CLOUD+POWERED_DOWN`.
+
+Both panels share category definitions and the same bottom-to-top stacking order:
+Busy, Draining, Idle, Drained, Other/error, Maintenance, Powered down. Each
+node contributes to one category and one state combination at a time. Overlapping
+flags do not double-count nodes. Only exported flags are represented; Slurm flags
+not exposed by the exporter cannot appear in the legend.
+
+### Node categories
+
+The error conditions in Other/error take precedence over Powered down, which
+takes precedence over Maintenance and the remaining categories. Otherwise,
+unclassified nodes also fall into Other/error. Allocated resources means a base
+state of `ALLOCATED` or `MIXED`; unfinished job cleanup means `COMPLETING` is set.
+A flag is set only when its metric label equals `"true"`; `"false"` and absent
+labels both mean it is not set.
+
+| Category | Definition |
+| --- | --- |
+| Powered down | Base state `DOWN`, or any of `POWERED_DOWN`, `POWER_UP`, or `POWERING_UP`, without an Other/error error condition. Includes startup and DOWN states; does not imply every node is physically powered off. |
+| Maintenance | Marked for maintenance, without an error or Powered down condition. |
+| Draining | Has DRAIN and allocated resources or unfinished job cleanup, without maintenance, error, or Powered down conditions. |
+| Drained | Base state IDLE with DRAIN and no unfinished job cleanup, without maintenance, error, or Powered down conditions. |
+| Busy | Has allocated resources or unfinished job cleanup, without DRAIN, maintenance, error, or Powered down conditions. |
+| Idle | Base state IDLE without unfinished job cleanup, DRAIN, maintenance, error, or Powered down conditions. Includes reserved and planned nodes; does not guarantee eligibility for every job. |
+| Other/error | Base state `ERROR`, or any of `NOT_RESPONDING`, `INVALID` (invalid registration), or `FAIL`. Also includes all otherwise unclassified nodes. |
+
+`CLOUD`, `RESERVED`, `PLANNED`, `POWER_DOWN`, `POWERING_DOWN`, and `POWER_DRAIN` do not
+determine the category. For example, `MIXED+CLOUD+DRAIN+POWER_DOWN` is Draining,
+and `IDLE+DRAIN+COMPLETING` remains Draining until job cleanup finishes.
+POWER_DOWN and POWERING_DOWN alone do not place a node in Powered down; its base
+state and other flags still determine the category. This is a dashboard grouping, not a guarantee
+that the node can accept new jobs.

--- a/helm/soperator-fluxcd/values.yaml
+++ b/helm/soperator-fluxcd/values.yaml
@@ -478,7 +478,7 @@ observability:
             cpu: 100m
       grafana:
         image:
-          tag: "11.6.14-security-04"
+          tag: "13.1.4"
         nodeSelector:
           slurm.nebius.ai/nodeset: system
         affinity:
@@ -515,6 +515,9 @@ observability:
         - monitoring-system
         - logs-system
       grafanaIni:
+        feature_toggles:
+          # Keep dashboard exports compatible with the o11y Classic JSON workflow.
+          dashboardNewLayouts: false
         auth:
           disable_login_form: true
         auth.basic:

--- a/helm/soperator-monitoring-dashboards/dashboards/cluster_health.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/cluster_health.json
@@ -2357,7 +2357,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Node states breakdown:\n- **Down**: Nodes not operational (DOWN or ERROR states)\n- **Drained**: IDLE nodes with DRAIN flag\n- **Draining**: Nodes with DRAIN flag running jobs\n- **Busy**: Nodes running jobs normally (ALLOCATED or MIXED)\n- **Idle**: Nodes ready and available to accept new jobs\n- **Maintenance**: Nodes temporarily unavailable for administrative tasks",
+          "description": "Node categories are mutually exclusive:\n- Other/error: ERROR, NOT_RESPONDING, INVALID (invalid registration), or FAIL; these conditions take precedence over all other categories. Also includes otherwise unclassified nodes.\n- Powered down: DOWN, POWERED_DOWN, POWER_UP, or POWERING_UP, unless an Other/error error condition is present. This grouping does not imply every node is physically powered off.\n- Maintenance: Nodes marked for maintenance, excluding the error and powered-down conditions above.\n- Draining: Nodes with DRAIN and allocated resources (ALLOCATED or MIXED) or unfinished job cleanup (COMPLETING), excluding the conditions above.\n- Drained: IDLE nodes with DRAIN, no COMPLETING, and none of the conditions above.\n- Busy: Nodes with allocated resources or unfinished job cleanup, without DRAIN and none of the conditions above.\n- Idle: IDLE nodes without COMPLETING or DRAIN and none of the conditions above. Includes reserved and planned nodes; does not guarantee eligibility for every job.\nCLOUD, RESERVED, PLANNED, POWER_DOWN, POWERING_DOWN, and POWER_DRAIN do not determine the category.\n\nNodes by Categories and Nodes by State use the same category definitions and the same bottom-to-top stacking order: Busy → Draining → Idle → Drained → Other/error → Maintenance → Powered down. Nodes by Categories shows totals per category; Nodes by State breaks each category down into exact state combinations.\n\nNodes by Categories uses query order (A–G) for its series and bottom-to-top stacking order. It does not use numbering prefixes or ordering transformations.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2372,21 +2372,22 @@
                 "barAlignment": 0,
                 "barWidthFactor": 0.6,
                 "drawStyle": "line",
-                "fillOpacity": 50,
-                "gradientMode": "opacity",
+                "fillOpacity": 70,
+                "gradientMode": "none",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
                   "viz": false
                 },
                 "insertNulls": false,
-                "lineInterpolation": "linear",
+                "lineInterpolation": "stepAfter",
                 "lineWidth": 1,
                 "pointSize": 5,
                 "scaleDistribution": {
                   "type": "linear"
                 },
                 "showPoints": "never",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -2402,7 +2403,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2410,19 +2412,20 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "decimals": 0
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Down"
+                  "options": "Powered down"
                 },
                 "properties": [
                   {
                     "id": "color",
                     "value": {
-                      "fixedColor": "rgba(242, 73, 92, 1)",
+                      "fixedColor": "#8F3BB8",
                       "mode": "fixed"
                     }
                   }
@@ -2506,13 +2509,13 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Unknown"
+                  "options": "Other/error"
                 },
                 "properties": [
                   {
                     "id": "color",
                     "value": {
-                      "fixedColor": "rgba(163, 74, 163, 1)",
+                      "fixedColor": "#F2495C",
                       "mode": "fixed"
                     }
                   }
@@ -2528,6 +2531,10 @@
           },
           "id": 82,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
                 "mean",
@@ -2536,6 +2543,8 @@
                 "min"
               ],
               "displayMode": "table",
+              "enableFacetedFilter": false,
+              "overflow": "ellipsis",
               "placement": "bottom",
               "showLegend": true
             },
@@ -2553,10 +2562,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=~\"DOWN|ERROR\", state_is_maintenance!=\"true\", node_name=~\"$node_name\"})",
+              "expr": "count(slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base=~\"ALLOCATED|MIXED\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain!=\"true\"} or slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base!~\"DOWN|ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain!=\"true\", state_is_completing=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Down",
+              "legendFormat": "Busy",
               "range": true,
               "refId": "A",
               "useDashValues": false
@@ -2567,10 +2576,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=\"IDLE\", state_is_maintenance!=\"true\", state_is_drain=\"true\", node_name=~\"$node_name\"})",
+              "expr": "count(slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base=~\"ALLOCATED|MIXED\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain=\"true\"} or slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base!~\"DOWN|ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain=\"true\", state_is_completing=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Drained",
+              "legendFormat": "Draining",
               "range": true,
               "refId": "B",
               "useDashValues": false
@@ -2581,10 +2590,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=~\"ALLOCATED|MIXED\", state_is_maintenance!=\"true\", state_is_drain=\"true\", node_name=~\"$node_name\"})",
+              "expr": "count(slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base=\"IDLE\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain!=\"true\", state_is_completing!=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Draining",
+              "legendFormat": "Idle",
               "range": true,
               "refId": "C",
               "useDashValues": false
@@ -2595,10 +2604,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=~\"ALLOCATED|MIXED\", state_is_maintenance!=\"true\", state_is_drain!=\"true\", node_name=~\"$node_name\"})",
+              "expr": "count(slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base=\"IDLE\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain=\"true\", state_is_completing!=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Busy",
+              "legendFormat": "Drained",
               "range": true,
               "refId": "D",
               "useDashValues": false
@@ -2609,10 +2618,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=\"IDLE\", state_is_maintenance!=\"true\", state_is_drain!=\"true\", node_name=~\"$node_name\"})",
+              "expr": "count(slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base=\"ERROR\"} or slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_is_not_responding=\"true\"} or slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_is_invalid=\"true\"} or slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_is_fail=\"true\"} or slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base!~\"IDLE|ALLOCATED|MIXED|DOWN|ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_completing!=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Idle",
+              "legendFormat": "Other/error",
               "range": true,
               "refId": "E",
               "useDashValues": false
@@ -2623,7 +2632,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_is_maintenance=\"true\", node_name=~\"$node_name\"})",
+              "expr": "count(slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base!~\"DOWN|ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Maintenance",
@@ -2637,16 +2646,582 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=\"UNKNOWN\", state_is_maintenance!=\"true\", node_name=~\"$node_name\"})",
+              "expr": "count(slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base=\"DOWN\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\"} or slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base!=\"ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down=\"true\"} or slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base!=\"ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_power_up=\"true\"} or slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\", state_base!=\"ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powering_up=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Unknown",
+              "legendFormat": "Powered down",
               "range": true,
               "refId": "G",
               "useDashValues": false
             }
           ],
+          "title": "Nodes by Categories",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Node counts by exact Slurm scheduling state and exported flags, grouped by the same categories as Nodes by Categories. Legends include the category followed by the native state combination.\nERROR, NOT_RESPONDING, INVALID (invalid registration), and FAIL take precedence and map to Other/error. Otherwise DOWN, POWERED_DOWN, POWER_UP, and POWERING_UP map to Powered down. POWER_DOWN and POWERING_DOWN do not determine the category.\n\nNodes by Categories and Nodes by State use the same category definitions and the same bottom-to-top stacking order: Busy → Draining → Idle → Drained → Other/error → Maintenance → Powered down. Nodes by Categories shows totals per category; Nodes by State breaks each category down into exact state combinations.\n\nColors share the category palette. Busy MIXED nodes use lighter blue than ALLOCATED; the exact MIXED+CLOUD combination uses an intermediate blue. Power-up flags use lighter shades; power-down flags use darker shades; base DOWN uses the darkest shade. COMPLETING in Busy/Draining and RESERVED/PLANNED in Idle use slightly darker shades. Power shading takes precedence over these details, and base DOWN takes precedence over all other shading. Unmatched series are bright pink.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#FF69B4",
+                "mode": "fixed"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 70,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "stepAfter",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Busy: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#1F78C1",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Draining: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FFC107",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Idle: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#33A249",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Drained: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FF9830",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Other\\/error: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2495C",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Maintenance: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#808080",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Powered down: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#8F3BB8",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Busy: MIXED(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#62A1D4",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Busy: MIXED\\+CLOUD$/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#418DCA",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Idle: .*\\+(?:RESERVED|PLANNED)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#2B8A3E",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Busy: .*\\+COMPLETING(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#19609A",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Draining: .*\\+COMPLETING(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#CC9A06",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Powered down: .*\\+(?:POWER_UP|POWERING_UP)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#B176CD",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Other\\/error: .*\\+(?:POWER_UP|POWERING_UP)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F6808D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Busy: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#175A91",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Draining: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#BF9105",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Idle: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#267A37",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Drained: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#BF7224",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Other\\/error: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#B63745",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Maintenance: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#606060",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Powered down: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#6B2C8A",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Powered down: DOWN(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#4F2065",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Other\\/error: DOWN(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#852833",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 151
+          },
+          "id": 103,
+          "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "enableFacetedFilter": false,
+              "overflow": "ellipsis",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "11.5.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "count by (state_base, state_is_cloud, state_is_drain, state_is_maintenance, state_is_reserved, state_is_completing, state_is_fail, state_is_planned, state_is_not_responding, state_is_invalid, state_is_power_down, state_is_power_drain, state_is_powered_down, state_is_powering_down, state_is_powering_up, state_is_power_up) (slurm_node_info{node_name=~\"$node_name\", cluster=~\"$cluster\"})",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{state_base}}+CLOUD={{state_is_cloud}}+DRAIN={{state_is_drain}}+MAINTENANCE={{state_is_maintenance}}+RESERVED={{state_is_reserved}}+COMPLETING={{state_is_completing}}+FAIL={{state_is_fail}}+PLANNED={{state_is_planned}}+NOT_RESPONDING={{state_is_not_responding}}+INVALID={{state_is_invalid}}+POWER_DOWN={{state_is_power_down}}+POWER_DRAIN={{state_is_power_drain}}+POWERED_DOWN={{state_is_powered_down}}+POWERING_DOWN={{state_is_powering_down}}+POWERING_UP={{state_is_powering_up}}+POWER_UP={{state_is_power_up}}",
+              "range": true,
+              "refId": "A",
+              "useDashValues": false
+            }
+          ],
           "title": "Nodes by State",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/\\+[A-Z_]+=(?!true(?:\\+|$))[^+]*/g",
+                "renamePattern": ""
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/=true/g",
+                "renamePattern": ""
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "Time",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^(?!Time$|time$)(.+)$/",
+                "renamePattern": "5_Other/error: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=(?:ALLOCATED|MIXED)(?:\\+|$)|.*\\+COMPLETING(?:\\+|$)).+)$/",
+                "renamePattern": "1_Busy: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=IDLE(?:\\+|$))(?!.*\\+COMPLETING(?:\\+|$)).+)$/",
+                "renamePattern": "3_Idle: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=IDLE(?:\\+|$))(?=.*\\+DRAIN(?:\\+|$))(?!.*\\+COMPLETING(?:\\+|$)).+)$/",
+                "renamePattern": "4_Drained: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=.*\\+DRAIN(?:\\+|$))(?=(?:ALLOCATED|MIXED)(?:\\+|$)|.*\\+COMPLETING(?:\\+|$)).+)$/",
+                "renamePattern": "2_Draining: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=.*\\+MAINTENANCE(?:\\+|$)).+)$/",
+                "renamePattern": "6_Maintenance: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=DOWN(?:\\+|$)|.*\\+(?:POWERED_DOWN|POWER_UP|POWERING_UP)(?:\\+|$)).+)$/",
+                "renamePattern": "7_Powered down: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=ERROR(?:\\+|$)|.*\\+(?:NOT_RESPONDING|INVALID|FAIL)(?:\\+|$)).+)$/",
+                "renamePattern": "5_Other/error: $1"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {},
+                "orderBy": [
+                  {
+                    "desc": false,
+                    "type": "name"
+                  }
+                ],
+                "orderByMode": "auto",
+                "renameByName": {}
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_/",
+                "renamePattern": ""
+              }
+            }
+          ],
           "type": "timeseries"
         },
         {
@@ -3056,7 +3631,7 @@
             ]
           },
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 12,
             "x": 12,
             "y": 236
@@ -3306,7 +3881,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 243
+            "y": 244
           },
           "id": 84,
           "options": {

--- a/helm/soperator-monitoring-dashboards/dashboards/slurm_controller.json
+++ b/helm/soperator-monitoring-dashboards/dashboards/slurm_controller.json
@@ -1953,7 +1953,7 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
+            "x": 12,
             "y": 19
           },
           "id": 212,
@@ -2195,7 +2195,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Node states breakdown:\n- **Down**: Nodes not operational (DOWN or ERROR states)\n- **Drained**: IDLE nodes with DRAIN flag\n- **Draining**: Nodes with DRAIN flag running jobs\n- **Busy**: Nodes running jobs normally (ALLOCATED or MIXED)\n- **Idle**: Nodes ready and available to accept new jobs\n- **Maintenance**: Nodes temporarily unavailable for administrative tasks",
+          "description": "Node categories are mutually exclusive:\n- Other/error: ERROR, NOT_RESPONDING, INVALID (invalid registration), or FAIL; these conditions take precedence over all other categories. Also includes otherwise unclassified nodes.\n- Powered down: DOWN, POWERED_DOWN, POWER_UP, or POWERING_UP, unless an Other/error error condition is present. This grouping does not imply every node is physically powered off.\n- Maintenance: Nodes marked for maintenance, excluding the error and powered-down conditions above.\n- Draining: Nodes with DRAIN and allocated resources (ALLOCATED or MIXED) or unfinished job cleanup (COMPLETING), excluding the conditions above.\n- Drained: IDLE nodes with DRAIN, no COMPLETING, and none of the conditions above.\n- Busy: Nodes with allocated resources or unfinished job cleanup, without DRAIN and none of the conditions above.\n- Idle: IDLE nodes without COMPLETING or DRAIN and none of the conditions above. Includes reserved and planned nodes; does not guarantee eligibility for every job.\nCLOUD, RESERVED, PLANNED, POWER_DOWN, POWERING_DOWN, and POWER_DRAIN do not determine the category.\n\nNodes by Categories and Nodes by State use the same category definitions and the same bottom-to-top stacking order: Busy → Draining → Idle → Drained → Other/error → Maintenance → Powered down. Nodes by Categories shows totals per category; Nodes by State breaks each category down into exact state combinations.\n\nNodes by Categories uses query order (A–G) for its series and bottom-to-top stacking order. It does not use numbering prefixes or ordering transformations.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2210,21 +2210,22 @@
                 "barAlignment": 0,
                 "barWidthFactor": 0.6,
                 "drawStyle": "line",
-                "fillOpacity": 50,
-                "gradientMode": "opacity",
+                "fillOpacity": 70,
+                "gradientMode": "none",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
                   "viz": false
                 },
                 "insertNulls": false,
-                "lineInterpolation": "linear",
+                "lineInterpolation": "stepAfter",
                 "lineWidth": 1,
                 "pointSize": 5,
                 "scaleDistribution": {
                   "type": "linear"
                 },
                 "showPoints": "never",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -2240,7 +2241,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2248,19 +2250,20 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "short",
+              "decimals": 0
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Down"
+                  "options": "Powered down"
                 },
                 "properties": [
                   {
                     "id": "color",
                     "value": {
-                      "fixedColor": "rgba(242, 73, 92, 1)",
+                      "fixedColor": "#8F3BB8",
                       "mode": "fixed"
                     }
                   }
@@ -2344,13 +2347,13 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Unknown"
+                  "options": "Other/error"
                 },
                 "properties": [
                   {
                     "id": "color",
                     "value": {
-                      "fixedColor": "rgba(163, 74, 163, 1)",
+                      "fixedColor": "#F2495C",
                       "mode": "fixed"
                     }
                   }
@@ -2361,11 +2364,15 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
+            "x": 0,
             "y": 19
           },
           "id": 214,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
                 "mean",
@@ -2374,6 +2381,8 @@
                 "min"
               ],
               "displayMode": "table",
+              "enableFacetedFilter": false,
+              "overflow": "ellipsis",
               "placement": "bottom",
               "showLegend": true
             },
@@ -2391,10 +2400,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=~\"DOWN|ERROR\", state_is_maintenance!=\"true\"})",
+              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=~\"ALLOCATED|MIXED\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain!=\"true\"} or slurm_node_info{cluster=~\"$cluster\", state_base!~\"DOWN|ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain!=\"true\", state_is_completing=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Down",
+              "legendFormat": "Busy",
               "range": true,
               "refId": "A",
               "useDashValues": false
@@ -2405,10 +2414,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=\"IDLE\", state_is_maintenance!=\"true\", state_is_drain=\"true\"})",
+              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=~\"ALLOCATED|MIXED\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain=\"true\"} or slurm_node_info{cluster=~\"$cluster\", state_base!~\"DOWN|ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain=\"true\", state_is_completing=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Drained",
+              "legendFormat": "Draining",
               "range": true,
               "refId": "B",
               "useDashValues": false
@@ -2419,10 +2428,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=~\"ALLOCATED|MIXED\", state_is_maintenance!=\"true\", state_is_drain=\"true\"})",
+              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=\"IDLE\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain!=\"true\", state_is_completing!=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Draining",
+              "legendFormat": "Idle",
               "range": true,
               "refId": "C",
               "useDashValues": false
@@ -2433,10 +2442,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=~\"ALLOCATED|MIXED\", state_is_maintenance!=\"true\", state_is_drain!=\"true\"})",
+              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=\"IDLE\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_drain=\"true\", state_is_completing!=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Busy",
+              "legendFormat": "Drained",
               "range": true,
               "refId": "D",
               "useDashValues": false
@@ -2447,10 +2456,10 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=\"IDLE\", state_is_maintenance!=\"true\", state_is_drain!=\"true\"})",
+              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=\"ERROR\"} or slurm_node_info{cluster=~\"$cluster\", state_is_not_responding=\"true\"} or slurm_node_info{cluster=~\"$cluster\", state_is_invalid=\"true\"} or slurm_node_info{cluster=~\"$cluster\", state_is_fail=\"true\"} or slurm_node_info{cluster=~\"$cluster\", state_base!~\"IDLE|ALLOCATED|MIXED|DOWN|ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance!=\"true\", state_is_completing!=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Idle",
+              "legendFormat": "Other/error",
               "range": true,
               "refId": "E",
               "useDashValues": false
@@ -2461,7 +2470,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_is_maintenance=\"true\"})",
+              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base!~\"DOWN|ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down!=\"true\", state_is_power_up!=\"true\", state_is_powering_up!=\"true\", state_is_maintenance=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Maintenance",
@@ -2475,16 +2484,582 @@
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=\"UNKNOWN\", state_is_maintenance!=\"true\"})",
+              "expr": "count(slurm_node_info{cluster=~\"$cluster\", state_base=\"DOWN\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\"} or slurm_node_info{cluster=~\"$cluster\", state_base!=\"ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powered_down=\"true\"} or slurm_node_info{cluster=~\"$cluster\", state_base!=\"ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_power_up=\"true\"} or slurm_node_info{cluster=~\"$cluster\", state_base!=\"ERROR\", state_is_not_responding!=\"true\", state_is_invalid!=\"true\", state_is_fail!=\"true\", state_is_powering_up=\"true\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Unknown",
+              "legendFormat": "Powered down",
               "range": true,
               "refId": "G",
               "useDashValues": false
             }
           ],
+          "title": "Nodes by Categories",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Node counts by exact Slurm scheduling state and exported flags, grouped by the same categories as Nodes by Categories. Legends include the category followed by the native state combination.\nERROR, NOT_RESPONDING, INVALID (invalid registration), and FAIL take precedence and map to Other/error. Otherwise DOWN, POWERED_DOWN, POWER_UP, and POWERING_UP map to Powered down. POWER_DOWN and POWERING_DOWN do not determine the category.\n\nNodes by Categories and Nodes by State use the same category definitions and the same bottom-to-top stacking order: Busy → Draining → Idle → Drained → Other/error → Maintenance → Powered down. Nodes by Categories shows totals per category; Nodes by State breaks each category down into exact state combinations.\n\nColors share the category palette. Busy MIXED nodes use lighter blue than ALLOCATED; the exact MIXED+CLOUD combination uses an intermediate blue. Power-up flags use lighter shades; power-down flags use darker shades; base DOWN uses the darkest shade. COMPLETING in Busy/Draining and RESERVED/PLANNED in Idle use slightly darker shades. Power shading takes precedence over these details, and base DOWN takes precedence over all other shading. Unmatched series are bright pink.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#FF69B4",
+                "mode": "fixed"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 70,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "stepAfter",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Busy: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#1F78C1",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Draining: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FFC107",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Idle: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#33A249",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Drained: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FF9830",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Other\\/error: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2495C",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Maintenance: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#808080",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Powered down: /"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#8F3BB8",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Busy: MIXED(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#62A1D4",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Busy: MIXED\\+CLOUD$/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#418DCA",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Idle: .*\\+(?:RESERVED|PLANNED)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#2B8A3E",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Busy: .*\\+COMPLETING(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#19609A",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Draining: .*\\+COMPLETING(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#CC9A06",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Powered down: .*\\+(?:POWER_UP|POWERING_UP)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#B176CD",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Other\\/error: .*\\+(?:POWER_UP|POWERING_UP)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F6808D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Busy: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#175A91",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Draining: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#BF9105",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Idle: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#267A37",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Drained: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#BF7224",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Other\\/error: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#B63745",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Maintenance: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#606060",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Powered down: .*\\+(?:POWER_DOWN|POWERING_DOWN|POWER_DRAIN)(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#6B2C8A",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Powered down: DOWN(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#4F2065",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Other\\/error: DOWN(?:\\+|$)/"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#852833",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 236,
+          "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "enableFacetedFilter": false,
+              "overflow": "ellipsis",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "11.6.14",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "count by (state_base, state_is_cloud, state_is_drain, state_is_maintenance, state_is_reserved, state_is_completing, state_is_fail, state_is_planned, state_is_not_responding, state_is_invalid, state_is_power_down, state_is_power_drain, state_is_powered_down, state_is_powering_down, state_is_powering_up, state_is_power_up) (slurm_node_info{cluster=~\"$cluster\"})",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{state_base}}+CLOUD={{state_is_cloud}}+DRAIN={{state_is_drain}}+MAINTENANCE={{state_is_maintenance}}+RESERVED={{state_is_reserved}}+COMPLETING={{state_is_completing}}+FAIL={{state_is_fail}}+PLANNED={{state_is_planned}}+NOT_RESPONDING={{state_is_not_responding}}+INVALID={{state_is_invalid}}+POWER_DOWN={{state_is_power_down}}+POWER_DRAIN={{state_is_power_drain}}+POWERED_DOWN={{state_is_powered_down}}+POWERING_DOWN={{state_is_powering_down}}+POWERING_UP={{state_is_powering_up}}+POWER_UP={{state_is_power_up}}",
+              "range": true,
+              "refId": "A",
+              "useDashValues": false
+            }
+          ],
           "title": "Nodes by State",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/\\+[A-Z_]+=(?!true(?:\\+|$))[^+]*/g",
+                "renamePattern": ""
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/=true/g",
+                "renamePattern": ""
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "Time",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^(?!Time$|time$)(.+)$/",
+                "renamePattern": "5_Other/error: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=(?:ALLOCATED|MIXED)(?:\\+|$)|.*\\+COMPLETING(?:\\+|$)).+)$/",
+                "renamePattern": "1_Busy: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=IDLE(?:\\+|$))(?!.*\\+COMPLETING(?:\\+|$)).+)$/",
+                "renamePattern": "3_Idle: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=IDLE(?:\\+|$))(?=.*\\+DRAIN(?:\\+|$))(?!.*\\+COMPLETING(?:\\+|$)).+)$/",
+                "renamePattern": "4_Drained: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=.*\\+DRAIN(?:\\+|$))(?=(?:ALLOCATED|MIXED)(?:\\+|$)|.*\\+COMPLETING(?:\\+|$)).+)$/",
+                "renamePattern": "2_Draining: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=.*\\+MAINTENANCE(?:\\+|$)).+)$/",
+                "renamePattern": "6_Maintenance: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=DOWN(?:\\+|$)|.*\\+(?:POWERED_DOWN|POWER_UP|POWERING_UP)(?:\\+|$)).+)$/",
+                "renamePattern": "7_Powered down: $1"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_[^:]+: ((?=ERROR(?:\\+|$)|.*\\+(?:NOT_RESPONDING|INVALID|FAIL)(?:\\+|$)).+)$/",
+                "renamePattern": "5_Other/error: $1"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {},
+                "orderBy": [
+                  {
+                    "desc": false,
+                    "type": "name"
+                  }
+                ],
+                "orderByMode": "auto",
+                "renameByName": {}
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "/^[1-9]_/",
+                "renamePattern": ""
+              }
+            }
+          ],
           "type": "timeseries"
         },
         {
@@ -4042,11 +4617,11 @@
                   },
                   {
                     "color": "yellow",
-                    "value": 1.0
+                    "value": 1
                   },
                   {
                     "color": "red",
-                    "value": 5.0
+                    "value": 5
                   }
                 ]
               },


### PR DESCRIPTION
## Problem

Soperator 4.0 added cloud and power-state labels to exported node metrics, but the dashboards do not use them. As described in [SCHED-2009](https://nebius.atlassian.net/browse/SCHED-2009), this hides ephemeral-node lifecycle states, making provisioning and power-management issues harder to investigate.

The existing category-only view also hides the native Slurm state combinations behind each total, requiring users to interpret custom groups without seeing the familiar underlying states.

## Solution

Update both **Cluster Health & Overview** and **Slurm Controller** with two complementary charts:

- **Nodes by Categories** uses a count query for each mutually exclusive category: Busy, Draining, Idle, Drained, Other/error, Maintenance, and Powered down. Alternative conditions are combined before counting so overlapping flags do not double-count nodes.
- **Nodes by State** uses one query grouped by the exported state labels, then assigns category prefixes through legend transformations, producing names such as `Busy: MIXED+CLOUD`. It uses the same category definitions, base colors, and stacking order as the category chart, while exposing familiar Slurm combinations.

Error conditions take precedence over Powered down, followed by Maintenance and the remaining categories. Powered down includes base `DOWN` and startup flags, so it does not necessarily mean the node is physically powered off.

Category colors are the baseline; more specific overrides vary the shade within that category. Match **both the category prefix and the relevant state/flag** in each override—for example, `/^Busy: .*\+COMPLETING(?:\+|$)/` for Busy nodes finishing job cleanup. Place specific overrides after the category defaults, with the highest-priority rules last. A broad `IDLE` or `MIXED` matcher could incorrectly recolor a node belonging to another category. Unmatched series use bright pink as a fallback.

Upgrade Grafana from **11.6.14-security-04 to 13.1.4** and disable dynamic dashboards by default with `grafanaIni.feature_toggles.dashboardNewLayouts: false`, preserving the Classic JSON workflow used for o11y dashboard compatibility.

Related Nebo PR: [Dashboard conversion and duplicate-variable fix](https://gitlab.nebius.dev/nebius/nebo/-/merge_requests/152014/diffs#e2feb0cf79297792a980667cca0beda8a719fca2).

## Testing

- All 152 Soperator FluxCD Helm tests, both chart lints, and whitespace checks passed.
- Five local dashboard checks passed, including exhaustive category/legend checks across 177,147 base-state and flag combinations; the local check script is not included in this PR.
- Verified all 16 exported state labels are included in the query and legend.
- Deployed both dashboards to development Grafana 13.1.4, confirmed rendering and matching node totals, and verified dynamic dashboards are disabled.
- Submitted a two-minute CPU-only Slurm job and verified the transition:
  `2 IDLE+CLOUD` → `1 IDLE+CLOUD + 1 MIXED+CLOUD` → `2 IDLE+CLOUD`.
- The updated graph can be reviewed against existing data in this [temporary dashboard copy](https://grafana.nebius.dev/goto/ffxq23r1y8b28e?orgId=default).

## Release Notes

Improvement: Node dashboards now pair consistent category totals with detailed Slurm state combinations, including cloud and power flags; see the [dashboard and category documentation](https://github.com/nebius/soperator/blob/SCHED-2009-node-state-combinations/docs/slurm-exporter.md#grafana-dashboards). Grafana is upgraded to 13.1.4 with dynamic dashboards disabled by default to retain Classic JSON compatibility; chart categories and legend names change.

[SCHED-2009]: https://nebius.atlassian.net/browse/SCHED-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ