### PR TITLE
SCHED-2454: report E2E results in PR comments

### DIFF
--- a/.github/scripts/acceptance_summary.py
+++ b/.github/scripts/acceptance_summary.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
-"""Render a godog cucumber JSON report as markdown for GitHub step summary."""
+"""Render a godog cucumber JSON report as Markdown."""
+import argparse
 import json
+import re
 import sys
 
 NS_PER_SEC = 1_000_000_000
@@ -15,13 +17,33 @@ _STATUS_PRIORITY = {
     "passed": 1,
 }
 
+_MARKDOWN_SPECIAL = re.compile(r"([\\`*_[\]<>|])")
+_FAILED_SCENARIO_LIMIT = 10
+
 
 def fmt_s(ns):
     return f"{(ns or 0) / NS_PER_SEC:.1f}s"
 
 
+def fmt_duration(ns):
+    seconds = (ns or 0) / NS_PER_SEC
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+
+    total_seconds = round(seconds)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes}m {seconds}s"
+    return f"{minutes}m {seconds}s"
+
+
 def cell(s):
     return str(s).replace("|", "\\|")
+
+
+def markdown(s):
+    return _MARKDOWN_SPECIAL.sub(r"\\\1", str(s))
 
 
 def scenario_status(steps):
@@ -33,37 +55,104 @@ def scenario_status(steps):
     )
 
 
-def render(features, out):
+def scenarios(features):
+    for feature in features:
+        for scenario in feature.get("elements", []):
+            steps = scenario.get("steps", [])
+            yield {
+                "feature": feature.get("name", ""),
+                "name": scenario.get("name", ""),
+                "steps": steps,
+                "status": scenario_status(steps),
+                "duration": sum(
+                    step.get("result", {}).get("duration", 0) for step in steps
+                ),
+            }
+
+
+def render_summary(features, out):
     out.write("### Acceptance\n")
-    for feat in features:
-        for scen in feat.get("elements", []):
-            steps = scen.get("steps", [])
-            total_ns = sum(s.get("result", {}).get("duration", 0) for s in steps)
-            status = scenario_status(steps)
-            out.write("\n")
+    for scenario in scenarios(features):
+        out.write("\n")
+        out.write(
+            f"#### {cell(scenario['feature'])} / {cell(scenario['name'])} / "
+            f"{scenario['status']} / {fmt_s(scenario['duration'])}\n"
+        )
+        if not scenario["steps"]:
+            continue
+        out.write("\n| Step | Status | Time |\n")
+        out.write("| --- | --- | --- |\n")
+        for step in scenario["steps"]:
+            keyword = step.get("keyword", "").strip()
+            name = step.get("name", "")
+            label = f"{keyword} {name}".strip()
+            result = step.get("result", {})
             out.write(
-                f"#### {cell(feat.get('name', ''))} / "
-                f"{cell(scen.get('name', ''))} / {status} / {fmt_s(total_ns)}\n"
+                f"| {cell(label)} | {result.get('status', '')} | "
+                f"{fmt_s(result.get('duration', 0))} |\n"
             )
-            if not steps:
-                continue
-            out.write("\n| Step | Status | Time |\n")
-            out.write("| --- | --- | --- |\n")
-            for s in steps:
-                keyword = s.get("keyword", "").strip()
-                name = s.get("name", "")
-                label = f"{keyword} {name}".strip()
-                res = s.get("result", {})
-                out.write(
-                    f"| {cell(label)} | {res.get('status', '')} | "
-                    f"{fmt_s(res.get('duration', 0))} |\n"
-                )
+
+
+def first_failing_step(steps):
+    for step in steps:
+        status = step.get("result", {}).get("status", "")
+        if status not in ("", "passed", "skipped"):
+            keyword = step.get("keyword", "").strip()
+            name = step.get("name", "")
+            return f"{keyword} {name}".strip()
+    return "unknown"
+
+
+def render_comment(features, out):
+    all_scenarios = list(scenarios(features))
+    passed = sum(scenario["status"] == "passed" for scenario in all_scenarios)
+    skipped = sum(scenario["status"] == "skipped" for scenario in all_scenarios)
+    failed_scenarios = [
+        scenario
+        for scenario in all_scenarios
+        if scenario["status"] not in ("passed", "skipped")
+    ]
+
+    out.write(
+        f"{passed} passed · {len(failed_scenarios)} failed · {skipped} skipped\n"
+    )
+    if not failed_scenarios:
+        return
+
+    out.write("\n<details>\n")
+    out.write(f"<summary>Failed scenarios ({len(failed_scenarios)})</summary>\n\n")
+    for scenario in failed_scenarios[:_FAILED_SCENARIO_LIMIT]:
+        out.write(
+            f"- **{markdown(scenario['feature'])} / {markdown(scenario['name'])}**\n"
+        )
+        out.write(
+            "  - First failing step: "
+            f"{markdown(first_failing_step(scenario['steps']))}\n"
+        )
+        out.write(f"  - Duration: {fmt_duration(scenario['duration'])}\n")
+
+    remaining = len(failed_scenarios) - _FAILED_SCENARIO_LIMIT
+    if remaining > 0:
+        out.write(f"- {remaining} more failed scenarios; see the workflow run.\n")
+    out.write("\n</details>\n")
 
 
 def main():
