### PR TITLE
SCHED-2210: Collect reusable E2E artifacts

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -679,11 +679,8 @@ jobs:
         timeout-minutes: 30
         shell: bash
         env:
-          # Opt in to terraform DEBUG logging only for the destroy flow.
-          # bin/e2e destroy reads this and calls tf.SetLogPath() on the
-          # terraform-exec handle — otherwise terraform-exec strips TF_LOG from
-          # the subprocess env. Init/Apply steps don't set this, so they stay
-          # clean. See internal/e2e/destroy.go.
+          # Keep Terraform core diagnostics while excluding provider DEBUG logs,
+          # which may contain raw credentials such as short-lived IAM tokens.
           TF_DESTROY_LOG_PATH: ${{ env.E2E_ARTIFACTS_DIR }}/terraform/destroy-debug.log
         run: |
           cd ${{ env.PATH_TO_INSTALLATION }}

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -224,6 +224,7 @@ jobs:
       RUN_UNSTABLE_TESTS: ${{ inputs.run_unstable_tests || 'false' }}
       RUN_ESSENTIAL_TESTS: ${{ inputs.run_essential_tests || 'false' }}
       SLURM_CLUSTER_NAME: "soperator"
+      E2E_ARTIFACTS_DIR: "${{ github.workspace }}/e2e-artifacts"
 
     steps:
       - name: Checkout repository
@@ -470,6 +471,46 @@ jobs:
           echo "SOPERATOR_VERSION=$SOPERATOR_VERSION" >> $GITHUB_ENV
           echo "SOPERATOR_UNSTABLE=$SOPERATOR_UNSTABLE" >> $GITHUB_ENV
 
+      - name: Initialize E2E artifacts
+        shell: bash
+        env:
+          NEBIUS_PROJECT_ID: ${{ needs.resolve-profile.outputs.nebius_project_id }}
+          NEBIUS_REGION: ${{ needs.resolve-profile.outputs.nebius_region }}
+        run: |
+          mkdir -p \
+            "$E2E_ARTIFACTS_DIR/metadata" \
+            "$E2E_ARTIFACTS_DIR/terraform" \
+            "$E2E_ARTIFACTS_DIR/acceptance" \
+            "$E2E_ARTIFACTS_DIR/snapshots/before-acceptance" \
+            "$E2E_ARTIFACTS_DIR/snapshots/before-destroy"
+          jq -n \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg ref "$GITHUB_REF_NAME" \
+            --arg sha "$GITHUB_SHA" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --arg run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --arg profile "$PROFILE_NAME" \
+            --arg nebius_project_id "$NEBIUS_PROJECT_ID" \
+            --arg nebius_region "$NEBIUS_REGION" \
+            --arg soperator_version "$SOPERATOR_VERSION" \
+            --arg terraform_ref "$TERRAFORM_REPO_REF" \
+            --arg acceptance_ref "$SOPERATOR_E2E_REPO_BRANCH" \
+            '{
+              repository: $repository,
+              ref: $ref,
+              sha: $sha,
+              run_id: $run_id,
+              run_attempt: $run_attempt,
+              run_url: $run_url,
+              profile: $profile,
+              nebius_project_id: $nebius_project_id,
+              nebius_region: $nebius_region,
+              soperator_version: $soperator_version,
+              terraform_ref: $terraform_ref,
+              acceptance_ref: $acceptance_ref
+            }' > "$E2E_ARTIFACTS_DIR/metadata/run.json"
+
       - name: Checkout Terraform repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -498,6 +539,7 @@ jobs:
 
       - name: Cleanup previous Terraform state
         timeout-minutes: 30
+        shell: bash
         run: |
           cd ${{ env.PATH_TO_INSTALLATION }}
           source .envrc
@@ -511,10 +553,11 @@ jobs:
           # Destroy any leftover resources from a previous run using the saved terraform bundle
           # (the exact code that created the state), falling back to the current checkout.
           # Runs before init so the new run starts from a clean, empty state.
-          bin/e2e cleanup-previous
+          bin/e2e cleanup-previous 2>&1 | tee "$E2E_ARTIFACTS_DIR/terraform/cleanup-previous.log"
 
       - name: Terraform Init
         timeout-minutes: 30
+        shell: bash
         run: |
           cd ${{ env.PATH_TO_INSTALLATION }}
           source .envrc
@@ -525,10 +568,12 @@ jobs:
           aws configure set region $NEBIUS_REGION
           aws configure set endpoint_url https://storage.$NEBIUS_REGION.nebius.cloud:443
 
-          bin/e2e init
+          bin/e2e init 2>&1 | tee "$E2E_ARTIFACTS_DIR/terraform/init.log"
 
       - name: Terraform Apply
+        id: terraform_apply
         timeout-minutes: 90
+        shell: bash
         run: |
           cd ${{ env.PATH_TO_INSTALLATION }}
           source .envrc
@@ -540,7 +585,7 @@ jobs:
           aws configure set region $NEBIUS_REGION
           aws configure set endpoint_url https://storage.$NEBIUS_REGION.nebius.cloud:443
 
-          bin/e2e apply
+          bin/e2e apply 2>&1 | tee "$E2E_ARTIFACTS_DIR/terraform/apply.log"
 
       - name: Kill leftover Terraform processes
         if: always()
@@ -561,17 +606,31 @@ jobs:
           # provider plugin comm names are truncated, match by full cmdline
           pkill -9 -f terraform-provider || true
 
+      - name: Collect artifacts before acceptance
+        if: steps.terraform_apply.outcome == 'success'
+        continue-on-error: true
+        shell: bash
+        run: |
+          kubectl_context="$(kubectl config current-context 2>/dev/null || true)"
+          bin/acceptance collect-artifacts \
+            --kubectl-context "$kubectl_context" \
+            --slurm-cluster-name "$SLURM_CLUSTER_NAME" \
+            --soperator-version "$SOPERATOR_VERSION" \
+            --nebius-project-id "$NEBIUS_PROJECT_ID" \
+            --output-dir "$E2E_ARTIFACTS_DIR/snapshots/before-acceptance"
+
       - name: Acceptance Tests
         id: acceptance
         timeout-minutes: 120
         shell: bash
         run: |
-          kubectl_context="$(kubectl config current-context)"
+          kubectl_context="$(kubectl config current-context 2>/dev/null || true)"
           args=(
+            run
             --kubectl-context "$kubectl_context"
             --slurm-cluster-name "$SLURM_CLUSTER_NAME"
             --soperator-version "$SOPERATOR_VERSION"
-            --report-dir e2e-reports/acceptance
+            --output-dir "$E2E_ARTIFACTS_DIR/acceptance"
           )
           if [[ "$RUN_UNSTABLE_TESTS" == "true" ]]; then
             args+=(--run-unstable)
@@ -579,14 +638,14 @@ jobs:
           if [[ "$RUN_ESSENTIAL_TESTS" == "true" ]]; then
             args+=(--run-essential)
           fi
-          bin/acceptance "${args[@]}"
+          bin/acceptance "${args[@]}" 2>&1 | tee "$E2E_ARTIFACTS_DIR/acceptance/acceptance.log"
 
       - name: Acceptance Summary
         id: acceptance_summary
         if: always()
         shell: bash
         run: |
-          json="e2e-reports/acceptance/soperator.cucumber.json"
+          json="$E2E_ARTIFACTS_DIR/acceptance/soperator.cucumber.json"
           if [[ ! -f "$json" ]]; then
             echo "no cucumber report at $json"
             echo "report_available=false" >> "$GITHUB_OUTPUT"
@@ -602,199 +661,30 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Upload Acceptance Reports
+      - name: Collect artifacts before destroy
         if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: acceptance-reports
-          path: e2e-reports/acceptance/
-          retention-days: 14
-
-      - name: K8s Cluster Info and NodeGroups
-        if: always()
+        continue-on-error: true
         shell: bash
         run: |
