### PR TITLE
Sched 2449 e2e scenario selection

### DIFF
--- a/.github/scripts/e2e_pr_comment.py
+++ b/.github/scripts/e2e_pr_comment.py
@@ -54,6 +54,8 @@ def parameters(context, include_resolved_profile=False):
             ("Essential tests only", context["RUN_ESSENTIAL_TESTS"]),
         ]
     )
+    if context.get("SCENARIOS", "").strip():
+        values.append(("Scenarios", context["SCENARIOS"]))
     return "\n".join(f"- {name}: {inline_code(value)}" for name, value in values)
 
 

--- a/.github/workflows/e2e_pr_command.yml
+++ b/.github/workflows/e2e_pr_command.yml
@@ -56,11 +56,15 @@ jobs:
             exit 1
           }
 
-          if [[ "$COMMENT_BODY" =~ ^/(e2e-essential|e2e)([[:blank:]]+([^[:space:]]+))?[[:blank:]]*$ ]]; then
+          usage='Usage: `/e2e [terraform-branch] [--scenarios="<selectors>"]` or `/e2e-essential [terraform-branch] [--scenarios="<selectors>"]`. Separate selectors with commas, semicolons, or whitespace. Double quotes are optional for lists without whitespace. Example: `/e2e --scenarios="features/internal_ssh.feature:3, features/observability.feature"`.'
+          comment_body="${COMMENT_BODY//[[:space:]]/ }"
+          request_pattern="^/(e2e-essential|e2e)([[:blank:]]+([^[:space:]\"-][^[:space:]\"]*))?([[:blank:]]+--scenarios=(\"([^\"]*)\"|([^[:space:]\"']*)))?[[:blank:]]*$"
+          if [[ "$comment_body" =~ $request_pattern ]]; then
             e2e_command="${BASH_REMATCH[1]}"
             terraform_ref="${BASH_REMATCH[3]:-main}"
+            scenarios="${BASH_REMATCH[6]:-${BASH_REMATCH[7]:-}}"
           else
-            fail_with_comment 'Usage: `/e2e`, `/e2e <terraform-branch>`, `/e2e-essential`, or `/e2e-essential <terraform-branch>`.'
+            fail_with_comment "$usage"
           fi
 
           run_essential_tests=false
@@ -95,6 +99,7 @@ jobs:
             echo "head_ref=$head_ref"
             echo "terraform_ref=$terraform_ref"
             echo "run_essential_tests=$run_essential_tests"
+            echo "scenarios=$scenarios"
           } >> "$GITHUB_OUTPUT"
 
       - name: Dispatch E2E
@@ -103,6 +108,7 @@ jobs:
           HEAD_REF: ${{ steps.request.outputs.head_ref }}
           TERRAFORM_REF: ${{ steps.request.outputs.terraform_ref }}
           RUN_ESSENTIAL_TESTS: ${{ steps.request.outputs.run_essential_tests }}
+          SCENARIOS: ${{ steps.request.outputs.scenarios }}
         run: |
           if ! gh workflow run e2e_test.yml \
             --repo "$REPOSITORY" \
@@ -112,6 +118,7 @@ jobs:
             -f profile=@auto-select \
             -f run_unstable_tests=false \
             -f "run_essential_tests=$RUN_ESSENTIAL_TESTS" \
+            -f "scenarios=$SCENARIOS" \
             -f is_scheduled=false \
             -f "pr_number=$PR_NUMBER"; then
             message="Could not dispatch E2E for \`$HEAD_REF\`. See the command workflow logs for details."

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -46,6 +46,11 @@ on:
         required: false
         default: "false"
         type: string
+      scenarios:
+        description: "Acceptance features/scenarios, e.g. features/internal_ssh.feature:3, features/observability.feature. Separate with commas, semicolons, or whitespace (empty = all compatible)."
+        required: false
+        default: ""
+        type: string
       pr_number:
         description: "PR to update with the E2E result"
         required: false
@@ -84,6 +89,7 @@ jobs:
           REQUESTED_PROFILE: ${{ inputs.profile }}
           RUN_UNSTABLE_TESTS: ${{ inputs.run_unstable_tests || 'false' }}
           RUN_ESSENTIAL_TESTS: ${{ inputs.run_essential_tests || 'false' }}
+          SCENARIOS: ${{ inputs.scenarios }}
         run: |
           marker="<!-- soperator-e2e-run:${GITHUB_RUN_ID} -->"
           python3 .github/scripts/e2e_pr_comment.py start > /tmp/e2e-pr-comment.md