-    with open(sys.argv[1]) as f:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("report")
+    parser.add_argument(
+        "--format",
+        choices=("summary", "comment"),
+        default="summary",
+    )
+    args = parser.parse_args()
+
+    with open(args.report) as f:
         features = json.load(f)
-    render(features, sys.stdout)
+    if args.format == "comment":
+        render_comment(features, sys.stdout)
+    else:
+        render_summary(features, sys.stdout)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/acceptance_summary.py
+++ b/.github/scripts/acceptance_summary.py
@@ -17,33 +17,16 @@ _STATUS_PRIORITY = {
     "passed": 1,
 }
 
-_MARKDOWN_SPECIAL = re.compile(r"([\\`*_[\]<>|])")
 _FAILED_SCENARIO_LIMIT = 10
+_ERROR_MESSAGE_LIMIT = 4_000
 
 
 def fmt_s(ns):
     return f"{(ns or 0) / NS_PER_SEC:.1f}s"
 
 
-def fmt_duration(ns):
-    seconds = (ns or 0) / NS_PER_SEC
-    if seconds < 60:
-        return f"{seconds:.1f}s"
-
-    total_seconds = round(seconds)
-    hours, remainder = divmod(total_seconds, 3600)
-    minutes, seconds = divmod(remainder, 60)
-    if hours:
-        return f"{hours}h {minutes}m {seconds}s"
-    return f"{minutes}m {seconds}s"
-
-
 def cell(s):
     return str(s).replace("|", "\\|")
-
-
-def markdown(s):
-    return _MARKDOWN_SPECIAL.sub(r"\\\1", str(s))
 
 
 def scenario_status(steps):
