### PR TITLE
SCHED-2470:  worker POWER_UP causes missing Slurm instance IDs

### DIFF
--- a/cmd/powermanager/main.go
+++ b/cmd/powermanager/main.go
@@ -255,6 +255,10 @@ func waitForNodes(ctx context.Context, namespace, nodes string, timeout time.Dur
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
+	// Whether a NodeSet is ephemeral does not change while a power action runs, so it is resolved
+	// once per NodeSet rather than on every tick.
+	ephemeral := make(map[string]bool, len(nodesByNodeSet))
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -262,6 +266,22 @@ func waitForNodes(ctx context.Context, namespace, nodes string, timeout time.Dur
 		case <-ticker.C:
 			allDone := true
 			for nodeSetName, ordinals := range nodesByNodeSet {
+				isEphemeral, known := ephemeral[nodeSetName]
+				if !known {
+					var err error
+					isEphemeral, err = nodeSetIsEphemeral(ctx, client, namespace, nodeSetName)
+					if err != nil {
+						log.V(1).Info("Error reading NodeSet, will retry", "nodeSet", nodeSetName, "error", err)
+						allDone = false
+						continue
+					}
+					ephemeral[nodeSetName] = isEphemeral
+				}
+				// Power actions skip non-ephemeral NodeSets, so there is no update to wait for.
+				if !isEphemeral {
+					continue
+				}
+
 				done, err := checkNodesStatus(ctx, client, namespace, nodeSetName, ordinals, waitForAdded)
 				if err != nil {
 					log.V(1).Info("Error checking activeNodes, will retry", "nodeSet", nodeSetName, "error", err)
@@ -279,6 +299,23 @@ func waitForNodes(ctx context.Context, namespace, nodes string, timeout time.Dur
 			}
 		}
 	}
+}
+
+// nodeSetIsEphemeral reports whether power actions apply to the NodeSet. A NodeSet that is gone
+// counts as non-ephemeral: nothing will update its NodeSetPowerState either.
+func nodeSetIsEphemeral(ctx context.Context, client ctrlclient.Client, namespace, nodeSetName string) (bool, error) {
+	nodeSet := &slurmv1alpha1.NodeSet{}
+	if err := client.Get(ctx, ctrlclient.ObjectKey{
+		Namespace: namespace,
+		Name:      nodeSetName,
+	}, nodeSet); err != nil {
+		if ctrlclient.IgnoreNotFound(err) == nil {
+			return false, nil
+		}
+		return false, fmt.Errorf("get NodeSet: %w", err)
+	}
+
+	return nodeSet.Spec.EphemeralNodes != nil && *nodeSet.Spec.EphemeralNodes, nil
 }
 
 // checkNodesStatus checks if all specified ordinals are in or not in the NodeSetPowerState's activeNodes.

--- a/cmd/powermanager/main_test.go
+++ b/cmd/powermanager/main_test.go
@@ -17,10 +17,83 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	slurmv1alpha1 "nebius.ai/slurm-operator/api/v1alpha1"
 )
