### PR TITLE
SCHED-1418: Fix e2e failures due to missing nvidia-persistenced socket

### DIFF
--- a/internal/consts/container.go
+++ b/internal/consts/container.go
@@ -1,22 +1,23 @@
 package consts
 
 const (
-	ContainerNameSlurmctld         = SlurmctldName
-	ContainerNameAccounting        = AccountingName
-	ContainerNameMunge             = Munge
-	ContainerNameSSSD              = "sssd"
-	ContainerNameSlurmd            = SlurmdName
-	ContainerNameREST              = Slurmrestd
-	ContainerNameSshd              = SshdName
-	ContainerNameWorkerInit        = "worker-init"
-	ContainerNameDockerProxy       = "docker-proxy"
-	ContainerNameWaitForDatabase   = "wait-for-database"
-	ContainerNameWaitForAccounting = "wait-for-accounting"
-	ContainerNamePopulateJail      = populateJail
-	ContainerNameExporter          = Exporter
-	ContainerNameRebooter          = "rebooter"
-	ContainerNameCustom            = "custom-container"
-	ContainerNameSConfigController = SConfigControllerName
+	ContainerNameSlurmctld                 = SlurmctldName
+	ContainerNameAccounting                = AccountingName
+	ContainerNameMunge                     = Munge
+	ContainerNameSSSD                      = "sssd"
+	ContainerNameSlurmd                    = SlurmdName
+	ContainerNameREST                      = Slurmrestd
+	ContainerNameSshd                      = SshdName
+	ContainerNameWorkerInit                = "worker-init"
+	ContainerNameWaitForNvidiaPersistenced = "wait-for-nvidia-persistenced"
+	ContainerNameDockerProxy               = "docker-proxy"
+	ContainerNameWaitForDatabase           = "wait-for-database"
+	ContainerNameWaitForAccounting         = "wait-for-accounting"
+	ContainerNamePopulateJail              = populateJail
+	ContainerNameExporter                  = Exporter
+	ContainerNameRebooter                  = "rebooter"
+	ContainerNameCustom                    = "custom-container"
+	ContainerNameSConfigController         = SConfigControllerName
 
 	ContainerSecurityContextCapabilitySysAdmin = "SYS_ADMIN"
 	ContainerSecurityContextCapabilitySetFcap  = "SETFCAP"

--- a/internal/consts/volume.go
+++ b/internal/consts/volume.go
@@ -67,6 +67,7 @@ const (
 	VolumeNameSysctl                   = sysctl
 	VolumeNameSupervisordConfigMap     = "supervisord-config"
 	VolumeNameRuntime                  = "runtime"
+	VolumeNameHostRun                  = "host-run"
 	VolumeNameInMemorySubmount         = "in-memory"
 	VolumeNameTmpDisk                  = "tmp-disk"
 	VolumeNameHostLogJournal           = hostLogJournal
@@ -100,6 +101,8 @@ const (
 	VolumeMountSubPathSysctl                = sysctlConfFile
 	VolumeMountPathSupervisordConfig        = "/etc/supervisor/conf.d/"
 	VolumeMountPathRuntime                  = "/run"
+	VolumeHostPathRun                       = "/run"
+	VolumeMountPathHostRun                  = "/host-run"
 	VolumeMountPathInMemorySubmount         = VolumeMountPathJailUpper + "/mnt/memory"
 	VolumeMountPathTmpDisk                  = "/tmp"
 	VolumeHostPathJournal                   = "/var/log/journal"

--- a/internal/render/worker/container.go
+++ b/internal/render/worker/container.go
@@ -11,6 +11,7 @@ import (
 	"nebius.ai/slurm-operator/internal/check"
 	"nebius.ai/slurm-operator/internal/naming"
 	"nebius.ai/slurm-operator/internal/utils/sliceutils"
+	"nebius.ai/slurm-operator/internal/utils/stringutils"
 
 	slurmv1 "nebius.ai/slurm-operator/api/v1"
 	"nebius.ai/slurm-operator/internal/consts"
@@ -92,6 +93,31 @@ func RenderContainerWorkerInit(
 		Command:                  command,
 		VolumeMounts:             volumeMounts,
 		Env:                      env,
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+	}
+}
+
+// Wait for the host socket before creating slurmd so the NVIDIA runtime can discover and inject it.
+func renderContainerNvidiaPersistencedWaiter(container *values.Container) corev1.Container {
+	return corev1.Container{
+		Name:            consts.ContainerNameWaitForNvidiaPersistenced,
+		Image:           container.Image,
+		ImagePullPolicy: container.ImagePullPolicy,
+		Command:         []string{"/bin/sh", "-ec"},
+		Args: []string{
+			// language=bash
+			fmt.Sprintf(stringutils.Dedent(`
+			until [ -S %s/nvidia-persistenced/socket ]; do
+			    echo "Waiting for the NVIDIA persistenced socket on the host..."
+			    sleep 5
+			done
+			echo "NVIDIA persistenced socket is ready"
+			`), consts.VolumeMountPathHostRun),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			renderVolumeMountHostRun(),
+		},
 		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 	}

--- a/internal/render/worker/statefulset.go
+++ b/internal/render/worker/statefulset.go
@@ -61,6 +61,9 @@ func RenderNodeSetStatefulSet(
 			common.SSSDLdapCAConfigMap(nodeSet.SSSDLdapCAConfigMapName),
 		))
 	}
+	if nodeSet.GPU.Enabled {
+		initContainers = append(initContainers, renderContainerNvidiaPersistencedWaiter(&nodeSet.ContainerSlurmd))
+	}
 	initContainers = append(initContainers,
 		RenderContainerWorkerInit(
 			&nodeSet.ContainerSlurmd,

--- a/internal/render/worker/statefulset_test.go
+++ b/internal/render/worker/statefulset_test.go
@@ -144,7 +144,7 @@ func Test_RenderContainerWorkerInit(t *testing.T) {
 	})
 }
 
-func TestRenderNodeSetStatefulSet_SlurmdGPUEnv(t *testing.T) {
+func TestRenderNodeSetStatefulSet_SlurmdGPUConfiguration(t *testing.T) {
 	tests := []struct {
 		name                       string
 		clusterWithGPU             bool
@@ -225,6 +225,56 @@ func TestRenderNodeSetStatefulSet_SlurmdGPUEnv(t *testing.T) {
 
 			assertEnvValue(t, result.Spec.Template.Spec.Containers[0].Env, "SLURM_CLUSTER_WITH_GPU", tt.expectedClusterWithGPUFlag)
 			assertEnvValue(t, result.Spec.Template.Spec.Containers[0].Env, "NODESET_GPU_ENABLED", tt.expectedNodeSetGPUFlag)
+
+			if tt.nodeSetGPUEnabled {
+				assert.Contains(t, result.Spec.Template.Spec.Volumes, corev1.Volume{
+					Name: "host-run",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/run",
+							Type: ptr.To(corev1.HostPathDirectory),
+						},
+					},
+				})
+			} else {
+				assertNoHostPathVolume(t, result.Spec.Template.Spec.Volumes, "host-run")
+			}
+
+			var waiterCount int
+			for i, container := range result.Spec.Template.Spec.InitContainers {
+				assertNoVolumeMount(t, container.VolumeMounts, "persistenced-required")
+				if container.Name != "wait-for-nvidia-persistenced" {
+					assertNoVolumeMount(t, container.VolumeMounts, "host-run")
+					continue
+				}
+				waiterCount++
+				assert.Equal(t, nodeSet.ContainerSlurmd.Image, container.Image)
+				assert.Equal(t, nodeSet.ContainerSlurmd.ImagePullPolicy, container.ImagePullPolicy)
+				assert.Nil(t, container.RestartPolicy, "the waiter must exit before the next init container starts")
+				assert.Empty(t, container.Resources, "waiting for the host socket does not require GPU allocation")
+				assert.Equal(t, []string{"/bin/sh", "-ec"}, container.Command)
+				if assert.Len(t, container.Args, 1) {
+					assert.Contains(t, container.Args[0], "until [ -S /host-run/nvidia-persistenced/socket ]; do")
+				}
+				assert.Equal(t, []corev1.VolumeMount{{
+					Name:      "host-run",
+					MountPath: "/host-run",
+					ReadOnly:  true,
+				}}, container.VolumeMounts)
+				if assert.Less(t, i+1, len(result.Spec.Template.Spec.InitContainers)) {
+					assert.Equal(t, consts.ContainerNameWorkerInit, result.Spec.Template.Spec.InitContainers[i+1].Name)
+				}
+			}
+			if tt.nodeSetGPUEnabled {
+				assert.Equal(t, 1, waiterCount)
+			} else {
+				assert.Zero(t, waiterCount)
+			}
+			assertNoHostPathVolume(t, result.Spec.Template.Spec.Volumes, "persistenced-required")
+			for _, container := range result.Spec.Template.Spec.Containers {
+				assertNoVolumeMount(t, container.VolumeMounts, "host-run")
+				assertNoVolumeMount(t, container.VolumeMounts, "persistenced-required")
+			}
 		})
 	}
 }