@@ -62,6 +45,7 @@ def scenarios(features):
             yield {
                 "feature": feature.get("name", ""),
                 "name": scenario.get("name", ""),
+                "uri": feature.get("uri", ""),
                 "steps": steps,
                 "status": scenario_status(steps),
                 "duration": sum(
@@ -93,14 +77,68 @@ def render_summary(features, out):
             )
 
 
-def first_failing_step(steps):
+def failed_step(steps):
     for step in steps:
-        status = step.get("result", {}).get("status", "")
+        result = step.get("result", {})
+        status = result.get("status", "")
         if status not in ("", "passed", "skipped"):
-            keyword = step.get("keyword", "").strip()
-            name = step.get("name", "")
-            return f"{keyword} {name}".strip()
-    return "unknown"
+            return step
+    return None
+
+
+def truncate_error_message(message):
+    message = str(message).strip()
+    truncation_notice = "\n… (truncated; see workflow run)"
+    if len(message) > _ERROR_MESSAGE_LIMIT:
+        message = message[: _ERROR_MESSAGE_LIMIT - len(truncation_notice)]
+        message += truncation_notice
+    return message
+
+
+def render_failed_steps(failed_scenarios, remaining, out):
+    lines = ["--- Failed steps:"]
+    for scenario in failed_scenarios:
+        step = failed_step(scenario["steps"])
+        scenario_location = scenario["uri"] or "unknown"
+        lines.extend(
+            [
+                "",
+                f"  Scenario: {scenario['name']} # {scenario_location}",
+            ]
+        )
+        if step is None:
+            lines.append("    unknown")
+            continue
+
+        keyword = step.get("keyword", "").strip()
+        name = step.get("name", "")
+        step_label = f"{keyword} {name}".strip()
+        step_line = step.get("line")
+        step_location = scenario_location
+        if scenario_location != "unknown" and step_line is not None:
+            step_location = f"{scenario_location}:{step_line}"
+        lines.append(f"    {step_label} # {step_location}")
+
+        error_message = step.get("result", {}).get("error_message", "")
+        if error_message:
+            error_lines = truncate_error_message(error_message).split("\n")
+            lines.append(f"      Error: {error_lines[0]}")
+            lines.extend(f"             {line}" for line in error_lines[1:])
+
+    if remaining > 0:
+        lines.extend(
+            [
+                "",
+                f"  {remaining} more failed scenarios; see the workflow run.",
+            ]
+        )
+
+    body = "\n".join(lines)
+
+    backtick_runs = re.findall(r"`+", body)
+    fence_length = max(3, max(map(len, backtick_runs), default=0) + 1)
+    fence = "`" * fence_length
+    out.write(f"{fence}text\n{body}\n{fence}\n")
 
 
 def render_comment(features, out):
@@ -121,19 +159,12 @@ def render_comment(features, out):
 
     out.write("\n<details>\n")
     out.write(f"<summary>Failed scenarios ({len(failed_scenarios)})</summary>\n\n")
-    for scenario in failed_scenarios[:_FAILED_SCENARIO_LIMIT]:
-        out.write(
-            f"- **{markdown(scenario['feature'])} / {markdown(scenario['name'])}**\n"
-        )
-        out.write(
-            "  - First failing step: "
-            f"{markdown(first_failing_step(scenario['steps']))}\n"
-        )
-        out.write(f"  - Duration: {fmt_duration(scenario['duration'])}\n")
-
     remaining = len(failed_scenarios) - _FAILED_SCENARIO_LIMIT
-    if remaining > 0:
-        out.write(f"- {remaining} more failed scenarios; see the workflow run.\n")
+    render_failed_steps(
+        failed_scenarios[:_FAILED_SCENARIO_LIMIT],
+        remaining,
+        out,
+    )
     out.write("\n</details>\n")
 
 

--- a/.github/scripts/e2e_pr_comment.py
+++ b/.github/scripts/e2e_pr_comment.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Render the PR status comment for a dispatched E2E workflow."""
+import argparse
+import json
+import os
+
+
+UNSUCCESSFUL_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "stale",
+    "timed_out",
+}
+
+
+def inline_code(value):
+    value = str(value).replace("\n", " ")
+    delimiter = "`"
+    while delimiter in value:
+        delimiter += "`"
+    padding = " " if value.startswith("`") or value.endswith("`") else ""
+    return f"{delimiter}{padding}{value}{padding}{delimiter}"
+
+
+def run_url(context):
+    url = (
+        f"{context['GITHUB_SERVER_URL']}/{context['GITHUB_REPOSITORY']}"
+        f"/actions/runs/{context['GITHUB_RUN_ID']}"
+    )
+    attempt = int(context.get("GITHUB_RUN_ATTEMPT", "1"))
+    if attempt > 1:
+        return f"{url}/attempts/{attempt}"
+    return url
+
+
+def marker(context):
+    return f"<!-- soperator-e2e-run:{context['GITHUB_RUN_ID']} -->"
+
+
+def parameters(context, include_resolved_profile=False):
+    values = [
+        ("Soperator branch", context["SOPERATOR_BRANCH"]),
+        ("Terraform branch", context["TERRAFORM_BRANCH"]),
+        ("Soperator E2E branch", context["SOPERATOR_E2E_BRANCH"]),
+        ("Profile", context["REQUESTED_PROFILE"]),
+    ]
+    resolved_profile = context.get("RESOLVED_PROFILE", "")
+    if include_resolved_profile and resolved_profile:
+        values.append(("Resolved profile", resolved_profile))
+    values.extend(
+        [
+            ("Unstable tests", context["RUN_UNSTABLE_TESTS"]),
+            ("Essential tests only", context["RUN_ESSENTIAL_TESTS"]),
+        ]
+    )
+    return "\n".join(f"- {name}: {inline_code(value)}" for name, value in values)
+
+
+def render_start(context):
+    return "\n".join(
+        [
+            marker(context),
+            "### ⏳ E2E running",
+            "",
+            "E2E was dispatched with:",
+            "",
+            parameters(context),
+            "",
+            f"[Workflow run]({run_url(context)})",
+            "",
+        ]
+    )
+
+
+def find_job(jobs, name=None, prefix=None):
+    for job in jobs.get("jobs", []):
+        if name is not None and job.get("name") == name:
+            return job
+        if prefix is not None and job.get("name", "").startswith(prefix):
+            return job
+    return None
+
+
+def first_unsuccessful_step(job, before=None, after=None):
+    if not job:
+        return None
+    for step in sorted(job.get("steps", []), key=lambda item: item.get("number", 0)):
+        number = step.get("number", 0)
+        if before is not None and number >= before:
+            continue
+        if after is not None and number <= after:
+            continue
+        if step.get("conclusion") in UNSUCCESSFUL_CONCLUSIONS:
+            return step.get("name")
+    return None
+
+
+def acceptance_step_number(job):
+    if not job:
+        return None
+    for step in job.get("steps", []):
+        if step.get("name") == "Acceptance Tests":
+            return step.get("number")
+    return None
+
+
+def result_header(context):
+    results = (context["RESOLVE_RESULT"], context["E2E_RESULT"])
+    if results == ("success", "success"):
+        return "### ✅ E2E passed"
+    if "cancelled" in results:
+        return "### ⏹️ E2E cancelled"
+    return "### ❌ E2E failed"
+
+
+def acceptance_result(context, summary):
+    outcome = context.get("ACCEPTANCE_OUTCOME", "")
+    report_available = context.get("ACCEPTANCE_REPORT_AVAILABLE") == "true"
+    if outcome == "skipped" or not outcome:
+        return "Acceptance tests: not run"
+    if outcome == "cancelled":
+        return "Acceptance tests: cancelled"
+    if report_available and summary.strip():
+        return summary.strip()
+    return "Acceptance report unavailable"
+
+
+def render_final(context, jobs, acceptance_summary):
+    resolve_job = find_job(jobs, name="resolve-profile")
+    e2e_job = find_job(jobs, prefix="e2e-test (")
+    acceptance_number = acceptance_step_number(e2e_job)
+
+    before_failure = None
+    after_failure = None
+    if context["RESOLVE_RESULT"] != "success":
+        before_failure = first_unsuccessful_step(resolve_job) or "resolve-profile"
+    elif acceptance_number is None:
+        before_failure = first_unsuccessful_step(e2e_job) or "e2e-test"
+    else:
+        before_failure = first_unsuccessful_step(e2e_job, before=acceptance_number)
+        after_failure = first_unsuccessful_step(e2e_job, after=acceptance_number)
+
+    sections = [
+        marker(context),
+        result_header(context),
+        "",
+        "E2E was dispatched with:",
+        "",
+        parameters(context, include_resolved_profile=True),
+    ]
+
+    if before_failure:
+        sections.extend(
+            [
+                "",
+                "### Failure before acceptance",
+                "",
+                f"- Failed step: {inline_code(before_failure)}",
+                "- Acceptance tests: not run",
+            ]
+        )
+    else:
+        sections.extend(
+            [
+                "",
+                "### Acceptance results",
+                "",
+                acceptance_result(context, acceptance_summary),
+            ]
+        )
+        if after_failure:
+            sections.extend(
+                [
+                    "",
+                    "### Failure after acceptance",
+                    "",
+                    f"- Failed step: {inline_code(after_failure)}",
+                ]
+            )
+
+    sections.extend(["", f"[Workflow run]({run_url(context)})", ""])
+    return "\n".join(sections)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("phase", choices=("start", "final"))
+    parser.add_argument("--jobs")
+    parser.add_argument("--acceptance-summary")
+    args = parser.parse_args()
+
+    if args.phase == "start":
+        print(render_start(os.environ), end="")
+        return
+
+    with open(args.jobs) as jobs_file:
+        jobs = json.load(jobs_file)
+    summary = ""
+    if args.acceptance_summary:
+        with open(args.acceptance_summary) as summary_file:
+            summary = summary_file.read()
+    print(render_final(os.environ, jobs, summary), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_e2e_reporting.py
+++ b/.github/scripts/test_e2e_reporting.py
@@ -6,17 +6,22 @@ from acceptance_summary import NS_PER_SEC, render_comment
 from e2e_pr_comment import render_final, render_start
 
 
-def cucumber_step(name, status, seconds=1):
-    return {
+def cucumber_step(name, status, seconds=1, error_message="", line=4):
+    step = {
         "keyword": "Given ",
         "name": name,
+        "line": line,
         "result": {"status": status, "duration": seconds * NS_PER_SEC},
     }
+    if error_message:
+        step["result"]["error_message"] = error_message
+    return step
 
 
 def cucumber_scenario(feature, name, steps):
     return {
         "name": feature,
+        "uri": "features/example.feature:3",
         "elements": [{"name": name, "steps": steps}],
     }
 
@@ -72,7 +77,12 @@ class AcceptanceCommentTest(unittest.TestCase):
                 "containers [see] GPUs",
                 [
                     cucumber_step("the cluster exists", "passed", 2),
-                    cucumber_step("the GPU smoke job succeeds", "failed", 65),
+                    cucumber_step(
+                        "the GPU smoke job succeeds",
+                        "failed",
+                        65,
+                        "pod gpu-smoke is not Ready",
+                    ),
                 ],
             ),
             cucumber_scenario(
@@ -88,9 +98,56 @@ class AcceptanceCommentTest(unittest.TestCase):
 
         result = output.getvalue()
         self.assertIn("1 passed · 1 failed · 1 skipped", result)
-        self.assertIn("Enroot \\*GPU\\* / containers \\[see\\] GPUs", result)
-        self.assertIn("First failing step: Given the GPU smoke job succeeds", result)
-        self.assertIn("Duration: 1m 7s", result)
+        self.assertIn("--- Failed steps:", result)
+        self.assertIn(
+            "Scenario: containers [see] GPUs # features/example.feature:3",
+            result,
+        )
+        self.assertIn(
+            "Given the GPU smoke job succeeds # features/example.feature:3:4",
+            result,
+        )
+        self.assertIn("Error: pod gpu-smoke is not Ready", result)
+        self.assertNotIn("Duration:", result)
+
+    def test_renders_multiline_error_with_safe_code_fence(self):
+        features = [
+            cucumber_scenario(
+                "Cluster creation",
+                "cluster is ready",
+                [
+                    cucumber_step(
+                        "all pods are Ready",
+                        "failed",
+                        error_message="first line\ncontains ``` from command output",
+                    )
+                ],
+            )
+        ]
+        output = io.StringIO()
+
+        render_comment(features, output)
+
+        result = output.getvalue()
+        self.assertIn("````text\n", result)
+        self.assertIn("      Error: first line\n", result)
+        self.assertIn("             contains ``` from command output\n", result)
+
+    def test_truncates_long_error_message(self):
+        features = [
+            cucumber_scenario(
+                "Feature",
+                "Scenario",
+                [cucumber_step("failure", "failed", error_message="x" * 5_000)],
+            )
+        ]
+        output = io.StringIO()
+
+        render_comment(features, output)
+
+        result = output.getvalue()
+        self.assertIn("… (truncated; see workflow run)", result)
+        self.assertNotIn("x" * 4_001, result)
 
     def test_limits_failed_scenarios(self):
         features = [
@@ -106,8 +163,8 @@ class AcceptanceCommentTest(unittest.TestCase):
         render_comment(features, output)
 
         result = output.getvalue()
-        self.assertEqual(result.count("First failing step:"), 10)
-        self.assertIn("2 more failed scenarios; see the workflow run.", result)
+        self.assertEqual(result.count("  Scenario:"), 10)
+        self.assertIn("  2 more failed scenarios; see the workflow run.", result)
 
 
 class E2EPRCommentTest(unittest.TestCase):

--- a/.github/scripts/test_e2e_reporting.py
+++ b/.github/scripts/test_e2e_reporting.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+import io
+import unittest
+
+from acceptance_summary import NS_PER_SEC, render_comment
+from e2e_pr_comment import render_final, render_start
+
+
+def cucumber_step(name, status, seconds=1):
+    return {
+        "keyword": "Given ",
+        "name": name,
+        "result": {"status": status, "duration": seconds * NS_PER_SEC},
+    }
+
+
+def cucumber_scenario(feature, name, steps):
+    return {
+        "name": feature,
+        "elements": [{"name": name, "steps": steps}],
+    }
+
+
+def context(**overrides):
+    values = {
+        "GITHUB_SERVER_URL": "https://github.com",
+        "GITHUB_REPOSITORY": "nebius/soperator",
+        "GITHUB_RUN_ID": "12345",
+        "GITHUB_RUN_ATTEMPT": "1",
+        "SOPERATOR_BRANCH": "feature",
+        "TERRAFORM_BRANCH": "main",
+        "SOPERATOR_E2E_BRANCH": "feature",
+        "REQUESTED_PROFILE": "@auto-select",
+        "RESOLVED_PROFILE": "KCS_B200",
+        "RUN_UNSTABLE_TESTS": "false",
+        "RUN_ESSENTIAL_TESTS": "true",
+        "RESOLVE_RESULT": "success",
+        "E2E_RESULT": "success",
+        "ACCEPTANCE_OUTCOME": "success",
+        "ACCEPTANCE_REPORT_AVAILABLE": "true",
+    }
+    values.update(overrides)
+    return values
+
+
+def workflow_jobs(before=None, acceptance="success", after=None):
+    steps = [
+        {"name": "Set up job", "number": 1, "conclusion": "success"},
+        {"name": "Terraform Apply", "number": 2, "conclusion": before or "success"},
+        {"name": "Acceptance Tests", "number": 3, "conclusion": acceptance},
+        {"name": "Upload Acceptance Reports", "number": 4, "conclusion": "success"},
+        {"name": "Terraform Destroy", "number": 5, "conclusion": after or "success"},
+    ]
+    return {
+        "jobs": [
+            {
+                "name": "resolve-profile",
+                "steps": [
+                    {"name": "Resolve profile", "number": 1, "conclusion": "success"}
+                ],
+            },
+            {"name": "e2e-test (KCS_B200)", "steps": steps},
+        ]
+    }
+
+
+class AcceptanceCommentTest(unittest.TestCase):
+    def test_renders_compact_failure_details(self):
+        features = [
+            cucumber_scenario(
+                "Enroot *GPU*",
+                "containers [see] GPUs",
+                [
+                    cucumber_step("the cluster exists", "passed", 2),
+                    cucumber_step("the GPU smoke job succeeds", "failed", 65),
+                ],
+            ),
+            cucumber_scenario(
+                "Accounting",
+                "jobs are recorded",
+                [cucumber_step("sacct contains the job", "passed", 3)],
+            ),
+            cucumber_scenario("Skipped", "not selected", []),
+        ]
+        output = io.StringIO()
+
+        render_comment(features, output)
+
+        result = output.getvalue()
+        self.assertIn("1 passed · 1 failed · 1 skipped", result)
+        self.assertIn("Enroot \\*GPU\\* / containers \\[see\\] GPUs", result)
+        self.assertIn("First failing step: Given the GPU smoke job succeeds", result)
+        self.assertIn("Duration: 1m 7s", result)
+
+    def test_limits_failed_scenarios(self):
+        features = [
+            cucumber_scenario(
+                "Feature",
+                f"Scenario {index}",
+                [cucumber_step("failure", "failed")],
+            )
+            for index in range(12)
+        ]
+        output = io.StringIO()
+
+        render_comment(features, output)
+
+        result = output.getvalue()
+        self.assertEqual(result.count("First failing step:"), 10)
+        self.assertIn("2 more failed scenarios; see the workflow run.", result)
+
+
+class E2EPRCommentTest(unittest.TestCase):
+    def test_initial_comment_has_exact_run_and_parameters(self):
+        result = render_start(context())
+
+        self.assertIn("### ⏳ E2E running", result)
+        self.assertIn("- Soperator branch: `feature`", result)
+        self.assertIn("- Essential tests only: `true`", result)
+        self.assertIn(
+            "[Workflow run](https://github.com/nebius/soperator/actions/runs/12345)",
+            result,
+        )
+        self.assertNotIn("Build All", result)
+
+    def test_failure_before_acceptance_shows_only_first_failure(self):
+        jobs = workflow_jobs(before="failure", after="failure")
+        result = render_final(
+            context(E2E_RESULT="failure", ACCEPTANCE_OUTCOME="skipped"),
+            jobs,
+            "",
+        )
+
+        self.assertIn("### Failure before acceptance", result)
+        self.assertIn("Failed step: `Terraform Apply`", result)
+        self.assertIn("Acceptance tests: not run", result)
+        self.assertNotIn("Failure after acceptance", result)
+        self.assertNotIn("Terraform Destroy", result)
+
+    def test_acceptance_and_later_failure_are_both_reported(self):
+        result = render_final(
+            context(E2E_RESULT="failure", ACCEPTANCE_OUTCOME="failure"),
+            workflow_jobs(acceptance="failure", after="failure"),
+            "16 passed · 2 failed · 1 skipped",
+        )
+
+        self.assertIn("### Acceptance results", result)
+        self.assertIn("16 passed · 2 failed · 1 skipped", result)
+        self.assertIn("### Failure after acceptance", result)
+        self.assertIn("Failed step: `Terraform Destroy`", result)
+
+    def test_after_acceptance_failure_omits_successful_steps(self):
+        result = render_final(
+            context(E2E_RESULT="failure"),
+            workflow_jobs(after="failure"),
+            "18 passed · 0 failed · 0 skipped",
+        )
+
+        self.assertIn("18 passed · 0 failed · 0 skipped", result)
+        self.assertIn("Failed step: `Terraform Destroy`", result)
+        self.assertNotIn("Terraform Apply", result)
+
+    def test_only_first_failure_after_acceptance_is_shown(self):
+        jobs = workflow_jobs(after="failure")
+        jobs["jobs"][1]["steps"][3]["conclusion"] = "failure"
+
+        result = render_final(
+            context(E2E_RESULT="failure"),
+            jobs,
+            "18 passed · 0 failed · 0 skipped",
+        )
+
+        self.assertIn("Failed step: `Upload Acceptance Reports`", result)
+        self.assertNotIn("Terraform Destroy", result)
+
+    def test_success_does_not_list_cleanup(self):
+        result = render_final(
+            context(),
+            workflow_jobs(),
+            "18 passed · 0 failed · 0 skipped",
+        )
+
+        self.assertIn("### ✅ E2E passed", result)
+        self.assertNotIn("Terraform Destroy", result)
+
+    def test_missing_acceptance_report_is_explicit(self):
+        result = render_final(
+            context(ACCEPTANCE_REPORT_AVAILABLE="false"),
+            workflow_jobs(),
+            "",
+        )
+
+        self.assertIn("Acceptance report unavailable", result)
+
+    def test_rerun_links_to_attempt(self):
+        result = render_start(context(GITHUB_RUN_ATTEMPT="2"))
+
+        self.assertIn("/actions/runs/12345/attempts/2", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/e2e_pr_command.yml
+++ b/.github/workflows/e2e_pr_command.yml
@@ -128,7 +128,6 @@ jobs:
             echo "e2e_command=/$e2e_command"
             echo "terraform_ref=$terraform_ref"
             echo "run_essential_tests=$run_essential_tests"
-            echo "build_url=$build_url"
           } >> "$GITHUB_OUTPUT"
 
       - name: Dispatch E2E
@@ -139,7 +138,6 @@ jobs:
           E2E_COMMAND: ${{ steps.request.outputs.e2e_command }}
           TERRAFORM_REF: ${{ steps.request.outputs.terraform_ref }}
           RUN_ESSENTIAL_TESTS: ${{ steps.request.outputs.run_essential_tests }}
-          BUILD_URL: ${{ steps.request.outputs.build_url }}
         run: |
           current_head_sha=$(gh api \
             "repos/$REPOSITORY/pulls/$PR_NUMBER" \
@@ -164,20 +162,9 @@ jobs:
             -f profile=@auto-select \
             -f run_unstable_tests=false \
             "${essential_input[@]}" \
-            -f is_scheduled=false; then
+            -f is_scheduled=false \
+            -f "pr_number=$PR_NUMBER"; then
             message="Could not dispatch E2E for \`$HEAD_REF\`. See the command workflow logs for details."
             gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body "$message"
             exit 1
           fi
-
-          workflow_url="$GITHUB_SERVER_URL/$REPOSITORY/actions/workflows/e2e_test.yml"
-          message=$(printf '%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n\n%s' \
-            'E2E was dispatched with:' \
-            "- Soperator branch: \`$HEAD_REF\`" \
-            "- Terraform branch: \`$TERRAFORM_REF\`" \
-            "- Soperator E2E branch: \`$HEAD_REF\`" \
-            '- Profile: `@auto-select`' \
-            '- Unstable tests: `false`' \
-            "- Essential tests only: \`$RUN_ESSENTIAL_TESTS\`" \
-            "[Build All]($BUILD_URL) · [E2E runs]($workflow_url)")
-          gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body "$message"

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -46,12 +46,66 @@ on:
         required: false
         default: "false"
         type: string
+      pr_number:
+        description: "PR to update with the E2E result"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
   actions: write
 
 jobs:
+  report-pr-start:
+    name: Report E2E start to PR
+    if: inputs.pr_number != ''
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    outputs:
+      comment_id: ${{ steps.comment.outputs.comment_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Create or update PR comment
+        id: comment
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          SOPERATOR_BRANCH: ${{ github.ref_name }}
+          TERRAFORM_BRANCH: ${{ inputs.terraform_repo_ref || github.ref_name }}
+          SOPERATOR_E2E_BRANCH: ${{ inputs.soperator_e2e_repo_branch || 'main' }}
+          REQUESTED_PROFILE: ${{ inputs.profile }}
+          RUN_UNSTABLE_TESTS: ${{ inputs.run_unstable_tests || 'false' }}
+          RUN_ESSENTIAL_TESTS: ${{ inputs.run_essential_tests || 'false' }}
+        run: |
+          marker="<!-- soperator-e2e-run:${GITHUB_RUN_ID} -->"
+          python3 .github/scripts/e2e_pr_comment.py start > /tmp/e2e-pr-comment.md
+
+          comment_id=$(gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+            | jq -r --arg marker "$marker" \
+              '[.[][] | select(.body | contains($marker))][0].id // empty')
+
+          payload=$(jq --null-input --rawfile body /tmp/e2e-pr-comment.md '{body: $body}')
+          if [[ -n "$comment_id" ]]; then
+            response=$(gh api --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+              --input - <<<"$payload")
+          else
+            response=$(gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              --input - <<<"$payload")
+          fi
+
+          echo "comment_id=$(jq -r '.id' <<<"$response")" >> "$GITHUB_OUTPUT"
+
   resolve-profile:
     runs-on: ubuntu-latest
     environment: e2e
@@ -145,6 +199,10 @@ jobs:
   e2e-test:
     needs: resolve-profile
     name: e2e-test (${{ needs.resolve-profile.outputs.profile_name }})
+    outputs:
+      acceptance_outcome: ${{ steps.acceptance.outcome }}
+      acceptance_report_available: ${{ steps.acceptance_summary.outputs.report_available }}
+      acceptance_summary: ${{ steps.acceptance_summary.outputs.comment }}
     concurrency:
       # Per-project mutex: runs targeting the same Nebius project are serialized,
       # different projects can run concurrently. Queued runs wait, never cancel in-progress ones.
@@ -504,6 +562,7 @@ jobs:
           pkill -9 -f terraform-provider || true
 
       - name: Acceptance Tests
+        id: acceptance
         timeout-minutes: 120
         shell: bash
         run: |
@@ -523,15 +582,25 @@ jobs:
           bin/acceptance "${args[@]}"
 
       - name: Acceptance Summary
+        id: acceptance_summary
         if: always()
         shell: bash
         run: |
           json="e2e-reports/acceptance/soperator.cucumber.json"
           if [[ ! -f "$json" ]]; then
             echo "no cucumber report at $json"
+            echo "report_available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           python3 .github/scripts/acceptance_summary.py "$json" >> "$GITHUB_STEP_SUMMARY"
+          comment=$(python3 .github/scripts/acceptance_summary.py \
+            "$json" --format comment)
+          {
+            echo 'report_available=true'
+            echo 'comment<<EOF'
+            echo "$comment"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload Acceptance Reports
         if: always()
@@ -876,6 +945,68 @@ jobs:
               echo "Terraform repo not checked out."
             fi
           } >> $GITHUB_STEP_SUMMARY
+
+  report-pr-result:
+    name: Report E2E result to PR
+    needs: [report-pr-start, resolve-profile, e2e-test]
+    if: always() && inputs.pr_number != ''
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Update PR comment
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          COMMENT_ID: ${{ needs.report-pr-start.outputs.comment_id }}
+          SOPERATOR_BRANCH: ${{ github.ref_name }}
+          TERRAFORM_BRANCH: ${{ inputs.terraform_repo_ref || github.ref_name }}
+          SOPERATOR_E2E_BRANCH: ${{ inputs.soperator_e2e_repo_branch || 'main' }}
+          REQUESTED_PROFILE: ${{ inputs.profile }}
+          RESOLVED_PROFILE: ${{ needs.resolve-profile.outputs.profile_name }}
+          RUN_UNSTABLE_TESTS: ${{ inputs.run_unstable_tests || 'false' }}
+          RUN_ESSENTIAL_TESTS: ${{ inputs.run_essential_tests || 'false' }}
+          RESOLVE_RESULT: ${{ needs.resolve-profile.result }}
+          E2E_RESULT: ${{ needs.e2e-test.result }}
+          ACCEPTANCE_OUTCOME: ${{ needs.e2e-test.outputs.acceptance_outcome }}
+          ACCEPTANCE_REPORT_AVAILABLE: ${{ needs.e2e-test.outputs.acceptance_report_available }}
+          ACCEPTANCE_SUMMARY: ${{ needs.e2e-test.outputs.acceptance_summary }}
+        run: |
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100" \
+            | jq '{jobs: [.[].jobs[]]}' > /tmp/e2e-jobs.json
+          printf '%s\n' "$ACCEPTANCE_SUMMARY" > /tmp/acceptance-comment.md
+          python3 .github/scripts/e2e_pr_comment.py final \
+            --jobs /tmp/e2e-jobs.json \
+            --acceptance-summary /tmp/acceptance-comment.md \
+            > /tmp/e2e-pr-comment.md
+
+          comment_id="$COMMENT_ID"
+          if [[ -z "$comment_id" ]]; then
+            marker="<!-- soperator-e2e-run:${GITHUB_RUN_ID} -->"
+            comment_id=$(gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+              | jq -r --arg marker "$marker" \
+                '[.[][] | select(.body | contains($marker))][0].id // empty')
+          fi
+
+          payload=$(jq --null-input --rawfile body /tmp/e2e-pr-comment.md '{body: $body}')
+          if [[ -n "$comment_id" ]]; then
+            gh api --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+              --input - <<<"$payload"
+          else
+            gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              --input - <<<"$payload"
+          fi
 
   notify-failure:
     name: Notify Slack on E2E failure

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
     outputs:
       comment_id: ${{ steps.comment.outputs.comment_id }}
     steps:
@@ -955,7 +955,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Problem

PR-triggered E2E runs only post a dispatch confirmation with a generic workflow link. Contributors must manually find the correct run and inspect it to determine whether setup, acceptance tests, or a later step failed.

## Solution

Update the original E2E status comment throughout the run. It now links directly to the workflow run and reports the final outcome, including acceptance scenario failures or the first failed workflow step before or after acceptance. Scheduled and manually triggered runs remain unchanged.

## Testing
<!-- ❗ Required: How did you test this change?
List manual steps and environments. If no tests done, explain why.
This section is very important on the release testing phase.-->

## Release Notes
<!-- ❗ Required: 1–2 sentences, user-facing.
State the benefit and call out risks (breaking changes, migrations, flags). Example:
Feature: Added X to improve Y for Z users.
Breaking: Renamed config flag `old.flag` -> `new.flag`. -->