@@ -182,6 +188,7 @@ jobs:
           PROFILE_YAML: ${{ steps.resolve.outputs.profile_yaml }}
           TERRAFORM_REPO_REF: ${{ github.event.inputs.terraform_repo_ref || github.ref_name }}
           SOPERATOR_E2E_REPO_BRANCH: ${{ inputs.soperator_e2e_repo_branch || 'main' }}
+          SCENARIOS: ${{ inputs.scenarios }}
         run: |
           {
             echo "### Run Parameters"
@@ -189,6 +196,11 @@ jobs:
             echo "- Branch: \`${{ github.ref_name }}\`"
             echo "- Terraform branch: \`$TERRAFORM_REPO_REF\`"
             echo "- Soperator E2E repo branch: \`$SOPERATOR_E2E_REPO_BRANCH\`"
+            if [[ -n "$SCENARIOS" ]]; then
+              echo "- Scenarios: \`$SCENARIOS\`"
+            else
+              echo "- Scenarios: not specified (all to be run)"
+            fi
             echo "- Profile: \`$PROFILE_NAME\`"
             echo ""
             echo '```yaml'
@@ -223,6 +235,7 @@ jobs:
       E2E_PROFILE_YAML: ${{ needs.resolve-profile.outputs.profile_yaml }}
       RUN_UNSTABLE_TESTS: ${{ inputs.run_unstable_tests || 'false' }}
       RUN_ESSENTIAL_TESTS: ${{ inputs.run_essential_tests || 'false' }}
+      SCENARIOS: ${{ inputs.scenarios }}
       SLURM_CLUSTER_NAME: "soperator"
       E2E_ARTIFACTS_DIR: "${{ github.workspace }}/e2e-artifacts"
 
@@ -638,6 +651,11 @@ jobs:
           if [[ "$RUN_ESSENTIAL_TESTS" == "true" ]]; then
             args+=(--run-essential)
           fi
+          while read -r -a scenario_paths; do
+            for scenario in "${scenario_paths[@]}"; do
+              args+=(--scenario "$scenario")
+            done
+          done <<< "${SCENARIOS//[[:space:],;]/ }"
           bin/acceptance "${args[@]}" 2>&1 | tee "$E2E_ARTIFACTS_DIR/acceptance/acceptance.log"
 
       - name: Acceptance Summary
@@ -860,6 +878,7 @@ jobs:
           RESOLVED_PROFILE: ${{ needs.resolve-profile.outputs.profile_name }}
           RUN_UNSTABLE_TESTS: ${{ inputs.run_unstable_tests || 'false' }}
           RUN_ESSENTIAL_TESTS: ${{ inputs.run_essential_tests || 'false' }}
+          SCENARIOS: ${{ inputs.scenarios }}
           RESOLVE_RESULT: ${{ needs.resolve-profile.result }}
           E2E_RESULT: ${{ needs.e2e-test.result }}
           ACCEPTANCE_OUTCOME: ${{ needs.e2e-test.outputs.acceptance_outcome }}

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -80,8 +80,30 @@ bin/acceptance run \
   --scenario features/internal_ssh.feature:3
 ```
 
-The `--scenario` flag is for local/manual investigation only. The GitHub
-Actions e2e workflow does not pass it.
+In the GitHub Actions **E2E test soperator** workflow, use the optional
+`scenarios` field to select the same feature paths or exact scenario lines.
+Separate multiple selectors with commas, semicolons, or whitespace, for example
+`features/internal_ssh.feature:3, features/observability.feature:3`.
+Separators can be mixed; repeated separators and surrounding whitespace are
+ignored. Feature paths must not contain these separators.
+Each selector is passed as a separate `--scenario` argument. Leave the field
+empty to run all compatible scenarios subject to the tag filters below.
+Paths refer to features in the selected **E2E repo branch**.
+
+On a PR, use `/e2e [terraform-branch] --scenarios="<selectors>"` or
+`/e2e-essential [terraform-branch] --scenarios="<selectors>"`. Use the same
+separators as the workflow input. Double quotes are optional for lists without
+whitespace; use double quotes when the list contains spaces:
+
+```text
+/e2e --scenarios="features/internal_ssh.feature:3, features/observability.feature"
+/e2e my-terraform-branch --scenarios=features/internal_ssh.feature:3
+```
+
+The Terraform branch defaults to `main`. Omit `--scenarios` or pass an empty
+list to keep the default scenario selection. The same tag filters apply.
+The PR branch must contain a workflow declaring the `scenarios` input, even
+when the list is empty.
 
 `--run-essential` composes with the other selectors. By default, unstable
 essential scenarios are still excluded; pass `--run-unstable` to include them.


### PR DESCRIPTION
## Problem

CI acceptance tests can run all compatible scenarios or only essential scenarios, but cannot select specific tests. Investigating a failure therefore requires running more tests than needed.

## Solution

### Run from the GitHub UI

Open **Actions → E2E test soperator → Run workflow** and fill in the optional `scenarios` input with feature paths or `path:line` selectors:

```text
features/internal_ssh.feature:3, features/observability.feature
```

Separate selectors with commas, semicolons, or whitespace. Leave the input empty to preserve the default test selection.

### Run using the GitHub CLI

Pass selectors through the `scenarios` workflow input using `gh workflow run`:

```bash
gh workflow run e2e_test.yml \
  --repo nebius/soperator \
  --ref YOUR_SOPERATOR_BRANCH \
  -f terraform_repo_ref=main \
  -f soperator_e2e_repo_branch=YOUR_SOPERATOR_BRANCH \
  -f 'scenarios=features/internal_ssh.feature:3, features/observability.feature'
```

The same selector formats and separators as the GitHub UI apply.

### Run using a PR comment

Use `--scenarios` with `/e2e` or `/e2e-essential` to select feature paths or `path:line` selectors. Separate selectors with commas, semicolons, or whitespace; use double quotes if the list contains spaces.

```text
/e2e --scenarios="features/internal_ssh.feature:3, features/observability.feature"
/e2e-essential --scenarios=features/internal_ssh.feature:3
```

### Applies to all run methods

If `run_essential_tests=true` (also enabled by `/e2e-essential`), a selected scenario runs only if it is tagged `@essential`.

## Testing

### Pre-commit checks

- Workflow linting (`actionlint`, ShellCheck disabled), YAML/Bash syntax, and `git diff --check` passed.
- All 12 reporting tests passed.

### Run from the GitHub UI

[Run 34613216548](https://github.com/nebius/soperator/actions/runs/34613216548) completed successfully on September 11, 2026, using profile `MAN_H200` and commit `99de2c77`.

- Manually dispatched with `scenarios=features/internal_ssh.feature:3, features/observability.feature`, covering both exact scenario-line and whole-feature selection.
- The Cucumber report contains exactly the two selected scenarios: 4 steps passed, 0 failed, with a summed step duration of 18.67 seconds.
- Terraform Apply, Acceptance Tests, and Terraform Destroy all succeeded.
- PR-reporting jobs were skipped in this run, so it does not validate PR reporting.

### Run using the GitHub CLI

[Run 34618562373](https://github.com/nebius/soperator/actions/runs/34618562373) completed successfully on September 11, 2026, using profile `KCS_B200` and commit `99de2c77`.

- Dispatched using `gh workflow run`, with the same two selectors, Terraform ref `main`, and `pr_number=2975`.
- The Cucumber report contains exactly the two selected scenarios: 4 steps passed, 0 failed, with a summed step duration of 11.50 seconds.
- Terraform Apply, Acceptance Tests, Terraform Destroy, and both PR-reporting jobs succeeded.
- Verified the [comment on PR #2975](https://github.com/nebius/soperator/pull/2975#issuecomment-5637042133) was updated from the start notification to `E2E passed`, showing the requested branches and scenarios, the resolved profile, and `2 passed · 0 failed · 0 skipped`.

### Run using a PR comment

- Tested quoted and unquoted `--scenarios` values locally using the actual workflow parser: 87 cases passed, covering optional Terraform branches, both commands, mixed separators, empty lists, and malformed input. Unquoted lists cannot contain whitespace.
- A full end-to-end test triggered by an `/e2e` comment is possible only after this PR merges into `main`, because GitHub loads the `issue_comment` workflow from the default branch.

## Release Notes

Feature: Run selected acceptance features or individual scenarios through the `scenarios` input in the GitHub Actions UI or `gh workflow run`, or a `--scenarios=...` list (double quotes required when it contains whitespace) in `/e2e` and `/e2e-essential` PR comments. Default test selection and essential/unstable filters are unchanged; PR-comment runs require the PR branch to contain the updated workflow declaring `scenarios`.