-          echo "=== K8s Clusters ==="
-          clusters_table=$(nebius mk8s cluster list --parent-id "$NEBIUS_PROJECT_ID" --format table)
-          echo "$clusters_table"
-
-          clusters_json=$(nebius mk8s cluster list --parent-id "$NEBIUS_PROJECT_ID" --format json)
-          cluster_ids=$(echo "$clusters_json" | jq -r '.items[].metadata.id // empty')
-
-          {
-            echo "### K8s Clusters"
-            echo '```'
-            echo "$clusters_table"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          for cluster_id in $cluster_ids; do
-            echo ""
-            echo "--- Node groups for cluster: $cluster_id ---"
-            ng_json=$(nebius mk8s node-group list --parent-id "$cluster_id" --page-size 1000 --format json)
-
-            # Summary table
-            summary=$(echo "$ng_json" | jq -r '
-              ["ID", "NAME", "STATE", "READY/TARGET"],
-              ["--", "----", "-----", "------------"],
-              (.items[] |
-                [
-                  .metadata.id,
-                  .metadata.name,
-                  .status.state,
-                  "\(.status.ready_node_count // "?")/\(.status.target_node_count // "?")"
-                ]
-              ) | @tsv')
-            echo "$summary" | column -t
-
-            {
-              echo "### Node Groups: $cluster_id"
-              echo '```'
-              echo "$summary" | column -t
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-
-            # Full JSON for non-RUNNING node groups
-            not_running=$(echo "$ng_json" | jq '[.items[] | select(.status.state != "RUNNING")]')
-            if [ "$(echo "$not_running" | jq 'length')" -gt 0 ]; then
-              echo ""
-              echo "=== Non-RUNNING node groups (full details) ==="
-              echo "$not_running" | jq .
-            fi
-          done
-
-      - name: "K8s Cluster: Pods"
-        if: always()
-        shell: bash
-        run: kubectl get pods -A -o wide
-
-      - name: "K8s Cluster: Events"
-        if: always()
-        shell: bash
-        run: kubectl get events -A --sort-by='.lastTimestamp'
-
-      - name: "K8s Cluster: Nodes"
-        if: always()
-        shell: bash
-        run: |
-          kubectl get nodes
-          echo ""
-          kubectl get nodes -o yaml
-
-      - name: "K8s Cluster: Jobs"
-        if: always()
-        shell: bash
-        run: |
-          kubectl -n soperator get job
-          echo ""
-          kubectl -n soperator get job -o yaml
-
-      - name: "K8s Cluster: Helm Releases"
-        if: always()
-        shell: bash
-        run: |
-          kubectl get helmreleases -n flux-system
-          echo ""
-          kubectl get helmreleases -n flux-system -o yaml
-
-      - name: "K8s Cluster: Slurm Cluster CRs"
-        if: always()
-        shell: bash
-        run: |
-          kubectl get slurmclusters -A
-          echo ""
-          kubectl get slurmclusters -A -o yaml
-
-      - name: "K8s Cluster: Slurm Active Checks CRs"
-        if: always()
-        shell: bash
-        run: |
-          kubectl get activechecks -A
-          echo ""
-          kubectl get activechecks -A -o yaml
-
-      - name: Slurm Cluster State
-        if: always()
-        shell: bash
-        run: |
-          kubectl exec -n soperator ${SLURM_CLUSTER_NAME}-controller-0 -- sinfo -N || true
-          kubectl exec -n soperator ${SLURM_CLUSTER_NAME}-controller-0 -- squeue || true
-          kubectl exec -n soperator ${SLURM_CLUSTER_NAME}-controller-0 -- sdiag || true
-          kubectl exec -n soperator ${SLURM_CLUSTER_NAME}-controller-0 -- sacct --format=JobID,JobName,Partition,Account,AllocCPUS,State,ExitCode -S now-6hours || true
-          kubectl exec -n soperator ${SLURM_CLUSTER_NAME}-controller-0 -- sacct --parsable2 --allusers --starttime=now-6hours | column -t -s'|'
-
-      - name: Collect Full Kubernetes Cluster Info
-        if: always()
-        shell: bash
-        run: |
-          mkdir -p ./cluster-info
-          kubectl cluster-info dump --namespaces=kruise-system,soperator-system,soperator,flux-system,cert-manager-system --output-directory=./cluster-info
-
-      - name: Upload Full Kubernetes Cluster Info
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: cluster-info
-          path: ./cluster-info
-          retention-days: 7
-
-      - name: Collect Jail Files
-        if: always()
-        shell: bash
-        run: |
-          mkdir -p ./jail/etc/slurm ./jail/opt/soperator-outputs
-          SCONFIG_POD=$(kubectl get pod -n soperator \
-            -l app.kubernetes.io/component=sconfigcontroller \
-            --field-selector=status.phase=Running \
-            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-          if [[ -n "$SCONFIG_POD" ]]; then
-            echo "Copying jail files from $SCONFIG_POD"
-            kubectl exec -n soperator "$SCONFIG_POD" -- find /mnt/jail -maxdepth 4 -not -path '*/proc/*' > ./jail/tree.txt 2>&1 || true
-            .github/workflows/scripts/retry.sh \
-              kubectl cp "soperator/$SCONFIG_POD:/mnt/jail/etc/slurm/" ./jail/etc/slurm
-            .github/workflows/scripts/retry.sh \
-              kubectl cp "soperator/$SCONFIG_POD:/mnt/jail/opt/soperator-outputs" ./jail/opt/soperator-outputs
-          else
-            echo "No running sconfigcontroller pod found, skipping jail files collection"
-          fi
-          # soperator-outputs/local is node-local (worker boot disk), invisible through the
-          # shared jail — collect it from every worker pod via its host mount.
-          WORKER_PODS=$(kubectl get pods -n soperator \
-            -l slurm.nebius.ai/worker=true \
-            --field-selector=status.phase=Running \
-            -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
-          for pod in $WORKER_PODS; do
-            echo "Copying node-local soperator-outputs from $pod"
-            mkdir -p "./jail/workers/$pod"
-            kubectl cp -c slurmd \
-              "soperator/$pod:/mnt/jail.upper/opt/soperator-outputs/local" \
-              "./jail/workers/$pod" || true
-          done
-
-      - name: Zip Jail
-        if: always()
-        run: |
-          zip -r jail jail
-
-      - name: Upload Jail
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          archive: false
-          name: jail
-          path: jail.zip
-          retention-days: 7
+          kubectl_context="$(kubectl config current-context 2>/dev/null || true)"
+          bin/acceptance collect-artifacts \
+            --kubectl-context "$kubectl_context" \
+            --slurm-cluster-name "$SLURM_CLUSTER_NAME" \
+            --soperator-version "$SOPERATOR_VERSION" \
+            --nebius-project-id "$NEBIUS_PROJECT_ID" \
+            --output-dir "$E2E_ARTIFACTS_DIR/snapshots/before-destroy"
 
       - name: Terraform Destroy
         if: always()
         timeout-minutes: 30
+        shell: bash
         env:
           # Opt in to terraform DEBUG logging only for the destroy flow.
           # bin/e2e destroy reads this and calls tf.SetLogPath() on the
           # terraform-exec handle — otherwise terraform-exec strips TF_LOG from
           # the subprocess env. Init/Apply steps don't set this, so they stay
           # clean. See internal/e2e/destroy.go.
-          TF_DESTROY_LOG_PATH: ${{ runner.temp }}/tf-destroy.log
+          TF_DESTROY_LOG_PATH: ${{ env.E2E_ARTIFACTS_DIR }}/terraform/destroy-debug.log
         run: |
           cd ${{ env.PATH_TO_INSTALLATION }}
           source .envrc
@@ -806,24 +696,15 @@ jobs:
           aws configure set region $NEBIUS_REGION
           aws configure set endpoint_url https://storage.$NEBIUS_REGION.nebius.cloud:443
 
-          bin/e2e destroy
-
-      - name: Upload Terraform Destroy debug log
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: tf-destroy-debug-log
-          path: ${{ runner.temp }}/tf-destroy.log
-          if-no-files-found: ignore
-          retention-days: 7
-          # Debug log is plain text terraform DEBUG output, highly
-          # compressible, and runner CPU is free, so max out the DEFLATE level.
-          compression-level: 9
+          bin/e2e destroy 2>&1 | tee "$E2E_ARTIFACTS_DIR/terraform/destroy.log"
 
       - name: Force cleanup compute instances on failure
         if: failure()
         shell: bash
         run: |
+          mkdir -p "$E2E_ARTIFACTS_DIR/terraform"
+          exec > >(tee -a "$E2E_ARTIFACTS_DIR/terraform/force-cleanup.log") 2>&1
+
           echo "=== Node groups state before cleanup ==="
           clusters_json=$(nebius mk8s cluster list --parent-id "$NEBIUS_PROJECT_ID" --format json 2>/dev/null || true)
           cluster_ids=$(echo "$clusters_json" | jq -r '.items[].metadata.id // empty' 2>/dev/null || true)
@@ -861,6 +742,15 @@ jobs:
           done
 
           echo "=== Cleanup complete ==="
+
+      - name: Upload E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-artifacts
+          path: ${{ env.E2E_ARTIFACTS_DIR }}/
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Add build info to job summary
         if: always()

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -26,7 +26,9 @@ go -C e2e build -o ../bin/acceptance ./cmd/acceptance
 Run the shared suite against an existing cluster:
 
 ```bash
-bin/acceptance --kubectl-context <dev-context>
+bin/acceptance run \
+  --kubectl-context <dev-context> \
+  --output-dir e2e-artifacts/acceptance
 ```
 
 The target Soperator version controls which version-tagged scenarios are run.
@@ -46,7 +48,7 @@ Flux discovery reads the standard Soperator HelmRelease
 cannot resolve a version, the CLI fails before running scenarios and asks for
 `--soperator-version`.
 
-All flags:
+`run` flags:
 
 - `--kubectl-context`: required. All local kubectl calls use this context.
 - `--slurm-cluster-name`: optional, defaults to `soperator`.
@@ -60,8 +62,8 @@ All flags:
 - `--scenario`: optional. Runs all compatible scenarios in the provided feature
   file, or the single scenario at an exact `Scenario:` line, for example
   `features/internal_ssh.feature:3`. May be repeated.
-- `--report-dir`: optional. When set, the runner writes Cucumber and JUnit
-  reports into that directory.
+- `--output-dir`: required. The runner writes Cucumber and JUnit reports plus
+  per-scenario artifacts into this directory.
 
 CPU/GPU scenarios are selected by tags like other scenarios. Steps that need a
 specific worker kind query live Slurm and NodeSet state at scenario time. They
@@ -72,7 +74,10 @@ also fail on partial degradation.
 For focused manual runs on a dev cluster, pass the scenario location:
 
 ```bash
-bin/acceptance --kubectl-context <dev-context> --scenario features/internal_ssh.feature:3
+bin/acceptance run \
+  --kubectl-context <dev-context> \
+  --output-dir e2e-artifacts/acceptance \
+  --scenario features/internal_ssh.feature:3
 ```
 
 The `--scenario` flag is for local/manual investigation only. The GitHub
@@ -88,6 +93,35 @@ so it runs only when both `--run-essential` and `--run-unstable` are set.
 
 Note: The node replacement scenario uses the local `nebius` CLI to check
 instance removal.
+
+Collect a reusable cluster snapshot before or after acceptance:
+
+```bash
+bin/acceptance collect-artifacts \
+  --kubectl-context <dev-context> \
+  --slurm-cluster-name soperator \
+  --soperator-version 5.0.0 \
+  --output-dir e2e-artifacts/snapshots/before-destroy
+```
+
+The common snapshot contains Kubernetes, Soperator, redacted FluxCD, Slurm,
+and jail diagnostics. Add `--nebius-project-id <project-id>` to include Managed
+Kubernetes clusters and node groups. When that optional flag is omitted, the
+command does not create or invoke an `mk8s` collector.
+
+Collectors are dependency-bound and reusable by another E2E runtime:
+
+```go
+type Collector interface {
+	Name() string
+	Collect(ctx context.Context, destination string) error
+}
+```
+
+Managed E2E can compose the common constructors with collectors built from its
+own runtime dependencies. `artifacts.CollectAll` runs all collectors, keeps
+successful output when another collector fails, and records the failure in the
+affected collector directory.
 
 ## Reusable Runner API
 
@@ -105,6 +139,7 @@ runner, err := acceptance.NewRunner(acceptance.RunnerConfig{
 	KubectlContext:         kubectlContext,
 	SlurmClusterName:       "soperator",
 	TargetSoperatorVersion: "5.0.0",
+	OutputDir:              "e2e-artifacts/acceptance",
 	Suites:                 []acceptance.SuiteConfig{suite},
 })
 ```
@@ -114,6 +149,9 @@ target cluster. `SlurmClusterName` defaults to `soperator` when omitted.
 `TargetSoperatorVersion` is normalized once and stored in static
 `framework.ClusterInfo`. The caller controls scenario selection through
 `SuiteConfig.Source.Paths` and Godog tag filtering through `SuiteConfig.Tags`.
+When `OutputDir` is set, each scenario receives matching runner and jail paths
+through `framework.ScenarioArtifacts(ctx)`. Product-specific steps can write
+their own files directly to those paths without registering a collector.
 
 `acceptance.SoperatorSuite(targetSoperatorVersion)` embeds the public Soperator
 feature files, registers public Soperator steps, enables the default shared

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -108,6 +108,9 @@ The common snapshot contains Kubernetes, Soperator, redacted FluxCD, Slurm,
 and jail diagnostics. Add `--nebius-project-id <project-id>` to include Managed
 Kubernetes clusters and node groups. When that optional flag is omitted, the
 `mk8s` collector creates no files and does not invoke the Nebius CLI.
+If Terraform fails before a Kubernetes context is available, omit
+`--kubectl-context` and provide `--nebius-project-id`; the command will skip the
+Kubernetes-bound collectors and still capture Managed Kubernetes state.
 
 Collectors are dependency-bound and reusable by another E2E runtime:
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -107,7 +107,7 @@ bin/acceptance collect-artifacts \
 The common snapshot contains Kubernetes, Soperator, redacted FluxCD, Slurm,
 and jail diagnostics. Add `--nebius-project-id <project-id>` to include Managed
 Kubernetes clusters and node groups. When that optional flag is omitted, the
-command does not create or invoke an `mk8s` collector.
+`mk8s` collector creates no files and does not invoke the Nebius CLI.
 
 Collectors are dependency-bound and reusable by another E2E runtime:
 

--- a/e2e/acceptance/artifacts/collector.go
+++ b/e2e/acceptance/artifacts/collector.go
@@ -1,0 +1,82 @@
+// Package artifacts collects reusable diagnostics from Soperator E2E environments.
+package artifacts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+var invalidCollectorName = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+// Collector writes one category of diagnostics to a caller-owned directory.
+type Collector interface {
+	Name() string
+	Collect(ctx context.Context, destination string) error
+}
+
+// CollectAll runs every collector and returns their combined failures.
+func CollectAll(ctx context.Context, root string, collectors ...Collector) error {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return fmt.Errorf("artifact output directory is required")
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return fmt.Errorf("create artifact output directory %q: %w", root, err)
+	}
+
+	seen := make(map[string]struct{}, len(collectors))
+	var failures []error
+	for i, collector := range collectors {
+		if collector == nil {
+			failures = append(failures, fmt.Errorf("collector %d is nil", i))
+			continue
+		}
+		name := sanitizeCollectorName(collector.Name())
+		if _, ok := seen[name]; ok {
+			failures = append(failures, fmt.Errorf("collector name %q is duplicated", name))
+			continue
+		}
+		seen[name] = struct{}{}
+
+		destination := filepath.Join(root, name)
+		if err := os.MkdirAll(destination, 0o755); err != nil {
+			failures = append(failures, fmt.Errorf("create collector %q directory: %w", name, err))
+			continue
+		}
+		if err := collector.Collect(ctx, destination); err != nil {
+			wrappedErr := fmt.Errorf("collect %s artifacts: %w", name, err)
+			failures = append(failures, wrappedErr)
+			if writeErr := os.WriteFile(filepath.Join(destination, "_error.txt"), []byte(wrappedErr.Error()+"\n"), 0o600); writeErr != nil {
+				failures = append(failures, fmt.Errorf("write collector %q error: %w", name, writeErr))
+			}
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// CommonCollectors returns the shared cluster diagnostics.
+func CommonCollectors(runtime framework.Runtime) []Collector {
+	return []Collector{
+		NewKubernetesCollector(runtime.Kubectl()),
+		NewSoperatorCollector(runtime.Kubectl()),
+		NewFluxCDCollector(runtime.Kubectl()),
+		NewSlurmCollector(runtime.Controller()),
+		NewJailCollector(runtime.Kubectl()),
+	}
+}
+
+func sanitizeCollectorName(name string) string {
+	name = invalidCollectorName.ReplaceAllString(strings.TrimSpace(name), "-")
+	name = strings.Trim(name, "-._")
+	if name == "" {
+		return "unknown"
+	}
+	return name
+}

--- a/e2e/acceptance/artifacts/collector.go
+++ b/e2e/acceptance/artifacts/collector.go
@@ -62,13 +62,14 @@ func CollectAll(ctx context.Context, root string, collectors ...Collector) error
 }
 
 // CommonCollectors returns the shared cluster diagnostics.
-func CommonCollectors(runtime framework.Runtime) []Collector {
+func CommonCollectors(runtime framework.Runtime, nebiusProjectID string) []Collector {
 	return []Collector{
 		NewKubernetesCollector(runtime.Kubectl()),
 		NewSoperatorCollector(runtime.Kubectl()),
 		NewFluxCDCollector(runtime.Kubectl()),
 		NewSlurmCollector(runtime.Controller()),
 		NewJailCollector(runtime.Kubectl()),
+		NewMK8sCollector(runtime.Local(), nebiusProjectID),
 	}
 }
 

--- a/e2e/acceptance/artifacts/collector_test.go
+++ b/e2e/acceptance/artifacts/collector_test.go
@@ -9,12 +9,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
 type testCollector struct {
 	name string
 	err  error
 }
+
+type commonCollectorsRuntime struct {
+	framework.Runtime
+	args    framework.ArgsScope
+	command framework.CommandScope
+}
+
+func (r *commonCollectorsRuntime) Kubectl() framework.ArgsScope       { return r.args }
+func (r *commonCollectorsRuntime) Local() framework.ArgsScope         { return r.args }
+func (r *commonCollectorsRuntime) Controller() framework.CommandScope { return r.command }
 
 func (c testCollector) Name() string {
 	return c.name
@@ -52,4 +64,22 @@ func TestCollectAllRejectsDuplicateSanitizedNames(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "duplicated")
+}
+
+func TestCommonCollectorsIncludeOptionalMK8s(t *testing.T) {
+	runtime := &commonCollectorsRuntime{
+		args: framework.NewArgsScope(func(context.Context, ...string) (string, error) {
+			return "", nil
+		}),
+		command: framework.NewCommandScope(func(context.Context, string) (string, error) {
+			return "", nil
+		}),
+	}
+	collectors := CommonCollectors(runtime, "")
+
+	var names []string
+	for _, collector := range collectors {
+		names = append(names, collector.Name())
+	}
+	assert.Equal(t, []string{"kubernetes", "soperator", "fluxcd", "slurm", "jail", "mk8s"}, names)
 }

--- a/e2e/acceptance/artifacts/collector_test.go
+++ b/e2e/acceptance/artifacts/collector_test.go
@@ -1,0 +1,55 @@
+package artifacts
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testCollector struct {
+	name string
+	err  error
+}
+
+func (c testCollector) Name() string {
+	return c.name
+}
+
+func (c testCollector) Collect(_ context.Context, destination string) error {
+	err := os.WriteFile(filepath.Join(destination, "output.txt"), []byte(c.name), 0o600)
+	return errors.Join(err, c.err)
+}
+
+func TestCollectAllPreservesOutputAndContinuesAfterFailure(t *testing.T) {
+	root := t.TempDir()
+
+	err := CollectAll(t.Context(), root,
+		testCollector{name: "first / unsafe", err: errors.New("expected failure")},
+		testCollector{name: "second"},
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "expected failure")
+	assert.FileExists(t, filepath.Join(root, "first-unsafe", "output.txt"))
+	assert.FileExists(t, filepath.Join(root, "first-unsafe", "_error.txt"))
+	assert.FileExists(t, filepath.Join(root, "second", "output.txt"))
+}
+
+func TestCollectAllRejectsEmptyOutputDir(t *testing.T) {
+	err := CollectAll(t.Context(), "", testCollector{name: "collector"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "artifact output directory is required")
+}
+
+func TestCollectAllRejectsDuplicateSanitizedNames(t *testing.T) {
+	err := CollectAll(t.Context(), t.TempDir(),
+		testCollector{name: "same name"},
+		testCollector{name: "same/name"},
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "duplicated")
+}

--- a/e2e/acceptance/artifacts/command.go
+++ b/e2e/acceptance/artifacts/command.go
@@ -1,0 +1,71 @@
+package artifacts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+func collectArgs(
+	ctx context.Context,
+	destination string,
+	filename string,
+	scope framework.ArgsScope,
+	args ...string,
+) error {
+	if scope == nil {
+		return fmt.Errorf("run %s: command scope is unavailable", strings.Join(args, " "))
+	}
+	output, commandErr := scope.Run(ctx, args...)
+	writeErr := writeArtifact(destination, filename, output)
+	if commandErr != nil && writeErr != nil {
+		return errors.Join(
+			fmt.Errorf("run %s: %w", strings.Join(args, " "), commandErr),
+			fmt.Errorf("write command output: %w", writeErr),
+		)
+	}
+	if commandErr != nil {
+		return fmt.Errorf("run %s: %w", strings.Join(args, " "), commandErr)
+	}
+	return writeErr
+}
+
+func collectCommand(
+	ctx context.Context,
+	destination string,
+	filename string,
+	scope framework.CommandScope,
+	command string,
+) error {
+	if scope == nil {
+		return fmt.Errorf("run %s: command scope is unavailable", command)
+	}
+	output, commandErr := scope.Run(ctx, command)
+	writeErr := writeArtifact(destination, filename, output)
+	if commandErr != nil && writeErr != nil {
+		return errors.Join(
+			fmt.Errorf("run %s: %w", command, commandErr),
+			fmt.Errorf("write command output: %w", writeErr),
+		)
+	}
+	if commandErr != nil {
+		return fmt.Errorf("run %s: %w", command, commandErr)
+	}
+	return writeErr
+}
+
+func writeArtifact(destination, filename, content string) error {
+	artifactPath := filepath.Join(destination, filepath.Clean(filename))
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		return fmt.Errorf("create artifact parent directory: %w", err)
+	}
+	if err := os.WriteFile(artifactPath, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("write artifact %q: %w", artifactPath, err)
+	}
+	return nil
+}

--- a/e2e/acceptance/artifacts/fluxcd.go
+++ b/e2e/acceptance/artifacts/fluxcd.go
@@ -2,13 +2,9 @@ package artifacts
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/nebius/soperator/e2e/acceptance/framework"
-	"gopkg.in/yaml.v3"
 )
 
 const fluxNamespace = "flux-system"
@@ -17,7 +13,7 @@ type fluxCDCollector struct {
 	kubectl framework.ArgsScope
 }
 
-// NewFluxCDCollector creates a collector for redacted FluxCD configuration and status.
+// NewFluxCDCollector creates a collector for FluxCD configuration and status.
 func NewFluxCDCollector(kubectl framework.ArgsScope) Collector {
 	return &fluxCDCollector{kubectl: kubectl}
 }
@@ -30,66 +26,16 @@ func (c *fluxCDCollector) Collect(ctx context.Context, destination string) error
 		"get", "helmreleases", "-n", fluxNamespace, "-o", "wide"); err != nil {
 		failures = append(failures, err)
 	}
-	if err := c.collectRedactedResource(ctx, destination, "helmreleases"); err != nil {
+	if err := collectArgs(ctx, destination, "helmreleases.yaml", c.kubectl,
+		"get", "helmreleases", "-n", fluxNamespace, "-o", "yaml"); err != nil {
 		failures = append(failures, err)
 	}
 
 	for _, resource := range []string{"kustomizations", "gitrepositories", "ocirepositories", "helmrepositories"} {
-		if err := c.collectRedactedResource(ctx, destination, resource); err != nil {
+		if err := collectArgs(ctx, destination, resource+".yaml", c.kubectl,
+			"get", resource, "-n", fluxNamespace, "-o", "yaml"); err != nil {
 			failures = append(failures, err)
 		}
 	}
 	return errors.Join(failures...)
-}
-
-func (c *fluxCDCollector) collectRedactedResource(ctx context.Context, destination, resource string) error {
-	output, err := c.kubectl.Run(ctx, "get", resource, "-n", fluxNamespace, "-o", "json")
-	if err != nil {
-		return fmt.Errorf("get FluxCD %s: %w", resource, err)
-	}
-	var value any
-	if err := json.Unmarshal([]byte(output), &value); err != nil {
-		return fmt.Errorf("decode FluxCD %s: %w", resource, err)
-	}
-	encoded, err := yaml.Marshal(redactValue(value))
-	if err != nil {
-		return fmt.Errorf("encode redacted FluxCD %s: %w", resource, err)
-	}
-	return writeArtifact(destination, resource+".yaml", string(encoded))
-}
-
-func redactValue(value any) any {
-	switch typed := value.(type) {
-	case map[string]any:
-		redacted := make(map[string]any, len(typed))
-		for key, child := range typed {
-			if sensitiveFluxKey(key) {
-				redacted[key] = "[redacted]"
-				continue
-			}
-			redacted[key] = redactValue(child)
-		}
-		return redacted
-	case []any:
-		redacted := make([]any, len(typed))
-		for i, child := range typed {
-			redacted[i] = redactValue(child)
-		}
-		return redacted
-	default:
-		return value
-	}
-}
-
-func sensitiveFluxKey(key string) bool {
-	normalized := strings.NewReplacer("-", "", "_", "", ".", "").Replace(strings.ToLower(key))
-	if normalized == "secretref" || normalized == "secretkeyref" {
-		return false
-	}
-	for _, fragment := range []string{"password", "passwd", "token", "privatekey", "accesskey", "credential", "clientsecret"} {
-		if strings.Contains(normalized, fragment) {
-			return true
-		}
-	}
-	return normalized == "secret"
 }

--- a/e2e/acceptance/artifacts/fluxcd.go
+++ b/e2e/acceptance/artifacts/fluxcd.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/nebius/soperator/e2e/acceptance/framework"
@@ -17,20 +15,6 @@ const fluxNamespace = "flux-system"
 
 type fluxCDCollector struct {
 	kubectl framework.ArgsScope
-}
-
-type fluxObjectList struct {
-	Items []map[string]any `json:"items"`
-}
-
-type fluxValuesReference struct {
-	Release    string `yaml:"release"`
-	Namespace  string `yaml:"namespace"`
-	Kind       string `yaml:"kind"`
-	Name       string `yaml:"name"`
-	ValuesKey  string `yaml:"valuesKey,omitempty"`
-	TargetPath string `yaml:"targetPath,omitempty"`
-	Optional   bool   `yaml:"optional"`
 }
 
 // NewFluxCDCollector creates a collector for redacted FluxCD configuration and status.
@@ -46,7 +30,7 @@ func (c *fluxCDCollector) Collect(ctx context.Context, destination string) error
 		"get", "helmreleases", "-n", fluxNamespace, "-o", "wide"); err != nil {
 		failures = append(failures, err)
 	}
-	if err := c.collectHelmReleases(ctx, destination); err != nil {
+	if err := c.collectRedactedResource(ctx, destination, "helmreleases"); err != nil {
 		failures = append(failures, err)
 	}
 
@@ -55,45 +39,7 @@ func (c *fluxCDCollector) Collect(ctx context.Context, destination string) error
 			failures = append(failures, err)
 		}
 	}
-	if err := collectArgs(ctx, destination, "events.txt", c.kubectl,
-		"get", "events", "-n", fluxNamespace, "--sort-by=.lastTimestamp"); err != nil {
-		failures = append(failures, err)
-	}
 	return errors.Join(failures...)
-}
-
-func (c *fluxCDCollector) collectHelmReleases(ctx context.Context, destination string) error {
-	output, err := c.kubectl.Run(ctx, "get", "helmreleases", "-n", fluxNamespace, "-o", "json")
-	if err != nil {
-		return fmt.Errorf("get FluxCD HelmReleases: %w", err)
-	}
-
-	var releases fluxObjectList
-	if err := json.Unmarshal([]byte(output), &releases); err != nil {
-		return fmt.Errorf("decode FluxCD HelmReleases: %w", err)
-	}
-	var releaseDocument any
-	if err := json.Unmarshal([]byte(output), &releaseDocument); err != nil {
-		return fmt.Errorf("decode FluxCD HelmRelease document: %w", err)
-	}
-	sanitized, err := yaml.Marshal(redactValue(releaseDocument))
-	if err != nil {
-		return fmt.Errorf("encode redacted FluxCD HelmReleases: %w", err)
-	}
-	if err := writeArtifact(destination, "helmreleases.yaml", string(sanitized)); err != nil {
-		return err
-	}
-
-	references := helmValuesReferences(releases.Items)
-	referenceYAML, err := yaml.Marshal(references)
-	if err != nil {
-		return fmt.Errorf("encode FluxCD values references: %w", err)
-	}
-	if err := writeArtifact(destination, "values-from/references.yaml", string(referenceYAML)); err != nil {
-		return err
-	}
-
-	return c.collectValuesConfigMaps(ctx, destination, references)
 }
 
 func (c *fluxCDCollector) collectRedactedResource(ctx context.Context, destination, resource string) error {
@@ -110,118 +56,6 @@ func (c *fluxCDCollector) collectRedactedResource(ctx context.Context, destinati
 		return fmt.Errorf("encode redacted FluxCD %s: %w", resource, err)
 	}
 	return writeArtifact(destination, resource+".yaml", string(encoded))
-}
-
-func (c *fluxCDCollector) collectValuesConfigMaps(
-	ctx context.Context,
-	destination string,
-	references []fluxValuesReference,
-) error {
-	byNamespace := make(map[string][]fluxValuesReference)
-	for _, reference := range references {
-		if strings.EqualFold(reference.Kind, "ConfigMap") {
-			byNamespace[reference.Namespace] = append(byNamespace[reference.Namespace], reference)
-		}
-	}
-
-	var failures []error
-	for namespace, namespaceReferences := range byNamespace {
-		output, err := c.kubectl.Run(ctx, "get", "configmaps", "-n", namespace, "-o", "json")
-		if err != nil {
-			failures = append(failures, fmt.Errorf("list FluxCD values ConfigMaps in %s: %w", namespace, err))
-			continue
-		}
-		var configMaps fluxObjectList
-		if err := json.Unmarshal([]byte(output), &configMaps); err != nil {
-			failures = append(failures, fmt.Errorf("decode FluxCD values ConfigMaps in %s: %w", namespace, err))
-			continue
-		}
-		byName := make(map[string]map[string]any, len(configMaps.Items))
-		for _, configMap := range configMaps.Items {
-			metadata, _ := configMap["metadata"].(map[string]any)
-			name, _ := metadata["name"].(string)
-			byName[name] = configMap
-		}
-
-		seen := make(map[string]struct{})
-		for _, reference := range namespaceReferences {
-			if _, ok := seen[reference.Name]; ok {
-				continue
-			}
-			seen[reference.Name] = struct{}{}
-			configMap, ok := byName[reference.Name]
-			if !ok {
-				if !reference.Optional {
-					failures = append(failures, fmt.Errorf("find required FluxCD values ConfigMap %s/%s", namespace, reference.Name))
-				}
-				continue
-			}
-			if err := writeValuesConfigMap(destination, namespace, reference.Name, configMap); err != nil {
-				failures = append(failures, err)
-			}
-		}
-	}
-	return errors.Join(failures...)
-}
-
-func writeValuesConfigMap(destination, namespace, name string, configMap map[string]any) error {
-	delete(configMap, "binaryData")
-	if data, ok := configMap["data"].(map[string]any); ok {
-		for key, raw := range data {
-			text, ok := raw.(string)
-			if !ok {
-				data[key] = redactValue(raw)
-				continue
-			}
-			var decoded any
-			if err := yaml.Unmarshal([]byte(text), &decoded); err != nil {
-				data[key] = "[unparseable value omitted]"
-				continue
-			}
-			data[key] = redactValue(decoded)
-		}
-	}
-	encoded, err := yaml.Marshal(redactValue(configMap))
-	if err != nil {
-		return fmt.Errorf("encode FluxCD values ConfigMap %s/%s: %w", namespace, name, err)
-	}
-	filename := filepath.Join("values-from", sanitizeCollectorName(namespace+"-"+name)+".yaml")
-	return writeArtifact(destination, filename, string(encoded))
-}
-
-func helmValuesReferences(releases []map[string]any) []fluxValuesReference {
-	var references []fluxValuesReference
-	for _, release := range releases {
-		metadata, _ := release["metadata"].(map[string]any)
-		spec, _ := release["spec"].(map[string]any)
-		valuesFrom, _ := spec["valuesFrom"].([]any)
-		releaseName, _ := metadata["name"].(string)
-		namespace, _ := metadata["namespace"].(string)
-		if namespace == "" {
-			namespace = fluxNamespace
-		}
-		for _, raw := range valuesFrom {
-			value, _ := raw.(map[string]any)
-			reference := fluxValuesReference{
-				Release:    releaseName,
-				Namespace:  namespace,
-				Kind:       stringValue(value["kind"], "Secret"),
-				Name:       stringValue(value["name"], ""),
-				ValuesKey:  stringValue(value["valuesKey"], ""),
-				TargetPath: stringValue(value["targetPath"], ""),
-				Optional:   boolValue(value["optional"]),
-			}
-			if reference.Name != "" {
-				references = append(references, reference)
-			}
-		}
-	}
-	sort.Slice(references, func(i, j int) bool {
-		left := references[i].Namespace + "/" + references[i].Name + "/" + references[i].Release
-		right := references[j].Namespace + "/" + references[j].Name + "/" + references[j].Release
-		return left < right
-	})
-	return references
 }
 
 func redactValue(value any) any {
@@ -258,16 +92,4 @@ func sensitiveFluxKey(key string) bool {
 		}
 	}
 	return normalized == "secret"
-}
-
-func stringValue(value any, fallback string) string {
-	if text, ok := value.(string); ok && strings.TrimSpace(text) != "" {
-		return text
-	}
-	return fallback
-}
-
-func boolValue(value any) bool {
-	boolean, _ := value.(bool)
-	return boolean
 }

--- a/e2e/acceptance/artifacts/fluxcd.go
+++ b/e2e/acceptance/artifacts/fluxcd.go
@@ -1,0 +1,273 @@
+package artifacts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+	"gopkg.in/yaml.v3"
+)
+
+const fluxNamespace = "flux-system"
+
+type fluxCDCollector struct {
+	kubectl framework.ArgsScope
+}
+
+type fluxObjectList struct {
+	Items []map[string]any `json:"items"`
+}
+
+type fluxValuesReference struct {
+	Release    string `yaml:"release"`
+	Namespace  string `yaml:"namespace"`
+	Kind       string `yaml:"kind"`
+	Name       string `yaml:"name"`
+	ValuesKey  string `yaml:"valuesKey,omitempty"`
+	TargetPath string `yaml:"targetPath,omitempty"`
+	Optional   bool   `yaml:"optional"`
+}
+
+// NewFluxCDCollector creates a collector for redacted FluxCD configuration and status.
+func NewFluxCDCollector(kubectl framework.ArgsScope) Collector {
+	return &fluxCDCollector{kubectl: kubectl}
+}
+
+func (c *fluxCDCollector) Name() string { return "fluxcd" }
+
+func (c *fluxCDCollector) Collect(ctx context.Context, destination string) error {
+	var failures []error
+	if err := collectArgs(ctx, destination, "helmreleases.txt", c.kubectl,
+		"get", "helmreleases", "-n", fluxNamespace, "-o", "wide"); err != nil {
+		failures = append(failures, err)
+	}
+	if err := c.collectHelmReleases(ctx, destination); err != nil {
+		failures = append(failures, err)
+	}
+
+	for _, resource := range []string{"kustomizations", "gitrepositories", "ocirepositories", "helmrepositories"} {
+		if err := c.collectRedactedResource(ctx, destination, resource); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	if err := collectArgs(ctx, destination, "events.txt", c.kubectl,
+		"get", "events", "-n", fluxNamespace, "--sort-by=.lastTimestamp"); err != nil {
+		failures = append(failures, err)
+	}
+	return errors.Join(failures...)
+}
+
+func (c *fluxCDCollector) collectHelmReleases(ctx context.Context, destination string) error {
+	output, err := c.kubectl.Run(ctx, "get", "helmreleases", "-n", fluxNamespace, "-o", "json")
+	if err != nil {
+		return fmt.Errorf("get FluxCD HelmReleases: %w", err)
+	}
+
+	var releases fluxObjectList
+	if err := json.Unmarshal([]byte(output), &releases); err != nil {
+		return fmt.Errorf("decode FluxCD HelmReleases: %w", err)
+	}
+	var releaseDocument any
+	if err := json.Unmarshal([]byte(output), &releaseDocument); err != nil {
+		return fmt.Errorf("decode FluxCD HelmRelease document: %w", err)
+	}
+	sanitized, err := yaml.Marshal(redactValue(releaseDocument))
+	if err != nil {
+		return fmt.Errorf("encode redacted FluxCD HelmReleases: %w", err)
+	}
+	if err := writeArtifact(destination, "helmreleases.yaml", string(sanitized)); err != nil {
+		return err
+	}
+
+	references := helmValuesReferences(releases.Items)
+	referenceYAML, err := yaml.Marshal(references)
+	if err != nil {
+		return fmt.Errorf("encode FluxCD values references: %w", err)
+	}
+	if err := writeArtifact(destination, "values-from/references.yaml", string(referenceYAML)); err != nil {
+		return err
+	}
+
+	return c.collectValuesConfigMaps(ctx, destination, references)
+}
+
+func (c *fluxCDCollector) collectRedactedResource(ctx context.Context, destination, resource string) error {
+	output, err := c.kubectl.Run(ctx, "get", resource, "-n", fluxNamespace, "-o", "json")
+	if err != nil {
+		return fmt.Errorf("get FluxCD %s: %w", resource, err)
+	}
+	var value any
+	if err := json.Unmarshal([]byte(output), &value); err != nil {
+		return fmt.Errorf("decode FluxCD %s: %w", resource, err)
+	}
+	encoded, err := yaml.Marshal(redactValue(value))
+	if err != nil {
+		return fmt.Errorf("encode redacted FluxCD %s: %w", resource, err)
+	}
+	return writeArtifact(destination, resource+".yaml", string(encoded))
+}
+
+func (c *fluxCDCollector) collectValuesConfigMaps(
+	ctx context.Context,
+	destination string,
+	references []fluxValuesReference,
+) error {
+	byNamespace := make(map[string][]fluxValuesReference)
+	for _, reference := range references {
+		if strings.EqualFold(reference.Kind, "ConfigMap") {
+			byNamespace[reference.Namespace] = append(byNamespace[reference.Namespace], reference)
+		}
+	}
+
+	var failures []error
+	for namespace, namespaceReferences := range byNamespace {
+		output, err := c.kubectl.Run(ctx, "get", "configmaps", "-n", namespace, "-o", "json")
+		if err != nil {
+			failures = append(failures, fmt.Errorf("list FluxCD values ConfigMaps in %s: %w", namespace, err))
+			continue
+		}
+		var configMaps fluxObjectList
+		if err := json.Unmarshal([]byte(output), &configMaps); err != nil {
+			failures = append(failures, fmt.Errorf("decode FluxCD values ConfigMaps in %s: %w", namespace, err))
+			continue
+		}
+		byName := make(map[string]map[string]any, len(configMaps.Items))
+		for _, configMap := range configMaps.Items {
+			metadata, _ := configMap["metadata"].(map[string]any)
+			name, _ := metadata["name"].(string)
+			byName[name] = configMap
+		}
+
+		seen := make(map[string]struct{})
+		for _, reference := range namespaceReferences {
+			if _, ok := seen[reference.Name]; ok {
+				continue
+			}
+			seen[reference.Name] = struct{}{}
+			configMap, ok := byName[reference.Name]
+			if !ok {
+				if !reference.Optional {
+					failures = append(failures, fmt.Errorf("find required FluxCD values ConfigMap %s/%s", namespace, reference.Name))
+				}
+				continue
+			}
+			if err := writeValuesConfigMap(destination, namespace, reference.Name, configMap); err != nil {
+				failures = append(failures, err)
+			}
+		}
+	}
+	return errors.Join(failures...)
+}
+
+func writeValuesConfigMap(destination, namespace, name string, configMap map[string]any) error {
+	delete(configMap, "binaryData")
+	if data, ok := configMap["data"].(map[string]any); ok {
+		for key, raw := range data {
+			text, ok := raw.(string)
+			if !ok {
+				data[key] = redactValue(raw)
+				continue
+			}
+			var decoded any
+			if err := yaml.Unmarshal([]byte(text), &decoded); err != nil {
+				data[key] = "[unparseable value omitted]"
+				continue
+			}
+			data[key] = redactValue(decoded)
+		}
+	}
+	encoded, err := yaml.Marshal(redactValue(configMap))
+	if err != nil {
+		return fmt.Errorf("encode FluxCD values ConfigMap %s/%s: %w", namespace, name, err)
+	}
+	filename := filepath.Join("values-from", sanitizeCollectorName(namespace+"-"+name)+".yaml")
+	return writeArtifact(destination, filename, string(encoded))
+}
+
+func helmValuesReferences(releases []map[string]any) []fluxValuesReference {
+	var references []fluxValuesReference
+	for _, release := range releases {
+		metadata, _ := release["metadata"].(map[string]any)
+		spec, _ := release["spec"].(map[string]any)
+		valuesFrom, _ := spec["valuesFrom"].([]any)
+		releaseName, _ := metadata["name"].(string)
+		namespace, _ := metadata["namespace"].(string)
+		if namespace == "" {
+			namespace = fluxNamespace
+		}
+		for _, raw := range valuesFrom {
+			value, _ := raw.(map[string]any)
+			reference := fluxValuesReference{
+				Release:    releaseName,
+				Namespace:  namespace,
+				Kind:       stringValue(value["kind"], "Secret"),
+				Name:       stringValue(value["name"], ""),
+				ValuesKey:  stringValue(value["valuesKey"], ""),
+				TargetPath: stringValue(value["targetPath"], ""),
+				Optional:   boolValue(value["optional"]),
+			}
+			if reference.Name != "" {
+				references = append(references, reference)
+			}
+		}
+	}
+	sort.Slice(references, func(i, j int) bool {
+		left := references[i].Namespace + "/" + references[i].Name + "/" + references[i].Release
+		right := references[j].Namespace + "/" + references[j].Name + "/" + references[j].Release
+		return left < right
+	})
+	return references
+}
+
+func redactValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		redacted := make(map[string]any, len(typed))
+		for key, child := range typed {
+			if sensitiveFluxKey(key) {
+				redacted[key] = "[redacted]"
+				continue
+			}
+			redacted[key] = redactValue(child)
+		}
+		return redacted
+	case []any:
+		redacted := make([]any, len(typed))
+		for i, child := range typed {
+			redacted[i] = redactValue(child)
+		}
+		return redacted
+	default:
+		return value
+	}
+}
+
+func sensitiveFluxKey(key string) bool {
+	normalized := strings.NewReplacer("-", "", "_", "", ".", "").Replace(strings.ToLower(key))
+	if normalized == "secretref" || normalized == "secretkeyref" {
+		return false
+	}
+	for _, fragment := range []string{"password", "passwd", "token", "privatekey", "accesskey", "credential", "clientsecret"} {
+		if strings.Contains(normalized, fragment) {
+			return true
+		}
+	}
+	return normalized == "secret"
+}
+
+func stringValue(value any, fallback string) string {
+	if text, ok := value.(string); ok && strings.TrimSpace(text) != "" {
+		return text
+	}
+	return fallback
+}
+
+func boolValue(value any) bool {
+	boolean, _ := value.(bool)
+	return boolean
+}

--- a/e2e/acceptance/artifacts/fluxcd_test.go
+++ b/e2e/acceptance/artifacts/fluxcd_test.go
@@ -11,25 +11,6 @@ import (
 	"github.com/nebius/soperator/e2e/acceptance/framework"
 )
 
-func TestRedactValuePreservesSecretReferences(t *testing.T) {
-	input := map[string]any{
-		"password": "plain-text-password",
-		"apiToken": "plain-text-token",
-		"secretRef": map[string]any{
-			"name": "values-secret",
-			"key":  "values.yaml",
-		},
-		"nested": map[string]any{"client-secret": "plain-text-client-secret"},
-	}
-
-	redacted, ok := redactValue(input).(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "[redacted]", redacted["password"])
-	assert.Equal(t, "[redacted]", redacted["apiToken"])
-	assert.Equal(t, map[string]any{"name": "values-secret", "key": "values.yaml"}, redacted["secretRef"])
-	assert.Equal(t, map[string]any{"client-secret": "[redacted]"}, redacted["nested"])
-}
-
 func TestFluxCDCollectorCollectsOnlyReconciliationResources(t *testing.T) {
 	var calls [][]string
 	collector := &fluxCDCollector{kubectl: framework.NewArgsScope(func(_ context.Context, args ...string) (string, error) {
@@ -41,11 +22,11 @@ func TestFluxCDCollectorCollectsOnlyReconciliationResources(t *testing.T) {
 	require.NoError(t, collector.Collect(t.Context(), destination))
 	assert.Equal(t, [][]string{
 		{"get", "helmreleases", "-n", fluxNamespace, "-o", "wide"},
-		{"get", "helmreleases", "-n", fluxNamespace, "-o", "json"},
-		{"get", "kustomizations", "-n", fluxNamespace, "-o", "json"},
-		{"get", "gitrepositories", "-n", fluxNamespace, "-o", "json"},
-		{"get", "ocirepositories", "-n", fluxNamespace, "-o", "json"},
-		{"get", "helmrepositories", "-n", fluxNamespace, "-o", "json"},
+		{"get", "helmreleases", "-n", fluxNamespace, "-o", "yaml"},
+		{"get", "kustomizations", "-n", fluxNamespace, "-o", "yaml"},
+		{"get", "gitrepositories", "-n", fluxNamespace, "-o", "yaml"},
+		{"get", "ocirepositories", "-n", fluxNamespace, "-o", "yaml"},
+		{"get", "helmrepositories", "-n", fluxNamespace, "-o", "yaml"},
 	}, calls)
 	for _, filename := range []string{
 		"helmreleases.txt",

--- a/e2e/acceptance/artifacts/fluxcd_test.go
+++ b/e2e/acceptance/artifacts/fluxcd_test.go
@@ -1,0 +1,76 @@
+package artifacts
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+func TestRedactValuePreservesSecretReferences(t *testing.T) {
+	input := map[string]any{
+		"password": "plain-text-password",
+		"apiToken": "plain-text-token",
+		"secretRef": map[string]any{
+			"name": "values-secret",
+			"key":  "values.yaml",
+		},
+		"nested": map[string]any{"client-secret": "plain-text-client-secret"},
+	}
+
+	redacted, ok := redactValue(input).(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "[redacted]", redacted["password"])
+	assert.Equal(t, "[redacted]", redacted["apiToken"])
+	assert.Equal(t, map[string]any{"name": "values-secret", "key": "values.yaml"}, redacted["secretRef"])
+	assert.Equal(t, map[string]any{"client-secret": "[redacted]"}, redacted["nested"])
+}
+
+func TestCollectValuesConfigMapsSkipsMissingOptionalReferences(t *testing.T) {
+	var calls int
+	collector := &fluxCDCollector{kubectl: framework.NewArgsScope(func(_ context.Context, args ...string) (string, error) {
+		calls++
+		assert.Equal(t, []string{"get", "configmaps", "-n", "flux-system", "-o", "json"}, args)
+		return `{"items":[{"metadata":{"name":"present"},"data":{"values.yaml":"password: unsafe\nreplicas: 2"}}]}`, nil
+	})}
+	destination := t.TempDir()
+
+	err := collector.collectValuesConfigMaps(t.Context(), destination, []fluxValuesReference{
+		{Namespace: "flux-system", Kind: "ConfigMap", Name: "present"},
+		{Namespace: "flux-system", Kind: "ConfigMap", Name: "absent", Optional: true},
+		{Namespace: "flux-system", Kind: "Secret", Name: "never-read"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+
+	content, err := os.ReadFile(filepath.Join(destination, "values-from", "flux-system-present.yaml"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "unsafe")
+	assert.Contains(t, string(content), "[redacted]")
+}
+
+func TestHelmValuesReferencesIncludeConfigMapsAndSecrets(t *testing.T) {
+	references := helmValuesReferences([]map[string]any{
+		{
+			"metadata": map[string]any{"name": "soperator", "namespace": "flux-system"},
+			"spec": map[string]any{"valuesFrom": []any{
+				map[string]any{"kind": "Secret", "name": "private-values", "valuesKey": "values.yaml"},
+				map[string]any{"kind": "ConfigMap", "name": "public-values", "targetPath": "workers"},
+				map[string]any{"name": "default-secret"},
+			}},
+		},
+	})
+
+	require.Len(t, references, 3)
+	assert.Equal(t, "Secret", references[0].Kind)
+	assert.Equal(t, "default-secret", references[0].Name)
+	assert.Equal(t, "Secret", references[1].Kind)
+	assert.Equal(t, "private-values", references[1].Name)
+	assert.Equal(t, "ConfigMap", references[2].Kind)
+	assert.Equal(t, "public-values", references[2].Name)
+}

--- a/e2e/acceptance/artifacts/fluxcd_test.go
+++ b/e2e/acceptance/artifacts/fluxcd_test.go
@@ -2,7 +2,6 @@ package artifacts
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -31,46 +30,33 @@ func TestRedactValuePreservesSecretReferences(t *testing.T) {
 	assert.Equal(t, map[string]any{"client-secret": "[redacted]"}, redacted["nested"])
 }
 
-func TestCollectValuesConfigMapsSkipsMissingOptionalReferences(t *testing.T) {
-	var calls int
+func TestFluxCDCollectorCollectsOnlyReconciliationResources(t *testing.T) {
+	var calls [][]string
 	collector := &fluxCDCollector{kubectl: framework.NewArgsScope(func(_ context.Context, args ...string) (string, error) {
-		calls++
-		assert.Equal(t, []string{"get", "configmaps", "-n", "flux-system", "-o", "json"}, args)
-		return `{"items":[{"metadata":{"name":"present"},"data":{"values.yaml":"password: unsafe\nreplicas: 2"}}]}`, nil
+		calls = append(calls, args)
+		return `{"items":[]}`, nil
 	})}
 	destination := t.TempDir()
 
-	err := collector.collectValuesConfigMaps(t.Context(), destination, []fluxValuesReference{
-		{Namespace: "flux-system", Kind: "ConfigMap", Name: "present"},
-		{Namespace: "flux-system", Kind: "ConfigMap", Name: "absent", Optional: true},
-		{Namespace: "flux-system", Kind: "Secret", Name: "never-read"},
-	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, calls)
-
-	content, err := os.ReadFile(filepath.Join(destination, "values-from", "flux-system-present.yaml"))
-	require.NoError(t, err)
-	assert.NotContains(t, string(content), "unsafe")
-	assert.Contains(t, string(content), "[redacted]")
-}
-
-func TestHelmValuesReferencesIncludeConfigMapsAndSecrets(t *testing.T) {
-	references := helmValuesReferences([]map[string]any{
-		{
-			"metadata": map[string]any{"name": "soperator", "namespace": "flux-system"},
-			"spec": map[string]any{"valuesFrom": []any{
-				map[string]any{"kind": "Secret", "name": "private-values", "valuesKey": "values.yaml"},
-				map[string]any{"kind": "ConfigMap", "name": "public-values", "targetPath": "workers"},
-				map[string]any{"name": "default-secret"},
-			}},
-		},
-	})
-
-	require.Len(t, references, 3)
-	assert.Equal(t, "Secret", references[0].Kind)
-	assert.Equal(t, "default-secret", references[0].Name)
-	assert.Equal(t, "Secret", references[1].Kind)
-	assert.Equal(t, "private-values", references[1].Name)
-	assert.Equal(t, "ConfigMap", references[2].Kind)
-	assert.Equal(t, "public-values", references[2].Name)
+	require.NoError(t, collector.Collect(t.Context(), destination))
+	assert.Equal(t, [][]string{
+		{"get", "helmreleases", "-n", fluxNamespace, "-o", "wide"},
+		{"get", "helmreleases", "-n", fluxNamespace, "-o", "json"},
+		{"get", "kustomizations", "-n", fluxNamespace, "-o", "json"},
+		{"get", "gitrepositories", "-n", fluxNamespace, "-o", "json"},
+		{"get", "ocirepositories", "-n", fluxNamespace, "-o", "json"},
+		{"get", "helmrepositories", "-n", fluxNamespace, "-o", "json"},
+	}, calls)
+	for _, filename := range []string{
+		"helmreleases.txt",
+		"helmreleases.yaml",
+		"kustomizations.yaml",
+		"gitrepositories.yaml",
+		"ocirepositories.yaml",
+		"helmrepositories.yaml",
+	} {
+		assert.FileExists(t, filepath.Join(destination, filename))
+	}
+	assert.NoDirExists(t, filepath.Join(destination, "values-from"))
+	assert.NoFileExists(t, filepath.Join(destination, "events.txt"))
 }

--- a/e2e/acceptance/artifacts/jail.go
+++ b/e2e/acceptance/artifacts/jail.go
@@ -7,8 +7,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+const (
+	jailCopyAttempts = 3
+	jailCopyDelay    = 5 * time.Second
 )
 
 type jailCollector struct {
@@ -110,7 +116,7 @@ func (c *jailCollector) copyFromPod(ctx context.Context, pod, container, source,
 		args = append(args, "-c", container)
 	}
 	args = append(args, fmt.Sprintf("%s/%s:%s", framework.SoperatorNamespace, pod, source), destination)
-	if _, err := c.kubectl.Run(ctx, args...); err != nil {
+	if _, err := c.kubectl.RunWithRetry(ctx, jailCopyAttempts, jailCopyDelay, args...); err != nil {
 		return fmt.Errorf("copy %s from pod %s: %w", source, pod, err)
 	}
 	return nil

--- a/e2e/acceptance/artifacts/jail.go
+++ b/e2e/acceptance/artifacts/jail.go
@@ -71,13 +71,6 @@ func (c *jailCollector) collectSharedJail(ctx context.Context, destination, pod 
 		}
 	}
 
-	scenarioSource := "/mnt/jail" + framework.AcceptanceScenarioArtifactsDir
-	if _, err := c.kubectl.Run(ctx, "exec", "-n", framework.SoperatorNamespace, pod, "--", "test", "-d", scenarioSource); err == nil {
-		if err := c.copyFromPod(ctx, pod, "", scenarioSource+"/.", filepath.Join(destination, "scenarios")); err != nil {
-			failures = append(failures, err)
-		}
-	}
-
 	return errors.Join(failures...)
 }
 

--- a/e2e/acceptance/artifacts/jail.go
+++ b/e2e/acceptance/artifacts/jail.go
@@ -1,0 +1,117 @@
+package artifacts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+type jailCollector struct {
+	kubectl framework.ArgsScope
+}
+
+// NewJailCollector creates a collector for shared and node-local jail files.
+func NewJailCollector(kubectl framework.ArgsScope) Collector {
+	return &jailCollector{kubectl: kubectl}
+}
+
+func (c *jailCollector) Name() string { return "jail" }
+
+func (c *jailCollector) Collect(ctx context.Context, destination string) error {
+	var failures []error
+	pod, err := c.runningPod(ctx, "app.kubernetes.io/component=sconfigcontroller")
+	if err != nil {
+		failures = append(failures, err)
+	} else {
+		if err := c.collectSharedJail(ctx, destination, pod); err != nil {
+			failures = append(failures, err)
+		}
+	}
+
+	workers, err := c.runningPods(ctx, "slurm.nebius.ai/worker=true")
+	if err != nil {
+		failures = append(failures, err)
+	}
+	for _, worker := range workers {
+		workerDestination := filepath.Join(destination, "workers", sanitizeCollectorName(worker))
+		if err := c.copyFromPod(ctx, worker, "slurmd", "/mnt/jail.upper/opt/soperator-outputs/local/.", workerDestination); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	return errors.Join(failures...)
+}
+
+func (c *jailCollector) collectSharedJail(ctx context.Context, destination, pod string) error {
+	var failures []error
+	if err := collectArgs(ctx, destination, "tree.txt", c.kubectl,
+		"exec", "-n", framework.SoperatorNamespace, pod, "--",
+		"sh", "-lc", "find /mnt/jail -maxdepth 6 -not -path '*/proc/*' 2>&1 || true"); err != nil {
+		failures = append(failures, err)
+	}
+	for _, copy := range []struct {
+		source      string
+		destination string
+	}{
+		{"/mnt/jail/etc/slurm/.", "etc/slurm"},
+		{"/mnt/jail/opt/soperator-outputs/.", "opt/soperator-outputs"},
+	} {
+		if err := c.copyFromPod(ctx, pod, "", copy.source, filepath.Join(destination, copy.destination)); err != nil {
+			failures = append(failures, err)
+		}
+	}
+
+	scenarioSource := "/mnt/jail" + framework.AcceptanceScenarioArtifactsDir
+	if _, err := c.kubectl.Run(ctx, "exec", "-n", framework.SoperatorNamespace, pod, "--", "test", "-d", scenarioSource); err == nil {
+		if err := c.copyFromPod(ctx, pod, "", scenarioSource+"/.", filepath.Join(destination, "scenarios")); err != nil {
+			failures = append(failures, err)
+		}
+	}
+
+	return errors.Join(failures...)
+}
+
+func (c *jailCollector) runningPod(ctx context.Context, selector string) (string, error) {
+	pods, err := c.runningPods(ctx, selector)
+	if err != nil {
+		return "", err
+	}
+	if len(pods) == 0 {
+		return "", fmt.Errorf("find running pod with selector %q: no pods found", selector)
+	}
+	return pods[0], nil
+}
+
+func (c *jailCollector) runningPods(ctx context.Context, selector string) ([]string, error) {
+	if c.kubectl == nil {
+		return nil, fmt.Errorf("find running pods with selector %q: kubectl scope is unavailable", selector)
+	}
+	output, err := c.kubectl.Run(ctx,
+		"get", "pods", "-n", framework.SoperatorNamespace,
+		"-l", selector, "--field-selector=status.phase=Running",
+		"-o", "jsonpath={.items[*].metadata.name}",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find running pods with selector %q: %w", selector, err)
+	}
+	return strings.Fields(output), nil
+}
+
+func (c *jailCollector) copyFromPod(ctx context.Context, pod, container, source, destination string) error {
+	if err := os.MkdirAll(destination, 0o755); err != nil {
+		return fmt.Errorf("create jail artifact directory %q: %w", destination, err)
+	}
+	args := []string{"cp"}
+	if container != "" {
+		args = append(args, "-c", container)
+	}
+	args = append(args, fmt.Sprintf("%s/%s:%s", framework.SoperatorNamespace, pod, source), destination)
+	if _, err := c.kubectl.Run(ctx, args...); err != nil {
+		return fmt.Errorf("copy %s from pod %s: %w", source, pod, err)
+	}
+	return nil
+}

--- a/e2e/acceptance/artifacts/jail_test.go
+++ b/e2e/acceptance/artifacts/jail_test.go
@@ -1,0 +1,50 @@
+package artifacts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type retryRecordingArgsScope struct {
+	attempts int
+	delay    time.Duration
+	args     []string
+}
+
+func (s *retryRecordingArgsScope) Run(context.Context, ...string) (string, error) {
+	return "", nil
+}
+
+func (s *retryRecordingArgsScope) RunWithRetry(
+	_ context.Context,
+	attempts int,
+	delay time.Duration,
+	args ...string,
+) (string, error) {
+	s.attempts = attempts
+	s.delay = delay
+	s.args = args
+	return "", nil
+}
+
+func (s *retryRecordingArgsScope) RunWithDefaultRetry(context.Context, ...string) (string, error) {
+	return "", nil
+}
+
+func TestJailCopyUsesRetries(t *testing.T) {
+	scope := &retryRecordingArgsScope{}
+	collector := &jailCollector{kubectl: scope}
+	destination := t.TempDir()
+
+	err := collector.copyFromPod(t.Context(), "worker-0", "slurmd", "/source/.", destination)
+	require.NoError(t, err)
+	assert.Equal(t, jailCopyAttempts, scope.attempts)
+	assert.Equal(t, jailCopyDelay, scope.delay)
+	assert.Equal(t, []string{
+		"cp", "-c", "slurmd", "soperator/worker-0:/source/.", destination,
+	}, scope.args)
+}

--- a/e2e/acceptance/artifacts/kubernetes.go
+++ b/e2e/acceptance/artifacts/kubernetes.go
@@ -1,0 +1,52 @@
+package artifacts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+type kubernetesCollector struct {
+	kubectl framework.ArgsScope
+}
+
+// NewKubernetesCollector creates a collector for general Kubernetes state.
+func NewKubernetesCollector(kubectl framework.ArgsScope) Collector {
+	return &kubernetesCollector{kubectl: kubectl}
+}
+
+func (c *kubernetesCollector) Name() string { return "kubernetes" }
+
+func (c *kubernetesCollector) Collect(ctx context.Context, destination string) error {
+	commands := []struct {
+		filename string
+		args     []string
+	}{
+		{"pods.txt", []string{"get", "pods", "-A", "-o", "wide"}},
+		{"events.txt", []string{"get", "events", "-A", "--sort-by=.lastTimestamp"}},
+		{"nodes.txt", []string{"get", "nodes", "-o", "wide"}},
+		{"nodes.yaml", []string{"get", "nodes", "-o", "yaml"}},
+		{"jobs.txt", []string{"get", "jobs", "-n", framework.SoperatorNamespace, "-o", "wide"}},
+		{"jobs.yaml", []string{"get", "jobs", "-n", framework.SoperatorNamespace, "-o", "yaml"}},
+	}
+
+	var failures []error
+	for _, command := range commands {
+		if err := collectArgs(ctx, destination, command.filename, c.kubectl, command.args...); err != nil {
+			failures = append(failures, err)
+		}
+	}
+
+	dumpDir := filepath.Join(destination, "cluster-info")
+	if err := collectArgs(ctx, destination, "cluster-info-command.txt", c.kubectl,
+		"cluster-info", "dump",
+		"--namespaces=kruise-system,soperator-system,soperator,flux-system,cert-manager-system",
+		fmt.Sprintf("--output-directory=%s", dumpDir),
+	); err != nil {
+		failures = append(failures, err)
+	}
+	return errors.Join(failures...)
+}

--- a/e2e/acceptance/artifacts/mk8s.go
+++ b/e2e/acceptance/artifacts/mk8s.go
@@ -1,0 +1,74 @@
+package artifacts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+type mk8sCollector struct {
+	local     framework.ArgsScope
+	projectID string
+}
+
+type mk8sClusterList struct {
+	Items []struct {
+		Metadata struct {
+			ID string `json:"id"`
+		} `json:"metadata"`
+	} `json:"items"`
+}
+
+// NewMK8sCollector creates a collector for Managed Kubernetes resources in one project.
+func NewMK8sCollector(local framework.ArgsScope, projectID string) Collector {
+	return &mk8sCollector{local: local, projectID: strings.TrimSpace(projectID)}
+}
+
+func (c *mk8sCollector) Name() string { return "mk8s" }
+
+func (c *mk8sCollector) Collect(ctx context.Context, destination string) error {
+	if c.projectID == "" {
+		return fmt.Errorf("Nebius project ID is required")
+	}
+	clustersJSON, err := c.local.Run(ctx,
+		"nebius", "mk8s", "cluster", "list", "--parent-id", c.projectID, "--format", "json")
+	if err != nil {
+		return fmt.Errorf("list Managed Kubernetes clusters: %w", err)
+	}
+	var failures []error
+	if err := writeArtifact(destination, "clusters.json", clustersJSON); err != nil {
+		failures = append(failures, err)
+	}
+	if err := collectArgs(ctx, destination, "clusters.txt", c.local,
+		"nebius", "mk8s", "cluster", "list", "--parent-id", c.projectID, "--format", "table"); err != nil {
+		failures = append(failures, err)
+	}
+
+	var clusters mk8sClusterList
+	if err := json.Unmarshal([]byte(clustersJSON), &clusters); err != nil {
+		failures = append(failures, fmt.Errorf("decode Managed Kubernetes clusters: %w", err))
+		return errors.Join(failures...)
+	}
+	for _, cluster := range clusters.Items {
+		clusterID := strings.TrimSpace(cluster.Metadata.ID)
+		if clusterID == "" {
+			failures = append(failures, fmt.Errorf("Managed Kubernetes cluster has empty ID"))
+			continue
+		}
+		dir := filepath.Join("node-groups", sanitizeCollectorName(clusterID))
+		if err := collectArgs(ctx, destination, filepath.Join(dir, "node-groups.json"), c.local,
+			"nebius", "mk8s", "node-group", "list", "--parent-id", clusterID, "--page-size", "1000", "--format", "json"); err != nil {
+			failures = append(failures, err)
+		}
+		if err := collectArgs(ctx, destination, filepath.Join(dir, "node-groups.txt"), c.local,
+			"nebius", "mk8s", "node-group", "list", "--parent-id", clusterID, "--page-size", "1000", "--format", "table"); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	return errors.Join(failures...)
+}

--- a/e2e/acceptance/artifacts/mk8s.go
+++ b/e2e/acceptance/artifacts/mk8s.go
@@ -33,7 +33,7 @@ func (c *mk8sCollector) Name() string { return "mk8s" }
 
 func (c *mk8sCollector) Collect(ctx context.Context, destination string) error {
 	if c.projectID == "" {
-		return fmt.Errorf("Nebius project ID is required")
+		return nil
 	}
 	clustersJSON, err := c.local.Run(ctx,
 		"nebius", "mk8s", "cluster", "list", "--parent-id", c.projectID, "--format", "json")

--- a/e2e/acceptance/artifacts/mk8s.go
+++ b/e2e/acceptance/artifacts/mk8s.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -33,6 +34,7 @@ func (c *mk8sCollector) Name() string { return "mk8s" }
 
 func (c *mk8sCollector) Collect(ctx context.Context, destination string) error {
 	if c.projectID == "" {
+		log.Printf("artifacts: skip mk8s collector: Nebius project ID is not provided")
 		return nil
 	}
 	clustersJSON, err := c.local.Run(ctx,

--- a/e2e/acceptance/artifacts/mk8s_test.go
+++ b/e2e/acceptance/artifacts/mk8s_test.go
@@ -1,0 +1,20 @@
+package artifacts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+func TestMK8sCollectorSkipsWithoutProjectID(t *testing.T) {
+	local := framework.NewArgsScope(func(context.Context, ...string) (string, error) {
+		t.Fatal("Nebius CLI must not be invoked without a project ID")
+		return "", nil
+	})
+
+	err := NewMK8sCollector(local, " ").Collect(t.Context(), t.TempDir())
+	require.NoError(t, err)
+}

--- a/e2e/acceptance/artifacts/slurm.go
+++ b/e2e/acceptance/artifacts/slurm.go
@@ -1,0 +1,39 @@
+package artifacts
+
+import (
+	"context"
+	"errors"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+type slurmCollector struct {
+	controller framework.CommandScope
+}
+
+// NewSlurmCollector creates a collector for Slurm controller state.
+func NewSlurmCollector(controller framework.CommandScope) Collector {
+	return &slurmCollector{controller: controller}
+}
+
+func (c *slurmCollector) Name() string { return "slurm" }
+
+func (c *slurmCollector) Collect(ctx context.Context, destination string) error {
+	commands := []struct {
+		filename string
+		command  string
+	}{
+		{"sinfo.txt", "sinfo -N --long"},
+		{"squeue.txt", "squeue --all --long"},
+		{"sdiag.txt", "sdiag"},
+		{"sacct.txt", "sacct --allusers --starttime=now-6hours --format=JobID,JobName,Partition,Account,AllocCPUS,State,ExitCode"},
+		{"sacct-parsable.txt", "sacct --parsable2 --allusers --starttime=now-6hours --format=JobID,JobName,Partition,Account,AllocCPUS,State,ExitCode,NodeList,Reason,StdOut,StdErr,WorkDir"},
+	}
+	var failures []error
+	for _, command := range commands {
+		if err := collectCommand(ctx, destination, command.filename, c.controller, command.command); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	return errors.Join(failures...)
+}

--- a/e2e/acceptance/artifacts/soperator.go
+++ b/e2e/acceptance/artifacts/soperator.go
@@ -1,0 +1,33 @@
+package artifacts
+
+import (
+	"context"
+	"errors"
+
+	"github.com/nebius/soperator/e2e/acceptance/framework"
+)
+
+type soperatorCollector struct {
+	kubectl framework.ArgsScope
+}
+
+// NewSoperatorCollector creates a collector for Soperator custom resources.
+func NewSoperatorCollector(kubectl framework.ArgsScope) Collector {
+	return &soperatorCollector{kubectl: kubectl}
+}
+
+func (c *soperatorCollector) Name() string { return "soperator" }
+
+func (c *soperatorCollector) Collect(ctx context.Context, destination string) error {
+	resources := []string{"slurmclusters", "nodesets", "activechecks", "jailedconfigs"}
+	var failures []error
+	for _, resource := range resources {
+		if err := collectArgs(ctx, destination, resource+".txt", c.kubectl, "get", resource, "-A", "-o", "wide"); err != nil {
+			failures = append(failures, err)
+		}
+		if err := collectArgs(ctx, destination, resource+".yaml", c.kubectl, "get", resource, "-A", "-o", "yaml"); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	return errors.Join(failures...)
+}

--- a/e2e/acceptance/framework/artifacts.go
+++ b/e2e/acceptance/framework/artifacts.go
@@ -1,0 +1,102 @@
+package framework
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const AcceptanceScenarioArtifactsDir = "/opt/soperator-outputs/shared/acceptance/scenarios"
+
+const maxArtifactPathPartLength = 80
+
+var invalidArtifactPathPart = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+type scenarioArtifactsCtxKey struct{}
+
+// ScenarioArtifactPaths contains the runner and jail directories assigned to one scenario.
+type ScenarioArtifactPaths struct {
+	RunnerDir string
+	JailDir   string
+}
+
+// ArtifactsManager prepares per-scenario artifact directories.
+type ArtifactsManager struct {
+	outputDir string
+	jail      CommandScope
+}
+
+// NewArtifactsManager creates a scenario artifact manager.
+func NewArtifactsManager(outputDir string, jail CommandScope) *ArtifactsManager {
+	return &ArtifactsManager{
+		outputDir: strings.TrimSpace(outputDir),
+		jail:      jail,
+	}
+}
+
+// PrepareScenario creates and attaches the artifact paths for one scenario.
+func (m *ArtifactsManager) PrepareScenario(
+	ctx context.Context,
+	suiteName string,
+	scenarioURI string,
+	scenarioName string,
+	scenarioID string,
+) (context.Context, error) {
+	if m == nil || m.outputDir == "" {
+		return ctx, nil
+	}
+
+	suitePart := sanitizeArtifactPathPart(suiteName)
+	scenarioPart := scenarioArtifactPathPart(scenarioURI, scenarioName, scenarioID)
+	paths := ScenarioArtifactPaths{
+		RunnerDir: filepath.Join(m.outputDir, "scenarios", suitePart, scenarioPart),
+		JailDir:   path.Join(AcceptanceScenarioArtifactsDir, suitePart, scenarioPart),
+	}
+	ctx = context.WithValue(ctx, scenarioArtifactsCtxKey{}, paths)
+
+	var failures []error
+	if err := os.MkdirAll(paths.RunnerDir, 0o755); err != nil {
+		failures = append(failures, fmt.Errorf("create runner artifact directory %q: %w", paths.RunnerDir, err))
+	}
+	if m.jail == nil {
+		failures = append(failures, fmt.Errorf("create jail artifact directory %q: jail scope is unavailable", paths.JailDir))
+	} else {
+		command := fmt.Sprintf("install -d -m 0777 %s", ShellQuote(paths.JailDir))
+		if _, err := m.jail.Run(ctx, command); err != nil {
+			failures = append(failures, fmt.Errorf("create jail artifact directory %q: %w", paths.JailDir, err))
+		}
+	}
+
+	return ctx, errors.Join(failures...)
+}
+
+// ScenarioArtifacts returns the artifact paths assigned to the current scenario.
+func ScenarioArtifacts(ctx context.Context) (ScenarioArtifactPaths, bool) {
+	paths, ok := ctx.Value(scenarioArtifactsCtxKey{}).(ScenarioArtifactPaths)
+	return paths, ok
+}
+
+func scenarioArtifactPathPart(uri, name, id string) string {
+	uriPart := sanitizeArtifactPathPart(path.Base(strings.TrimSpace(uri)))
+	namePart := sanitizeArtifactPathPart(name)
+	hash := sha256.Sum256([]byte(id))
+	return fmt.Sprintf("%s-%s-%x", uriPart, namePart, hash[:4])
+}
+
+func sanitizeArtifactPathPart(value string) string {
+	part := invalidArtifactPathPart.ReplaceAllString(strings.TrimSpace(value), "-")
+	part = strings.Trim(part, "-._")
+	if part == "" {
+		part = "unknown"
+	}
+	if len(part) > maxArtifactPathPartLength {
+		part = strings.TrimRight(part[:maxArtifactPathPartLength], "-._")
+	}
+	return part
+}

--- a/e2e/acceptance/framework/artifacts_test.go
+++ b/e2e/acceptance/framework/artifacts_test.go
@@ -1,0 +1,77 @@
+package framework
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type artifactCommandScope struct {
+	command string
+	err     error
+}
+
+func (s *artifactCommandScope) Run(_ context.Context, command string) (string, error) {
+	s.command = command
+	return "", s.err
+}
+
+func (s *artifactCommandScope) RunWithRetry(ctx context.Context, command string, _ int, _ time.Duration) (string, error) {
+	return s.Run(ctx, command)
+}
+
+func (s *artifactCommandScope) RunWithDefaultRetry(ctx context.Context, command string) (string, error) {
+	return s.Run(ctx, command)
+}
+
+func TestArtifactsManagerPreparesScenarioPaths(t *testing.T) {
+	jail := &artifactCommandScope{}
+	manager := NewArtifactsManager(t.TempDir(), jail)
+
+	ctx, err := manager.PrepareScenario(
+		context.Background(),
+		"managed/suite",
+		"features/passive checks.feature",
+		"drop_page_cache runs",
+		"pickle-1",
+	)
+	require.NoError(t, err)
+
+	paths, ok := ScenarioArtifacts(ctx)
+	require.True(t, ok)
+	assert.DirExists(t, paths.RunnerDir)
+	assert.Contains(t, filepath.ToSlash(paths.RunnerDir), "/scenarios/managed-suite/")
+	assert.Equal(t,
+		"/opt/soperator-outputs/shared/acceptance/scenarios/managed-suite/passive-checks.feature-drop_page_cache-runs-6a180a5b",
+		paths.JailDir,
+	)
+	assert.Contains(t, jail.command, "install -d -m 0777")
+	assert.Contains(t, jail.command, paths.JailDir)
+}
+
+func TestArtifactsManagerAttachesPathsWhenJailCreationFails(t *testing.T) {
+	jail := &artifactCommandScope{err: errors.New("jail unavailable")}
+	manager := NewArtifactsManager(t.TempDir(), jail)
+
+	ctx, err := manager.PrepareScenario(context.Background(), "suite", "feature", "scenario", "id")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "jail unavailable")
+
+	paths, ok := ScenarioArtifacts(ctx)
+	require.True(t, ok)
+	assert.DirExists(t, paths.RunnerDir)
+}
+
+func TestArtifactsManagerIsDisabledWithoutOutputDir(t *testing.T) {
+	manager := NewArtifactsManager("", &artifactCommandScope{})
+
+	ctx, err := manager.PrepareScenario(context.Background(), "suite", "feature", "scenario", "id")
+	require.NoError(t, err)
+	_, ok := ScenarioArtifacts(ctx)
+	assert.False(t, ok)
+}

--- a/e2e/acceptance/framework/slurm_client.go
+++ b/e2e/acceptance/framework/slurm_client.go
@@ -21,8 +21,8 @@ func NewSlurmClient(runtime Runtime) *SlurmClient {
 }
 
 // SbatchOptions describes a Slurm batch submission from an acceptance test.
-// SubmitBatch adds -o/-e pointing inside OutputDir, which defaults to
-// AcceptanceJobOutputDir.
+// SubmitBatch adds -o/-e pointing inside OutputDir. When OutputDir is empty,
+// scenario artifacts take precedence over AcceptanceJobOutputDir.
 type SbatchOptions struct {
 	JobName      string   // required; used in output filename
 	Nodes        int      // -N (omitted if 0)
@@ -32,7 +32,7 @@ type SbatchOptions struct {
 	ExtraFlags   []string // verbatim flags appended before --wrap
 	Wrap         string   // --wrap body
 	RunAsUser    string   // submit through sudo -iu (omitted if empty)
-	OutputDir    string   // defaults to AcceptanceJobOutputDir
+	OutputDir    string   // explicit output directory; defaults to scenario artifacts, then AcceptanceJobOutputDir
 }
 
 // SbatchJob is the handle returned by SubmitBatch. StdoutPath and StderrPath
@@ -64,7 +64,12 @@ func (s *SlurmClient) SubmitBatch(ctx context.Context, opts SbatchOptions) (Sbat
 	}
 	outputDir := strings.TrimSpace(opts.OutputDir)
 	if outputDir == "" {
-		outputDir = AcceptanceJobOutputDir
+		if artifacts, ok := ScenarioArtifacts(ctx); ok {
+			outputDir = artifacts.JailDir
+		}
+		if outputDir == "" {
+			outputDir = AcceptanceJobOutputDir
+		}
 	}
 	runAsUser := strings.TrimSpace(opts.RunAsUser)
 

--- a/e2e/acceptance/framework/slurm_client_test.go
+++ b/e2e/acceptance/framework/slurm_client_test.go
@@ -44,6 +44,34 @@ func TestSubmitBatchRunsAsUserWithCustomOutputDir(t *testing.T) {
 	assert.Contains(t, runtime.jailCommand, "-e "+ShellQuote(outputDir+"/%x-%j.err"))
 }
 
+func TestSubmitBatchUsesScenarioArtifactDir(t *testing.T) {
+	runtime := &submitBatchRuntime{}
+	ctx := context.WithValue(t.Context(), scenarioArtifactsCtxKey{}, ScenarioArtifactPaths{
+		JailDir: "/opt/soperator-outputs/shared/acceptance/scenarios/suite/scenario",
+	})
+
+	job, err := NewSlurmClient(runtime).SubmitBatch(ctx, SbatchOptions{
+		JobName: "smoke",
+		Wrap:    "true",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/opt/soperator-outputs/shared/acceptance/scenarios/suite/scenario/smoke-123.out", job.StdoutPath)
+	assert.Contains(t, runtime.jailCommand, "scenarios/suite/scenario")
+}
+
+func TestSubmitBatchFallsBackOutsideScenario(t *testing.T) {
+	runtime := &submitBatchRuntime{}
+
+	job, err := NewSlurmClient(runtime).SubmitBatch(t.Context(), SbatchOptions{
+		JobName: "smoke",
+		Wrap:    "true",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, AcceptanceJobOutputDir+"/smoke-123.out", job.StdoutPath)
+}
+
 func TestParseSacctJob(t *testing.T) {
 	dump := `
 123.batch|COMPLETED|0:0||

--- a/e2e/acceptance/internal/sharedsteps/accounting.go
+++ b/e2e/acceptance/internal/sharedsteps/accounting.go
@@ -259,10 +259,20 @@ func (s *Accounting) submitAccountingSmokeJob(ctx context.Context) error {
 	if s.worker.Name == "" {
 		return fmt.Errorf("worker for accounting smoke job is not selected")
 	}
-	stdoutPath := accountingTestUserHome + "/e2e-accounting.out"
-	stderrPath := accountingTestUserHome + "/e2e-accounting.err"
+	outputDir := accountingTestUserHome
+	prepareOutputDir := ""
+	if artifacts, ok := framework.ScenarioArtifacts(ctx); ok {
+		outputDir = artifacts.JailDir
+		prepareOutputDir = fmt.Sprintf("install -d -o %s -g %s -m 0777 %s && ",
+			framework.ShellQuote(accountingTestUser),
+			framework.ShellQuote(accountingTestUser),
+			framework.ShellQuote(outputDir),
+		)
+	}
+	stdoutPath := outputDir + "/e2e-accounting.out"
+	stderrPath := outputDir + "/e2e-accounting.err"
 	command := strings.Join([]string{
-		"sudo", "-iu", framework.ShellQuote(accountingTestUser), "--", "sbatch",
+		prepareOutputDir + "sudo", "-iu", framework.ShellQuote(accountingTestUser), "--", "sbatch",
 		"--parsable",
 		"--job-name=" + framework.ShellQuote(accountingTestJobName),
 		"--account=" + framework.ShellQuote(accountingTestAccount),

--- a/e2e/acceptance/internal/sharedsteps/gpu_profiling.go
+++ b/e2e/acceptance/internal/sharedsteps/gpu_profiling.go
@@ -119,7 +119,7 @@ func (s *GPUProfiling) theSoperatorchecksUserSubmitsAnNsightComputeProfilingJob(
 		TasksPerNode: 1,
 		Wrap:         wrap,
 		RunAsUser:    gpuProfilingUser,
-		OutputDir:    gpuProfilingOutputDir,
+		OutputDir:    gpuProfilingArtifactDir(ctx),
 	})
 	if err != nil {
 		return err
@@ -141,7 +141,8 @@ func (s *GPUProfiling) theSoperatorchecksUserSubmitsAFullNodeNsightSystemsProfil
 	if s.worker.Name == "" {
 		return fmt.Errorf("GPU profiling worker is not selected")
 	}
-	reportBase := path.Join(gpuProfilingOutputDir, fmt.Sprintf("nsys-%d", time.Now().UnixNano()))
+	outputDir := gpuProfilingArtifactDir(ctx)
+	reportBase := path.Join(outputDir, fmt.Sprintf("nsys-%d", time.Now().UnixNano()))
 	wrap := fmt.Sprintf(
 		"test \"$(id -u)\" -ne 0 && test \"$(id -un)\" = %s && "+
 			"nsys profile --trace=cuda,nvtx -o %s all_reduce_perf -b 512M -e 8G -f 2 -g %d",
@@ -157,7 +158,7 @@ func (s *GPUProfiling) theSoperatorchecksUserSubmitsAFullNodeNsightSystemsProfil
 		TasksPerNode: 1,
 		Wrap:         wrap,
 		RunAsUser:    gpuProfilingUser,
-		OutputDir:    gpuProfilingOutputDir,
+		OutputDir:    outputDir,
 	})
 	if err != nil {
 		return err
@@ -167,6 +168,13 @@ func (s *GPUProfiling) theSoperatorchecksUserSubmitsAFullNodeNsightSystemsProfil
 	s.runtime.Logf("Nsight Systems: worker=%s GPUs=%d job_id=%s report=%s stdout=%s stderr=%s",
 		s.worker.Name, s.worker.SlurmNode.GPUCount, job.ID, s.reportPath, job.StdoutPath, job.StderrPath)
 	return nil
+}
+
+func gpuProfilingArtifactDir(ctx context.Context) string {
+	if artifacts, ok := framework.ScenarioArtifacts(ctx); ok {
+		return artifacts.JailDir
+	}
+	return gpuProfilingOutputDir
 }
 
 func (s *GPUProfiling) theNsightSystemsProfilingJobSucceedsAndProducesAReport(ctx context.Context) error {

--- a/e2e/acceptance/internal/sharedsteps/soperator_utils.go
+++ b/e2e/acceptance/internal/sharedsteps/soperator_utils.go
@@ -46,6 +46,7 @@ type SoperatorUtils struct {
 	taskInfoOutput       string
 	reportPath           string
 	reportAttempted      bool
+	preserveReport       bool
 }
 
 func NewSoperatorUtils(runtime framework.Runtime, selector *framework.WorkerSelector) *SoperatorUtils {
@@ -71,7 +72,7 @@ func (s *SoperatorUtils) CleanupAndReset(ctx context.Context) {
 			s.runtime.Logf("cleanup: remove NVIDIA bug report from worker %s: %v", s.worker.Name, err)
 		}
 	}
-	if s.reportPath != "" {
+	if s.reportPath != "" && !s.preserveReport {
 		if _, err := s.runtime.Jail().Run(ctx, fmt.Sprintf("rm -f %s", framework.ShellQuote(s.reportPath))); err != nil {
 			s.runtime.Logf("cleanup: remove downloaded NVIDIA bug report %s: %v", s.reportPath, err)
 		}
@@ -83,6 +84,7 @@ func (s *SoperatorUtils) CleanupAndReset(ctx context.Context) {
 	s.taskInfoOutput = ""
 	s.reportPath = ""
 	s.reportAttempted = false
+	s.preserveReport = false
 }
 
 func (s *SoperatorUtils) selectWorker(ctx context.Context) error {
@@ -184,8 +186,14 @@ func (s *SoperatorUtils) downloadNVIDIABugReport(ctx context.Context) error {
 	}
 
 	s.reportAttempted = true
-	s.reportPath = path.Join("/tmp", s.worker.Name+"-nvidia-bug-report.log.gz")
-	command := fmt.Sprintf("cd /tmp && %s -i %s",
+	reportDir := "/tmp"
+	if artifacts, ok := framework.ScenarioArtifacts(ctx); ok {
+		reportDir = artifacts.JailDir
+		s.preserveReport = true
+	}
+	s.reportPath = path.Join(reportDir, s.worker.Name+"-nvidia-bug-report.log.gz")
+	command := fmt.Sprintf("cd %s && %s -i %s",
+		framework.ShellQuote(reportDir),
 		framework.ShellQuote(path.Join(soperatorUtilsDir, "worker_nvidia_bug_report.sh")),
 		framework.ShellQuote(s.worker.SlurmNode.InstanceID),
 	)

--- a/e2e/acceptance/public_api_test.go
+++ b/e2e/acceptance/public_api_test.go
@@ -28,6 +28,12 @@ func TestPublicRunnerAPIIsImportable(t *testing.T) {
 	assert.NotNil(t, runner)
 }
 
+func TestPublicRuntimeAPIIsImportable(t *testing.T) {
+	runtime, err := acceptance.NewRuntime("dev-context", "soperator", "5.0.0")
+	require.NoError(t, err)
+	assert.NotNil(t, runtime)
+}
+
 func TestPublicRunnerAPIAcceptsCallerOwnedStaticSuites(t *testing.T) {
 	productFeatures := acceptance.FeatureSource{
 		FS: fstest.MapFS{

--- a/e2e/acceptance/runner.go
+++ b/e2e/acceptance/runner.go
@@ -30,10 +30,10 @@ var suiteNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 // Runner executes a configured Godog acceptance suite against a Soperator cluster.
 type Runner struct {
 	suites                 []SuiteConfig
-	kubectlContext         string
 	slurmClusterName       string
 	targetSoperatorVersion string
-	reportDir              string
+	outputDir              string
+	runtime                framework.Runtime
 }
 
 // RunnerConfig configures an acceptance suite run.
@@ -41,7 +41,7 @@ type RunnerConfig struct {
 	KubectlContext         string
 	SlurmClusterName       string
 	TargetSoperatorVersion string
-	ReportDir              string
+	OutputDir              string
 	Suites                 []SuiteConfig
 }
 
@@ -72,25 +72,28 @@ func NewRunner(config RunnerConfig) (*Runner, error) {
 	if len(suites) == 0 {
 		return nil, fmt.Errorf("at least one suite is required")
 	}
+	runtime, err := NewRuntime(kubectlContext, slurmClusterName, normalizedTargetVersion)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Runner{
 		suites:                 suites,
-		kubectlContext:         kubectlContext,
 		slurmClusterName:       slurmClusterName,
 		targetSoperatorVersion: normalizedTargetVersion,
-		reportDir:              strings.TrimSpace(config.ReportDir),
+		outputDir:              strings.TrimSpace(config.OutputDir),
+		runtime:                runtime,
 	}, nil
 }
 
 // Run executes the configured acceptance suite.
 func (r *Runner) Run(ctx context.Context) error {
-	w := newWorld(r.kubectlContext, r.slurmClusterName, r.targetSoperatorVersion)
 	info := &framework.ClusterInfo{
 		SlurmClusterName:       r.slurmClusterName,
 		TargetSoperatorVersion: r.targetSoperatorVersion,
 	}
 
-	return r.runConfiguredSuites(ctx, info, w, r.suites)
+	return r.runConfiguredSuites(ctx, info, r.runtime, r.suites)
 }
 
 func (r *Runner) runConfiguredSuites(ctx context.Context, info *framework.ClusterInfo, runtime framework.Runtime, suites []SuiteConfig) error {
@@ -209,16 +212,21 @@ func (r *Runner) suiteFeaturePaths(info *framework.ClusterInfo, suite SuiteConfi
 }
 
 func (r *Runner) runSuite(ctx context.Context, info *framework.ClusterInfo, runtime framework.Runtime, suite SuiteConfig, features []string) error {
-	format, err := reports.Format(r.reportDir, suite.Name)
+	format, err := reports.Format(r.outputDir, suite.Name)
 	if err != nil {
 		return fmt.Errorf("suite %q report format: %w", suite.Name, err)
 	}
 
+	var jail framework.CommandScope
+	if runtime != nil {
+		jail = runtime.Jail()
+	}
+	artifactsManager := framework.NewArtifactsManager(r.outputDir, jail)
 	tags := r.suiteTagFilter(suite)
 	godogSuite := godog.TestSuite{
 		Name: suite.Name,
 		ScenarioInitializer: func(sc *godog.ScenarioContext) {
-			r.initializeSuiteScenario(sc, info, runtime, suite)
+			r.initializeSuiteScenario(sc, info, runtime, suite, artifactsManager)
 		},
 		Options: &godog.Options{
 			Format:         format,
@@ -240,12 +248,38 @@ func (r *Runner) runSuite(ctx context.Context, info *framework.ClusterInfo, runt
 	return nil
 }
 
-func (r *Runner) initializeSuiteScenario(sc *godog.ScenarioContext, info *framework.ClusterInfo, runtime framework.Runtime, suite SuiteConfig) {
+func (r *Runner) initializeSuiteScenario(
+	sc *godog.ScenarioContext,
+	info *framework.ClusterInfo,
+	runtime framework.Runtime,
+	suite SuiteConfig,
+	artifactsManager *framework.ArtifactsManager,
+) {
+	registerScenarioArtifacts(sc, suite.Name, runtime, artifactsManager)
 	registerTimingHooks(sc)
 	registerSkipHook(sc)
 	for _, register := range suite.StepRegistrars {
 		register(sc, info, runtime)
 	}
+}
+
+func registerScenarioArtifacts(
+	sc *godog.ScenarioContext,
+	suiteName string,
+	runtime framework.Runtime,
+	manager *framework.ArtifactsManager,
+) {
+	sc.Before(func(ctx context.Context, scenario *godog.Scenario) (context.Context, error) {
+		preparedCtx, err := manager.PrepareScenario(ctx, suiteName, scenario.Uri, scenario.Name, scenario.Id)
+		if err != nil {
+			if runtime != nil {
+				runtime.Logf("Prepare artifacts for scenario %q: %v", scenario.Name, err)
+			} else {
+				log.Printf("acceptance: prepare artifacts for scenario %q: %v", scenario.Name, err)
+			}
+		}
+		return preparedCtx, nil
+	})
 }
 
 func registerSkipHook(sc *godog.ScenarioContext) {
@@ -304,6 +338,23 @@ func newWorld(kubectlContext, slurmClusterName, soperatorVersion string) *world 
 		slurmClusterName: slurmClusterName,
 		soperatorVersion: soperatorVersion,
 	}
+}
+
+// NewRuntime constructs the shared acceptance runtime.
+func NewRuntime(kubectlContext, slurmClusterName, targetSoperatorVersion string) (framework.Runtime, error) {
+	slurmClusterName = strings.TrimSpace(slurmClusterName)
+	if slurmClusterName == "" {
+		slurmClusterName = defaultSlurmClusterName
+	}
+	targetSoperatorVersion = strings.TrimSpace(targetSoperatorVersion)
+	if targetSoperatorVersion == "" {
+		return nil, fmt.Errorf("target Soperator version is required")
+	}
+	normalizedVersion, err := framework.NormalizeSoperatorVersion(targetSoperatorVersion)
+	if err != nil {
+		return nil, fmt.Errorf("target Soperator version: %w", err)
+	}
+	return newWorld(strings.TrimSpace(kubectlContext), slurmClusterName, normalizedVersion), nil
 }
 
 func (w *world) logf(format string, args ...any) {

--- a/e2e/acceptance/runner_test.go
+++ b/e2e/acceptance/runner_test.go
@@ -3,6 +3,8 @@ package acceptance
 import (
 	"context"
 	"errors"
+	"os"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -251,6 +253,41 @@ func TestRunnerRunConfiguredSuitesErrorsWhenAllSuitesAreEmpty(t *testing.T) {
 	err = runner.runConfiguredSuites(context.Background(), testClusterInfo(), nil, runner.suites)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "no acceptance scenarios compatible with Soperator version 5.0.0")
+}
+
+func TestRunnerMakesScenarioArtifactPathsAvailableToSteps(t *testing.T) {
+	outputDir := t.TempDir()
+	var observed framework.ScenarioArtifactPaths
+	runner, err := NewRunner(RunnerConfig{
+		KubectlContext:         "dev-context",
+		TargetSoperatorVersion: testTargetSoperatorVersion,
+		OutputDir:              outputDir,
+		Suites: []SuiteConfig{
+			{
+				Name:   "sample",
+				Source: testRunnableFeatureSource("features/passing.feature", "scenario artifacts are available"),
+				StepRegistrars: []StepRegistrar{
+					func(sc *godog.ScenarioContext, _ *framework.ClusterInfo, _ framework.Runtime) {
+						sc.Step(`^scenario artifacts are available$`, func(ctx context.Context) error {
+							var ok bool
+							observed, ok = framework.ScenarioArtifacts(ctx)
+							if !ok {
+								return errors.New("scenario artifacts are missing")
+							}
+							return nil
+						})
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, runner.runConfiguredSuites(context.Background(), testClusterInfo(), nil, runner.suites))
+	assert.True(t, strings.HasPrefix(observed.RunnerDir, outputDir+"/scenarios/sample/"))
+	assert.True(t, strings.HasPrefix(observed.JailDir, framework.AcceptanceScenarioArtifactsDir+"/sample/"))
+	_, err = os.Stat(observed.RunnerDir)
+	require.NoError(t, err)
 }
 
 func testSampleSuite() SuiteConfig {

--- a/e2e/acceptance/world.go
+++ b/e2e/acceptance/world.go
@@ -25,6 +25,11 @@ type world struct {
 	soperatorVersion string
 }
 
+// NewLocalArgsScope creates a local process scope without requiring a Kubernetes runtime.
+func NewLocalArgsScope() framework.ArgsScope {
+	return (&world{logPrefix: "acceptance"}).Local()
+}
+
 func (w *world) Logf(format string, args ...any) {
 	w.logf(format, args...)
 }

--- a/e2e/cmd/acceptance/cli/options.go
+++ b/e2e/cmd/acceptance/cli/options.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -99,6 +100,12 @@ func collectArtifacts(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("parse collect-artifacts args: %w", err)
 	}
+	if opts.KubectlContext == "" {
+		log.Printf("artifacts: skip Kubernetes-bound collectors: kubectl context is not provided")
+		return artifacts.CollectAll(ctx, opts.OutputDir,
+			artifacts.NewMK8sCollector(acceptance.NewLocalArgsScope(), opts.NebiusProjectID),
+		)
+	}
 	targetVersion, err := resolveTargetSoperatorVersion(ctx, opts.KubectlContext, opts.SoperatorVersion)
 	if err != nil {
 		return err
@@ -153,7 +160,7 @@ func parseCollectOptions(args []string) (collectOptions, error) {
 	opts := collectOptions{SlurmClusterName: defaultSlurmClusterName}
 	fs := flag.NewFlagSet("acceptance collect-artifacts", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
-	fs.StringVar(&opts.KubectlContext, "kubectl-context", "", "kubectl context to collect from")
+	fs.StringVar(&opts.KubectlContext, "kubectl-context", "", "optional kubectl context; when omitted, only MK8s artifacts are collected")
 	fs.StringVar(&opts.SlurmClusterName, "slurm-cluster-name", opts.SlurmClusterName, "SlurmCluster resource name")
 	fs.StringVar(&opts.SoperatorVersion, "soperator-version", "", "target Soperator version; when omitted, Flux HelmRelease discovery is used")
 	fs.StringVar(&opts.NebiusProjectID, "nebius-project-id", "", "optional Nebius project ID for Managed Kubernetes artifacts")
@@ -169,8 +176,11 @@ func parseCollectOptions(args []string) (collectOptions, error) {
 	opts.SoperatorVersion = strings.TrimSpace(opts.SoperatorVersion)
 	opts.NebiusProjectID = strings.TrimSpace(opts.NebiusProjectID)
 	opts.OutputDir = strings.TrimSpace(opts.OutputDir)
-	if err := validateCommonOptions(opts.KubectlContext, opts.OutputDir); err != nil {
-		return collectOptions{}, err
+	if opts.OutputDir == "" {
+		return collectOptions{}, fmt.Errorf("--output-dir is required")
+	}
+	if opts.KubectlContext == "" && opts.NebiusProjectID == "" {
+		return collectOptions{}, fmt.Errorf("at least one of --kubectl-context or --nebius-project-id is required")
 	}
 	return opts, nil
 }

--- a/e2e/cmd/acceptance/cli/options.go
+++ b/e2e/cmd/acceptance/cli/options.go
@@ -9,18 +9,27 @@ import (
 	"strings"
 
 	"github.com/nebius/soperator/e2e/acceptance"
+	"github.com/nebius/soperator/e2e/acceptance/artifacts"
 )
 
 const defaultSlurmClusterName = "soperator"
 
-type options struct {
+type runOptions struct {
 	KubectlContext    string
 	SlurmClusterName  string
 	SoperatorVersion  string
 	RunUnstableTests  bool
 	RunEssentialTests bool
 	ScenarioPaths     []string
-	ReportDir         string
+	OutputDir         string
+}
+
+type collectOptions struct {
+	KubectlContext   string
+	SlurmClusterName string
+	SoperatorVersion string
+	NebiusProjectID  string
+	OutputDir        string
 }
 
 type scenarioPathFlag []string
@@ -38,29 +47,43 @@ func (f *scenarioPathFlag) Set(value string) error {
 	return nil
 }
 
-// Run parses CLI-style acceptance arguments and runs the shared acceptance suite.
+// Run parses an acceptance subcommand and executes it.
 func Run(ctx context.Context, args []string) error {
-	opts, err := parseOptions(args)
+	if len(args) == 0 {
+		return fmt.Errorf("subcommand is required: use run or collect-artifacts")
+	}
+
+	switch args[0] {
+	case "run":
+		return runAcceptance(ctx, args[1:])
+	case "collect-artifacts":
+		return collectArtifacts(ctx, args[1:])
+	case "help", "-h", "--help":
+		return nil
+	default:
+		return fmt.Errorf("unknown subcommand %q: use run or collect-artifacts", args[0])
+	}
+}
+
+func runAcceptance(ctx context.Context, args []string) error {
+	opts, err := parseRunOptions(args)
 	if errors.Is(err, flag.ErrHelp) {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("parse acceptance args: %w", err)
+		return fmt.Errorf("parse run args: %w", err)
 	}
 
-	targetSoperatorVersion, err := resolveTargetSoperatorVersion(ctx, opts)
+	targetVersion, err := resolveTargetSoperatorVersion(ctx, opts.KubectlContext, opts.SoperatorVersion)
 	if err != nil {
 		return err
 	}
-
-	suite := suiteFromOptions(opts, targetSoperatorVersion)
-
 	runner, err := acceptance.NewRunner(acceptance.RunnerConfig{
 		KubectlContext:         opts.KubectlContext,
 		SlurmClusterName:       opts.SlurmClusterName,
-		TargetSoperatorVersion: targetSoperatorVersion,
-		ReportDir:              opts.ReportDir,
-		Suites:                 []acceptance.SuiteConfig{suite},
+		TargetSoperatorVersion: targetVersion,
+		OutputDir:              opts.OutputDir,
+		Suites:                 []acceptance.SuiteConfig{suiteFromOptions(opts, targetVersion)},
 	})
 	if err != nil {
 		return err
@@ -68,7 +91,30 @@ func Run(ctx context.Context, args []string) error {
 	return runner.Run(ctx)
 }
 
-func suiteFromOptions(opts options, targetSoperatorVersion string) acceptance.SuiteConfig {
+func collectArtifacts(ctx context.Context, args []string) error {
+	opts, err := parseCollectOptions(args)
+	if errors.Is(err, flag.ErrHelp) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("parse collect-artifacts args: %w", err)
+	}
+	targetVersion, err := resolveTargetSoperatorVersion(ctx, opts.KubectlContext, opts.SoperatorVersion)
+	if err != nil {
+		return err
+	}
+	runtime, err := acceptance.NewRuntime(opts.KubectlContext, opts.SlurmClusterName, targetVersion)
+	if err != nil {
+		return err
+	}
+	collectors := artifacts.CommonCollectors(runtime)
+	if opts.NebiusProjectID != "" {
+		collectors = append(collectors, artifacts.NewMK8sCollector(runtime.Local(), opts.NebiusProjectID))
+	}
+	return artifacts.CollectAll(ctx, opts.OutputDir, collectors...)
+}
+
+func suiteFromOptions(opts runOptions, targetSoperatorVersion string) acceptance.SuiteConfig {
 	suite := acceptance.SoperatorSuite(targetSoperatorVersion)
 	if len(opts.ScenarioPaths) > 0 {
 		suite.Source.Paths = opts.ScenarioPaths
@@ -82,45 +128,78 @@ func suiteFromOptions(opts options, targetSoperatorVersion string) acceptance.Su
 	return suite
 }
 
-func parseOptions(args []string) (options, error) {
-	opts := options{
-		SlurmClusterName: defaultSlurmClusterName,
-	}
-
-	fs := flag.NewFlagSet("acceptance", flag.ContinueOnError)
+func parseRunOptions(args []string) (runOptions, error) {
+	opts := runOptions{SlurmClusterName: defaultSlurmClusterName}
+	fs := flag.NewFlagSet("acceptance run", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	fs.StringVar(&opts.KubectlContext, "kubectl-context", "", "kubectl context to use for acceptance tests")
 	fs.StringVar(&opts.SlurmClusterName, "slurm-cluster-name", opts.SlurmClusterName, "SlurmCluster resource name")
 	fs.StringVar(&opts.SoperatorVersion, "soperator-version", "", "target Soperator version; when omitted, Flux HelmRelease discovery is used")
 	fs.BoolVar(&opts.RunUnstableTests, "run-unstable", false, "run scenarios tagged @unstable")
 	fs.BoolVar(&opts.RunEssentialTests, "run-essential", false, "run only scenarios tagged @essential")
-	fs.Var((*scenarioPathFlag)(&opts.ScenarioPaths), "scenario", "feature file or exact Scenario line to run, e.g. features/internal_ssh.feature:3; may be repeated")
-	fs.StringVar(&opts.ReportDir, "report-dir", "", "optional directory for Cucumber and JUnit reports")
-
+	fs.Var((*scenarioPathFlag)(&opts.ScenarioPaths), "scenario", "feature file or exact Scenario line to run; may be repeated")
+	fs.StringVar(&opts.OutputDir, "output-dir", "", "directory for reports and per-scenario artifacts")
 	if err := fs.Parse(args); err != nil {
-		return options{}, err
+		return runOptions{}, err
 	}
 	if fs.NArg() > 0 {
-		return options{}, fmt.Errorf("unexpected acceptance arguments: %s", strings.Join(fs.Args(), " "))
+		return runOptions{}, fmt.Errorf("unexpected run arguments: %s", strings.Join(fs.Args(), " "))
 	}
-
-	opts.KubectlContext = strings.TrimSpace(opts.KubectlContext)
-	if opts.KubectlContext == "" {
-		return options{}, fmt.Errorf("--kubectl-context is required")
+	trimRunOptions(&opts)
+	if err := validateCommonOptions(opts.KubectlContext, opts.OutputDir); err != nil {
+		return runOptions{}, err
 	}
-	opts.SlurmClusterName = strings.TrimSpace(opts.SlurmClusterName)
-	opts.SoperatorVersion = strings.TrimSpace(opts.SoperatorVersion)
-	opts.ReportDir = strings.TrimSpace(opts.ReportDir)
-
 	return opts, nil
 }
 
-func resolveTargetSoperatorVersion(ctx context.Context, opts options) (string, error) {
-	if opts.SoperatorVersion != "" {
-		return opts.SoperatorVersion, nil
+func parseCollectOptions(args []string) (collectOptions, error) {
+	opts := collectOptions{SlurmClusterName: defaultSlurmClusterName}
+	fs := flag.NewFlagSet("acceptance collect-artifacts", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.StringVar(&opts.KubectlContext, "kubectl-context", "", "kubectl context to collect from")
+	fs.StringVar(&opts.SlurmClusterName, "slurm-cluster-name", opts.SlurmClusterName, "SlurmCluster resource name")
+	fs.StringVar(&opts.SoperatorVersion, "soperator-version", "", "target Soperator version; when omitted, Flux HelmRelease discovery is used")
+	fs.StringVar(&opts.NebiusProjectID, "nebius-project-id", "", "optional Nebius project ID for Managed Kubernetes artifacts")
+	fs.StringVar(&opts.OutputDir, "output-dir", "", "directory for collected artifacts")
+	if err := fs.Parse(args); err != nil {
+		return collectOptions{}, err
 	}
+	if fs.NArg() > 0 {
+		return collectOptions{}, fmt.Errorf("unexpected collect-artifacts arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	opts.KubectlContext = strings.TrimSpace(opts.KubectlContext)
+	opts.SlurmClusterName = strings.TrimSpace(opts.SlurmClusterName)
+	opts.SoperatorVersion = strings.TrimSpace(opts.SoperatorVersion)
+	opts.NebiusProjectID = strings.TrimSpace(opts.NebiusProjectID)
+	opts.OutputDir = strings.TrimSpace(opts.OutputDir)
+	if err := validateCommonOptions(opts.KubectlContext, opts.OutputDir); err != nil {
+		return collectOptions{}, err
+	}
+	return opts, nil
+}
 
-	version, err := discoverFluxSoperatorVersion(ctx, opts.KubectlContext)
+func trimRunOptions(opts *runOptions) {
+	opts.KubectlContext = strings.TrimSpace(opts.KubectlContext)
+	opts.SlurmClusterName = strings.TrimSpace(opts.SlurmClusterName)
+	opts.SoperatorVersion = strings.TrimSpace(opts.SoperatorVersion)
+	opts.OutputDir = strings.TrimSpace(opts.OutputDir)
+}
+
+func validateCommonOptions(kubectlContext, outputDir string) error {
+	if kubectlContext == "" {
+		return fmt.Errorf("--kubectl-context is required")
+	}
+	if outputDir == "" {
+		return fmt.Errorf("--output-dir is required")
+	}
+	return nil
+}
+
+func resolveTargetSoperatorVersion(ctx context.Context, kubectlContext, configuredVersion string) (string, error) {
+	if configuredVersion != "" {
+		return configuredVersion, nil
+	}
+	version, err := discoverFluxSoperatorVersion(ctx, kubectlContext)
 	if err != nil {
 		return "", fmt.Errorf("discover target Soperator version from Flux HelmRelease: %w; pass --soperator-version to override", err)
 	}

--- a/e2e/cmd/acceptance/cli/options.go
+++ b/e2e/cmd/acceptance/cli/options.go
@@ -107,10 +107,7 @@ func collectArtifacts(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	collectors := artifacts.CommonCollectors(runtime)
-	if opts.NebiusProjectID != "" {
-		collectors = append(collectors, artifacts.NewMK8sCollector(runtime.Local(), opts.NebiusProjectID))
-	}
+	collectors := artifacts.CommonCollectors(runtime, opts.NebiusProjectID)
 	return artifacts.CollectAll(ctx, opts.OutputDir, collectors...)
 }
 

--- a/e2e/cmd/acceptance/cli/options_test.go
+++ b/e2e/cmd/acceptance/cli/options_test.go
@@ -50,6 +50,20 @@ func TestParseCollectOptionsProjectIsOptional(t *testing.T) {
 	assert.Equal(t, "snapshot", opts.OutputDir)
 }
 
+func TestParseCollectOptionsAllowsProjectWithoutKubernetesContext(t *testing.T) {
+	opts, err := parseCollectOptions([]string{"--nebius-project-id", "project-id", "--output-dir", "snapshot"})
+	require.NoError(t, err)
+
+	assert.Empty(t, opts.KubectlContext)
+	assert.Equal(t, "project-id", opts.NebiusProjectID)
+}
+
+func TestParseCollectOptionsRequiresAtLeastOneArtifactSource(t *testing.T) {
+	_, err := parseCollectOptions([]string{"--output-dir", "snapshot"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "at least one of --kubectl-context or --nebius-project-id is required")
+}
+
 func TestSuiteFromOptionsSelectsEssentialScenarios(t *testing.T) {
 	suite := suiteFromOptions(runOptions{RunEssentialTests: true}, "5.0.0")
 	assert.Equal(t, "@essential", suite.Tags)

--- a/e2e/cmd/acceptance/cli/options_test.go
+++ b/e2e/cmd/acceptance/cli/options_test.go
@@ -1,14 +1,15 @@
 package cli
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseOptionsDefaults(t *testing.T) {
-	opts, err := parseOptions([]string{"--kubectl-context", "dev-context"})
+func TestParseRunOptionsDefaults(t *testing.T) {
+	opts, err := parseRunOptions([]string{"--kubectl-context", "dev-context", "--output-dir", "artifacts"})
 	require.NoError(t, err)
 
 	assert.Equal(t, "dev-context", opts.KubectlContext)
@@ -17,11 +18,11 @@ func TestParseOptionsDefaults(t *testing.T) {
 	assert.False(t, opts.RunEssentialTests)
 	assert.Empty(t, opts.SoperatorVersion)
 	assert.Empty(t, opts.ScenarioPaths)
-	assert.Empty(t, opts.ReportDir)
+	assert.Equal(t, "artifacts", opts.OutputDir)
 }
 
-func TestParseOptionsExplicitValues(t *testing.T) {
-	opts, err := parseOptions([]string{
+func TestParseRunOptionsExplicitValues(t *testing.T) {
+	opts, err := parseRunOptions([]string{
 		"--kubectl-context", "dev-context",
 		"--slurm-cluster-name", "custom",
 		"--soperator-version", "4.1.5-reb85d0e5",
@@ -29,50 +30,62 @@ func TestParseOptionsExplicitValues(t *testing.T) {
 		"--run-essential=true",
 		"--scenario", "features/internal_ssh.feature:3",
 		"--scenario=features/observability.feature:3",
-		"--report-dir", "reports",
+		"--output-dir", "reports",
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, "dev-context", opts.KubectlContext)
 	assert.Equal(t, "custom", opts.SlurmClusterName)
-	assert.Equal(t, "4.1.5-reb85d0e5", opts.SoperatorVersion)
 	assert.True(t, opts.RunUnstableTests)
 	assert.True(t, opts.RunEssentialTests)
 	assert.Equal(t, []string{"features/internal_ssh.feature:3", "features/observability.feature:3"}, opts.ScenarioPaths)
-	assert.Equal(t, "reports", opts.ReportDir)
+	assert.Equal(t, "reports", opts.OutputDir)
+}
+
+func TestParseCollectOptionsProjectIsOptional(t *testing.T) {
+	opts, err := parseCollectOptions([]string{"--kubectl-context", "dev-context", "--output-dir", "snapshot"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "soperator", opts.SlurmClusterName)
+	assert.Empty(t, opts.NebiusProjectID)
+	assert.Equal(t, "snapshot", opts.OutputDir)
 }
 
 func TestSuiteFromOptionsSelectsEssentialScenarios(t *testing.T) {
-	suite := suiteFromOptions(options{RunEssentialTests: true}, "5.0.0")
-
+	suite := suiteFromOptions(runOptions{RunEssentialTests: true}, "5.0.0")
 	assert.Equal(t, "@essential", suite.Tags)
 	assert.True(t, suite.ExcludeUnstable)
 }
 
 func TestSuiteFromOptionsCanIncludeUnstableEssentialScenarios(t *testing.T) {
-	suite := suiteFromOptions(options{
-		RunEssentialTests: true,
-		RunUnstableTests:  true,
-	}, "5.0.0")
-
+	suite := suiteFromOptions(runOptions{RunEssentialTests: true, RunUnstableTests: true}, "5.0.0")
 	assert.Equal(t, "@essential", suite.Tags)
 	assert.False(t, suite.ExcludeUnstable)
 }
 
-func TestParseOptionsRequiresKubectlContext(t *testing.T) {
-	_, err := parseOptions(nil)
+func TestParseRunOptionsRequiresCommonOptions(t *testing.T) {
+	_, err := parseRunOptions(nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "--kubectl-context is required")
-}
 
-func TestParseOptionsRejectsExtraArgs(t *testing.T) {
-	_, err := parseOptions([]string{"--kubectl-context", "dev-context", "extra"})
+	_, err = parseRunOptions([]string{"--kubectl-context", "dev-context"})
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "unexpected acceptance arguments")
+	assert.ErrorContains(t, err, "--output-dir is required")
 }
 
-func TestParseOptionsRejectsEmptyScenario(t *testing.T) {
-	_, err := parseOptions([]string{"--kubectl-context", "dev-context", "--scenario", " "})
+func TestParseRunOptionsRejectsExtraArgs(t *testing.T) {
+	_, err := parseRunOptions([]string{"--kubectl-context", "dev-context", "--output-dir", "out", "extra"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unexpected run arguments")
+}
+
+func TestParseRunOptionsRejectsEmptyScenario(t *testing.T) {
+	_, err := parseRunOptions([]string{"--kubectl-context", "dev-context", "--output-dir", "out", "--scenario", " "})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "--scenario value cannot be empty")
+}
+
+func TestRunRequiresExplicitSubcommand(t *testing.T) {
+	err := Run(context.Background(), nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "subcommand is required")
 }

--- a/internal/e2e/destroy.go
+++ b/internal/e2e/destroy.go
@@ -17,10 +17,10 @@ import (
 // so this opt-in path is the only way to get terraform logs out of bin/e2e
 // destroy. The file is typically uploaded as a CI artifact afterwards.
 //
-// The resulting file contains terraform DEBUG output: operational identifiers
-// (tenant/project/cluster/bucket IDs) and AWS-style access key IDs in SigV4
-// Authorization headers. Raw secrets, bearer tokens, and HTTP bodies are not
-// captured at DEBUG level, but treat the artifact as semi-sensitive.
+// Only Terraform core logging is enabled. Provider DEBUG logging is excluded
+// because providers may log raw credentials such as short-lived IAM tokens.
+// Core logs still contain operational identifiers and must be treated as
+// internal diagnostics.
 const tfDestroyLogPathEnvVar = "TF_DESTROY_LOG_PATH"
 
 func Destroy(ctx context.Context, cfg Config) error {
@@ -46,14 +46,17 @@ func enableTFDestroyLogging(tf *tfexec.Terraform) {
 	if path == "" {
 		return
 	}
+	// SetLogCore must precede SetLogPath. Otherwise terraform-exec enables global
+	// TRACE logging by default, which also enables unsafe provider logging.
+	if err := tf.SetLogCore("DEBUG"); err != nil {
+		log.Printf("SetLogCore(DEBUG) failed, continuing without terraform debug logging: %v", err)
+		return
+	}
 	if err := tf.SetLogPath(path); err != nil {
 		log.Printf("SetLogPath(%q) failed, continuing without terraform debug logging: %v", path, err)
 		return
 	}
-	if err := tf.SetLog("DEBUG"); err != nil {
-		log.Printf("SetLog(DEBUG) failed, terraform debug logging may remain disabled: %v", err)
-	}
-	log.Printf("Terraform debug logging enabled, writing to %s", path)
+	log.Printf("Terraform core debug logging enabled, writing to %s", path)
 }
 
 func destroyWithK8sRecovery(ctx context.Context, tf *tfexec.Terraform, varFilePath, nebiusProjectID string) error {


### PR DESCRIPTION
## Problem

Soperator E2E diagnostics were collected by separate GitHub Actions steps only after acceptance. When Terraform apply failed or acceptance did not start, important environment state could be lost. The collection logic was also tied to GitHub Actions, which prevented the managed Soperator E2E pipeline from reusing it, and scenarios had no consistent runner and jail locations for their own debugging output.

## Solution

Added reusable artifact collection to the acceptance framework for Kubernetes, Soperator, FluxCD, Slurm, jail, and optional Managed Kubernetes state. The E2E workflow now stores run metadata, Terraform and acceptance logs, reports, per-scenario artifacts, and cluster snapshots in one artifact tree; snapshots are taken before acceptance and again before destroy, and the tree is uploaded from an always() step.

The acceptance CLI now has explicit run and collect-artifacts commands using a shared --output-dir. Managed Kubernetes collection is skipped when no project ID is supplied and can run independently when Terraform fails before a Kubernetes context exists. Jail copying includes retries and preserves scenario output through the existing shared soperator-outputs tree.