+
+func TestNodeSetIsEphemeral(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		ephemeral      *bool
+		missingNodeSet bool
+		want           bool
+	}{
+		{name: "ephemeral", ephemeral: ptr.To(true), want: true},
+		{name: "non-ephemeral", ephemeral: ptr.To(false)},
+		{name: "unset defaults to non-ephemeral"},
+		{name: "missing nodeset", missingNodeSet: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if !tc.missingNodeSet {
+				nodeSet := &slurmv1alpha1.NodeSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "worker", Namespace: "test"},
+				}
+				nodeSet.Spec.EphemeralNodes = tc.ephemeral
+				builder.WithObjects(nodeSet)
+			}
+
+			got, err := nodeSetIsEphemeral(context.Background(), builder.Build(), "test", "worker")
+			if err != nil {
+				t.Fatalf("nodeSetIsEphemeral returned error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("nodeSetIsEphemeral = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckNodesStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		missingPowerState bool
+		checkAdded        bool
+		ordinal           int32
+		wantDone          bool
+		wantErr           bool
+	}{
+		{name: "missing state", missingPowerState: true, checkAdded: true, wantErr: true},
+		{name: "added", checkAdded: true, wantDone: true},
+		{name: "pending addition", checkAdded: true, ordinal: 1},
+		{name: "removed", ordinal: 1, wantDone: true},
+		{name: "pending removal"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if !tc.missingPowerState {
+				powerState := &slurmv1alpha1.NodeSetPowerState{
+					ObjectMeta: metav1.ObjectMeta{Name: "worker", Namespace: "test"},
+				}
+				powerState.Spec.ActiveNodes = []int32{0}
+				builder.WithObjects(powerState)
+			}
+
+			done, err := checkNodesStatus(context.Background(), builder.Build(), "test", "worker", []int32{tc.ordinal}, tc.checkAdded)
+			if done != tc.wantDone || (err != nil) != tc.wantErr {
+				t.Fatalf("checkNodesStatus = (%v, %v), want (%v, error=%v)", done, err, tc.wantDone, tc.wantErr)
+			}
+		})
+	}
+}
 
 func TestParseNodeList(t *testing.T) {
 	tests := []struct {

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -145,7 +145,7 @@ PartitionName=main Nodes=ALL Default=YES State=UP
 
 | Field | Required | Meaning |
 | --- | --- | --- |
-| `name` | yes | Identifies the topology. Partitions reference it, and workers register into it with `scontrol update ... Topology=<name>:<unit>`. |
+| `name` | yes | Identifies the topology. Partitions reference it, and workers join it at slurmd registration with `--conf "topology=<name>:<unit>"`. |
 | `topo.type` | yes | `tree`, `block` or `flat`. |
 | `topo.blockSizes` | no | Planning base block size followed by any higher-level sizes to enforce. Each successive value must be a power of two larger than the previous one. Only for `type: block`. |
 | `clusterDefault` | no | Marks the topology used by partitions without a `topologyRef` and by cluster-wide operations not tied to a partition. |
@@ -308,14 +308,20 @@ ConfigMap, and the plugin type decides which labels a topology reads:
 - `tree` walks the contiguous `tier-1`..`tier-N` chain, highest tier closest to the root. `tier-0`
   names a block rather than a switch and is left out of the tree.
 
-Workers register themselves into their topology with `scontrol update ... Topology=<name>:<unit>`,
-and the unit they pick is the one the rendered config places them in: the `tier-1` switch for a
-tree, the `tier-0` block for a block topology. A node covered by several topologies registers into
-all of them at once:
+Workers join their topology as part of slurmd registration, and the unit they pick is the one the
+rendered config places them in: the `tier-1` switch for a tree, the `tier-0` block for a block
+topology. A node covered by several topologies joins all of them at once:
 
 ```
-scontrol update NodeName=h100-0 Topology=ib-gpu:nvl0,eth-cpu:root:leaf01
+slurmd --conf "topology=ib-gpu:nvl0,eth-cpu:root:leaf01"
 ```
+
+The init container resolves the value: it waits for the operator to publish a topology placing this
+worker, then leaves the specification on the volume it shares with the slurmd container, which
+passes it to `slurmd --conf`. Registration carries it, rather than a `scontrol update` issued
+beforehand, because such an update moves the node into a state where slurmctld discards the
+`InstanceId` and `Extra` that registration brings with it. Resolving it in the init container also
+keeps the wait off slurmd's own startup.
 
 Nodes with no usable labels, and nodes whose pods are not scheduled yet, land in a catch-all
 `unknown` unit per fabric, so the topology stays complete across the pod lifecycle. That is why a
@@ -401,9 +407,9 @@ only on those clusters and skips it on 5.0.0 and later.
 Two different mechanisms keep the running cluster in step with the file, and it is worth knowing
 which one is doing the work.
 
-A node moving between switches is pushed straight into the running slurmctld by the worker itself
-with `scontrol update ... Topology=`. No re-read is involved, and none is wanted: restarting slurmd
-across the cluster because one pod was rescheduled would be a poor trade.
+A node moving between switches travels with its own slurmd registration, which is what a
+rescheduled pod performs on startup anyway. No re-read is involved, and none is wanted: re-reading
+the file across the cluster because one pod moved would be a poor trade.
 
 A structural change cannot be learned that way, so the operator asks sconfigcontroller for a
 `scontrol reconfigure`. The request is recorded in the topology `JailedConfig` as a `Reconfigure`
@@ -429,7 +435,7 @@ flat=flat:[]:true,tree-ib=tree:[]:false,block-nvl72=block:[18]:false
 | topologies reordered in the spec | |
 
 The right-hand column is deliberate: those are node membership changes, and membership travels
-through the worker's own `scontrol update`, not through a cluster-wide re-read.
+with the worker's own slurmd registration, not through a cluster-wide re-read.
 
 #### Two further gates
 
@@ -475,9 +481,9 @@ them without digging through operator logs:
 #### What a reconfigure does not do
 
 It does not move already-registered nodes between topologies. Re-reading the file lays the nodes out
-as written, but slurmctld then applies each node's own `Topology=` registration on top, and treats
-that registration as the complete list: a node is removed from every topology its registration does
-not name. Workers compute that registration once, in their init container.
+as written, but slurmctld then applies each node's own registered topology on top, and treats it as
+the complete list: a node is removed from every topology its registration does not name. Workers
+compute that value once, in their init container.
 
 So a node that was running before a topology was added stays out of it until its pod restarts, no
 matter how many times the cluster is reconfigured. Adding a topology and expecting existing nodes to

--- a/images/worker/slurmd_entrypoint.sh
+++ b/images/worker/slurmd_entrypoint.sh
@@ -48,6 +48,19 @@ echo "Export Soperator node metadata"
 echo "Evaluate variables in the Slurm node 'Extra' field"
 evaluated_extra=$(eval echo "$SLURM_NODE_EXTRA")
 
+# The topology is passed to registration instead of being pushed with a separate scontrol update:
+# an update issued before slurmd starts makes slurmctld drop the InstanceId and Extra that
+# registration carries. worker-init resolved it and left it here, so nothing is waited for.
+node_topology=""
+if [ "${SLURM_TOPOLOGY_ENABLED}" = "true" ]; then
+    if [ ! -f "${SLURMD_TOPOLOGY_PATH}" ]; then
+        echo "Error: topology is enabled but ${SLURMD_TOPOLOGY_PATH} is missing; worker-init did not resolve it" >&2
+        exit 1
+    fi
+    node_topology=$(cat "${SLURMD_TOPOLOGY_PATH}")
+    echo "Registering into topology: ${node_topology:-<none>}"
+fi
+
 echo "Start slurmd daemon"
 
 slurmd_args=(
@@ -59,6 +72,12 @@ slurmd_args=(
 if [ "${evaluated_extra}" != "" ]; then
   slurmd_args+=(
     --extra "${evaluated_extra}"
+  )
+fi
+
+if [ "${node_topology}" != "" ]; then
+  slurmd_args+=(
+    --conf "${node_topology}"
   )
 fi
 

--- a/images/worker/worker_init.py
+++ b/images/worker/worker_init.py
@@ -6,6 +6,12 @@ Supports two modes:
   wait-controller  - Wait for Slurm controller (slurmctld) to be ready
   wait-topology    - Wait for topology data from ConfigMap (for ephemeral nodes)
 
+The worker joins its topology through slurmd registration rather than a separate scontrol update:
+an update issued before slurmd starts perturbs the node state that slurmctld inspects when it
+decides whether to store the InstanceId and Extra that registration carries. wait-topology resolves
+the specification and leaves it on a volume shared with the slurmd container, so that waiting for
+the topology config never delays slurmd's own startup.
+
 Environment Variables (all modes):
     WORKER_INIT_RANDOM_DELAY_SECONDS: Upper bound of a random startup delay applied before
         running any command. The actual delay is picked uniformly from
@@ -21,6 +27,8 @@ Environment Variables (wait-topology):
     TOPOLOGY_CONFIGMAP_PATH: Path to mounted ConfigMap (default: /tmp/slurm/topology-node-labels)
     TOPOLOGY_WAIT_TIMEOUT: Max wait time in seconds (default: 180)
     TOPOLOGY_POLL_INTERVAL: Poll interval in seconds (default: 5)
+    SLURMD_TOPOLOGY_PATH: File the resolved specification is written to
+        (default: /run/soperator/slurmd_topology)
 """
 
 import argparse
@@ -49,6 +57,11 @@ SLURM_CONFIG_LINK_SOURCE: Path = Path("/mnt/jail/etc/slurm")
 SLURM_CONFIG_LINK_TARGET: Path = Path("/etc/slurm")
 SLURM_CONFIG_PATH: Path = Path("/etc/slurm/slurm_base.conf.noedit")
 SLURM_TOPOLOGY_YAML_PATH: Path = Path("/etc/slurm/topology.yaml")
+
+# Handed to the slurmd container through a shared volume, so that the wait for the topology config
+# happens in this init container rather than in front of slurmd. It holds the bare "topology=..."
+# fragment the entrypoint passes to slurmd as --conf.
+DEFAULT_SLURMD_TOPOLOGY_PATH: Path = Path("/run/soperator/slurmd_topology")
 
 TOPOLOGY_PLUGIN_TREE: str = "topology/tree"
 TOPOLOGY_PLUGIN_BLOCK: str = "topology/block"
@@ -135,19 +148,6 @@ def get_controller_max_attempts() -> int:
 def get_controller_poll_interval() -> int:
     """Get the poll interval in seconds for controller readiness checks."""
     return int(os.environ.get("CONTROLLER_POLL_INTERVAL", "5"))
-
-
-def get_node_addr() -> str:
-    pod_name: str = get_from_env_required("K8S_POD_NAME")
-    logger.info("Using K8S_POD_NAME=%s for NodeAddr construction", pod_name)
-
-    service_name: str = get_from_env_required("K8S_SERVICE_NAME")
-    logger.info("Using K8S_SERVICE_NAME=%s for NodeAddr construction", service_name)
-
-    pod_namespace: str = get_from_env_required("K8S_POD_NAMESPACE")
-    logger.info("Using K8S_POD_NAMESPACE=%s for NodeAddr construction", pod_namespace)
-
-    return f"nodeaddr={pod_name}.{service_name}.{pod_namespace}.svc"
 
 
 def wait_for_controller() -> None:
@@ -652,54 +652,28 @@ def _format_tier_topology(
     return ""
 
 
-def apply_node_topology(hostname: str, topology: str) -> None:
-    """Apply topology and clear manual drain state for a resumed worker.
+def get_slurmd_topology_path() -> Path:
+    """Get the path the resolved topology specification is written to."""
+    return Path(
+        os.environ.get("SLURMD_TOPOLOGY_PATH", str(DEFAULT_SLURMD_TOPOLOGY_PATH))
+    )
 
-    Users may drain POWERED_DOWN workers to prevent Slurm from automatically
-    powering them up for queued jobs. When this worker is actually resumed,
-    clear that drain marker so it can schedule jobs again.
+
+def write_slurmd_topology(topology: str) -> None:
+    """Hand the topology to the slurmd container, which passes it to slurmd as --conf.
+
+    An empty file is written when no topology places this worker: the entrypoint distinguishes that
+    from a resolution that never ran, which must not be mistaken for "no topology".
     """
+    path: Path = get_slurmd_topology_path()
     try:
-        node_addr: str = get_node_addr()
-        cmd = [
-            "scontrol",
-            "update",
-            f"nodename={hostname}",
-            f"{node_addr}",
-        ]
-        # An empty topology means there is no unit to register into, which is the case for a worker
-        # covered only by flat topologies.
-        if topology:
-            cmd.append(f"{topology}")
-        cmd.append("State=POWER_UP")
-        logger.info("Running: %s", " ".join(cmd))
-        result: subprocess.CompletedProcess[str] = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if result.returncode != 0:
-            output: str = (result.stdout + result.stderr).strip()
-            if "Invalid node name" in output:
-                logger.warning(
-                    "scontrol update: node %s not yet registered (dynamic node first start), skipping: %s",
-                    hostname,
-                    output,
-                )
-                return
-            logger.error(
-                "scontrol update failed (rc=%d): %s", result.returncode, output
-            )
-            sys.exit(1)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(topology)
+    except OSError as e:
+        logger.error("Failed to write topology %s: %s", path, e)
+        sys.exit(1)
 
-        logger.info("Topology applied successfully for worker %s", hostname)
-    except subprocess.TimeoutExpired:
-        logger.error("scontrol update timed out")
-        sys.exit(1)
-    except FileNotFoundError:
-        logger.error("scontrol command not found")
-        sys.exit(1)
+    logger.info("Wrote topology %r to %s", topology, path)
 
 
 def wait_for_topology_file(wait_timeout: int, poll_interval: int) -> Path:
@@ -830,11 +804,11 @@ def is_gpu_enabled() -> bool:
 
 
 def wait_for_topology() -> None:
-    """Wait until this node is placed in the topology config, then register it via scontrol.
+    """Wait until this node is placed in the topology config, then hand its unit to slurmd.
 
     A worker joins whichever topologies the rendered config lists it in, which keeps it in step with
     the file by construction. A CPU-only worker is listed by none -- tree and block topologies
-    describe fabrics, and it sits on none -- so it waits for the config and registers nothing.
+    describe fabrics, and it sits on none -- so it waits for the config and joins nothing.
     """
     hostname: str = get_from_env_required("HOSTNAME")
 
@@ -848,7 +822,7 @@ def wait_for_topology() -> None:
             "Node %s is CPU-only, no topology lists it; skipping topology registration",
             hostname,
         )
-        apply_node_topology(hostname, "")
+        write_slurmd_topology("")
         return
 
     # A placeholder tree or block has no node list yet, but waiting is still necessary to avoid
@@ -868,7 +842,7 @@ def wait_for_topology() -> None:
             config_path,
             hostname,
         )
-        apply_node_topology(hostname, "")
+        write_slurmd_topology("")
         return
 
     node_name: str = get_node_name()
@@ -935,7 +909,7 @@ def wait_for_topology() -> None:
             hostname,
         )
 
-    apply_node_topology(hostname, topology)
+    write_slurmd_topology(topology)
 
 
 # endregion Topology functions

--- a/images/worker/worker_init_test.py
+++ b/images/worker/worker_init_test.py
@@ -17,6 +17,44 @@ from pathlib import Path
 import worker_init
 
 
+class TestWriteTopologyConf(unittest.TestCase):
+    """The topology is handed to slurmd through a file, not pushed with scontrol."""
+
+    def test_writes_the_specification_for_slurmd(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            conf = os.path.join(tmp, "soperator", "slurmd_topology")
+            with mock.patch.dict(os.environ, {"SLURMD_TOPOLOGY_PATH": conf}):
+                worker_init.write_slurmd_topology("topology=default:root:leaf")
+            self.assertEqual(Path(conf).read_text(), "topology=default:root:leaf")
+
+    def test_writes_an_empty_file_when_no_topology_places_the_worker(self):
+        """An empty file still records that the resolution ran, which "no file" would not."""
+        with tempfile.TemporaryDirectory() as tmp:
+            conf = os.path.join(tmp, "soperator", "slurmd_topology")
+            with mock.patch.dict(os.environ, {"SLURMD_TOPOLOGY_PATH": conf}):
+                worker_init.write_slurmd_topology("")
+            self.assertTrue(Path(conf).is_file())
+            self.assertEqual(Path(conf).read_text(), "")
+
+    def test_registration_is_not_pushed_with_scontrol(self):
+        """Nothing touches the node state before slurmd registers."""
+        with tempfile.TemporaryDirectory() as tmp:
+            conf = os.path.join(tmp, "slurmd_topology")
+            with mock.patch.dict(os.environ, {"SLURMD_TOPOLOGY_PATH": conf}), mock.patch(
+                "worker_init.subprocess.run"
+            ) as mock_run:
+                worker_init.write_slurmd_topology("topology=default:root:leaf")
+            mock_run.assert_not_called()
+
+    def test_path_defaults_to_the_shared_runtime_volume(self):
+        env = os.environ.copy()
+        env.pop("SLURMD_TOPOLOGY_PATH", None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertEqual(
+                worker_init.get_slurmd_topology_path(), Path("/run/soperator/slurmd_topology")
+            )
+
+
 class TestFormatSlurmTopology(unittest.TestCase):
     """Tests for format_slurm_topology function."""
 
@@ -954,9 +992,9 @@ class TestTopologyIntegration(unittest.TestCase):
         self.assertEqual(formatted, "topology=default:root:spine01:leaf01")
 
     @mock.patch("worker_init.wait_for_hostname_in_topology_config")
-    @mock.patch("worker_init.apply_node_topology")
+    @mock.patch("worker_init.write_slurmd_topology")
     def test_wait_for_topology_block_json_applies_tier_zero(
-        self, mock_apply, mock_wait_hostname):
+        self, mock_write, mock_wait_hostname):
         """A block topology registers the node under its tier-0 block."""
         node_name = "gpu-node-003"
         topology = '{"tier-0":"block1","tier-1":"leaf01","tier-2":"spine01"}'
@@ -988,7 +1026,7 @@ class TestTopologyIntegration(unittest.TestCase):
             worker_init.wait_for_topology()
 
         mock_wait_hostname.assert_called_once_with("worker-0", 180, 5, config_path)
-        mock_apply.assert_called_once_with("worker-0", "topology=block-nvl72:block1")
+        mock_write.assert_called_once_with("topology=block-nvl72:block1")
 
 
 class TestEdgeCases(unittest.TestCase):
@@ -1166,7 +1204,7 @@ class TestParseTopologyBindings(unittest.TestCase):
 class TestCpuOnlyWorkerInMultiTopology(unittest.TestCase):
     """A CPU-only worker appears in no node list, so it must not wait for its hostname."""
 
-    @mock.patch("worker_init.apply_node_topology")
+    @mock.patch("worker_init.write_slurmd_topology")
     @mock.patch("worker_init.wait_for_hostname_in_topology_config")
     @mock.patch("worker_init.is_gpu_enabled", return_value=False)
     @mock.patch(
@@ -1175,13 +1213,13 @@ class TestCpuOnlyWorkerInMultiTopology(unittest.TestCase):
     )
     @mock.patch.dict(os.environ, {"HOSTNAME": "cpu-0"})
     def test_skips_the_hostname_wait_and_the_registration(
-        self, mock_wait_file, mock_gpu, mock_wait_hostname, mock_apply
+        self, mock_wait_file, mock_gpu, mock_wait_hostname, mock_write
     ):
         worker_init.wait_for_topology()
 
         mock_wait_file.assert_called_once()
         mock_wait_hostname.assert_not_called()
-        mock_apply.assert_called_once_with("cpu-0", "")
+        mock_write.assert_called_once_with("")
 
 
 
@@ -1243,10 +1281,10 @@ class TestTopologyHostnameWait(unittest.TestCase):
         )
         mock_sleep.assert_called_once_with(1)
 
-    @mock.patch("worker_init.apply_node_topology")
+    @mock.patch("worker_init.write_slurmd_topology")
     @mock.patch("worker_init.wait_for_hostname_in_topology_config")
     def test_gpu_worker_skips_the_wait_and_registers_nothing(
-        self, mock_wait_hostname, mock_apply
+        self, mock_wait_hostname, mock_write
     ):
         node_name = "gpu-node-001"
 
@@ -1265,12 +1303,12 @@ class TestTopologyHostnameWait(unittest.TestCase):
             worker_init.wait_for_topology()
 
         mock_wait_hostname.assert_not_called()
-        mock_apply.assert_called_once_with("worker-0", "")
+        mock_write.assert_called_once_with("")
 
-    @mock.patch("worker_init.apply_node_topology")
+    @mock.patch("worker_init.write_slurmd_topology")
     @mock.patch("worker_init.wait_for_hostname_in_topology_config")
     def test_placeholder_waits_even_without_nodes(
-        self, mock_wait_hostname, mock_apply
+        self, mock_wait_hostname, mock_write
     ):
         node_name = "gpu-node-001"
 
@@ -1292,7 +1330,7 @@ class TestTopologyHostnameWait(unittest.TestCase):
             worker_init.wait_for_topology()
 
         mock_wait_hostname.assert_called_once_with("worker-0", 180, 5, config_path)
-        mock_apply.assert_called_once_with("worker-0", "")
+        mock_write.assert_called_once_with("")
 
 
 if __name__ == "__main__":

--- a/internal/consts/topology.go
+++ b/internal/consts/topology.go
@@ -3,4 +3,9 @@ package consts
 const (
 	// Default timeout in seconds for waiting for topology configuration when using ephemeral topology with topology plugin enabled
 	DefaultEphemeralTopologyWaitTimeout = int32(180)
+
+	// SlurmdTopologyPath is where worker-init leaves the topology this worker registers into, on
+	// the runtime volume it shares with the slurmd container. It holds the bare "topology=..."
+	// fragment that the entrypoint passes to slurmd as --conf, not a Slurm config file.
+	SlurmdTopologyPath = VolumeMountPathRuntime + "/soperator/slurmd_topology"
 )

--- a/internal/controller/nodesetcontroller/reconcile.go
+++ b/internal/controller/nodesetcontroller/reconcile.go
@@ -508,7 +508,6 @@ func (r NodeSetReconciler) executeReconciliation(
 					len(cluster.Spec.Topology.Topologies) > 0
 
 				desired, err := worker.RenderNodeSetStatefulSet(
-					cluster.Name,
 					nodeSetValues,
 					&secrets,
 					cluster.Spec.CgroupVersion,

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -20,9 +20,9 @@ import (
 
 // RenderContainerWorkerInit renders init [corev1.Container] for worker nodes.
 // It runs a script that waits for the controller to be ready before allowing the main slurmd container to start.
-// If topology is enabled, it also waits for the topology configuration to be ready before allowing slurmd to start.
+// If topology is enabled, it also resolves the topology this worker registers into and leaves it on
+// the runtime volume, so that slurmd starts without waiting for the topology config itself.
 func RenderContainerWorkerInit(
-	clusterName string,
 	container *values.Container,
 	topologyEnabled, gpuEnabled bool,
 	waitTimeoutSeconds int32,
@@ -38,46 +38,25 @@ func RenderContainerWorkerInit(
 		command = append(command, "wait-topology")
 	}
 
-	volumeMounts := []corev1.VolumeMount{
+	var volumeMounts []corev1.VolumeMount
+	if topologyEnabled {
+		// The runtime volume carries the resolved topology to slurmd. It is mounted first because
+		// the munge socket below sits inside it, and a nested mount must follow its parent.
+		volumeMounts = append(volumeMounts,
+			renderVolumeMountRuntime(),
+			corev1.VolumeMount{
+				Name:      consts.VolumeNameTopologyNodeLabels,
+				MountPath: consts.VolumeMountPathTopologyNodeLabels,
+				ReadOnly:  true,
+			},
+		)
+	}
+	volumeMounts = append(volumeMounts,
 		common.RenderVolumeMountJail(),
 		common.RenderVolumeMountMungeSocket(),
-	}
-	if topologyEnabled {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      consts.VolumeNameTopologyNodeLabels,
-			MountPath: consts.VolumeMountPathTopologyNodeLabels,
-			ReadOnly:  true,
-		})
-	}
+	)
 
 	env := []corev1.EnvVar{
-		{
-			Name: "K8S_NODE_NAME",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					APIVersion: corev1.SchemeGroupVersion.Version,
-					FieldPath:  "spec.nodeName",
-				},
-			},
-		},
-		{
-			Name: "K8S_POD_NAME",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					APIVersion: corev1.SchemeGroupVersion.Version,
-					FieldPath:  "metadata.name",
-				},
-			},
-		},
-		{
-			Name: "K8S_POD_NAMESPACE",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					APIVersion: corev1.SchemeGroupVersion.Version,
-					FieldPath:  "metadata.namespace",
-				},
-			},
-		},
 		{
 			Name:  "CONTROLLER_MAX_ATTEMPTS",
 			Value: "60",
@@ -86,10 +65,17 @@ func RenderContainerWorkerInit(
 			Name:  "CONTROLLER_POLL_INTERVAL",
 			Value: "5",
 		},
-		{
-			Name:  "K8S_SERVICE_NAME",
-			Value: naming.BuildServiceName(consts.ComponentTypeNodeSet, clusterName),
-		},
+	}
+
+	if gpuEnabled {
+		env = append(env, corev1.EnvVar{
+			Name:  "NODESET_GPU_ENABLED",
+			Value: "true",
+		})
+	}
+
+	if topologyEnabled {
+		env = append(env, renderNodeSetTopologyEnv(topologyFabric, waitTimeoutSeconds)...)
 	}
 
 	if randomDelaySeconds > 0 {
@@ -97,42 +83,6 @@ func RenderContainerWorkerInit(
 			Name:  "WORKER_INIT_RANDOM_DELAY_SECONDS",
 			Value: strconv.Itoa(int(randomDelaySeconds)),
 		})
-	}
-
-	if gpuEnabled {
-		env = append(env,
-			corev1.EnvVar{
-				Name:  "NODESET_GPU_ENABLED",
-				Value: "true",
-			},
-		)
-	}
-
-	if topologyEnabled {
-		env = append(env,
-			corev1.EnvVar{
-				Name:  "TOPOLOGY_CONFIGMAP_PATH",
-				Value: consts.VolumeMountPathTopologyNodeLabels,
-			},
-			corev1.EnvVar{
-				Name:  "TOPOLOGY_WAIT_TIMEOUT",
-				Value: strconv.Itoa(int(waitTimeoutSeconds)),
-			},
-			corev1.EnvVar{
-				Name:  "TOPOLOGY_POLL_INTERVAL",
-				Value: "5",
-			},
-		)
-		fabric := topologyFabric
-		if fabric == "" {
-			fabric = consts.SlurmTopologyDefaultFabric
-		}
-		env = append(env,
-			corev1.EnvVar{
-				Name:  "SLURM_TOPOLOGY_FABRIC",
-				Value: fabric,
-			},
-		)
 	}
 
 	return corev1.Container{
@@ -259,14 +209,17 @@ func renderContainerNodeSetSlurmd(
 		Command:         nodeSet.ContainerSlurmd.Command,
 		Args:            nodeSet.ContainerSlurmd.Args,
 		Env: append(
-			renderNodeSetSlurmdEnv(
-				cgroupVersion,
-				clusterWithGPU,
-				nodeSet.GPU.Enabled,
-				nodeSet.GPU.Nvidia.GDRCopyEnabled,
-				nodeSet.DockerEnabled,
-				nodeSet.NodeExtra,
-				realMemoryBytes,
+			append(
+				renderNodeSetSlurmdEnv(
+					cgroupVersion,
+					clusterWithGPU,
+					nodeSet.GPU.Enabled,
+					nodeSet.GPU.Nvidia.GDRCopyEnabled,
+					nodeSet.DockerEnabled,
+					nodeSet.NodeExtra,
+					realMemoryBytes,
+				),
+				renderSlurmdTopologyEnv(topologyEnabled)...,
 			),
 			nodeSet.ContainerSlurmd.CustomEnv...,
 		),
@@ -329,6 +282,64 @@ func renderVolumeMountRuntime() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      consts.VolumeNameRuntime,
 		MountPath: consts.VolumeMountPathRuntime,
+	}
+}
+
+// renderSlurmdTopologyEnv points slurmd at the topology worker-init resolved for it.
+func renderSlurmdTopologyEnv(topologyEnabled bool) []corev1.EnvVar {
+	if !topologyEnabled {
+		return nil
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name:  "SLURM_TOPOLOGY_ENABLED",
+			Value: "true",
+		},
+		{
+			Name:  "SLURMD_TOPOLOGY_PATH",
+			Value: consts.SlurmdTopologyPath,
+		},
+	}
+}
+
+// renderNodeSetTopologyEnv renders the environment the topology resolver reads in worker-init.
+func renderNodeSetTopologyEnv(topologyFabric string, waitTimeoutSeconds int32) []corev1.EnvVar {
+	fabric := topologyFabric
+	if fabric == "" {
+		fabric = consts.SlurmTopologyDefaultFabric
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name: "K8S_NODE_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: corev1.SchemeGroupVersion.Version,
+					FieldPath:  "spec.nodeName",
+				},
+			},
+		},
+		{
+			Name:  "TOPOLOGY_CONFIGMAP_PATH",
+			Value: consts.VolumeMountPathTopologyNodeLabels,
+		},
+		{
+			Name:  "TOPOLOGY_WAIT_TIMEOUT",
+			Value: strconv.Itoa(int(waitTimeoutSeconds)),
+		},
+		{
+			Name:  "TOPOLOGY_POLL_INTERVAL",
+			Value: "5",
+		},
+		{
+			Name:  "SLURM_TOPOLOGY_FABRIC",
+			Value: fabric,
+		},
+		{
+			Name:  "SLURMD_TOPOLOGY_PATH",
+			Value: consts.SlurmdTopologyPath,
+		},
 	}
 }
 

--- a/internal/render/worker/sssd_test.go
+++ b/internal/render/worker/sssd_test.go
@@ -71,7 +71,6 @@ func TestRenderNodeSetStatefulSet_SSSD(t *testing.T) {
 	}
 
 	result, err := worker.RenderNodeSetStatefulSet(
-		"test-cluster",
 		nodeSet,
 		&slurmv1.Secrets{},
 		consts.CGroupV2,

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -26,7 +26,6 @@ import (
 
 // RenderNodeSetStatefulSet renders new [kruisev1b1.StatefulSet] containing NodeSet worker pods
 func RenderNodeSetStatefulSet(
-	clusterName string,
 	nodeSet *values.SlurmNodeSet,
 	secrets *slurmv1.Secrets,
 	cgroupVersion string,
@@ -64,7 +63,6 @@ func RenderNodeSetStatefulSet(
 	}
 	initContainers = append(initContainers,
 		RenderContainerWorkerInit(
-			clusterName,
 			&nodeSet.ContainerSlurmd,
 			topologyPluginEnabled,
 			nodeSet.GPU.Enabled,

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -42,23 +42,18 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 	}
 
 	t.Run("with topology enabled", func(t *testing.T) {
-		result := worker.RenderContainerWorkerInit(
-			"test-cluster",
-			container,
-			true,
-			true,
-			300,
-			"fab-test",
-			0,
-		)
+		result := worker.RenderContainerWorkerInit(container, true, true, 300, "fab-test", 0)
 
 		assert.Equal(t, consts.ContainerNameWorkerInit, result.Name)
 		assert.Equal(t, container.Image, result.Image)
 		assert.Equal(t, container.ImagePullPolicy, result.ImagePullPolicy)
 		assert.Equal(t, []string{"python3", "/opt/bin/slurm/worker_init.py", "wait-controller", "wait-topology"}, result.Command)
-		assert.Equal(t, 11, len(result.Env)) // 6 base + 1 NODESET_GPU_ENABLED + 4 topology
-		assert.Equal(t, 3, len(result.VolumeMounts))
 		assertEnvValue(t, result.Env, "SLURM_TOPOLOGY_FABRIC", "fab-test")
+		assertEnvValue(t, result.Env, "TOPOLOGY_WAIT_TIMEOUT", "300")
+
+		// The resolved topology is handed to slurmd through the runtime volume, so that slurmd
+		// starts without waiting for the topology config itself.
+		assertEnvValue(t, result.Env, "SLURMD_TOPOLOGY_PATH", consts.SlurmdTopologyPath)
 
 		// The plugin is a property of each topology in the config, not of the cluster, so the
 		// worker no longer needs to be told one.
@@ -76,6 +71,7 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 			consts.VolumeNameJail:               consts.VolumeMountPathJail,
 			consts.VolumeNameMungeSocket:        consts.VolumeMountPathMungeSocket,
 			consts.VolumeNameTopologyNodeLabels: consts.VolumeMountPathTopologyNodeLabels,
+			consts.VolumeNameRuntime:            consts.VolumeMountPathRuntime,
 		}
 		assert.Equal(t, len(expectedMounts), len(result.VolumeMounts))
 		for _, mount := range result.VolumeMounts {
@@ -83,26 +79,30 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 			assert.True(t, exists, "Unexpected volume mount: %s", mount.Name)
 			assert.Equal(t, expectedPath, mount.MountPath, "Wrong mount path for volume %s", mount.Name)
 		}
+
+		// The munge socket lives inside the runtime volume. A runtime empty dir mounted after it
+		// would hide the socket, leaving scontrol ping unable to authenticate for the whole
+		// controller wait.
+		var runtimeIndex, mungeIndex int
+		for i, mount := range result.VolumeMounts {
+			switch mount.Name {
+			case consts.VolumeNameRuntime:
+				runtimeIndex = i
+			case consts.VolumeNameMungeSocket:
+				mungeIndex = i
+			}
+		}
+		assert.Less(t, runtimeIndex, mungeIndex,
+			"%s must be mounted before the %s nested in it", consts.VolumeNameRuntime, consts.VolumeNameMungeSocket)
 	})
 
 	t.Run("without topology", func(t *testing.T) {
-		result := worker.RenderContainerWorkerInit(
-			"test-cluster",
-			container,
-			false,
-			false,
-			0,
-			"",
-			0,
-		)
+		result := worker.RenderContainerWorkerInit(container, false, false, 0, "", 0)
 
 		assert.Equal(t, consts.ContainerNameWorkerInit, result.Name)
-		assert.Equal(t, container.Image, result.Image)
-		assert.Equal(t, container.ImagePullPolicy, result.ImagePullPolicy)
 		assert.Equal(t, []string{"python3", "/opt/bin/slurm/worker_init.py", "wait-controller"}, result.Command,
 			"wait-topology should not be present when topology is disabled")
-		assert.Equal(t, 6, len(result.Env), "only controller-related env vars expected")
-		assert.Equal(t, 2, len(result.VolumeMounts), "topology volume mount should not be present")
+		assert.Equal(t, 2, len(result.Env), "only controller-related env vars expected")
 
 		expectedMounts := map[string]string{
 			consts.VolumeNameJail:        consts.VolumeMountPathJail,
@@ -115,12 +115,12 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 			assert.Equal(t, expectedPath, mount.MountPath, "Wrong mount path for volume %s", mount.Name)
 		}
 
-		// Verify no topology env vars
 		for _, envVar := range result.Env {
 			assert.NotContains(t, []string{
 				"TOPOLOGY_CONFIGMAP_PATH",
 				"TOPOLOGY_WAIT_TIMEOUT",
 				"TOPOLOGY_POLL_INTERVAL",
+				"SLURMD_TOPOLOGY_PATH",
 				"SLURM_TOPOLOGY_PLUGIN",
 				"SLURM_TOPOLOGY_FABRIC",
 			}, envVar.Name,
@@ -129,105 +129,19 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 	})
 
 	t.Run("random delay env present when positive", func(t *testing.T) {
-		result := worker.RenderContainerWorkerInit(
-			"test-cluster",
-			container,
-			false,
-			false,
-			0,
-			"",
-			120,
-		)
+		result := worker.RenderContainerWorkerInit(container, false, false, 0, "", 120)
 
 		assertEnvValue(t, result.Env, "WORKER_INIT_RANDOM_DELAY_SECONDS", "120")
 	})
 
 	t.Run("random delay env absent when zero", func(t *testing.T) {
-		result := worker.RenderContainerWorkerInit(
-			"test-cluster",
-			container,
-			false,
-			false,
-			0,
-			"",
-			0,
-		)
+		result := worker.RenderContainerWorkerInit(container, false, false, 0, "", 0)
 
 		for _, envVar := range result.Env {
 			assert.NotEqual(t, "WORKER_INIT_RANDOM_DELAY_SECONDS", envVar.Name,
 				"random delay env var should not be present when delay is 0")
 		}
 	})
-}
-
-func Test_RenderContainerWorkerInit_K8SServiceName(t *testing.T) {
-	container := &values.Container{
-		NodeContainer: slurmv1.NodeContainer{
-			Image:           "test-image",
-			ImagePullPolicy: corev1.PullIfNotPresent,
-		},
-	}
-
-	findEnv := func(envs []corev1.EnvVar, name string) (corev1.EnvVar, bool) {
-		for _, e := range envs {
-			if e.Name == name {
-				return e, true
-			}
-		}
-		return corev1.EnvVar{}, false
-	}
-
-	tests := []struct {
-		name            string
-		clusterName     string
-		gpuEnabled      bool
-		expectedService string
-	}{
-		{
-			name:            "uses nodeset service name with gpu enabled",
-			clusterName:     "my-cluster",
-			gpuEnabled:      true,
-			expectedService: "my-cluster-nodeset-svc",
-		},
-		{
-			name:            "uses nodeset service name without gpu",
-			clusterName:     "my-cluster",
-			gpuEnabled:      false,
-			expectedService: "my-cluster-nodeset-svc",
-		},
-		{
-			name:            "different cluster name with gpu enabled",
-			clusterName:     "prod",
-			gpuEnabled:      true,
-			expectedService: "prod-nodeset-svc",
-		},
-		{
-			name:            "different cluster name without gpu",
-			clusterName:     "prod",
-			gpuEnabled:      false,
-			expectedService: "prod-nodeset-svc",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := worker.RenderContainerWorkerInit(
-				tt.clusterName,
-				container,
-				false,
-				tt.gpuEnabled,
-				0,
-				"",
-				0,
-			)
-
-			env, found := findEnv(result.Env, "K8S_SERVICE_NAME")
-			assert.True(t, found, "K8S_SERVICE_NAME env var must be present")
-			assert.Equal(t, tt.expectedService, env.Value,
-				"K8S_SERVICE_NAME should be %q for gpuEnabled=%v, got %q",
-				tt.expectedService, tt.gpuEnabled, env.Value)
-		})
-	}
 }
 
 func TestRenderNodeSetStatefulSet_SlurmdGPUEnv(t *testing.T) {
@@ -301,7 +215,6 @@ func TestRenderNodeSetStatefulSet_SlurmdGPUEnv(t *testing.T) {
 			}
 
 			result, err := worker.RenderNodeSetStatefulSet(
-				"test-cluster",
 				nodeSet,
 				&slurmv1.Secrets{},
 				consts.CGroupV2,
@@ -353,7 +266,6 @@ func TestRenderNodeSetStatefulSet_NvidiaIMEXCLIMount(t *testing.T) {
 	}
 
 	result, err := worker.RenderNodeSetStatefulSet(
-		"test-cluster",
 		nodeSet,
 		&slurmv1.Secrets{},
 		consts.CGroupV2,
@@ -411,7 +323,6 @@ func TestRenderNodeSetStatefulSet_NvidiaIMEXNotMountedForCPUWorker(t *testing.T)
 	}
 
 	result, err := worker.RenderNodeSetStatefulSet(
-		"test-cluster",
 		nodeSet,
 		&slurmv1.Secrets{},
 		consts.CGroupV2,
@@ -529,7 +440,6 @@ func TestRenderNodeSetStatefulSet_HostJournalMount(t *testing.T) {
 	}
 
 	result, err := worker.RenderNodeSetStatefulSet(
-		"test-cluster",
 		nodeSet,
 		&slurmv1.Secrets{},
 		consts.CGroupV2,
@@ -659,7 +569,8 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 		topologyPluginEnabled      bool
 		expectedInitContainerCount int
 		expectTopologyVolumes      bool
-		expectWaitForTopology      bool
+		expectTopologyEnv          bool
+		expectedWaitTimeout        string
 	}{
 		{
 			name:                       "topology plugin enabled with timeout",
@@ -668,7 +579,8 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 			topologyPluginEnabled:      true,
 			expectedInitContainerCount: 2, // munge + worker-init
 			expectTopologyVolumes:      true,
-			expectWaitForTopology:      true,
+			expectTopologyEnv:          true,
+			expectedWaitTimeout:        "300",
 		},
 		{
 			name:                       "topology plugin enabled with zero timeout uses default",
@@ -677,7 +589,8 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 			topologyPluginEnabled:      true,
 			expectedInitContainerCount: 2, // munge + worker-init
 			expectTopologyVolumes:      true,
-			expectWaitForTopology:      true, // default timeout is applied
+			expectTopologyEnv:          true,
+			expectedWaitTimeout:        "180", // default timeout is applied
 		},
 		{
 			name:                       "topology plugin disabled",
@@ -686,7 +599,7 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 			topologyPluginEnabled:      false,
 			expectedInitContainerCount: 2, // munge + worker-init
 			expectTopologyVolumes:      false,
-			expectWaitForTopology:      false,
+			expectTopologyEnv:          false,
 		},
 		{
 			name:                       "topology plugin disabled with ephemeral nodes",
@@ -695,7 +608,7 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 			topologyPluginEnabled:      false,
 			expectedInitContainerCount: 2,     // munge + worker-init
 			expectTopologyVolumes:      false, // no volume without topology plugin
-			expectWaitForTopology:      false, // no wait-topology without topology plugin
+			expectTopologyEnv:          false, // no resolver env without topology plugin
 		},
 	}
 
@@ -704,7 +617,6 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 			nodeSet := createNodeSet(tt.ephemeralNodes, tt.waitTimeout)
 
 			result, err := worker.RenderNodeSetStatefulSet(
-				"test-cluster",
 				nodeSet,
 				&slurmv1.Secrets{},
 				consts.CGroupV2,
@@ -718,26 +630,62 @@ func TestRenderNodeSetStatefulSet_TopologyPlugin(t *testing.T) {
 				"expected %d init containers", tt.expectedInitContainerCount)
 			assert.Len(t, result.Spec.Template.Spec.Containers, 2, "expected slurmd and docker-proxy containers")
 
-			// Verify worker-init container has topology command when topology plugin is enabled
-			var hasWaitForTopology bool
+			// worker-init resolves the topology and leaves it on the runtime volume; slurmd only
+			// learns where to read it from, so it never waits for the topology config.
 			var workerInitContainer *corev1.Container
-			for _, container := range result.Spec.Template.Spec.InitContainers {
+			for i, container := range result.Spec.Template.Spec.InitContainers {
 				if container.Name == consts.ContainerNameWorkerInit {
-					workerInitContainer = &container
-					for _, arg := range container.Command {
-						if arg == "wait-topology" {
-							hasWaitForTopology = true
-							break
-						}
-					}
+					workerInitContainer = &result.Spec.Template.Spec.InitContainers[i]
 					break
 				}
 			}
-			assert.Equal(t, tt.expectWaitForTopology, hasWaitForTopology,
+			assert.NotNil(t, workerInitContainer, "worker-init container should be present")
+
+			var hasWaitForTopology bool
+			for _, arg := range workerInitContainer.Command {
+				if arg == "wait-topology" {
+					hasWaitForTopology = true
+					break
+				}
+			}
+			assert.Equal(t, tt.expectTopologyEnv, hasWaitForTopology,
 				"wait-topology command presence mismatch")
-			if tt.expectWaitForTopology && assert.NotNil(t, workerInitContainer) {
+
+			var slurmdContainer *corev1.Container
+			for i, container := range result.Spec.Template.Spec.Containers {
+				if container.Name == consts.ContainerNameSlurmd {
+					slurmdContainer = &result.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			assert.NotNil(t, slurmdContainer, "slurmd container should be present")
+
+			var slurmdHasTopologyEnv bool
+			for _, envVar := range slurmdContainer.Env {
+				if envVar.Name == "SLURM_TOPOLOGY_ENABLED" {
+					slurmdHasTopologyEnv = true
+					break
+				}
+			}
+			assert.Equal(t, tt.expectTopologyEnv, slurmdHasTopologyEnv,
+				"slurmd topology env presence mismatch")
+
+			if tt.expectTopologyEnv {
 				assertEnvValue(t, workerInitContainer.Env, "TOPOLOGY_CONFIGMAP_PATH",
 					consts.VolumeMountPathTopologyNodeLabels)
+				assertEnvValue(t, workerInitContainer.Env, "TOPOLOGY_WAIT_TIMEOUT", tt.expectedWaitTimeout)
+				assertEnvValue(t, workerInitContainer.Env, "SLURMD_TOPOLOGY_PATH", consts.SlurmdTopologyPath)
+				assertEnvValue(t, slurmdContainer.Env, "SLURMD_TOPOLOGY_PATH", consts.SlurmdTopologyPath)
+
+				// Both ends of the handoff must see the same volume.
+				var initHasRuntimeMount bool
+				for _, mount := range workerInitContainer.VolumeMounts {
+					if mount.Name == consts.VolumeNameRuntime {
+						initHasRuntimeMount = true
+						break
+					}
+				}
+				assert.True(t, initHasRuntimeMount, "worker-init should mount the shared runtime volume")
 			}
 
 			// Verify topology-related volumes
@@ -847,7 +795,6 @@ func TestRenderNodeSetStatefulSet_DockerEnabled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := worker.RenderNodeSetStatefulSet(
-				"test-cluster",
 				createNodeSet(tt.dockerEnabled),
 				&slurmv1.Secrets{},
 				consts.CGroupV2,
@@ -906,7 +853,6 @@ func TestRenderNodeSetStatefulSet_NodeRealMemoryMetadata(t *testing.T) {
 
 	t.Run("exports the rendered Slurm RealMemory in bytes", func(t *testing.T) {
 		result, err := worker.RenderNodeSetStatefulSet(
-			"test-cluster",
 			createNodeSet(),
 			&slurmv1.Secrets{},
 			consts.CGroupV2,
@@ -933,7 +879,6 @@ func TestRenderNodeSetStatefulSet_NodeRealMemoryMetadata(t *testing.T) {
 		}}
 
 		_, err := worker.RenderNodeSetStatefulSet(
-			"test-cluster",
 			nodeSet,
 			&slurmv1.Secrets{},
 			consts.CGroupV2,
@@ -1035,7 +980,6 @@ func TestRenderNodeSetStatefulSet_PersistentVolumeClaimRetentionPolicy(t *testin
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := worker.RenderNodeSetStatefulSet(
-				"test-cluster",
 				tt.nodeSet,
 				&slurmv1.Secrets{},
 				consts.CGroupV2,
@@ -1102,7 +1046,6 @@ func TestRenderNodeSetStatefulSet_ScaleStrategy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := worker.RenderNodeSetStatefulSet(
-				"test-cluster",
 				makeNodeSet(tt.maxUnavailable),
 				&slurmv1.Secrets{},
 				consts.CGroupV2,
@@ -1132,7 +1075,6 @@ func TestRenderNodeSetStatefulSet_ScaleStrategy(t *testing.T) {
 		nodeSet.UpdateStrategy = consts.UpdateStrategySlurmAwareRollingUpdate
 
 		result, err := worker.RenderNodeSetStatefulSet(
-			"test-cluster",
 			nodeSet,
 			&slurmv1.Secrets{},
 			consts.CGroupV2,
@@ -1152,7 +1094,6 @@ func TestRenderNodeSetStatefulSet_ScaleStrategy(t *testing.T) {
 		nodeSet.UpdateStrategy = consts.UpdateStrategy("unsupported")
 
 		_, err := worker.RenderNodeSetStatefulSet(
-			"test-cluster",
 			nodeSet,
 			&slurmv1.Secrets{},
 			consts.CGroupV2,
@@ -1255,7 +1196,6 @@ func TestRenderNodeSetStatefulSet_EphemeralNodesReserveOrdinals(t *testing.T) {
 			nodeSet := createNodeSetWithActiveNodes(tt.ephemeralNodes, tt.activeNodes)
 
 			result, err := worker.RenderNodeSetStatefulSet(
-				"test-cluster",
 				nodeSet,
 				&slurmv1.Secrets{},
 				consts.CGroupV2,


### PR DESCRIPTION
## Problem

Workers registered into their topology with `scontrol update ... Topology=... State=POWER_UP`
from the init container, before slurmd started. That update moves the node into a state where
slurmctld discards the `InstanceId` and `Extra` that slurmd registration carries, so powered-up
workers ended up with missing Slurm instance IDs.

Separately, `powermanager` waited for `NodeSetPowerState` updates on non-ephemeral NodeSets,
which power actions skip — so the wait could only time out.

## Solution

The topology now travels with slurmd registration instead of a separate `scontrol update`:

- `worker_init.py` resolves the topology specification and writes it to
  `/run/soperator/slurmd_topology` on the runtime volume shared with slurmd
  (`write_slurmd_topology` replaces `apply_node_topology`). An empty file records
  "resolution ran, no topology" so the entrypoint can tell it apart from "never ran".
- `slurmd_entrypoint.sh` reads that file and passes it to `slurmd --conf "topology=..."`.
  The wait for the topology ConfigMap stays in the init container, off slurmd's startup path.
- Render: the runtime volume is mounted in worker-init before the munge socket nested in it,
  the topology env is split into helpers, and the now-unused `clusterName` /
  `K8S_POD_NAME`-style env for `NodeAddr` construction is dropped.
- `powermanager` resolves once per NodeSet whether it is ephemeral and skips waiting on the
  ones power actions do not touch.

`docs/topology.md` is updated accordingly.

## Testing

- `make test` — new unit tests: `TestWriteTopologyConf` (file contents, empty file, no
  `scontrol` call, default path), `TestNodeSetIsEphemeral`, `TestCheckNodesStatus`, plus updated
  worker render tests asserting `SLURMD_TOPOLOGY_PATH` and the runtime-before-munge mount order.
- `make lint`, `make helmtest`.

## Release Notes

Fix: workers now join their topology through slurmd registration instead of a pre-start
`scontrol update`, so powering up a worker no longer loses the node's `InstanceId` and `Extra`.
