### PR TITLE
SCHED-2476: add fallback in caching importer for no step id case

### DIFF
--- a/helm/slurm-cluster/slurm_scripts/pyxis_caching_importer.sh
+++ b/helm/slurm-cluster/slurm_scripts/pyxis_caching_importer.sh
@@ -7,7 +7,7 @@ readonly cmd="$1"
 
 readonly cache_dir="${ENROOT_CONTAINER_IMAGES_CACHE_DIR:-/var/cache/enroot-container-images}"
 readonly node_id="${SLURMD_NODENAME:-${HOSTNAME:-unknown}}"
-readonly squashfs_temp_path="${cache_dir}/${SLURM_JOB_ID}.${SLURM_STEP_ID}.${node_id}.sqsh"
+readonly squashfs_temp_path="${cache_dir}/${SLURM_JOB_ID}.${SLURM_STEP_ID:-nostepid}.${node_id}.sqsh"
 
 # Since it's not an ephemeral squashfs file, we can use compression.
 export ENROOT_SQUASH_OPTIONS="-comp zstd -Xcompression-level 3 -b 1M"


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->
```
#!/bin/bash
#SBATCH --job-name=pyxis-repro
#SBATCH --nodes=1
#SBATCH --ntasks=1
#SBATCH --time=00:10:00
#SBATCH --container-image=ubuntu:24.04
#SBATCH --output=pyxis-repro-%j.out

hostname
```
and
```
sbatch repro.sbatch
```
It'll fail
```
[2026-09-09T09:35:23.675] error: pyxis: importer release failed with exit code 1
[2026-09-09T09:35:23.676] error: pyxis: printing importer log file:
[2026-09-09T09:35:23.677] error: pyxis:     /opt/slurm_scripts/pyxis_caching_importer.sh: line 10: SLURM_STEP_ID: unbound variable
```

Failing part: release() call in pyxis

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->
Add fallback to default `nostepid` in `SLURM_STEP_ID` variable.
There might be one downside: if this sbatch fails, `release` won't be able to properly clean failed cache file.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->
Dev cluster

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
Fix: add fallback in `pyxis_caching_importer.sh` for sbatch case without `SLURM_STEP_ID`