--- a/internal/render/worker/volume.go
+++ b/internal/render/worker/volume.go
@@ -44,7 +44,7 @@ func renderVolumesAndClaimTemplateSpecsForNodeSet(
 		}
 	}
 	if nodeSet.GPU.Enabled {
-		volumes = append(volumes, renderVolumeNvidia())
+		volumes = append(volumes, renderVolumeNvidia(), renderVolumeHostRun())
 		volumes = append(volumes, common.RenderVolumesNvidiaIMEX()...)
 	}
 
@@ -163,6 +163,26 @@ func renderVolumeMountNvidia() corev1.VolumeMount {
 		Name:             consts.VolumeNameNvidia,
 		MountPath:        consts.VolumeMountPathNvidia,
 		MountPropagation: ptr.To(corev1.MountPropagationHostToContainer),
+	}
+}
+
+func renderVolumeHostRun() corev1.Volume {
+	return corev1.Volume{
+		Name: consts.VolumeNameHostRun,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: consts.VolumeHostPathRun,
+				Type: ptr.To(corev1.HostPathDirectory),
+			},
+		},
+	}
+}
+
+func renderVolumeMountHostRun() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      consts.VolumeNameHostRun,
+		MountPath: consts.VolumeMountPathHostRun,
+		ReadOnly:  true,
 	}
 }
 


### PR DESCRIPTION
## Problem

GPU workers intermittently fail the persistence health check. The hypothesis is that container creation races with host `nvidia-persistenced` service startup.

NVIDIA Toolkit 1.19.1 [discovers the socket under `/run` and `/var/run`](https://github.com/NVIDIA/nvidia-container-toolkit/blob/v1.19.1/internal/discover/ipc.go#L35-L49). If absent, it [logs a warning and continues without the mount](https://github.com/NVIDIA/nvidia-container-toolkit/blob/v1.19.1/internal/discover/mounts.go#L63-L72), allowing a worker to start without access to the daemon.

## Solution

Add a required `hostPath` volume with `type: Socket` for GPU workers. Kubelet blocks volume setup until `/run/nvidia-persistenced/socket` exists, before container creation and JIT-CDI discovery. Mount it read-only at a separate path to preserve NVIDIA’s normal injection.

This targets the suspected startup race; it does not address socket replacement after daemon restarts.

## Testing

Added rendering assertions for GPU and CPU workers. Manually verified that the socket requirement blocks Pod startup while the socket is absent. Whether this prevents the original intermittent E2E failure remains to be established.

## Release Notes

GPU workers now require the host persistenced socket before starting. Nodes without that socket will keep workers blocked during volume setup.