### PR TITLE
Select CUDA versions by PR target branch

### DIFF
--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -526,7 +526,7 @@ jobs:
           - cuda_version: "12.9.0"
             allow_failure: false
           - cuda_version: "13.0.3"
-            allow_failure: false
+            allow_failure: ${{ github.base_ref == 'soperator-release-4.0' || github.base_ref == 'soperator-release-4.1' }}
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
@@ -740,7 +740,7 @@ jobs:
           - cuda_version: "12.9.0"
             allow_failure: false
           - cuda_version: "13.0.3"
-            allow_failure: false
+            allow_failure: ${{ github.base_ref == 'soperator-release-4.0' || github.base_ref == 'soperator-release-4.1' }}
 
     env:
       UNSTABLE: ${{ needs.pre-build.outputs.unstable }}

--- a/.github/workflows/one_job.yml
+++ b/.github/workflows/one_job.yml
@@ -515,18 +515,21 @@ jobs:
       - pre-build
     if: needs.changes.outputs.should_build == 'true'
     runs-on: ${{ matrix.runner }}
-    continue-on-error: ${{ matrix.allow_failure }}
 
     strategy:
       fail-fast: false
       matrix:
         platform: [ linux/amd64, linux/arm64 ]
-        cuda_version: [ "12.9.0", "13.0.3" ]
+        # pull_request_target uses this definition from main for release-branch PRs.
+        cuda_version: >-
+          ${{
+            fromJSON(
+              (github.base_ref == 'soperator-release-4.0' || github.base_ref == 'soperator-release-4.1')
+              && '["12.9.0", "13.0.2"]'
+              || '["12.9.0", "13.0.3"]'
+            )
+          }}
         include:
-          - cuda_version: "12.9.0"
-            allow_failure: false
-          - cuda_version: "13.0.3"
-            allow_failure: ${{ github.base_ref == 'soperator-release-4.0' || github.base_ref == 'soperator-release-4.1' }}
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
@@ -730,17 +733,19 @@ jobs:
         needs.build-jail-images.result != 'cancelled'
       }}
     runs-on: ubuntu-24.04
-    continue-on-error: ${{ matrix.allow_failure }}
 
     strategy:
       fail-fast: false
       matrix:
-        cuda_version: ["12.9.0", "13.0.3"]
-        include:
-          - cuda_version: "12.9.0"
-            allow_failure: false
-          - cuda_version: "13.0.3"
-            allow_failure: ${{ github.base_ref == 'soperator-release-4.0' || github.base_ref == 'soperator-release-4.1' }}
+        # Keep this in sync with the build-jail-images matrix.
+        cuda_version: >-
+          ${{
+            fromJSON(
+              (github.base_ref == 'soperator-release-4.0' || github.base_ref == 'soperator-release-4.1')
+              && '["12.9.0", "13.0.2"]'
+              || '["12.9.0", "13.0.3"]'
+            )
+          }}
 
     env:
       UNSTABLE: ${{ needs.pre-build.outputs.unstable }}


### PR DESCRIPTION
## Summary

- build CUDA 12.9.0 and 13.0.2 for PRs targeting soperator-release-4.0 or soperator-release-4.1
- build CUDA 12.9.0 and 13.0.3 for main and other runs
- apply the same target-specific matrix to jail image builds and manifest creation
- keep every selected CUDA version required

This fixes the pull_request_target compatibility failure seen in #2972 without masking CUDA build failures.

## Testing

- parsed .github/workflows/one_job.yml with yq
- ran git diff --check