### PR TITLE
Exclude provider logs from Terraform destroy debug artifact

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -665,11 +665,8 @@ jobs:
         if: always()
         timeout-minutes: 30
         env:
-          # Opt in to terraform DEBUG logging only for the destroy flow.
-          # bin/e2e destroy reads this and calls tf.SetLogPath() on the
-          # terraform-exec handle — otherwise terraform-exec strips TF_LOG from
-          # the subprocess env. Init/Apply steps don't set this, so they stay
-          # clean. See internal/e2e/destroy.go.
+          # Keep Terraform core diagnostics while excluding provider DEBUG logs,
+          # which may contain raw credentials such as short-lived IAM tokens.
           TF_DESTROY_LOG_PATH: ${{ runner.temp }}/tf-destroy.log
         run: |
           cd ${{ env.PATH_TO_INSTALLATION }}

--- a/internal/e2e/destroy.go
+++ b/internal/e2e/destroy.go
@@ -17,10 +17,10 @@ import (
 // so this opt-in path is the only way to get terraform logs out of bin/e2e
 // destroy. The file is typically uploaded as a CI artifact afterwards.
 //
-// The resulting file contains terraform DEBUG output: operational identifiers
-// (tenant/project/cluster/bucket IDs) and AWS-style access key IDs in SigV4
-// Authorization headers. Raw secrets, bearer tokens, and HTTP bodies are not
-// captured at DEBUG level, but treat the artifact as semi-sensitive.
+// Only Terraform core logging is enabled. Provider DEBUG logging is excluded
+// because providers may log raw credentials such as short-lived IAM tokens.
+// Core logs still contain operational identifiers and must be treated as
+// internal diagnostics.
 const tfDestroyLogPathEnvVar = "TF_DESTROY_LOG_PATH"
 
 func Destroy(ctx context.Context, cfg Config) error {
@@ -46,14 +46,17 @@ func enableTFDestroyLogging(tf *tfexec.Terraform) {
 	if path == "" {
 		return
 	}
+	// SetLogCore must precede SetLogPath. Otherwise terraform-exec enables global
+	// TRACE logging by default, which also enables unsafe provider logging.
+	if err := tf.SetLogCore("DEBUG"); err != nil {
+		log.Printf("SetLogCore(DEBUG) failed, continuing without terraform debug logging: %v", err)
+		return
+	}
 	if err := tf.SetLogPath(path); err != nil {
 		log.Printf("SetLogPath(%q) failed, continuing without terraform debug logging: %v", path, err)
 		return
 	}
-	if err := tf.SetLog("DEBUG"); err != nil {
-		log.Printf("SetLog(DEBUG) failed, terraform debug logging may remain disabled: %v", err)
-	}
-	log.Printf("Terraform debug logging enabled, writing to %s", path)
+	log.Printf("Terraform core debug logging enabled, writing to %s", path)
 }
 
 func destroyWithK8sRecovery(ctx context.Context, tf *tfexec.Terraform, varFilePath, nebiusProjectID string) error {


### PR DESCRIPTION
## Problem

Terraform destroy enables global DEBUG logging for both Terraform core and providers. The Nebius provider can include raw short-lived IAM tokens in that output, which is uploaded as the `tf-destroy-debug-log` artifact.

## Solution

Enable DEBUG logging only for Terraform core and leave provider logging disabled. Configure the core log level before the log path because `terraform-exec` otherwise defaults global logging to TRACE when a path is set.

This preserves Terraform core diagnostics in the existing artifact without exporting provider credentials.

## Testing

`go test ./internal/e2e`
